### PR TITLE
test: cover provider error hints

### DIFF
--- a/packages/cli/src/commands/output.test.ts
+++ b/packages/cli/src/commands/output.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { apiError } from "./output.js";
+
+describe("apiError provider hints", () => {
+  it("matches the documented provider-specific patterns", () => {
+    expect(apiError("Incorrect API key provided")).toMatchObject({
+      retryable: false,
+      suggestion: expect.stringContaining("API key is invalid or expired"),
+    });
+
+    expect(apiError("invalid_api_key")).toMatchObject({
+      retryable: false,
+      suggestion: expect.stringContaining("API key is invalid or expired"),
+    });
+
+    expect(apiError("context_length_exceeded")).toMatchObject({
+      retryable: false,
+      suggestion: expect.stringContaining("context window"),
+    });
+
+    expect(apiError("overloaded_error")).toMatchObject({
+      retryable: true,
+      suggestion: expect.stringContaining("temporarily overloaded"),
+    });
+
+    expect(apiError("RESOURCE_EXHAUSTED")).toMatchObject({
+      retryable: true,
+      suggestion: expect.stringContaining("Quota exceeded"),
+    });
+
+    expect(apiError("API key test did not start with 'key_'")) .toMatchObject({
+      retryable: false,
+      suggestion: expect.stringContaining("API key is invalid or expired"),
+    });
+
+    expect(apiError("voice_not_found")).toMatchObject({
+      retryable: false,
+      suggestion: expect.stringContaining("Voice ID not found"),
+    });
+
+    expect(apiError("invalid_character_count")).toMatchObject({
+      retryable: false,
+      suggestion: expect.stringContaining("character limit"),
+    });
+
+    expect(apiError("INSUFFICIENT_BALANCE")).toMatchObject({
+      retryable: false,
+      suggestion: expect.stringContaining("credits exhausted"),
+    });
+  });
+
+  it("falls back to the default retry guidance when nothing matches", () => {
+    expect(apiError("plain failure", true)).toMatchObject({
+      retryable: true,
+      suggestion: "Retry the command.",
+    });
+
+    expect(apiError("plain failure", false)).toMatchObject({
+      retryable: false,
+      suggestion: undefined,
+    });
+  });
+
+  it("does not over-match unrelated messages", () => {
+    expect(apiError("model not found")).toMatchObject({
+      retryable: false,
+      suggestion: expect.stringContaining("model is unavailable"),
+    });
+
+    expect(apiError("authentication succeeded but model not found")).toMatchObject({
+      retryable: false,
+      suggestion: expect.stringContaining("model is unavailable"),
+    });
+  });
+});

--- a/packages/cli/src/commands/output.ts
+++ b/packages/cli/src/commands/output.ts
@@ -50,7 +50,7 @@ const PROVIDER_ERROR_HINTS: Array<{ pattern: RegExp; suggestion: string; retryab
   { pattern: /429|rate.?limit|too many requests/i, suggestion: "Rate limited. Wait 30-60 seconds and retry, or check your plan's rate limits.", retryable: true },
   { pattern: /RESOURCE_EXHAUSTED|quota.*exceeded|requests.*per.*(minute|day)/i, suggestion: "Quota exceeded. Wait for the quota window to reset, or upgrade your plan. Consider -p <other-provider> to use a different provider.", retryable: true },
   // Auth
-  { pattern: /401|unauthorized|(invalid|incorrect).*api.?key|invalid_api_key|authentication.*(failed|error)|missing.*api.?key/i, suggestion: "API key is invalid or expired. Run 'vibe setup' to update, or check the key at the provider's dashboard.", retryable: false },
+  { pattern: /401|unauthorized|(invalid|incorrect).*api.?key|invalid_api_key|authentication.*(failed|error)|missing.*api.?key|did not start with 'key_'/i, suggestion: "API key is invalid or expired. Run 'vibe setup' to update, or check the key at the provider's dashboard.", retryable: false },
   { pattern: /403|forbidden|permission.*denied/i, suggestion: "Access denied. Your API key may lack required permissions, or the feature requires a paid plan.", retryable: false },
   // Billing
   { pattern: /402|payment.*required|billing|INSUFFICIENT_BALANCE|insufficient.*(credit|funds|balance)|credits?.*exhausted/i, suggestion: "Account balance or credits exhausted. Top up at the provider dashboard, or try -p <other-provider>.", retryable: false },


### PR DESCRIPTION
## Summary
Adds focused coverage for `apiError()` provider hint matching and extends the auth pattern so Runway's `did not start with 'key_'` error gets the right hint.

## Changes
- add `packages/cli/src/commands/output.test.ts` covering provider-specific matches, retryability, and default fallbacks
- extend the auth regex in `PROVIDER_ERROR_HINTS` to recognize Runway's `key_` prefix error

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing
- [ ] `pnpm build` passes
- [x] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] Manual testing done (describe below)

**Manual test steps:**
N/A

## Screenshots
N/A

## Checklist
- [x] My code follows the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have added tests for new functionality
- [ ] I have updated documentation if needed (MODELS.md, CLAUDE.md, etc.)
- [x] My commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)

Fixes #39
