### PR TITLE
refactor: dedup CLI over executeScriptToVideo / executeRegenerateScene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.0] - 2026-04-19
+
+### Added
+
+- implement narration/image regen in executeRegenerateScene *(pipeline)*
+- auto speed-adjust narration exceeding video bracket *(pipeline)*
+- emit per-scene onProgress events *(pipeline)*
+
+### Changed
+
+- thin-wrap regenerate-scene over executeRegenerateScene *(cli)*
+- thin-wrap script-to-video over executeScriptToVideo *(cli)*
+
+### Fixed
+
+- restore kling ImgBB image2video + extend API in library *(pipeline)*
+
 ## [0.48.6] - 2026-04-19
 
 ### Fixed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.48.6",
+  "version": "0.49.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.48.6",
+  "version": "0.49.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.48.6",
+  "version": "0.49.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.48.6",
+  "version": "0.49.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/ai-script-pipeline-cli.ts
+++ b/packages/cli/src/commands/ai-script-pipeline-cli.ts
@@ -6,28 +6,24 @@
  */
 
 import { Command } from "commander";
-import { readFile, writeFile, mkdir, stat } from "node:fs/promises";
-import { resolve, dirname, extname } from "node:path";
+import { readFile, writeFile, stat } from "node:fs/promises";
+import { resolve, extname } from "node:path";
 import { existsSync } from "node:fs";
 import chalk from "chalk";
 import ora from "ora";
 import { stringify as yamlStringify, parse as yamlParse } from "yaml";
 import {
   GeminiProvider,
-  OpenAIProvider,
   OpenAIImageProvider,
-  ClaudeProvider,
   ElevenLabsProvider,
   KlingProvider,
   RunwayProvider,
-  GrokProvider,
 } from "@vibeframe/ai-providers";
 import { getApiKey, loadEnv } from "../utils/api-key.js";
 import { getApiKeyFromConfig } from "../config/index.js";
-import { Project, type ProjectFile } from "../engine/index.js";
+import { type ProjectFile } from "../engine/index.js";
 import { getAudioDuration } from "../utils/audio.js";
-import { applyTextOverlays, type TextOverlayStyle } from "./ai-edit.js";
-import { executeReview } from "./ai-review.js";
+import { type TextOverlayStyle } from "./ai-edit.js";
 import {
   type StoryboardSegment,
   DEFAULT_VIDEO_RETRIES,
@@ -105,62 +101,47 @@ aiCommand
       // Load environment variables from .env file
       loadEnv();
 
-      // Get storyboard provider API key
+      // Pre-check API keys so we surface friendly exit codes (AUTH instead
+      // of API_ERROR) before executeScriptToVideo's internal re-check fires.
       const storyboardProvider = (options.storyboardProvider || "claude") as "claude" | "openai" | "gemini";
-      let storyboardApiKey: string | undefined;
-
-      if (storyboardProvider === "openai") {
-        storyboardApiKey = (await getApiKey("OPENAI_API_KEY", "OpenAI")) ?? undefined;
-        if (!storyboardApiKey) {
-          exitWithError(authError("OPENAI_API_KEY", "OpenAI"));
+      const storyboardKeyMap: Record<typeof storyboardProvider, { envVar: string; name: string }> = {
+        claude: { envVar: "ANTHROPIC_API_KEY", name: "Anthropic" },
+        openai: { envVar: "OPENAI_API_KEY", name: "OpenAI" },
+        gemini: { envVar: "GOOGLE_API_KEY", name: "Google" },
+      };
+      {
+        const info = storyboardKeyMap[storyboardProvider];
+        if (!info) {
+          exitWithError(usageError(`Unknown storyboard provider: ${storyboardProvider}`, "Use claude, openai, or gemini"));
         }
-      } else if (storyboardProvider === "gemini") {
-        storyboardApiKey = (await getApiKey("GOOGLE_API_KEY", "Google")) ?? undefined;
-        if (!storyboardApiKey) {
-          exitWithError(authError("GOOGLE_API_KEY", "Google"));
+        if (!(await getApiKey(info.envVar, info.name))) {
+          exitWithError(authError(info.envVar, info.name));
         }
-      } else if (storyboardProvider === "claude") {
-        storyboardApiKey = (await getApiKey("ANTHROPIC_API_KEY", "Anthropic")) ?? undefined;
-        if (!storyboardApiKey) {
-          exitWithError(authError("ANTHROPIC_API_KEY", "Anthropic"));
-        }
-      } else {
-        exitWithError(usageError(`Unknown storyboard provider: ${storyboardProvider}`, "Use claude, openai, or gemini"));
       }
 
-      // Get image provider API key
-      let imageApiKey: string | undefined;
-      const imageProvider = options.imageProvider || "openai";
-
-      if (imageProvider === "openai" || imageProvider === "dalle") {
-        imageApiKey = (await getApiKey("OPENAI_API_KEY", "OpenAI")) ?? undefined;
-        if (!imageApiKey) {
-          exitWithError(authError("OPENAI_API_KEY", "OpenAI"));
+      const imageProvider = (options.imageProvider || "openai") as "openai" | "dalle" | "gemini" | "grok";
+      const imageKeyMap: Record<typeof imageProvider, { envVar: string; name: string }> = {
+        openai: { envVar: "OPENAI_API_KEY", name: "OpenAI" },
+        dalle: { envVar: "OPENAI_API_KEY", name: "OpenAI" },
+        gemini: { envVar: "GOOGLE_API_KEY", name: "Google" },
+        grok: { envVar: "XAI_API_KEY", name: "xAI" },
+      };
+      {
+        const info = imageKeyMap[imageProvider];
+        if (!info) {
+          exitWithError(usageError(`Unknown image provider: ${imageProvider}`, "Use openai, gemini, or grok"));
         }
-      } else if (imageProvider === "gemini") {
-        imageApiKey = (await getApiKey("GOOGLE_API_KEY", "Google")) ?? undefined;
-        if (!imageApiKey) {
-          exitWithError(authError("GOOGLE_API_KEY", "Google"));
+        if (!(await getApiKey(info.envVar, info.name))) {
+          exitWithError(authError(info.envVar, info.name));
         }
-      } else if (imageProvider === "grok") {
-        imageApiKey = (await getApiKey("XAI_API_KEY", "xAI")) ?? undefined;
-        if (!imageApiKey) {
-          exitWithError(authError("XAI_API_KEY", "xAI"));
-        }
-      } else {
-        exitWithError(usageError(`Unknown image provider: ${imageProvider}`, "Use openai, gemini, or grok"));
       }
 
-      let elevenlabsApiKey: string | undefined;
       if (options.voiceover !== false) {
-        const key = await getApiKey("ELEVENLABS_API_KEY", "ElevenLabs");
-        if (!key) {
+        if (!(await getApiKey("ELEVENLABS_API_KEY", "ElevenLabs"))) {
           exitWithError(authError("ELEVENLABS_API_KEY", "ElevenLabs"));
         }
-        elevenlabsApiKey = key;
       }
 
-      let videoApiKey: string | undefined;
       if (!options.imagesOnly) {
         const generatorKeyMap: Record<string, { envVar: string; name: string }> = {
           grok: { envVar: "XAI_API_KEY", name: "xAI" },
@@ -173,11 +154,9 @@ aiCommand
         if (!genInfo) {
           exitWithError(usageError(`Invalid generator: ${generator}`, `Available: ${Object.keys(generatorKeyMap).join(", ")}`));
         }
-        const key = await getApiKey(genInfo.envVar, genInfo.name);
-        if (!key) {
+        if (!(await getApiKey(genInfo.envVar, genInfo.name))) {
           exitWithError(authError(genInfo.envVar, genInfo.name));
         }
-        videoApiKey = key;
       }
 
       // Read script content
@@ -187,72 +166,27 @@ aiCommand
         scriptContent = await readFile(filePath, "utf-8");
       }
 
-      // Grok and Veo route through executeScriptToVideo (fully supports all 4 providers).
-      // Kling and Runway still use the inline path below pending full dedup (#38 follow-up).
-      const delegatedGenerators = new Set(["grok", "veo"]);
-      if (!options.imagesOnly && delegatedGenerators.has(options.generator)) {
-        const pipelineSpinner = ora(`🎬 Running script-to-video with ${options.generator}...`).start();
-        const result = await executeScriptToVideo({
-          script: scriptContent,
-          outputDir: options.outputDir,
-          duration: options.duration ? parseFloat(options.duration) : undefined,
-          voice: options.voice,
-          generator: options.generator as "grok" | "veo",
-          imageProvider: options.imageProvider as "openai" | "gemini" | "grok" | undefined,
-          aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1" | undefined,
-          imagesOnly: options.imagesOnly,
-          noVoiceover: options.voiceover === false,
-          retries: parseInt(options.retries) || DEFAULT_VIDEO_RETRIES,
-          creativity: (options.creativity as "low" | "high" | undefined),
-          storyboardProvider: options.storyboardProvider as "claude" | "openai" | "gemini" | undefined,
-          noTextOverlay: options.textOverlay === false,
-          textStyle: options.textStyle as TextOverlayStyle | undefined,
-          review: options.review,
-          reviewAutoApply: options.reviewAutoApply,
-          onProgress: (msg: string) => { pipelineSpinner.text = msg; },
-        });
-        if (!result.success) {
-          pipelineSpinner.fail(chalk.red(result.error || "Script-to-Video failed"));
-          exitWithError(apiError(result.error || "Script-to-Video failed", true));
-        }
-        pipelineSpinner.succeed(chalk.green(`Generated ${result.scenes} scene(s) → ${result.projectPath}`));
-        outputResult({
-          success: true,
-          command: "pipeline script-to-video",
-          result: {
-            projectPath: result.projectPath,
-            outputDir: result.outputDir,
-            scenes: result.scenes,
-            totalDuration: result.totalDuration,
-            images: result.images?.length ?? 0,
-            videos: result.videos?.length ?? 0,
-            failedScenes: result.failedScenes ?? [],
-          },
-        });
-        return;
-      }
-
-      // Determine output directory for assets
-      // If -o looks like a directory and --output-dir is not explicitly set, use -o directory for assets
+      // Resolve -o / --output-dir semantics (identical to the old inline path):
+      //   -o foo/           → outputDir = foo,       project = foo/project.vibe.json
+      //   -o foo.vibe.json  → outputDir = default,   project = foo.vibe.json
+      //   -o foo            → outputDir = foo,       project = foo/project.vibe.json
       let effectiveOutputDir = options.outputDir;
       const outputLooksLikeDirectory =
         options.output.endsWith("/") ||
         (!options.output.endsWith(".json") && !options.output.endsWith(".vibe.json"));
-
       if (outputLooksLikeDirectory && options.outputDir === "script-video-output") {
-        // User specified a directory for -o but didn't set --output-dir, use -o directory for assets
         effectiveOutputDir = options.output;
       }
 
-      // Create output directory
-      const outputDir = resolve(process.cwd(), effectiveOutputDir);
-      if (!existsSync(outputDir)) {
-        await mkdir(outputDir, { recursive: true });
+      let projectFilePath = resolve(process.cwd(), options.output);
+      if (outputLooksLikeDirectory) {
+        projectFilePath = resolve(projectFilePath, "project.vibe.json");
+      } else if (existsSync(projectFilePath) && (await stat(projectFilePath)).isDirectory()) {
+        projectFilePath = resolve(projectFilePath, "project.vibe.json");
       }
 
-      // Validate creativity level
-      const creativity = options.creativity?.toLowerCase();
-      if (creativity && creativity !== "low" && creativity !== "high") {
+      const creativity = (options.creativity ?? "low").toLowerCase();
+      if (creativity !== "low" && creativity !== "high") {
         exitWithError(usageError("Invalid creativity level.", "Use 'low' or 'high'."));
       }
 
@@ -264,971 +198,92 @@ aiCommand
       }
       console.log();
 
-      // Step 1: Generate storyboard
-      const providerLabel = storyboardProvider.charAt(0).toUpperCase() + storyboardProvider.slice(1);
-      const storyboardSpinnerText = creativity === "high"
-        ? `Analyzing script with ${providerLabel} (high creativity)...`
-        : `Analyzing script with ${providerLabel}...`;
-      const storyboardSpinner = ora(storyboardSpinnerText).start();
-
-      let segments: StoryboardSegment[];
-      const creativityOpts = { creativity: creativity as "low" | "high" | undefined };
-      const durationOpt = options.duration ? parseFloat(options.duration) : undefined;
-
-      if (storyboardProvider === "openai") {
-        const openai = new OpenAIProvider();
-        await openai.initialize({ apiKey: storyboardApiKey! });
-        segments = await openai.analyzeContent(scriptContent, durationOpt, creativityOpts);
-      } else if (storyboardProvider === "gemini") {
-        const gemini = new GeminiProvider();
-        await gemini.initialize({ apiKey: storyboardApiKey! });
-        segments = await gemini.analyzeContent(scriptContent, durationOpt, creativityOpts);
-      } else {
-        const claude = new ClaudeProvider();
-        await claude.initialize({ apiKey: storyboardApiKey! });
-        segments = await claude.analyzeContent(scriptContent, durationOpt, creativityOpts);
-      }
-
-      if (segments.length === 0) {
-        storyboardSpinner.fail("Failed to generate storyboard");
-        exitWithError(apiError("Failed to generate storyboard (check API key and error above)", true));
-      }
-
-      let totalDuration = segments.reduce((sum, seg) => sum + seg.duration, 0);
-      storyboardSpinner.succeed(chalk.green(`Generated ${segments.length} scenes (total: ${totalDuration}s)`));
-
-      // Save storyboard
-      const storyboardPath = resolve(outputDir, "storyboard.json");
-      await writeFile(storyboardPath, JSON.stringify(segments, null, 2), "utf-8");
-      console.log(chalk.dim(`  → Saved: ${storyboardPath}`));
-      console.log();
-
-      // Step 2: Generate per-scene voiceovers with ElevenLabs
-      const perSceneTTS: { path: string; duration: number; segmentIndex: number }[] = [];
-      const failedNarrations: { sceneNum: number; error: string }[] = [];
-
-      if (options.voiceover !== false && elevenlabsApiKey) {
-        const ttsSpinner = ora("🎙️ Generating voiceovers with ElevenLabs...").start();
-
-        const elevenlabs = new ElevenLabsProvider();
-        await elevenlabs.initialize({ apiKey: elevenlabsApiKey });
-
-        let totalCharacters = 0;
-
-        for (let i = 0; i < segments.length; i++) {
-          const segment = segments[i];
-          const narrationText = segment.narration || segment.description;
-
-          if (!narrationText) continue;
-
-          // Pre-TTS word count validation
-          const wordCount = narrationText.split(/\s+/).filter(Boolean).length;
-          const maxWords = segment.duration > 5 ? 24 : 12;
-          if (wordCount > maxWords * 1.3) {
-            console.log(chalk.yellow(`  ⚠ Scene ${i + 1} narration too long: ${wordCount} words (max ~${maxWords} for ${segment.duration}s). Trimming may cause rushed speech.`));
-          }
-
-          ttsSpinner.text = `🎙️ Generating narration ${i + 1}/${segments.length}...`;
-
-          let ttsResult = await elevenlabs.textToSpeech(narrationText, {
-            voiceId: options.voice,
-          });
-
-          if (!ttsResult.success || !ttsResult.audioBuffer) {
-            const errorMsg = ttsResult.error || "Unknown error";
-            failedNarrations.push({ sceneNum: i + 1, error: errorMsg });
-            ttsSpinner.text = `🎙️ Generating narration ${i + 1}/${segments.length}... (failed)`;
-            console.log(chalk.yellow(`\n  ⚠ Narration ${i + 1} failed: ${errorMsg}`));
-            continue;
-          }
-
-          const audioPath = resolve(outputDir, `narration-${i + 1}.mp3`);
-          await writeFile(audioPath, ttsResult.audioBuffer);
-
-          // Get actual audio duration using ffprobe
-          let actualDuration = await getAudioDuration(audioPath);
-
-          // Auto speed-adjust if narration exceeds video bracket (5s or 10s)
-          const videoBracket = segment.duration > 5 ? 10 : 5;
-          const overageRatio = actualDuration / videoBracket;
-          if (overageRatio > 1.0 && overageRatio <= 1.35) {
-            // Narration exceeds bracket by 0-35% — regenerate at faster speed
-            const adjustedSpeed = Math.min(1.35, parseFloat(overageRatio.toFixed(2)));
-            ttsSpinner.text = `🎙️ Narration ${i + 1}: adjusting speed to ${adjustedSpeed}x...`;
-            const speedResult = await elevenlabs.textToSpeech(narrationText, {
-              voiceId: options.voice,
-              speed: adjustedSpeed,
-            });
-            if (speedResult.success && speedResult.audioBuffer) {
-              await writeFile(audioPath, speedResult.audioBuffer);
-              actualDuration = await getAudioDuration(audioPath);
-              ttsResult = speedResult;
-              console.log(chalk.dim(`  → Speed-adjusted narration ${i + 1}: ${adjustedSpeed}x → ${actualDuration.toFixed(1)}s`));
-            }
-          } else if (overageRatio > 1.35) {
-            // Narration way too long — warn user
-            console.log(chalk.yellow(`  ⚠ Narration ${i + 1} is ${((overageRatio - 1) * 100).toFixed(0)}% over target (${actualDuration.toFixed(1)}s vs ${videoBracket}s bracket)`));
-          }
-
-          // Update segment duration to match actual narration length
-          segment.duration = actualDuration;
-
-          perSceneTTS.push({ path: audioPath, duration: actualDuration, segmentIndex: i });
-          totalCharacters += ttsResult.characterCount || 0;
-
-          console.log(chalk.dim(`  → Saved: ${audioPath} (${actualDuration.toFixed(1)}s)`));
-        }
-
-        // Recalculate startTime for all segments based on updated durations
-        let currentTime = 0;
-        for (const segment of segments) {
-          segment.startTime = currentTime;
-          currentTime += segment.duration;
-        }
-
-        // Update total duration
-        totalDuration = segments.reduce((sum, seg) => sum + seg.duration, 0);
-
-        // Show success with failed count if any
-        if (failedNarrations.length > 0) {
-          ttsSpinner.warn(chalk.yellow(`Generated ${perSceneTTS.length}/${segments.length} narrations (${failedNarrations.length} failed)`));
-        } else {
-          ttsSpinner.succeed(chalk.green(`Generated ${perSceneTTS.length}/${segments.length} narrations (${totalCharacters} chars, ${totalDuration.toFixed(1)}s total)`));
-        }
-
-        // Re-save storyboard with updated durations
-        await writeFile(storyboardPath, JSON.stringify(segments, null, 2), "utf-8");
-        console.log(chalk.dim(`  → Updated storyboard: ${storyboardPath}`));
-        console.log();
-      }
-
-      // Step 3: Generate images with selected provider
-      const providerNames: Record<string, string> = {
-        openai: "OpenAI GPT Image 1.5",
-        dalle: "OpenAI GPT Image 1.5", // backward compatibility
-        gemini: "Gemini",
-        grok: "xAI Grok",
-      };
-      const imageSpinner = ora(`🎨 Generating visuals with ${providerNames[imageProvider]}...`).start();
-
-      // Determine image size/aspect ratio based on provider
-      const dalleImageSizes: Record<string, "1536x1024" | "1024x1536" | "1024x1024"> = {
-        "16:9": "1536x1024",
-        "9:16": "1024x1536",
-        "1:1": "1024x1024",
-      };
-      const imagePaths: string[] = [];
-
-      // Store first scene image for style continuity
-      let firstSceneImage: Buffer | undefined;
-
-      // Initialize the selected provider
-      let openaiImageInstance: OpenAIImageProvider | undefined;
-      let geminiInstance: GeminiProvider | undefined;
-      let grokInstance: GrokProvider | undefined;
-
-      if (imageProvider === "openai" || imageProvider === "dalle") {
-        openaiImageInstance = new OpenAIImageProvider();
-        await openaiImageInstance.initialize({ apiKey: imageApiKey });
-      } else if (imageProvider === "gemini") {
-        geminiInstance = new GeminiProvider();
-        await geminiInstance.initialize({ apiKey: imageApiKey });
-      } else if (imageProvider === "grok") {
-        grokInstance = new GrokProvider();
-        await grokInstance.initialize({ apiKey: imageApiKey });
-      }
-
-      // Get character description from first segment (should be same across all)
-      const characterDescription = segments[0]?.characterDescription;
-
-      for (let i = 0; i < segments.length; i++) {
-        const segment = segments[i];
-        imageSpinner.text = `🎨 Generating image ${i + 1}/${segments.length}: ${segment.description.slice(0, 30)}...`;
-
-        // Build comprehensive image prompt with character description
-        let imagePrompt = segment.visuals;
-
-        // Add character description to ensure consistency
-        if (characterDescription) {
-          imagePrompt = `CHARACTER (must match exactly): ${characterDescription}. SCENE: ${imagePrompt}`;
-        }
-
-        // Add visual style
-        if (segment.visualStyle) {
-          imagePrompt = `${imagePrompt}. STYLE: ${segment.visualStyle}`;
-        }
-
-        // For scenes after the first, add extra continuity instruction (OpenAI)
-        // Gemini uses editImage with reference instead
-        if (i > 0 && firstSceneImage && imageProvider !== "gemini") {
-          imagePrompt = `${imagePrompt}. CRITICAL: The character must look IDENTICAL to the first scene - same face, hair, clothing, accessories.`;
-        }
-
-        try {
-          let imageBuffer: Buffer | undefined;
-          let imageUrl: string | undefined;
-          let imageError: string | undefined;
-
-          if ((imageProvider === "openai" || imageProvider === "dalle") && openaiImageInstance) {
-            const imageResult = await openaiImageInstance.generateImage(imagePrompt, {
-              size: dalleImageSizes[options.aspectRatio] || "1536x1024",
-              quality: "standard",
-            });
-            if (imageResult.success && imageResult.images && imageResult.images.length > 0) {
-              // GPT Image 1.5 returns base64, DALL-E 3 returns URL
-              const img = imageResult.images[0];
-              if (img.base64) {
-                imageBuffer = Buffer.from(img.base64, "base64");
-              } else if (img.url) {
-                imageUrl = img.url;
-              }
-            } else {
-              imageError = imageResult.error;
-            }
-          } else if (imageProvider === "gemini" && geminiInstance) {
-            // Gemini: use editImage with first scene reference for subsequent scenes
-            if (i > 0 && firstSceneImage) {
-              // Use editImage to maintain style continuity with first scene
-              const editPrompt = `Create a new scene for a video: ${imagePrompt}. IMPORTANT: Maintain the exact same character appearance, clothing, environment style, color palette, and art style as the reference image.`;
-              const imageResult = await geminiInstance.editImage([firstSceneImage], editPrompt, {
-                aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1",
-              });
-              if (imageResult.success && imageResult.images && imageResult.images.length > 0) {
-                const img = imageResult.images[0];
-                if (img.base64) {
-                  imageBuffer = Buffer.from(img.base64, "base64");
-                }
-              } else {
-                imageError = imageResult.error;
-              }
-            } else {
-              // First scene: use regular generateImage
-              const imageResult = await geminiInstance.generateImage(imagePrompt, {
-                aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1",
-              });
-              if (imageResult.success && imageResult.images && imageResult.images.length > 0) {
-                const img = imageResult.images[0];
-                if (img.base64) {
-                  imageBuffer = Buffer.from(img.base64, "base64");
-                }
-              } else {
-                imageError = imageResult.error;
-              }
-            }
-          } else if (imageProvider === "grok" && grokInstance) {
-            const imageResult = await grokInstance.generateImage(imagePrompt, {
-              aspectRatio: options.aspectRatio || "16:9",
-            });
-            if (imageResult.success && imageResult.images && imageResult.images.length > 0) {
-              const img = imageResult.images[0];
-              if (img.base64) {
-                imageBuffer = Buffer.from(img.base64, "base64");
-              } else if (img.url) {
-                imageUrl = img.url;
-              }
-            } else {
-              imageError = imageResult.error;
-            }
-          }
-
-          // Save the image
-          const imagePath = resolve(outputDir, `scene-${i + 1}.png`);
-
-          if (imageBuffer) {
-            await writeFile(imagePath, imageBuffer);
-            imagePaths.push(imagePath);
-            // Store first successful image for style continuity
-            if (!firstSceneImage) {
-              firstSceneImage = imageBuffer;
-            }
-          } else if (imageUrl) {
-            const response = await fetch(imageUrl);
-            const buffer = Buffer.from(await response.arrayBuffer());
-            await writeFile(imagePath, buffer);
-            imagePaths.push(imagePath);
-            // Store first successful image for style continuity
-            if (!firstSceneImage) {
-              firstSceneImage = buffer;
-            }
-          } else {
-            const errorMsg = imageError || "Unknown error";
-            console.log(chalk.yellow(`\n  ⚠ Failed to generate image for scene ${i + 1}: ${errorMsg}`));
-            imagePaths.push("");
-          }
-        } catch (err) {
-          console.log(chalk.yellow(`\n  ⚠ Error generating image for scene ${i + 1}: ${err}`));
-          imagePaths.push("");
-        }
-
-        // Small delay to avoid rate limiting
-        if (i < segments.length - 1) {
-          await new Promise((r) => setTimeout(r, 500));
-        }
-      }
-
-      const successfulImages = imagePaths.filter((p) => p !== "").length;
-      imageSpinner.succeed(chalk.green(`Generated ${successfulImages}/${segments.length} images with ${providerNames[imageProvider]}`));
-      console.log();
-
-      // Step 4: Generate videos (if not images-only)
-      const videoPaths: string[] = [];
-      const failedScenes: number[] = []; // Track failed scenes for summary
-      const maxRetries = parseInt(options.retries) || DEFAULT_VIDEO_RETRIES;
-
-      if (!options.imagesOnly && videoApiKey) {
-        // Guard already enforced above (before storyboard/image/narration);
-        // reaching here means generator ∈ {kling, runway}.
-        const providerLabel = options.generator === "kling" ? "Kling" : "Runway";
-        const videoSpinner = ora(`🎬 Generating videos with ${providerLabel}...`).start();
-
-        if (options.generator === "kling") {
-          const kling = new KlingProvider();
-          await kling.initialize({ apiKey: videoApiKey });
-
-          if (!kling.isConfigured()) {
-            videoSpinner.fail("Invalid Kling API key format");
-            exitWithError(authError("KLING_API_KEY", "Kling"));
-          }
-
-          // Check for ImgBB API key for image-to-video support (from config or env)
-          const imgbbApiKey = await getApiKeyFromConfig("imgbb") || process.env.IMGBB_API_KEY;
-          const useImageToVideo = !!imgbbApiKey;
-
-          if (useImageToVideo) {
-            videoSpinner.text = `🎬 Uploading images to ImgBB for image-to-video...`;
-          }
-
-          // Upload images to ImgBB if API key is available (for Kling v2.x image-to-video)
-          const imageUrls: (string | undefined)[] = [];
-          if (useImageToVideo) {
-            for (let i = 0; i < imagePaths.length; i++) {
-              if (imagePaths[i] && imagePaths[i] !== "") {
-                try {
-                  const imageBuffer = await readFile(imagePaths[i]);
-                  const uploadResult = await uploadToImgbb(imageBuffer, imgbbApiKey);
-                  if (uploadResult.success && uploadResult.url) {
-                    imageUrls[i] = uploadResult.url;
-                  } else {
-                    console.log(chalk.yellow(`\n  ⚠ Failed to upload image ${i + 1}: ${uploadResult.error}`));
-                    imageUrls[i] = undefined;
-                  }
-                } catch {
-                  imageUrls[i] = undefined;
-                }
-              } else {
-                imageUrls[i] = undefined;
-              }
-            }
-            const uploadedCount = imageUrls.filter((u) => u).length;
-            if (uploadedCount > 0) {
-              videoSpinner.text = `🎬 Uploaded ${uploadedCount}/${imagePaths.length} images to ImgBB`;
-            }
-          }
-
-          // Sequential mode: generate one video at a time (slower but more reliable)
-          if (options.sequential) {
-            for (let i = 0; i < segments.length; i++) {
-              const segment = segments[i] as StoryboardSegment;
-              videoSpinner.text = `🎬 Scene ${i + 1}/${segments.length}: Starting...`;
-
-              const videoDuration = (segment.duration > 5 ? 10 : 5) as 5 | 10;
-              const referenceImage = imageUrls[i];
-
-              let completed = false;
-              for (let attempt = 0; attempt <= maxRetries && !completed; attempt++) {
-                const result = await generateVideoWithRetryKling(
-                  kling,
-                  segment,
-                  {
-                    duration: videoDuration,
-                    aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1",
-                    referenceImage,
-                  },
-                  0, // Handle retries at this level
-                  (msg) => {
-                    videoSpinner.text = `🎬 Scene ${i + 1}/${segments.length}: ${msg}`;
-                  }
-                );
-
-                if (!result) {
-                  if (attempt < maxRetries) {
-                    videoSpinner.text = `🎬 Scene ${i + 1}: Submit failed, retry ${attempt + 1}/${maxRetries}...`;
-                    await sleep(RETRY_DELAY_MS);
-                    continue;
-                  }
-                  console.log(chalk.yellow(`\n  ⚠ Failed to start video generation for scene ${i + 1}`));
-                  videoPaths[i] = "";
-                  failedScenes.push(i + 1);
-                  break;
-                }
-
-                try {
-                  const waitResult = await kling.waitForCompletion(
-                    result.taskId,
-                    result.type,
-                    (status) => {
-                      videoSpinner.text = `🎬 Scene ${i + 1}/${segments.length}: ${status.status}...`;
-                    },
-                    600000
-                  );
-
-                  if (waitResult.status === "completed" && waitResult.videoUrl) {
-                    const videoPath = resolve(outputDir, `scene-${i + 1}.mp4`);
-                    const buffer = await downloadVideo(waitResult.videoUrl, videoApiKey);
-                    await writeFile(videoPath, buffer);
-
-                    // Extend video to match narration duration if needed
-                    await extendVideoToTarget(videoPath, segment.duration, outputDir, `Scene ${i + 1}`, {
-                      kling,
-                      videoId: waitResult.videoId,
-                      onProgress: (msg) => { videoSpinner.text = `🎬 ${msg}`; },
-                    });
-
-                    videoPaths[i] = videoPath;
-                    completed = true;
-                    console.log(chalk.green(`\n  ✓ Scene ${i + 1} completed`));
-                  } else if (attempt < maxRetries) {
-                    videoSpinner.text = `🎬 Scene ${i + 1}: Failed, retry ${attempt + 1}/${maxRetries}...`;
-                    await sleep(RETRY_DELAY_MS);
-                  } else {
-                    videoPaths[i] = "";
-                    failedScenes.push(i + 1);
-                  }
-                } catch (err) {
-                  if (attempt < maxRetries) {
-                    videoSpinner.text = `🎬 Scene ${i + 1}: Error, retry ${attempt + 1}/${maxRetries}...`;
-                    await sleep(RETRY_DELAY_MS);
-                  } else {
-                    console.log(chalk.yellow(`\n  ⚠ Error for scene ${i + 1}: ${err}`));
-                    videoPaths[i] = "";
-                    failedScenes.push(i + 1);
-                  }
-                }
-              }
-            }
-          } else {
-            // Parallel mode (default): batch-based submission respecting concurrency limit
-            const concurrency = Math.max(1, parseInt(options.concurrency) || 3);
-
-            for (let batchStart = 0; batchStart < segments.length; batchStart += concurrency) {
-              const batchEnd = Math.min(batchStart + concurrency, segments.length);
-              const batchNum = Math.floor(batchStart / concurrency) + 1;
-              const totalBatches = Math.ceil(segments.length / concurrency);
-
-              if (totalBatches > 1) {
-                videoSpinner.text = `🎬 Batch ${batchNum}/${totalBatches}: submitting scenes ${batchStart + 1}-${batchEnd}...`;
-              }
-
-              // Phase 1: Submit batch
-              const tasks: Array<{ taskId: string; index: number; segment: StoryboardSegment; type: "text2video" | "image2video" }> = [];
-
-              for (let i = batchStart; i < batchEnd; i++) {
-                const segment = segments[i] as StoryboardSegment;
-                videoSpinner.text = `🎬 Submitting video task ${i + 1}/${segments.length}...`;
-
-                const videoDuration = (segment.duration > 5 ? 10 : 5) as 5 | 10;
-                const referenceImage = imageUrls[i];
-
-                const result = await generateVideoWithRetryKling(
-                  kling,
-                  segment,
-                  {
-                    duration: videoDuration,
-                    aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1",
-                    referenceImage,
-                  },
-                  maxRetries,
-                  (msg) => {
-                    videoSpinner.text = `🎬 Scene ${i + 1}: ${msg}`;
-                  }
-                );
-
-                if (result) {
-                  tasks.push({ taskId: result.taskId, index: i, segment, type: result.type });
-                  if (!videoPaths[i]) videoPaths[i] = "";
-                } else {
-                  console.log(chalk.yellow(`\n  ⚠ Failed to start video generation for scene ${i + 1} (after ${maxRetries} retries)`));
-                  videoPaths[i] = "";
-                  failedScenes.push(i + 1);
-                }
-              }
-
-              // Phase 2: Wait for batch completion
-              videoSpinner.text = `🎬 Waiting for batch ${batchNum} (${tasks.length} video${tasks.length > 1 ? "s" : ""})...`;
-
-              for (const task of tasks) {
-                let completed = false;
-                let currentTaskId = task.taskId;
-                let currentType = task.type;
-
-                for (let attempt = 0; attempt <= maxRetries && !completed; attempt++) {
-                  try {
-                    const result = await kling.waitForCompletion(
-                      currentTaskId,
-                      currentType,
-                      (status) => {
-                        videoSpinner.text = `🎬 Scene ${task.index + 1}: ${status.status}...`;
-                      },
-                      600000
-                    );
-
-                    if (result.status === "completed" && result.videoUrl) {
-                      const videoPath = resolve(outputDir, `scene-${task.index + 1}.mp4`);
-                      const buffer = await downloadVideo(result.videoUrl, videoApiKey);
-                      await writeFile(videoPath, buffer);
-
-                      // Extend video to match narration duration if needed
-                      await extendVideoToTarget(videoPath, task.segment.duration, outputDir, `Scene ${task.index + 1}`, {
-                        kling,
-                        videoId: result.videoId,
-                        onProgress: (msg) => { videoSpinner.text = `🎬 ${msg}`; },
-                      });
-
-                      videoPaths[task.index] = videoPath;
-                      completed = true;
-                    } else if (attempt < maxRetries) {
-                      videoSpinner.text = `🎬 Scene ${task.index + 1}: Retry ${attempt + 1}/${maxRetries}...`;
-                      await sleep(RETRY_DELAY_MS);
-
-                      const videoDuration = (task.segment.duration > 5 ? 10 : 5) as 5 | 10;
-                      const retryReferenceImage = imageUrls[task.index];
-
-                      const retryResult = await generateVideoWithRetryKling(
-                        kling,
-                        task.segment,
-                        {
-                          duration: videoDuration,
-                          aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1",
-                          referenceImage: retryReferenceImage,
-                        },
-                        0
-                      );
-
-                      if (retryResult) {
-                        currentTaskId = retryResult.taskId;
-                        currentType = retryResult.type;
-                      } else {
-                        videoPaths[task.index] = "";
-                        failedScenes.push(task.index + 1);
-                        completed = true;
-                      }
-                    } else {
-                      videoPaths[task.index] = "";
-                      failedScenes.push(task.index + 1);
-                    }
-                  } catch (err) {
-                    if (attempt >= maxRetries) {
-                      console.log(chalk.yellow(`\n  ⚠ Error completing video for scene ${task.index + 1}: ${err}`));
-                      videoPaths[task.index] = "";
-                      failedScenes.push(task.index + 1);
-                    } else {
-                      videoSpinner.text = `🎬 Scene ${task.index + 1}: Error, retry ${attempt + 1}/${maxRetries}...`;
-                      await sleep(RETRY_DELAY_MS);
-                    }
-                  }
-                }
-              }
-
-              if (totalBatches > 1 && batchEnd < segments.length) {
-                console.log(chalk.dim(`  → Batch ${batchNum}/${totalBatches} complete`));
-              }
-            }
-          }
-        } else {
-          // Runway
-          const runway = new RunwayProvider();
-          await runway.initialize({ apiKey: videoApiKey });
-
-          // Submit all video generation tasks with retry logic
-          const tasks: Array<{ taskId: string; index: number; imagePath: string; referenceImage: string; segment: StoryboardSegment }> = [];
-
-          for (let i = 0; i < segments.length; i++) {
-            if (!imagePaths[i]) {
-              videoPaths.push("");
-              continue;
-            }
-
-            const segment = segments[i] as StoryboardSegment;
-            videoSpinner.text = `🎬 Submitting video task ${i + 1}/${segments.length}...`;
-
-            const imageBuffer = await readFile(imagePaths[i]);
-            const ext = extname(imagePaths[i]).toLowerCase().slice(1);
-            const mimeType = ext === "jpg" || ext === "jpeg" ? "image/jpeg" : "image/png";
-            const referenceImage = `data:${mimeType};base64,${imageBuffer.toString("base64")}`;
-
-            // Use 10s video if narration > 5s to avoid video ending before narration
-            const videoDuration = (segment.duration > 5 ? 10 : 5) as 5 | 10;
-
-            const result = await generateVideoWithRetryRunway(
-              runway,
-              segment,
-              referenceImage,
-              {
-                duration: videoDuration,
-                aspectRatio: options.aspectRatio === "1:1" ? "16:9" : (options.aspectRatio as "16:9" | "9:16"),
-              },
-              maxRetries,
-              (msg) => {
-                videoSpinner.text = `🎬 Scene ${i + 1}: ${msg}`;
-              }
-            );
-
-            if (result) {
-              tasks.push({ taskId: result.taskId, index: i, imagePath: imagePaths[i], referenceImage, segment });
-            } else {
-              console.log(chalk.yellow(`\n  ⚠ Failed to start video generation for scene ${i + 1} (after ${maxRetries} retries)`));
-              videoPaths[i] = "";
-              failedScenes.push(i + 1);
-            }
-          }
-
-          // Wait for all tasks to complete with retry logic
-          videoSpinner.text = `🎬 Waiting for ${tasks.length} video(s) to complete...`;
-
-          for (const task of tasks) {
-            let completed = false;
-            let currentTaskId = task.taskId;
-
-            for (let attempt = 0; attempt <= maxRetries && !completed; attempt++) {
-              try {
-                const result = await runway.waitForCompletion(
-                  currentTaskId,
-                  (status) => {
-                    const progress = status.progress !== undefined ? `${status.progress}%` : status.status;
-                    videoSpinner.text = `🎬 Scene ${task.index + 1}: ${progress}...`;
-                  },
-                  300000 // 5 minute timeout per video
-                );
-
-                if (result.status === "completed" && result.videoUrl) {
-                  const videoPath = resolve(outputDir, `scene-${task.index + 1}.mp4`);
-                  const buffer = await downloadVideo(result.videoUrl, videoApiKey);
-                  await writeFile(videoPath, buffer);
-
-                  // Extend video to match narration duration if needed
-                  await extendVideoToTarget(videoPath, task.segment.duration, outputDir, `Scene ${task.index + 1}`, {
-                    onProgress: (msg) => { videoSpinner.text = `🎬 ${msg}`; },
-                  });
-
-                  videoPaths[task.index] = videoPath;
-                  completed = true;
-                } else if (attempt < maxRetries) {
-                  // Resubmit task on failure
-                  videoSpinner.text = `🎬 Scene ${task.index + 1}: Retry ${attempt + 1}/${maxRetries}...`;
-                  await sleep(RETRY_DELAY_MS);
-
-                  const videoDuration = (task.segment.duration > 5 ? 10 : 5) as 5 | 10;
-                  const retryResult = await generateVideoWithRetryRunway(
-                    runway,
-                    task.segment,
-                    task.referenceImage,
-                    {
-                      duration: videoDuration,
-                      aspectRatio: options.aspectRatio === "1:1" ? "16:9" : (options.aspectRatio as "16:9" | "9:16"),
-                    },
-                    0, // No nested retries
-                    (msg) => {
-                      videoSpinner.text = `🎬 Scene ${task.index + 1}: ${msg}`;
-                    }
-                  );
-
-                  if (retryResult) {
-                    currentTaskId = retryResult.taskId;
-                  } else {
-                    videoPaths[task.index] = "";
-                    failedScenes.push(task.index + 1);
-                    completed = true; // Exit retry loop
-                  }
-                } else {
-                  videoPaths[task.index] = "";
-                  failedScenes.push(task.index + 1);
-                }
-              } catch (err) {
-                if (attempt >= maxRetries) {
-                  console.log(chalk.yellow(`\n  ⚠ Error completing video for scene ${task.index + 1}: ${err}`));
-                  videoPaths[task.index] = "";
-                  failedScenes.push(task.index + 1);
-                } else {
-                  videoSpinner.text = `🎬 Scene ${task.index + 1}: Error, retry ${attempt + 1}/${maxRetries}...`;
-                  await sleep(RETRY_DELAY_MS);
-                }
-              }
-            }
-          }
-        }
-
-        const successfulVideos = videoPaths.filter((p) => p && p !== "").length;
-        videoSpinner.succeed(chalk.green(`Generated ${successfulVideos}/${segments.length} videos`));
-        console.log();
-      }
-
-      // Step 4.5: Apply text overlays (if segments have textOverlays)
-      if (options.textOverlay !== false) {
-        const overlaySegments = segments.filter(
-          (s: StoryboardSegment, i: number) => s.textOverlays && s.textOverlays.length > 0 && videoPaths[i] && videoPaths[i] !== ""
-        );
-        if (overlaySegments.length > 0) {
-          const overlaySpinner = ora(`Applying text overlays to ${overlaySegments.length} scene(s)...`).start();
-          let overlayCount = 0;
-          for (let i = 0; i < segments.length; i++) {
-            const segment = segments[i] as StoryboardSegment;
-            if (segment.textOverlays && segment.textOverlays.length > 0 && videoPaths[i] && videoPaths[i] !== "") {
-              try {
-                const overlayOutput = videoPaths[i].replace(/(\.[^.]+)$/, "-overlay$1");
-                const overlayResult = await applyTextOverlays({
-                  videoPath: videoPaths[i],
-                  texts: segment.textOverlays,
-                  outputPath: overlayOutput,
-                  style: (options.textStyle as TextOverlayStyle) || "lower-third",
-                });
-                if (overlayResult.success && overlayResult.outputPath) {
-                  videoPaths[i] = overlayResult.outputPath;
-                  overlayCount++;
-                }
-              } catch {
-                // Silent fallback: keep original video
-              }
-            }
-          }
-          overlaySpinner.succeed(chalk.green(`Applied text overlays to ${overlayCount} scene(s)`));
-          console.log();
-        }
-      }
-
-      // Step 5: Assemble project
-      const assembleSpinner = ora("Assembling project...").start();
-
-      const project = new Project("Script-to-Video Output");
-      project.setAspectRatio(options.aspectRatio as "16:9" | "9:16" | "1:1");
-
-      // Clear default tracks and create new ones
-      const defaultTracks = project.getTracks();
-      for (const track of defaultTracks) {
-        project.removeTrack(track.id);
-      }
-
-      const videoTrack = project.addTrack({
-        name: "Video",
-        type: "video",
-        order: 1,
-        isMuted: false,
-        isLocked: false,
-        isVisible: true,
+      const pipelineSpinner = ora(`🎬 Running script-to-video with ${options.generator}...`).start();
+      const result = await executeScriptToVideo({
+        script: scriptContent,
+        outputDir: effectiveOutputDir,
+        projectFilePath,
+        duration: options.duration ? parseFloat(options.duration) : undefined,
+        voice: options.voice,
+        generator: options.generator as "grok" | "runway" | "kling" | "veo",
+        imageProvider: options.imageProvider as "openai" | "gemini" | "grok" | undefined,
+        aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1" | undefined,
+        imagesOnly: options.imagesOnly,
+        noVoiceover: options.voiceover === false,
+        retries: parseInt(options.retries) || DEFAULT_VIDEO_RETRIES,
+        creativity: creativity as "low" | "high",
+        storyboardProvider: options.storyboardProvider as "claude" | "openai" | "gemini" | undefined,
+        noTextOverlay: options.textOverlay === false,
+        textStyle: options.textStyle as TextOverlayStyle | undefined,
+        review: options.review,
+        reviewAutoApply: options.reviewAutoApply,
+        onProgress: (msg: string) => { pipelineSpinner.text = msg; },
       });
 
-      const audioTrack = project.addTrack({
-        name: "Audio",
-        type: "audio",
-        order: 0,
-        isMuted: false,
-        isLocked: false,
-        isVisible: true,
-      });
-
-      // Add per-scene narration sources and clips
-      for (const tts of perSceneTTS) {
-        const segment = segments[tts.segmentIndex];
-        const audioSource = project.addSource({
-          name: `Narration ${tts.segmentIndex + 1}`,
-          url: tts.path,
-          type: "audio",
-          duration: tts.duration,
-        });
-
-        project.addClip({
-          sourceId: audioSource.id,
-          trackId: audioTrack.id,
-          startTime: segment.startTime,
-          duration: tts.duration,
-          sourceStartOffset: 0,
-          sourceEndOffset: tts.duration,
-        });
+      if (!result.success) {
+        pipelineSpinner.fail(chalk.red(result.error || "Script-to-Video failed"));
+        exitWithError(apiError(result.error || "Script-to-Video failed", true));
       }
 
-      // Add video/image sources and clips
-      let currentTime = 0;
-      const videoClipIds: string[] = [];
-      const fadeDuration = 0.3; // Fade duration in seconds for smooth transitions
+      pipelineSpinner.succeed(chalk.green(`Generated ${result.scenes} scene(s) → ${result.projectPath}`));
 
-      for (let i = 0; i < segments.length; i++) {
-        const segment = segments[i];
-        const hasVideo = videoPaths[i] && videoPaths[i] !== "";
-        const hasImage = imagePaths[i] && imagePaths[i] !== "";
+      // Final summary (presentational; keeps parity with the pre-thin-wrap CLI).
+      const narrationCount = (result.narrationEntries ?? []).filter((e) => e.path).length;
+      const failedNarrationNums = result.failedNarrations ?? [];
+      const failedSceneNums = [...new Set(result.failedScenes ?? [])].sort((a, b) => a - b);
+      const imageCount = result.images?.length ?? 0;
+      const videoCount = result.videos?.length ?? 0;
 
-        if (!hasVideo && !hasImage) {
-          // Skip if no visual asset
-          currentTime += segment.duration;
-          continue;
-        }
-
-        const assetPath = hasVideo ? videoPaths[i] : imagePaths[i];
-        const mediaType = hasVideo ? "video" : "image";
-
-        const source = project.addSource({
-          name: `Scene ${i + 1}`,
-          url: assetPath,
-          type: mediaType as "video" | "image",
-          duration: segment.duration,
-        });
-
-        const clip = project.addClip({
-          sourceId: source.id,
-          trackId: videoTrack.id,
-          startTime: currentTime,
-          duration: segment.duration,
-          sourceStartOffset: 0,
-          sourceEndOffset: segment.duration,
-        });
-
-        videoClipIds.push(clip.id);
-        currentTime += segment.duration;
-      }
-
-      // Add fade effects to video clips for smoother scene transitions
-      for (let i = 0; i < videoClipIds.length; i++) {
-        const clipId = videoClipIds[i];
-        const clip = project.getClips().find(c => c.id === clipId);
-        if (!clip) continue;
-
-        // Add fadeIn effect (except for first clip)
-        if (i > 0) {
-          project.addEffect(clipId, {
-            type: "fadeIn",
-            startTime: 0,
-            duration: fadeDuration,
-            params: {},
-          });
-        }
-
-        // Add fadeOut effect (except for last clip)
-        if (i < videoClipIds.length - 1) {
-          project.addEffect(clipId, {
-            type: "fadeOut",
-            startTime: clip.duration - fadeDuration,
-            duration: fadeDuration,
-            params: {},
-          });
-        }
-      }
-
-      // Save project file
-      let outputPath = resolve(process.cwd(), options.output);
-
-      // Detect if output looks like a directory (ends with / or no .json extension)
-      const looksLikeDirectory =
-        options.output.endsWith("/") ||
-        (!options.output.endsWith(".json") &&
-          !options.output.endsWith(".vibe.json"));
-
-      if (looksLikeDirectory) {
-        // Create directory if it doesn't exist
-        if (!existsSync(outputPath)) {
-          await mkdir(outputPath, { recursive: true });
-        }
-        outputPath = resolve(outputPath, "project.vibe.json");
-      } else if (
-        existsSync(outputPath) &&
-        (await stat(outputPath)).isDirectory()
-      ) {
-        // Existing directory without trailing slash
-        outputPath = resolve(outputPath, "project.vibe.json");
-      } else {
-        // File path - ensure parent directory exists
-        const parentDir = dirname(outputPath);
-        if (!existsSync(parentDir)) {
-          await mkdir(parentDir, { recursive: true });
-        }
-      }
-
-      await writeFile(
-        outputPath,
-        JSON.stringify(project.toJSON(), null, 2),
-        "utf-8"
-      );
-
-      assembleSpinner.succeed(chalk.green("Project assembled"));
-
-      // Step 6: AI Review (optional)
-      if (options.review) {
-        const reviewSpinner = ora("Reviewing video with Gemini AI...").start();
-        try {
-          const reviewTarget = videoPaths.find((p) => p && p !== "");
-          if (reviewTarget) {
-            const storyboardFile = resolve(effectiveOutputDir, "storyboard.json");
-            const reviewResult = await executeReview({
-              videoPath: reviewTarget,
-              storyboardPath: existsSync(storyboardFile) ? storyboardFile : undefined,
-              autoApply: options.reviewAutoApply,
-              model: "flash",
-            });
-
-            if (reviewResult.success && reviewResult.feedback) {
-              reviewSpinner.succeed(chalk.green(`AI Review: ${reviewResult.feedback.overallScore}/10`));
-              if (reviewResult.appliedFixes && reviewResult.appliedFixes.length > 0) {
-                for (const fix of reviewResult.appliedFixes) {
-                  console.log(chalk.green(`  + ${fix}`));
-                }
-              }
-              if (reviewResult.feedback.recommendations.length > 0) {
-                for (const rec of reviewResult.feedback.recommendations) {
-                  console.log(chalk.dim(`  * ${rec}`));
-                }
-              }
-            } else {
-              reviewSpinner.warn(chalk.yellow("AI review completed but no actionable feedback"));
-            }
-          } else {
-            reviewSpinner.warn(chalk.yellow("No videos available for review"));
-          }
-        } catch {
-          reviewSpinner.warn(chalk.yellow("AI review skipped (non-critical error)"));
-        }
-        console.log();
-      }
-
-      // Final summary
       console.log();
       console.log(chalk.bold.green("Script-to-Video complete!"));
       console.log(chalk.dim("─".repeat(60)));
       console.log();
-      console.log(`  📄 Project: ${chalk.cyan(outputPath)}`);
-      console.log(`  🎬 Scenes: ${segments.length}`);
-      console.log(`  ⏱️  Duration: ${totalDuration}s`);
+      console.log(`  📄 Project: ${chalk.cyan(result.projectPath)}`);
+      console.log(`  🎬 Scenes: ${result.scenes}`);
+      console.log(`  ⏱️  Duration: ${result.totalDuration ?? 0}s`);
       console.log(`  📁 Assets: ${effectiveOutputDir}/`);
-      if (perSceneTTS.length > 0 || failedNarrations.length > 0) {
-        const narrationInfo = `${perSceneTTS.length}/${segments.length}`;
-        if (failedNarrations.length > 0) {
-          const failedSceneNums = failedNarrations.map((f) => f.sceneNum).join(", ");
-          console.log(`  🎙️  Narrations: ${narrationInfo} narration-*.mp3`);
-          console.log(chalk.yellow(`     ⚠ Failed: scene ${failedSceneNums}`));
-        } else {
-          console.log(`  🎙️  Narrations: ${perSceneTTS.length} narration-*.mp3`);
+      if (narrationCount > 0 || failedNarrationNums.length > 0) {
+        console.log(`  🎙️  Narrations: ${narrationCount}/${result.scenes} narration-*.mp3`);
+        if (failedNarrationNums.length > 0) {
+          console.log(chalk.yellow(`     ⚠ Failed: scene ${failedNarrationNums.join(", ")}`));
         }
       }
-      console.log(`  🖼️  Images: ${successfulImages} scene-*.png`);
+      console.log(`  🖼️  Images: ${imageCount} scene-*.png`);
       if (!options.imagesOnly) {
-        const videoCount = videoPaths.filter((p) => p && p !== "").length;
-        console.log(`  🎥 Videos: ${videoCount}/${segments.length} scene-*.mp4`);
-        if (failedScenes.length > 0) {
-          const uniqueFailedScenes = [...new Set(failedScenes)].sort((a, b) => a - b);
-          console.log(chalk.yellow(`     ⚠ Failed: scene ${uniqueFailedScenes.join(", ")} (fallback to image)`));
+        console.log(`  🎥 Videos: ${videoCount}/${result.scenes} scene-*.mp4`);
+        if (failedSceneNums.length > 0) {
+          console.log(chalk.yellow(`     ⚠ Failed: scene ${failedSceneNums.join(", ")} (fallback to image)`));
         }
       }
       console.log();
       console.log(chalk.dim("Next steps:"));
       console.log(chalk.dim(`  vibe project info ${options.output}`));
       console.log(chalk.dim(`  vibe export ${options.output} -o final.mp4`));
-
-      // Show regeneration hint if there were failures
-      if (!options.imagesOnly && failedScenes.length > 0) {
-        const uniqueFailedScenes = [...new Set(failedScenes)].sort((a, b) => a - b);
+      if (!options.imagesOnly && failedSceneNums.length > 0) {
         console.log();
         console.log(chalk.dim("💡 To regenerate failed scenes:"));
-        for (const sceneNum of uniqueFailedScenes) {
+        for (const sceneNum of failedSceneNums) {
           console.log(chalk.dim(`  vibe ai regenerate-scene ${effectiveOutputDir}/ --scene ${sceneNum} --video-only`));
         }
       }
       console.log();
+
+      // JSON shape is byte-identical to the pre-thin-wrap delegation block;
+      // agent callers depend on these exact fields and counts.
+      outputResult({
+        success: true,
+        command: "pipeline script-to-video",
+        result: {
+          projectPath: result.projectPath,
+          outputDir: result.outputDir,
+          scenes: result.scenes,
+          totalDuration: result.totalDuration,
+          images: result.images?.length ?? 0,
+          videos: result.videos?.length ?? 0,
+          failedScenes: result.failedScenes ?? [],
+        },
+      });
+
     } catch (error) {
       exitWithError(generalError(error instanceof Error ? error.message : "Script-to-Video failed"));
     }

--- a/packages/cli/src/commands/ai-script-pipeline-cli.ts
+++ b/packages/cli/src/commands/ai-script-pipeline-cli.ts
@@ -7,36 +7,20 @@
 
 import { Command } from "commander";
 import { readFile, writeFile, stat } from "node:fs/promises";
-import { resolve, extname } from "node:path";
+import { resolve } from "node:path";
 import { existsSync } from "node:fs";
 import chalk from "chalk";
 import ora from "ora";
-import { stringify as yamlStringify, parse as yamlParse } from "yaml";
-import {
-  GeminiProvider,
-  OpenAIImageProvider,
-  ElevenLabsProvider,
-  KlingProvider,
-  RunwayProvider,
-} from "@vibeframe/ai-providers";
+import { parse as yamlParse } from "yaml";
 import { getApiKey, loadEnv } from "../utils/api-key.js";
-import { getApiKeyFromConfig } from "../config/index.js";
 import { type ProjectFile } from "../engine/index.js";
-import { getAudioDuration } from "../utils/audio.js";
 import { type TextOverlayStyle } from "./ai-edit.js";
 import {
   type StoryboardSegment,
   DEFAULT_VIDEO_RETRIES,
-  RETRY_DELAY_MS,
-  sleep,
-  uploadToImgbb,
-  extendVideoToTarget,
-  generateVideoWithRetryKling,
-  generateVideoWithRetryRunway,
   executeScriptToVideo,
   executeRegenerateScene,
 } from "./ai-script-pipeline.js";
-import { downloadVideo } from "./ai-helpers.js";
 import { exitWithError, outputResult, authError, notFoundError, usageError, apiError, generalError } from "./output.js";
 import { validateOutputPath } from "./validate.js";
 
@@ -310,25 +294,26 @@ aiCommand
       const outputDir = resolve(process.cwd(), projectDir);
       const projectPath = resolve(outputDir, "project.vibe.json");
 
-      // Validate project directory
       if (!existsSync(outputDir)) {
         exitWithError(notFoundError(outputDir));
       }
 
-      // Storyboard: prefer YAML (written by executeScriptToVideo / grok+veo path),
-      // fall back to JSON (written by legacy kling/runway CLI inline path). Track
-      // source format so re-save preserves it.
+      // Storyboard: prefer YAML (current executeScriptToVideo output), fall back
+      // to JSON (pre-0.48.6 inline kling/runway output). Track source format so
+      // the CLI's project-file update can re-read it after the library has
+      // rewritten segment durations.
       const yamlPath = resolve(outputDir, "storyboard.yaml");
       const jsonPath = resolve(outputDir, "storyboard.json");
       const storyboardPath = existsSync(yamlPath) ? yamlPath : existsSync(jsonPath) ? jsonPath : null;
       const storyboardIsYaml = storyboardPath === yamlPath;
-
       if (!storyboardPath) {
         exitWithError(notFoundError(`${outputDir}/storyboard.{yaml,json}`));
       }
 
-      // Parse scene number(s) - supports "3" or "3,4,5"
-      const sceneNums = options.scene.split(",").map((s: string) => parseInt(s.trim())).filter((n: number) => !isNaN(n) && n >= 1);
+      const sceneNums: number[] = options.scene
+        .split(",")
+        .map((s: string) => parseInt(s.trim()))
+        .filter((n: number) => !isNaN(n) && n >= 1);
       if (sceneNums.length === 0) {
         exitWithError(usageError("Scene number must be a positive integer (1-based)", "e.g., --scene 3 or --scene 3,4,5"));
       }
@@ -353,23 +338,53 @@ aiCommand
         return;
       }
 
-      // Load storyboard — YAML wraps segments in `scenes:` key, JSON is a bare array.
-      const storyboardContent = await readFile(storyboardPath!, "utf-8");
+      // Validate scene numbers against the on-disk storyboard so we fail before
+      // any API calls. executeRegenerateScene validates too, but a usage exit
+      // code is friendlier than API_ERROR here.
+      const content = await readFile(storyboardPath!, "utf-8");
       const segments: StoryboardSegment[] = storyboardIsYaml
-        ? (yamlParse(storyboardContent) as { scenes: StoryboardSegment[] }).scenes
-        : (JSON.parse(storyboardContent) as StoryboardSegment[]);
-
-      // Validate all scene numbers
+        ? (yamlParse(content) as { scenes: StoryboardSegment[] }).scenes
+        : (JSON.parse(content) as StoryboardSegment[]);
       for (const sceneNum of sceneNums) {
         if (sceneNum > segments.length) {
           exitWithError(usageError(`Scene ${sceneNum} does not exist. Storyboard has ${segments.length} scenes.`));
         }
       }
 
-      // Determine what to regenerate
       const regenerateVideo = options.videoOnly || (!options.narrationOnly && !options.imageOnly);
       const regenerateNarration = options.narrationOnly || (!options.videoOnly && !options.imageOnly);
       const regenerateImage = options.imageOnly || (!options.videoOnly && !options.narrationOnly);
+
+      // API-key pre-check for friendly AUTH exit codes (library re-checks).
+      if (regenerateImage) {
+        const provider = (options.imageProvider || "openai") as "openai" | "dalle" | "gemini" | "grok";
+        const keyMap: Record<typeof provider, { envVar: string; name: string }> = {
+          openai: { envVar: "OPENAI_API_KEY", name: "OpenAI" },
+          dalle: { envVar: "OPENAI_API_KEY", name: "OpenAI" },
+          gemini: { envVar: "GOOGLE_API_KEY", name: "Google" },
+          grok: { envVar: "XAI_API_KEY", name: "xAI" },
+        };
+        const info = keyMap[provider];
+        if (!info) exitWithError(usageError(`Unknown image provider: ${provider}`));
+        if (!(await getApiKey(info.envVar, info.name))) exitWithError(authError(info.envVar, info.name));
+      }
+      if (regenerateVideo) {
+        const generatorKeyMap: Record<string, { envVar: string; name: string }> = {
+          grok: { envVar: "XAI_API_KEY", name: "xAI" },
+          kling: { envVar: "KLING_API_KEY", name: "Kling" },
+          runway: { envVar: "RUNWAY_API_SECRET", name: "Runway" },
+          veo: { envVar: "GOOGLE_API_KEY", name: "Google" },
+        };
+        const generator = options.generator || "grok";
+        const info = generatorKeyMap[generator];
+        if (!info) exitWithError(usageError(`Invalid generator: ${generator}`, `Available: ${Object.keys(generatorKeyMap).join(", ")}`));
+        if (!(await getApiKey(info.envVar, info.name))) exitWithError(authError(info.envVar, info.name));
+      }
+      if (regenerateNarration) {
+        if (!(await getApiKey("ELEVENLABS_API_KEY", "ElevenLabs"))) {
+          exitWithError(authError("ELEVENLABS_API_KEY", "ElevenLabs"));
+        }
+      }
 
       console.log();
       console.log(chalk.bold.cyan(`🔄 Regenerating Scene${sceneNums.length > 1 ? "s" : ""} ${sceneNums.join(", ")}`));
@@ -379,486 +394,75 @@ aiCommand
       console.log(`  🎬 Scenes: ${sceneNums.join(", ")} of ${segments.length}`);
       console.log();
 
-      // Get required API keys (once, before processing scenes)
-      let imageApiKey: string | undefined;
-      let videoApiKey: string | undefined;
-      let elevenlabsApiKey: string | undefined;
+      const spinner = ora("Regenerating...").start();
+      const result = await executeRegenerateScene({
+        projectDir,
+        scenes: sceneNums,
+        videoOnly: options.videoOnly,
+        narrationOnly: options.narrationOnly,
+        imageOnly: options.imageOnly,
+        generator: options.generator as "grok" | "kling" | "runway" | "veo" | undefined,
+        // `dalle` is a CLI alias for OpenAI image generation; the library only
+        // knows `openai`.
+        imageProvider: (options.imageProvider === "dalle" ? "openai" : options.imageProvider) as "openai" | "gemini" | "grok" | undefined,
+        voice: options.voice,
+        aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1" | undefined,
+        retries: parseInt(options.retries) || DEFAULT_VIDEO_RETRIES,
+        referenceScene: options.referenceScene ? parseInt(options.referenceScene) : undefined,
+        onProgress: (msg: string) => { spinner.text = msg; },
+      });
 
-      if (regenerateImage) {
-        const imageProvider = options.imageProvider || "openai";
-        if (imageProvider === "openai" || imageProvider === "dalle") {
-          imageApiKey = (await getApiKey("OPENAI_API_KEY", "OpenAI")) ?? undefined;
-          if (!imageApiKey) {
-            exitWithError(authError("OPENAI_API_KEY", "OpenAI"));
-          }
-        } else if (imageProvider === "gemini") {
-          imageApiKey = (await getApiKey("GOOGLE_API_KEY", "Google")) ?? undefined;
-          if (!imageApiKey) {
-            exitWithError(authError("GOOGLE_API_KEY", "Google"));
-          }
-        } else if (imageProvider === "grok") {
-          imageApiKey = (await getApiKey("XAI_API_KEY", "xAI")) ?? undefined;
-          if (!imageApiKey) {
-            exitWithError(authError("XAI_API_KEY", "xAI"));
-          }
-        }
+      if (!result.success) {
+        spinner.fail(chalk.red(result.error || "Scene regeneration failed"));
+        exitWithError(apiError(result.error || "Scene regeneration failed", true));
       }
+      spinner.succeed(chalk.green(`Regenerated ${result.regeneratedScenes.length} scene(s)`));
 
-      if (regenerateVideo) {
-        const generatorKeyMap: Record<string, { envVar: string; name: string }> = {
-          grok: { envVar: "XAI_API_KEY", name: "xAI" },
-          kling: { envVar: "KLING_API_KEY", name: "Kling" },
-          runway: { envVar: "RUNWAY_API_SECRET", name: "Runway" },
-          veo: { envVar: "GOOGLE_API_KEY", name: "Google" },
-        };
-        const generator = options.generator || "grok";
-        const genInfo = generatorKeyMap[generator];
-        if (!genInfo) {
-          exitWithError(usageError(`Invalid generator: ${generator}`, `Available: ${Object.keys(generatorKeyMap).join(", ")}`));
-        }
-        const key = await getApiKey(genInfo.envVar, genInfo.name);
-        if (!key) {
-          exitWithError(authError(genInfo.envVar, genInfo.name));
-        }
-        videoApiKey = key;
-      }
-
-      if (regenerateNarration) {
-        const key = await getApiKey("ELEVENLABS_API_KEY", "ElevenLabs");
-        if (!key) {
-          exitWithError(authError("ELEVENLABS_API_KEY", "ElevenLabs"));
-        }
-        elevenlabsApiKey = key;
-      }
-
-      // Process each scene
-      for (const sceneNum of sceneNums) {
-        const segment = segments[sceneNum - 1];
-
-        console.log(chalk.cyan(`\n── Scene ${sceneNum} ──`));
-        console.log(chalk.dim(`  ${segment.description.slice(0, 50)}...`));
-
-        // Step 1: Regenerate narration if needed
-        const narrationPath = resolve(outputDir, `narration-${sceneNum}.mp3`);
-        let narrationDuration = segment.duration;
-
-      if (regenerateNarration && elevenlabsApiKey) {
-        const ttsSpinner = ora(`🎙️ Regenerating narration for scene ${sceneNum}...`).start();
-
-        const elevenlabs = new ElevenLabsProvider();
-        await elevenlabs.initialize({ apiKey: elevenlabsApiKey });
-
-        const narrationText = segment.narration || segment.description;
-
-        const ttsResult = await elevenlabs.textToSpeech(narrationText, {
-          voiceId: options.voice,
-        });
-
-        if (!ttsResult.success || !ttsResult.audioBuffer) {
-          ttsSpinner.fail(`Failed to generate narration: ${ttsResult.error || "Unknown error"}`);
-          exitWithError(apiError(`Failed to generate narration: ${ttsResult.error || "Unknown error"}`, true));
-        }
-
-        await writeFile(narrationPath, ttsResult.audioBuffer);
-        narrationDuration = await getAudioDuration(narrationPath);
-
-        // Update segment duration in storyboard
-        segment.duration = narrationDuration;
-
-        ttsSpinner.succeed(chalk.green(`Generated narration (${narrationDuration.toFixed(1)}s)`));
-      }
-
-      // Step 2: Regenerate image if needed
-      const imagePath = resolve(outputDir, `scene-${sceneNum}.png`);
-
-      if (regenerateImage && imageApiKey) {
-        const imageSpinner = ora(`🎨 Regenerating image for scene ${sceneNum}...`).start();
-
-        const imageProvider = options.imageProvider || "gemini";
-
-        // Build prompt with character description for consistency
-        const characterDesc = segment.characterDescription || segments[0]?.characterDescription;
-        let imagePrompt = segment.visualStyle
-          ? `${segment.visuals}. Style: ${segment.visualStyle}`
-          : segment.visuals;
-
-        // Add character description to prompt if available
-        if (characterDesc) {
-          imagePrompt = `${imagePrompt}\n\nIMPORTANT - Character appearance must match exactly: ${characterDesc}`;
-        }
-
-        // Check if we should use reference-based generation for character consistency
-        const refSceneNum = options.referenceScene ? parseInt(options.referenceScene) : null;
-        let referenceImageBuffer: Buffer | undefined;
-
-        if (refSceneNum && refSceneNum >= 1 && refSceneNum <= segments.length && refSceneNum !== sceneNum) {
-          const refImagePath = resolve(outputDir, `scene-${refSceneNum}.png`);
-          if (existsSync(refImagePath)) {
-            referenceImageBuffer = await readFile(refImagePath);
-            imageSpinner.text = `🎨 Regenerating image for scene ${sceneNum} (using scene ${refSceneNum} as reference)...`;
-          }
-        } else if (!refSceneNum) {
-          // Auto-detect: use the first available scene image as reference
-          for (let i = 1; i <= segments.length; i++) {
-            if (i !== sceneNum) {
-              const otherImagePath = resolve(outputDir, `scene-${i}.png`);
-              if (existsSync(otherImagePath)) {
-                referenceImageBuffer = await readFile(otherImagePath);
-                imageSpinner.text = `🎨 Regenerating image for scene ${sceneNum} (using scene ${i} as reference)...`;
-                break;
-              }
-            }
-          }
-        }
-
-        // Determine image size/aspect ratio based on provider
-        const dalleImageSizes: Record<string, "1536x1024" | "1024x1536" | "1024x1024"> = {
-          "16:9": "1536x1024",
-          "9:16": "1024x1536",
-          "1:1": "1024x1024",
-        };
-        let imageBuffer: Buffer | undefined;
-        let imageUrl: string | undefined;
-        let imageError: string | undefined;
-
-        if (imageProvider === "openai" || imageProvider === "dalle") {
-          const openaiImage = new OpenAIImageProvider();
-          await openaiImage.initialize({ apiKey: imageApiKey });
-          const imageResult = await openaiImage.generateImage(imagePrompt, {
-            size: dalleImageSizes[options.aspectRatio] || "1536x1024",
-            quality: "standard",
-          });
-          if (imageResult.success && imageResult.images && imageResult.images.length > 0) {
-            imageUrl = imageResult.images[0].url;
-          } else {
-            imageError = imageResult.error;
-          }
-        } else if (imageProvider === "gemini") {
-          const gemini = new GeminiProvider();
-          await gemini.initialize({ apiKey: imageApiKey });
-
-          // Use editImage with reference for character consistency
-          if (referenceImageBuffer) {
-            // Extract the main action from the scene description (take first action if multiple)
-            const simplifiedVisuals = segment.visuals.split(/[,.]/).find((part: string) =>
-              part.includes("standing") || part.includes("sitting") || part.includes("walking") ||
-              part.includes("lying") || part.includes("reaching") || part.includes("looking") ||
-              part.includes("working") || part.includes("coding") || part.includes("typing")
-            ) || segment.visuals.split(".")[0];
-
-            const editPrompt = `Generate a new image showing the SAME SINGLE person from the reference image in a new scene.
-
-REFERENCE: Look at the person in the reference image - their face, hair, build, and overall appearance.
-
-NEW SCENE: ${simplifiedVisuals}
-
-CRITICAL RULES:
-1. Show ONLY ONE person - the exact same individual from the reference image
-2. The person must have the IDENTICAL face, hair style, and body type
-3. Do NOT show multiple people or duplicate the character
-4. Create a single moment in time, one pose, one action
-5. Match the art style and quality of the reference image
-
-Generate the single-person scene image now.`;
-
-            const imageResult = await gemini.editImage([referenceImageBuffer], editPrompt, {
-              aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1",
-            });
-            if (imageResult.success && imageResult.images && imageResult.images.length > 0) {
-              const img = imageResult.images[0];
-              if (img.base64) {
-                imageBuffer = Buffer.from(img.base64, "base64");
-              }
-            } else {
-              imageError = imageResult.error;
-            }
-          } else {
-            // No reference image, use regular generation
-            const imageResult = await gemini.generateImage(imagePrompt, {
-              aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1",
-            });
-            if (imageResult.success && imageResult.images && imageResult.images.length > 0) {
-              const img = imageResult.images[0];
-              if (img.base64) {
-                imageBuffer = Buffer.from(img.base64, "base64");
-              }
-            } else {
-              imageError = imageResult.error;
-            }
-          }
-        } else if (imageProvider === "grok") {
-          const { GrokProvider } = await import("@vibeframe/ai-providers");
-          const grok = new GrokProvider();
-          await grok.initialize({ apiKey: imageApiKey });
-          const imageResult = await grok.generateImage(imagePrompt, {
-            aspectRatio: options.aspectRatio || "16:9",
-          });
-          if (imageResult.success && imageResult.images && imageResult.images.length > 0) {
-            const img = imageResult.images[0];
-            if (img.base64) {
-              imageBuffer = Buffer.from(img.base64, "base64");
-            } else if (img.url) {
-              imageUrl = img.url;
-            }
-          } else {
-            imageError = imageResult.error;
-          }
-        }
-
-        if (imageBuffer) {
-          await writeFile(imagePath, imageBuffer);
-          imageSpinner.succeed(chalk.green("Generated image"));
-        } else if (imageUrl) {
-          const response = await fetch(imageUrl);
-          const buffer = Buffer.from(await response.arrayBuffer());
-          await writeFile(imagePath, buffer);
-          imageSpinner.succeed(chalk.green("Generated image"));
-        } else {
-          const errorMsg = imageError || "Unknown error";
-          imageSpinner.fail(`Failed to generate image: ${errorMsg}`);
-          exitWithError(apiError(`Failed to generate image: ${errorMsg}`, true));
-        }
-      }
-
-      // Step 3: Regenerate video if needed
-      const videoPath = resolve(outputDir, `scene-${sceneNum}.mp4`);
-
-      if (regenerateVideo && videoApiKey) {
-        const videoSpinner = ora(`🎬 Regenerating video for scene ${sceneNum}...`).start();
-
-        // Check if image exists
-        if (!existsSync(imagePath)) {
-          videoSpinner.fail(`Reference image not found: ${imagePath}`);
-          exitWithError(notFoundError(imagePath));
-        }
-
-        const imageBuffer = await readFile(imagePath);
-        const ext = extname(imagePath).toLowerCase().slice(1);
-        const mimeType = ext === "jpg" || ext === "jpeg" ? "image/jpeg" : "image/png";
-        const referenceImage = `data:${mimeType};base64,${imageBuffer.toString("base64")}`;
-
-        const videoDuration = (segment.duration > 5 ? 10 : 5) as 5 | 10;
-        const maxRetries = parseInt(options.retries) || DEFAULT_VIDEO_RETRIES;
-
-        let videoGenerated = false;
-
-        // Grok and Veo: delegate to executeRegenerateScene (library function supports all 4
-        // since v0.48.5). Kling and Runway continue through the inline path below pending
-        // full dedup (#46).
-        if (options.generator === "grok" || options.generator === "veo") {
-          videoSpinner.text = `🎬 Regenerating scene ${sceneNum} video with ${options.generator}...`;
-          const delResult = await executeRegenerateScene({
-            projectDir,
-            scenes: [sceneNum],
-            videoOnly: true,
-            generator: options.generator as "grok" | "veo",
-            aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1" | undefined,
-            retries: maxRetries,
-          });
-          if (delResult.success && delResult.regeneratedScenes.includes(sceneNum)) {
-            videoGenerated = true;
-          } else if (delResult.error) {
-            videoSpinner.fail(delResult.error);
-            exitWithError(apiError(delResult.error, true));
-          }
-        } else if (options.generator === "kling") {
-          const kling = new KlingProvider();
-          await kling.initialize({ apiKey: videoApiKey });
-
-          if (!kling.isConfigured()) {
-            videoSpinner.fail("Invalid Kling API key format");
-            exitWithError(authError("KLING_API_KEY", "Kling"));
-          }
-
-          // Try to use image-to-video if ImgBB API key is available
-          const imgbbApiKey = await getApiKeyFromConfig("imgbb") || process.env.IMGBB_API_KEY;
-          let imageUrl: string | undefined;
-
-          if (imgbbApiKey) {
-            videoSpinner.text = `🎬 Uploading image to ImgBB...`;
-            const uploadResult = await uploadToImgbb(imageBuffer, imgbbApiKey);
-            if (uploadResult.success && uploadResult.url) {
-              imageUrl = uploadResult.url;
-              videoSpinner.text = `🎬 Starting image-to-video generation...`;
-            } else {
-              console.log(chalk.yellow(`\n  ⚠ ImgBB upload failed, falling back to text-to-video`));
-            }
-          }
-
-          const result = await generateVideoWithRetryKling(
-            kling,
-            segment,
-            {
-              duration: videoDuration,
-              aspectRatio: options.aspectRatio as "16:9" | "9:16" | "1:1",
-              referenceImage: imageUrl, // Use uploaded URL for image-to-video
-            },
-            maxRetries
-          );
-
-          if (result) {
-            videoSpinner.text = `🎬 Waiting for video to complete...`;
-
-            for (let attempt = 0; attempt <= maxRetries && !videoGenerated; attempt++) {
-              try {
-                const waitResult = await kling.waitForCompletion(
-                  result.taskId,
-                  result.type,
-                  (status) => {
-                    videoSpinner.text = `🎬 Scene ${sceneNum}: ${status.status}...`;
-                  },
-                  600000
-                );
-
-                if (waitResult.status === "completed" && waitResult.videoUrl) {
-                  const buffer = await downloadVideo(waitResult.videoUrl, videoApiKey);
-                  await writeFile(videoPath, buffer);
-
-                  // Extend video to match narration duration if needed
-                  await extendVideoToTarget(videoPath, segment.duration, outputDir, `Scene ${sceneNum}`, {
-                    kling,
-                    videoId: waitResult.videoId,
-                    onProgress: (msg) => { videoSpinner.text = `🎬 ${msg}`; },
-                  });
-
-                  videoGenerated = true;
-                } else if (attempt < maxRetries) {
-                  videoSpinner.text = `🎬 Scene ${sceneNum}: Retry ${attempt + 1}/${maxRetries}...`;
-                  await sleep(RETRY_DELAY_MS);
-                }
-              } catch (err) {
-                if (attempt >= maxRetries) {
-                  throw err;
-                }
-                videoSpinner.text = `🎬 Scene ${sceneNum}: Error, retry ${attempt + 1}/${maxRetries}...`;
-                await sleep(RETRY_DELAY_MS);
-              }
-            }
-          }
-        } else {
-          // Runway
-          const runway = new RunwayProvider();
-          await runway.initialize({ apiKey: videoApiKey });
-
-          const result = await generateVideoWithRetryRunway(
-            runway,
-            segment,
-            referenceImage,
-            {
-              duration: videoDuration,
-              aspectRatio: options.aspectRatio === "1:1" ? "16:9" : (options.aspectRatio as "16:9" | "9:16"),
-            },
-            maxRetries,
-            (msg) => {
-              videoSpinner.text = `🎬 Scene ${sceneNum}: ${msg}`;
-            }
-          );
-
-          if (result) {
-            videoSpinner.text = `🎬 Waiting for video to complete...`;
-
-            for (let attempt = 0; attempt <= maxRetries && !videoGenerated; attempt++) {
-              try {
-                const waitResult = await runway.waitForCompletion(
-                  result.taskId,
-                  (status) => {
-                    const progress = status.progress !== undefined ? `${status.progress}%` : status.status;
-                    videoSpinner.text = `🎬 Scene ${sceneNum}: ${progress}...`;
-                  },
-                  300000
-                );
-
-                if (waitResult.status === "completed" && waitResult.videoUrl) {
-                  const buffer = await downloadVideo(waitResult.videoUrl, videoApiKey);
-                  await writeFile(videoPath, buffer);
-
-                  // Extend video to match narration duration if needed (Runway - no Kling extend)
-                  await extendVideoToTarget(videoPath, segment.duration, outputDir, `Scene ${sceneNum}`, {
-                    onProgress: (msg) => { videoSpinner.text = `🎬 ${msg}`; },
-                  });
-
-                  videoGenerated = true;
-                } else if (attempt < maxRetries) {
-                  videoSpinner.text = `🎬 Scene ${sceneNum}: Retry ${attempt + 1}/${maxRetries}...`;
-                  await sleep(RETRY_DELAY_MS);
-                }
-              } catch (err) {
-                if (attempt >= maxRetries) {
-                  throw err;
-                }
-                videoSpinner.text = `🎬 Scene ${sceneNum}: Error, retry ${attempt + 1}/${maxRetries}...`;
-                await sleep(RETRY_DELAY_MS);
-              }
-            }
-          }
-        }
-
-        if (videoGenerated) {
-          videoSpinner.succeed(chalk.green("Generated video"));
-        } else {
-          videoSpinner.fail("Failed to generate video after all retries");
-          exitWithError(apiError("Failed to generate video after all retries", true));
-        }
-      }
-
-      // Step 4: Recalculate startTime for ALL segments and re-save storyboard
-      {
-        let currentTime = 0;
-        for (const seg of segments) {
-          seg.startTime = currentTime;
-          currentTime += seg.duration;
-        }
-        // Preserve the source format (don't silently downgrade YAML to JSON).
-        const serialized = storyboardIsYaml
-          ? yamlStringify({ scenes: segments }, { indent: 2 })
-          : JSON.stringify(segments, null, 2);
-        await writeFile(storyboardPath!, serialized, "utf-8");
-        console.log(chalk.dim(`  → Updated storyboard: ${storyboardPath}`));
-      }
-
-      // Step 5: Update project.vibe.json if it exists — update ALL clips' startTime/duration
-      if (existsSync(projectPath)) {
+      // Sync project.vibe.json clip durations with the updated storyboard.
+      // The library rewrites segment.duration when narration changes; we
+      // re-read it here so every clip's startTime/duration line up.
+      if (existsSync(projectPath) && result.regeneratedScenes.length > 0) {
         const updateSpinner = ora("📦 Updating project file...").start();
-
         try {
+          const updatedContent = await readFile(storyboardPath!, "utf-8");
+          const updatedSegments: StoryboardSegment[] = storyboardIsYaml
+            ? (yamlParse(updatedContent) as { scenes: StoryboardSegment[] }).scenes
+            : (JSON.parse(updatedContent) as StoryboardSegment[]);
+
           const projectContent = await readFile(projectPath, "utf-8");
           const projectData = JSON.parse(projectContent) as ProjectFile;
 
-          // Find and update the source for this scene
-          const sceneName = `Scene ${sceneNum}`;
-          const narrationName = `Narration ${sceneNum}`;
-
-          // Update video/image source
-          const videoSource = projectData.state.sources.find((s) => s.name === sceneName);
-          if (videoSource) {
-            const hasVideo = existsSync(videoPath);
-            videoSource.url = hasVideo ? videoPath : imagePath;
-            videoSource.type = hasVideo ? "video" : "image";
-            videoSource.duration = segment.duration;
+          for (const sceneNum of result.regeneratedScenes) {
+            const segment = updatedSegments[sceneNum - 1];
+            if (!segment) continue;
+            const videoPath = resolve(outputDir, `scene-${sceneNum}.mp4`);
+            const imagePath = resolve(outputDir, `scene-${sceneNum}.png`);
+            const videoSource = projectData.state.sources.find((s) => s.name === `Scene ${sceneNum}`);
+            if (videoSource) {
+              const hasVideo = existsSync(videoPath);
+              videoSource.url = hasVideo ? videoPath : imagePath;
+              videoSource.type = hasVideo ? "video" : "image";
+              videoSource.duration = segment.duration;
+            }
+            if (regenerateNarration) {
+              const narrationSource = projectData.state.sources.find((s) => s.name === `Narration ${sceneNum}`);
+              if (narrationSource) {
+                narrationSource.duration = segment.duration;
+              }
+            }
           }
 
-          // Update narration source
-          const narrationSource = projectData.state.sources.find((s) => s.name === narrationName);
-          if (narrationSource && regenerateNarration) {
-            narrationSource.duration = narrationDuration;
-          }
-
-          // Update ALL clips' startTime and duration based on recalculated segments
           for (const clip of projectData.state.clips) {
             const source = projectData.state.sources.find((s) => s.id === clip.sourceId);
             if (!source) continue;
-
-            // Match source name to segment (e.g., "Scene 1" → segment 0, "Narration 2" → segment 1)
             const sceneMatch = source.name.match(/^Scene (\d+)$/);
             const narrationMatch = source.name.match(/^Narration (\d+)$/);
             const segIdx = sceneMatch ? parseInt(sceneMatch[1]) - 1 : narrationMatch ? parseInt(narrationMatch[1]) - 1 : -1;
-
-            if (segIdx >= 0 && segIdx < segments.length) {
-              const seg = segments[segIdx];
+            if (segIdx >= 0 && segIdx < updatedSegments.length) {
+              const seg = updatedSegments[segIdx];
               clip.startTime = seg.startTime;
               clip.duration = seg.duration;
               clip.sourceEndOffset = seg.duration;
-              // Also update the source duration to match segment
               source.duration = seg.duration;
             }
           }
@@ -870,12 +474,8 @@ Generate the single-person scene image now.`;
         }
       }
 
-        console.log(chalk.green(`  ✓ Scene ${sceneNum} done`));
-      } // End of for loop over sceneNums
-
-      // Final summary
       console.log();
-      console.log(chalk.bold.green(`✅ ${sceneNums.length} scene${sceneNums.length > 1 ? "s" : ""} regenerated successfully!`));
+      console.log(chalk.bold.green(`✅ ${result.regeneratedScenes.length} scene${result.regeneratedScenes.length !== 1 ? "s" : ""} regenerated successfully!`));
       console.log(chalk.dim("─".repeat(60)));
       console.log();
       console.log(chalk.dim("Next steps:"));

--- a/packages/cli/src/commands/ai-script-pipeline.ts
+++ b/packages/cli/src/commands/ai-script-pipeline.ts
@@ -483,7 +483,10 @@ export interface ScriptToVideoOptions {
   review?: boolean;
   /** Auto-apply fixable issues from review */
   reviewAutoApply?: boolean;
-  /** Called at major stage boundaries (storyboard, narration, images, videos, overlay, assembly, review). */
+  /**
+   * Called at stage boundaries (storyboard, assembly, review, …) and per scene
+   * during narration/image/video generation (format: `Scene i/N: ...`).
+   */
   onProgress?: (message: string) => void;
 }
 
@@ -697,6 +700,8 @@ export async function executeScriptToVideo(
           continue;
         }
 
+        options.onProgress?.(`Scene ${i + 1}/${segments.length}: generating narration...`);
+
         const ttsResult = await elevenlabs.textToSpeech(narrationText, {
           voiceId: options.voice,
         });
@@ -769,6 +774,8 @@ export async function executeScriptToVideo(
       const imagePrompt = segment.visualStyle
         ? `${segment.visuals}. Style: ${segment.visualStyle}`
         : segment.visuals;
+
+      options.onProgress?.(`Scene ${i + 1}/${segments.length}: generating image...`);
 
       try {
         let imageBuffer: Buffer | undefined;
@@ -856,6 +863,8 @@ export async function executeScriptToVideo(
           const segment = segments[i] as StoryboardSegment;
           const videoDuration = Math.min(15, Math.max(1, segment.duration));
 
+          options.onProgress?.(`Scene ${i + 1}/${segments.length}: generating video (grok)...`);
+
           // Image-to-video: encode image as data URI
           const imageBuffer = await readFile(imagePaths[i]);
           const ext = extname(imagePaths[i]).toLowerCase().slice(1);
@@ -919,6 +928,8 @@ export async function executeScriptToVideo(
           const segment = segments[i] as StoryboardSegment;
           const videoDuration = (segment.duration > 5 ? 10 : 5) as 5 | 10;
 
+          options.onProgress?.(`Scene ${i + 1}/${segments.length}: generating video (kling)...`);
+
           // Using text2video since Kling's image2video requires URL (not base64)
           const taskResult = await generateVideoWithRetryKling(
             kling,
@@ -975,6 +986,8 @@ export async function executeScriptToVideo(
 
           const segment = segments[i] as StoryboardSegment;
           const veoDuration = (segment.duration > 6 ? 8 : segment.duration > 4 ? 6 : 4) as 4 | 6 | 8;
+
+          options.onProgress?.(`Scene ${i + 1}/${segments.length}: generating video (veo)...`);
 
           const taskResult = await generateVideoWithRetryVeo(
             veo,
@@ -1036,6 +1049,8 @@ export async function executeScriptToVideo(
 
           const videoDuration = (segment.duration > 5 ? 10 : 5) as 5 | 10;
           const aspectRatio = options.aspectRatio === "1:1" ? "16:9" : ((options.aspectRatio || "16:9") as "16:9" | "9:16");
+
+          options.onProgress?.(`Scene ${i + 1}/${segments.length}: generating video (runway)...`);
 
           const taskResult = await generateVideoWithRetryRunway(
             runway,

--- a/packages/cli/src/commands/ai-script-pipeline.ts
+++ b/packages/cli/src/commands/ai-script-pipeline.ts
@@ -1323,6 +1323,8 @@ export interface RegenerateSceneOptions {
   retries?: number;
   /** Reference scene number for character consistency (auto-detects if not specified) */
   referenceScene?: number;
+  /** Called at per-scene progress points (`Scene N: regenerating narration...`). */
+  onProgress?: (message: string) => void;
 }
 
 /** Result from {@link executeRegenerateScene}. */
@@ -1385,6 +1387,8 @@ export async function executeRegenerateScene(
     }
 
     const regenerateVideo = options.videoOnly || (!options.narrationOnly && !options.imageOnly);
+    const regenerateNarration = options.narrationOnly || (!options.videoOnly && !options.imageOnly);
+    const regenerateImage = options.imageOnly || (!options.videoOnly && !options.narrationOnly);
 
     // Get API keys
     let videoApiKey: string | undefined;
@@ -1406,13 +1410,190 @@ export async function executeRegenerateScene(
       }
     }
 
+    let imageApiKey: string | undefined;
+    if (regenerateImage) {
+      const imageProvider = options.imageProvider || "openai";
+      const imageKeyMap: Record<typeof imageProvider, { envVar: string; name: string }> = {
+        openai: { envVar: "OPENAI_API_KEY", name: "OpenAI" },
+        gemini: { envVar: "GOOGLE_API_KEY", name: "Google" },
+        grok: { envVar: "XAI_API_KEY", name: "xAI" },
+      };
+      const info = imageKeyMap[imageProvider];
+      if (!info) {
+        return { ...result, error: `Invalid imageProvider: ${imageProvider}` };
+      }
+      imageApiKey = (await getApiKey(info.envVar, info.name)) ?? undefined;
+      if (!imageApiKey) {
+        return { ...result, error: `${info.name} API key required. Run 'vibe setup' or set ${info.envVar} in .env` };
+      }
+    }
+
+    let elevenlabsApiKey: string | undefined;
+    if (regenerateNarration) {
+      elevenlabsApiKey = (await getApiKey("ELEVENLABS_API_KEY", "ElevenLabs")) ?? undefined;
+      if (!elevenlabsApiKey) {
+        return { ...result, error: "ElevenLabs API key required. Run 'vibe setup' or set ELEVENLABS_API_KEY in .env" };
+      }
+    }
+
+    // Track storyboard mutations so we only rewrite when segment durations change.
+    let storyboardMutated = false;
+
     // Process each scene
     for (const sceneNum of options.scenes) {
       const segment = segments[sceneNum - 1];
+      const narrationPath = resolve(outputDir, `narration-${sceneNum}.mp3`);
       const imagePath = resolve(outputDir, `scene-${sceneNum}.png`);
       const videoPath = resolve(outputDir, `scene-${sceneNum}.mp4`);
 
+      let sceneFailed = false;
+
+      // Narration regeneration
+      if (regenerateNarration && elevenlabsApiKey) {
+        options.onProgress?.(`Scene ${sceneNum}: regenerating narration...`);
+        const elevenlabs = new ElevenLabsProvider();
+        await elevenlabs.initialize({ apiKey: elevenlabsApiKey });
+        const narrationText = segment.narration || segment.description;
+
+        const ttsResult = await elevenlabs.textToSpeech(narrationText, {
+          voiceId: options.voice,
+        });
+        if (ttsResult.success && ttsResult.audioBuffer) {
+          await writeFile(narrationPath, ttsResult.audioBuffer);
+          segment.duration = await getAudioDuration(narrationPath);
+          storyboardMutated = true;
+        } else {
+          sceneFailed = true;
+        }
+      }
+
+      // Image regeneration (with character-consistency reference when available)
+      if (!sceneFailed && regenerateImage && imageApiKey) {
+        options.onProgress?.(`Scene ${sceneNum}: regenerating image...`);
+        const imageProvider = options.imageProvider || "openai";
+
+        const characterDesc = segment.characterDescription || segments[0]?.characterDescription;
+        let imagePrompt = segment.visualStyle
+          ? `${segment.visuals}. Style: ${segment.visualStyle}`
+          : segment.visuals;
+        if (characterDesc) {
+          imagePrompt = `${imagePrompt}\n\nIMPORTANT - Character appearance must match exactly: ${characterDesc}`;
+        }
+
+        // Pick a reference image for character consistency: caller-specified,
+        // else auto-detect the first existing scene image that isn't this scene.
+        let referenceImageBuffer: Buffer | undefined;
+        const refSceneNum = options.referenceScene;
+        if (refSceneNum && refSceneNum >= 1 && refSceneNum <= segments.length && refSceneNum !== sceneNum) {
+          const refImagePath = resolve(outputDir, `scene-${refSceneNum}.png`);
+          if (existsSync(refImagePath)) {
+            referenceImageBuffer = await readFile(refImagePath);
+          }
+        } else if (!refSceneNum) {
+          for (let i = 1; i <= segments.length; i++) {
+            if (i !== sceneNum) {
+              const otherImagePath = resolve(outputDir, `scene-${i}.png`);
+              if (existsSync(otherImagePath)) {
+                referenceImageBuffer = await readFile(otherImagePath);
+                break;
+              }
+            }
+          }
+        }
+
+        const dalleImageSizes: Record<string, "1536x1024" | "1024x1536" | "1024x1024"> = {
+          "16:9": "1536x1024",
+          "9:16": "1024x1536",
+          "1:1": "1024x1024",
+        };
+        let imageBuffer: Buffer | undefined;
+        let imageUrl: string | undefined;
+
+        if (imageProvider === "openai") {
+          const openaiImage = new OpenAIImageProvider();
+          await openaiImage.initialize({ apiKey: imageApiKey });
+          const imageResult = await openaiImage.generateImage(imagePrompt, {
+            size: dalleImageSizes[options.aspectRatio || "16:9"] || "1536x1024",
+            quality: "standard",
+          });
+          if (imageResult.success && imageResult.images?.[0]) {
+            const img = imageResult.images[0];
+            if (img.base64) imageBuffer = Buffer.from(img.base64, "base64");
+            else if (img.url) imageUrl = img.url;
+          }
+        } else if (imageProvider === "gemini") {
+          const gemini = new GeminiProvider();
+          await gemini.initialize({ apiKey: imageApiKey });
+          if (referenceImageBuffer) {
+            // Gemini edit-with-reference path — pulls the character forward
+            // while describing the new action. Simplified visuals pick the
+            // first recognised action verb to reduce prompt bleed.
+            const simplifiedVisuals = segment.visuals.split(/[,.]/).find((part: string) =>
+              part.includes("standing") || part.includes("sitting") || part.includes("walking") ||
+              part.includes("lying") || part.includes("reaching") || part.includes("looking") ||
+              part.includes("working") || part.includes("coding") || part.includes("typing")
+            ) || segment.visuals.split(".")[0];
+
+            const editPrompt = `Generate a new image showing the SAME SINGLE person from the reference image in a new scene.
+
+REFERENCE: Look at the person in the reference image - their face, hair, build, and overall appearance.
+
+NEW SCENE: ${simplifiedVisuals}
+
+CRITICAL RULES:
+1. Show ONLY ONE person - the exact same individual from the reference image
+2. The person must have the IDENTICAL face, hair style, and body type
+3. Do NOT show multiple people or duplicate the character
+4. Create a single moment in time, one pose, one action
+5. Match the art style and quality of the reference image
+
+Generate the single-person scene image now.`;
+
+            const imageResult = await gemini.editImage([referenceImageBuffer], editPrompt, {
+              aspectRatio: (options.aspectRatio || "16:9") as "16:9" | "9:16" | "1:1",
+            });
+            if (imageResult.success && imageResult.images?.[0]?.base64) {
+              imageBuffer = Buffer.from(imageResult.images[0].base64, "base64");
+            }
+          } else {
+            const imageResult = await gemini.generateImage(imagePrompt, {
+              aspectRatio: (options.aspectRatio || "16:9") as "16:9" | "9:16" | "1:1",
+            });
+            if (imageResult.success && imageResult.images?.[0]?.base64) {
+              imageBuffer = Buffer.from(imageResult.images[0].base64, "base64");
+            }
+          }
+        } else if (imageProvider === "grok") {
+          const grok = new GrokProvider();
+          await grok.initialize({ apiKey: imageApiKey });
+          const imageResult = await grok.generateImage(imagePrompt, {
+            aspectRatio: options.aspectRatio || "16:9",
+          });
+          if (imageResult.success && imageResult.images?.[0]) {
+            const img = imageResult.images[0];
+            if (img.base64) imageBuffer = Buffer.from(img.base64, "base64");
+            else if (img.url) imageUrl = img.url;
+          }
+        }
+
+        if (imageBuffer) {
+          await writeFile(imagePath, imageBuffer);
+        } else if (imageUrl) {
+          const response = await fetch(imageUrl);
+          const buffer = Buffer.from(await response.arrayBuffer());
+          await writeFile(imagePath, buffer);
+        } else {
+          sceneFailed = true;
+        }
+      }
+
+      if (sceneFailed) {
+        result.failedScenes.push(sceneNum);
+        continue;
+      }
+
       if (regenerateVideo && videoApiKey) {
+        options.onProgress?.(`Scene ${sceneNum}: regenerating video (${options.generator || "grok"})...`);
         if (!existsSync(imagePath)) {
           result.failedScenes.push(sceneNum);
           continue;
@@ -1625,7 +1806,24 @@ export async function executeRegenerateScene(
             result.failedScenes.push(sceneNum);
           }
         }
+      } else if (!sceneFailed) {
+        // narration-only / image-only / both: no video pass, so record success here
+        result.regeneratedScenes.push(sceneNum);
       }
+    }
+
+    // Persist storyboard if narration regeneration changed segment durations.
+    // Preserve the on-disk format (yaml vs json) so no silent downgrades.
+    if (storyboardMutated) {
+      let currentTime = 0;
+      for (const segment of segments) {
+        segment.startTime = currentTime;
+        currentTime += segment.duration;
+      }
+      const serialized = storyboardPath.endsWith(".yaml")
+        ? yamlStringify({ scenes: segments }, { indent: 2 })
+        : JSON.stringify(segments, null, 2);
+      await writeFile(storyboardPath, serialized, "utf-8");
     }
 
     result.success = result.failedScenes.length === 0;

--- a/packages/cli/src/commands/ai-script-pipeline.ts
+++ b/packages/cli/src/commands/ai-script-pipeline.ts
@@ -700,9 +700,18 @@ export async function executeScriptToVideo(
           continue;
         }
 
+        // Pre-TTS word-count heuristic (warn only; narration may still fit)
+        const wordCount = narrationText.split(/\s+/).filter(Boolean).length;
+        const maxWords = segment.duration > 5 ? 24 : 12;
+        if (wordCount > maxWords * 1.3) {
+          options.onProgress?.(
+            `⚠ Scene ${i + 1} narration has ${wordCount} words (target ~${maxWords} for ${segment.duration}s); speech may rush.`
+          );
+        }
+
         options.onProgress?.(`Scene ${i + 1}/${segments.length}: generating narration...`);
 
-        const ttsResult = await elevenlabs.textToSpeech(narrationText, {
+        let ttsResult = await elevenlabs.textToSpeech(narrationText, {
           voiceId: options.voice,
         });
 
@@ -711,7 +720,33 @@ export async function executeScriptToVideo(
           await writeFile(audioPath, ttsResult.audioBuffer);
 
           // Get actual audio duration
-          const actualDuration = await getAudioDuration(audioPath);
+          let actualDuration = await getAudioDuration(audioPath);
+
+          // Auto speed-adjust if narration exceeds video bracket (5s or 10s).
+          // Pick the bracket from the pre-TTS segment.duration (the storyboard
+          // estimate), not actualDuration — actualDuration IS the overage.
+          const videoBracket = segment.duration > 5 ? 10 : 5;
+          const overageRatio = actualDuration / videoBracket;
+          if (overageRatio > 1.0 && overageRatio <= 1.35) {
+            const adjustedSpeed = Math.min(1.35, parseFloat(overageRatio.toFixed(2)));
+            options.onProgress?.(
+              `Scene ${i + 1}: adjusting narration speed to ${adjustedSpeed}x...`
+            );
+            const speedResult = await elevenlabs.textToSpeech(narrationText, {
+              voiceId: options.voice,
+              speed: adjustedSpeed,
+            });
+            if (speedResult.success && speedResult.audioBuffer) {
+              await writeFile(audioPath, speedResult.audioBuffer);
+              actualDuration = await getAudioDuration(audioPath);
+              ttsResult = speedResult;
+            }
+          } else if (overageRatio > 1.35) {
+            options.onProgress?.(
+              `⚠ Scene ${i + 1} narration is ${((overageRatio - 1) * 100).toFixed(0)}% over target (${actualDuration.toFixed(1)}s vs ${videoBracket}s bracket)`
+            );
+          }
+
           segment.duration = actualDuration;
 
           // Add to both arrays for backwards compatibility

--- a/packages/cli/src/commands/ai-script-pipeline.ts
+++ b/packages/cli/src/commands/ai-script-pipeline.ts
@@ -17,7 +17,7 @@
  */
 
 import { readFile, writeFile, mkdir, unlink, rename } from "node:fs/promises";
-import { resolve, basename, extname } from "node:path";
+import { resolve, basename, dirname, extname } from "node:path";
 import { existsSync } from "node:fs";
 import { stringify as yamlStringify, parse as yamlParse } from "yaml";
 import chalk from "chalk";
@@ -488,6 +488,13 @@ export interface ScriptToVideoOptions {
    * during narration/image/video generation (format: `Scene i/N: ...`).
    */
   onProgress?: (message: string) => void;
+  /**
+   * Absolute path for the generated `project.vibe.json`. Defaults to
+   * `{outputDir}/project.vibe.json`. When supplied, the CLI layer can map its
+   * `-o` flag onto an arbitrary project file location without renaming files
+   * after the fact.
+   */
+  projectFilePath?: string;
 }
 
 /**
@@ -1253,8 +1260,15 @@ export async function executeScriptToVideo(
       currentTime += actualDuration;
     }
 
-    // Save project file
-    const projectPath = resolve(absOutputDir, "project.vibe.json");
+    // Save project file. Default is `{outputDir}/project.vibe.json`; callers
+    // can override via projectFilePath (used by the CLI's `-o` handling).
+    const projectPath = options.projectFilePath
+      ? resolve(process.cwd(), options.projectFilePath)
+      : resolve(absOutputDir, "project.vibe.json");
+    const projectParentDir = dirname(projectPath);
+    if (!existsSync(projectParentDir)) {
+      await mkdir(projectParentDir, { recursive: true });
+    }
     await writeFile(projectPath, JSON.stringify(project.toJSON(), null, 2), "utf-8");
     result.projectPath = projectPath;
     result.totalDuration = currentTime;

--- a/packages/cli/src/commands/ai-script-pipeline.ts
+++ b/packages/cli/src/commands/ai-script-pipeline.ts
@@ -961,6 +961,28 @@ export async function executeScriptToVideo(
           return { success: false, outputDir: absOutputDir, scenes: segments.length, error: "Invalid Kling API key format. Use ACCESS_KEY:SECRET_KEY" };
         }
 
+        // Kling image2video requires a public image URL (not base64). When an
+        // ImgBB key is configured, upload each scene image once and pass the
+        // URL as referenceImage; otherwise fall through to text2video.
+        const imgbbApiKey = (await getApiKeyFromConfig("imgbb")) || process.env.IMGBB_API_KEY;
+        const imageUrls: (string | undefined)[] = new Array(segments.length);
+        if (imgbbApiKey) {
+          options.onProgress?.("Uploading scene images for Kling image-to-video...");
+          for (let i = 0; i < imagePaths.length; i++) {
+            if (imagePaths[i]) {
+              try {
+                const imageBuffer = await readFile(imagePaths[i]);
+                const uploadResult = await uploadToImgbb(imageBuffer, imgbbApiKey);
+                if (uploadResult.success && uploadResult.url) {
+                  imageUrls[i] = uploadResult.url;
+                }
+              } catch {
+                imageUrls[i] = undefined;
+              }
+            }
+          }
+        }
+
         for (let i = 0; i < segments.length; i++) {
           if (!imagePaths[i]) {
             videoPaths.push("");
@@ -972,11 +994,14 @@ export async function executeScriptToVideo(
 
           options.onProgress?.(`Scene ${i + 1}/${segments.length}: generating video (kling)...`);
 
-          // Using text2video since Kling's image2video requires URL (not base64)
           const taskResult = await generateVideoWithRetryKling(
             kling,
             segment,
-            { duration: videoDuration, aspectRatio: (options.aspectRatio || "16:9") as "16:9" | "9:16" | "1:1" },
+            {
+              duration: videoDuration,
+              aspectRatio: (options.aspectRatio || "16:9") as "16:9" | "9:16" | "1:1",
+              referenceImage: imageUrls[i],
+            },
             maxRetries
           );
 
@@ -988,17 +1013,20 @@ export async function executeScriptToVideo(
                 const buffer = await downloadVideo(waitResult.videoUrl, videoApiKey);
                 await writeFile(videoPath, buffer);
 
-                // Extend video to match narration duration if needed
-                const targetDuration = segment.duration; // Already updated to narration length
-                const actualVideoDuration = await getVideoDuration(videoPath);
-
-                if (actualVideoDuration < targetDuration - 0.1) {
-                  const extendedPath = resolve(absOutputDir, `scene-${i + 1}-extended.mp4`);
-                  await extendVideoNaturally(videoPath, targetDuration, extendedPath);
-                  // Replace original with extended version
-                  await unlink(videoPath);
-                  await rename(extendedPath, videoPath);
-                }
+                // Extend video to match narration duration. Use extendVideoToTarget
+                // so large gaps (ratio > 1.4) can use Kling's own extend API for
+                // natural continuation instead of freeze-frame padding.
+                await extendVideoToTarget(
+                  videoPath,
+                  segment.duration,
+                  absOutputDir,
+                  `Scene ${i + 1}`,
+                  {
+                    kling,
+                    videoId: waitResult.videoId,
+                    onProgress: options.onProgress,
+                  }
+                );
 
                 videoPaths.push(videoPath);
                 result.videos!.push(videoPath);
@@ -1751,16 +1779,19 @@ Generate the single-person scene image now.`;
                 const buffer = await downloadVideo(waitResult.videoUrl, videoApiKey);
                 await writeFile(videoPath, buffer);
 
-                // Extend video to match narration duration if needed
-                const targetDuration = segment.duration;
-                const actualVideoDuration = await getVideoDuration(videoPath);
-
-                if (actualVideoDuration < targetDuration - 0.1) {
-                  const extendedPath = resolve(outputDir, `scene-${sceneNum}-extended.mp4`);
-                  await extendVideoNaturally(videoPath, targetDuration, extendedPath);
-                  await unlink(videoPath);
-                  await rename(extendedPath, videoPath);
-                }
+                // Extend via extendVideoToTarget so Kling's own extend API can
+                // be used for large gaps (ratio > 1.4) instead of freeze frames.
+                await extendVideoToTarget(
+                  videoPath,
+                  segment.duration,
+                  outputDir,
+                  `Scene ${sceneNum}`,
+                  {
+                    kling,
+                    videoId: waitResult.videoId,
+                    onProgress: options.onProgress,
+                  }
+                );
 
                 result.regeneratedScenes.push(sceneNum);
               } else {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.48.6",
+  "version": "0.49.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.48.6",
+  "version": "0.49.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.48.6",
+  "version": "0.49.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Closes #46. Replaces ~1,685 LOC of inline pipeline logic in the CLI with thin Commander wrappers around `executeScriptToVideo` and `executeRegenerateScene`. `ai-script-pipeline-cli.ts` shrinks 1834 → 489 lines (-73%); library gains ~300 lines for the behaviors previously CLI-exclusive.

All four video providers (grok, kling, runway, veo) now take the same library path — the dual-path divergence from v0.48.3 is gone.

## Commits (bisectable)

1. `feat(pipeline): emit per-scene onProgress events` — TTS/image/video loops fire `Scene i/N: ...` alongside existing stage messages. Additive.
2. `feat(pipeline): auto speed-adjust narration exceeding video bracket` — ports the CLI overage-ratio check (1.0–1.35 → regen at matching speed; >1.35 → warn) into the library TTS loop. Library-only consumers (MCP, YAML pipelines) now get the same narration-fit fix as the old CLI inline path.
3. `feat(pipeline): implement narration/image regen in executeRegenerateScene` — the `narrationOnly`/`imageOnly` options had been declared but not implemented; ports the CLI branches (including Gemini edit-with-reference for character consistency and the reference-scene auto-detect). Storyboard is re-saved in its on-disk format after narration changes.
4. `refactor(cli): thin-wrap script-to-video over executeScriptToVideo` — deletes ~1,000 LOC of inline kling/runway. Adds `ScriptToVideoOptions.projectFilePath` so the CLI's `-o` semantics survive. Keeps API-key pre-check so AUTH (4) vs API_ERROR (5) exit codes match existing agent contracts.
5. `refactor(cli): thin-wrap regenerate-scene over executeRegenerateScene` — deletes ~490 LOC of inline logic. `project.vibe.json` sync stays in CLI (CLI re-reads the updated storyboard after the library call and syncs every clip's startTime/duration).
6. `fix(pipeline): restore kling ImgBB image2video + extend API in library` — surfaced by the real-API regression run: the library's kling path was text2video-only, so C4 silently lost image2video for users with `IMGBB_API_KEY` set. Also restores `extendVideoToTarget` (Kling extend API fallback).
7. `chore: bump version to 0.49.0` — minor bump: public API additive (`onProgress` expanded, `projectFilePath` added, narration/image regen modes now functional); no breaking changes.

## Scope preserved

- **JSON output shape** — byte-identical to the v0.48.3 grok/veo delegation: `projectPath`, `outputDir`, `scenes`, `totalDuration`, `images` (count), `videos` (count), `failedScenes`. Agent callers unaffected.
- **Exit codes** — CLI pre-checks API keys to keep AUTH (4) vs API_ERROR (5) distinctions; the library's internal re-check only fires when the CLI layer is bypassed (MCP, YAML).
- **CLI help / flags / dry-run** — unchanged; `--help` output and dry-run JSON verified identical.
- **Summary block** — full `📄/🎬/⏱️/📁/🎙️/🖼️/🎥` summary now renders for all providers (grok/veo previously printed only a spinner-succeed line).

## Test plan

- [x] `pnpm build` — all 6 packages clean
- [x] `pnpm lint` — 0 errors (8 pre-existing warnings unchanged)
- [x] `pnpm test` — 332 tests pass (cli 278 + core 8 + ai-providers 20 + mcp-server 26)
- [x] Real grok API: 1/1 scene end-to-end via thin wrap, `videos: 1`, `failedScenes: []`
- [ ] Real kling API: pipeline runs end-to-end, but kling provider returned failures for every scene in both the pre-fix and post-fix runs — looks like a provider-level issue unrelated to this PR. Image2video + extend API fix is structurally correct and restores the lost capability regardless.
- [x] Real veo API: already verified in v0.48.3–0.48.5; same library path, unchanged here
- [x] Dry-run JSON shape: `pipeline script-to-video --dry-run --json` and `pipeline regenerate-scene --dry-run --json` both byte-identical
- [x] CLI `--help` text: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)