### PR TITLE
fix(deps): bump @hyperframes/producer 0.4.4 → 0.4.6 (+ webgpu types)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.2] - 2026-04-20
+
+### Fixed
+
+- bump @hyperframes/producer to ^0.4.6 (+ @webgpu/types) *(deps)*
+
 ## [0.49.1] - 2026-04-19
 
 ### Changed
@@ -13,8 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- prefer billing hint over rate-limit for 429 balance errors *(cli)*
-- surface provider errors from video generation *(pipeline)*
+- surface provider errors + correct billing hint for 429 balance (#50) *(pipeline)*
 
 ## [0.48.6] - 2026-04-19
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",
@@ -115,7 +115,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "@google/generative-ai": "^0.21.0",
-    "@hyperframes/producer": "^0.4.4",
+    "@hyperframes/producer": "^0.4.6",
     "@vibeframe/ai-providers": "workspace:*",
     "@vibeframe/core": "workspace:*",
     "chalk": "^5.3.0",
@@ -130,6 +130,7 @@
   "devDependencies": {
     "@types/node": "^20.11.0",
     "@vitest/coverage-v8": "1",
+    "@webgpu/types": "^0.1.69",
     "tsx": "^4.21.0",
     "typescript": "^5.3.3",
     "vitest": "^1.2.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^0.21.0
         version: 0.21.0
       '@hyperframes/producer':
-        specifier: ^0.4.4
-        version: 0.4.4(typescript@5.9.3)
+        specifier: ^0.4.6
+        version: 0.4.10(typescript@5.9.3)
       '@vibeframe/ai-providers':
         specifier: workspace:*
         version: link:../ai-providers
@@ -172,6 +172,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: '1'
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.30))
+      '@webgpu/types':
+        specifier: ^0.1.69
+        version: 0.1.69
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -869,20 +872,20 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@hyperframes/core@0.4.4':
-    resolution: {integrity: sha512-7ycmibu7D3S3jNhkk9iEsQ58iGCHuewfOTiYDaUcHtsW/OiSkApMtYvy/pNfV6ylnpxE28Iv4EELuoPZcRMYJQ==}
+  '@hyperframes/core@0.4.10':
+    resolution: {integrity: sha512-qRcKjMgnIoS+lOiGJ8/Xno6RMkzWHb9tz6cWs/gJsVBOeL/DxVmPy/FrrjbMyGcXdAcn4W8pxKj31SRZePVvng==}
     peerDependencies:
       hono: ^4.0.0
     peerDependenciesMeta:
       hono:
         optional: true
 
-  '@hyperframes/engine@0.4.4':
-    resolution: {integrity: sha512-fuf0rtiHCplCbSOr8BkiVXqBqDvDjSUMWemSL+uwyv74NH18QHUHiRUjhllYCBWY7p0ex8S0THXqZE1tkQ2C3Q==}
+  '@hyperframes/engine@0.4.10':
+    resolution: {integrity: sha512-x/1Zi81Rc4xYiT0jrA7rk+wwxKzI33QMOFldMngHEaF32rTpwE1ZZRm14MqRa8JF2HD9POiCD7O/jlMmJx5IHQ==}
     engines: {node: '>=22'}
 
-  '@hyperframes/producer@0.4.4':
-    resolution: {integrity: sha512-TaxSJ/AROi+hLiX1SY7lyhJ+j4oxYPZre9A9/5byyw5Jy+xw0/LPjObKqdEScYq4NZfj91AKvV3AGIOCFI5V1g==}
+  '@hyperframes/producer@0.4.10':
+    resolution: {integrity: sha512-YWpuZrUetjBHVKI1L9XVUAiBdLnwfWbxIo/SrVR2TG3/EJARHcGsxni3Gue3xCV10RIlL2DpDW/+TSaYTS0MkQ==}
     engines: {node: '>=22'}
 
   '@istanbuljs/schema@0.1.3':
@@ -1603,6 +1606,9 @@ packages:
 
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -3960,7 +3966,7 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@hyperframes/core@0.4.4(hono@4.11.7)':
+  '@hyperframes/core@0.4.10(hono@4.11.7)':
     dependencies:
       '@chenglou/pretext': 0.0.5
     optionalDependencies:
@@ -3970,10 +3976,10 @@ snapshots:
     transitivePeerDependencies:
       - canvas
 
-  '@hyperframes/engine@0.4.4(typescript@5.9.3)':
+  '@hyperframes/engine@0.4.10(typescript@5.9.3)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
-      '@hyperframes/core': 0.4.4(hono@4.11.7)
+      '@hyperframes/core': 0.4.10(hono@4.11.7)
       hono: 4.11.7
       linkedom: 0.18.12
       puppeteer: 24.41.0(typescript@5.9.3)
@@ -3988,7 +3994,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperframes/producer@0.4.4(typescript@5.9.3)':
+  '@hyperframes/producer@0.4.10(typescript@5.9.3)':
     dependencies:
       '@fontsource/archivo-black': 5.2.8
       '@fontsource/eb-garamond': 5.2.7
@@ -4002,8 +4008,8 @@ snapshots:
       '@fontsource/outfit': 5.2.8
       '@fontsource/space-mono': 5.2.9
       '@hono/node-server': 1.19.9(hono@4.11.7)
-      '@hyperframes/core': 0.4.4(hono@4.11.7)
-      '@hyperframes/engine': 0.4.4(typescript@5.9.3)
+      '@hyperframes/core': 0.4.10(hono@4.11.7)
+      '@hyperframes/engine': 0.4.10(typescript@5.9.3)
       hono: 4.11.7
       linkedom: 0.18.12
       postcss: 8.5.6
@@ -4725,6 +4731,8 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@webgpu/types@0.1.69': {}
 
   abort-controller@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Upstream heygen-com/hyperframes#334 (filed by us, closed by @jrusso1020) identified a Puppeteer `waitForFunction` rAF-polling race in 0.4.4 screenshot mode with auto-workers — **fixed in 0.4.6 via #331** (switched to a Node-side `setTimeout(100ms)` loop).
- `^0.4.6` resolves to 0.4.10 via semver. 0.4.7+ adds HDR capture that references WebGPU globals — since `@hyperframes/engine` publishes TS source (not `.d.ts`), those globals leak into consumer compilation. Added `@webgpu/types` as a CLI devDep (matches upstream's own tsconfig) to restore the build.
- **Unblocks #41** (Phase 2: Lottie overlay via Hyperframes), which was held on #334's resolution.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm lint` — 0 errors (pre-existing 8 warnings unchanged)
- [x] Hyperframes integration test renders `simple-2clip` fixture in 9.6s on macOS (real Chrome, screenshot mode)
- [x] Full CLI suite: 279 passed / 11 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)