### PR TITLE
feat(motion): bump opus alias to Claude Opus 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.50.0] - 2026-04-20
+## [0.51.0] - 2026-04-24
 
 ### Added
 
-- emit <dotlottie-wc> for lottie sources *(renderer)*
-- copy lottie assets + vendor dotlottie-wc runtime *(renderer)*
-- detect lottie sources in timeline add-source *(cli)*
-- add "lottie" to MediaType union *(core)*
+- bump opus alias to claude-opus-4-7 *(motion)*
+
+### Documentation
+
+- add Claude Opus 4.7, mark 4.6 as legacy, correct pricing *(MODELS)*
+
+## [0.50.0] - 2026-04-24
+
+### Added
+
+- Lottie overlay via Hyperframes backend (closes #41) (#54)
 
 ### Fixed
 
 - bump @hyperframes/producer 0.4.4 → 0.4.6 (+ webgpu types) (#53) *(deps)*
-
-### Testing
-
-- image base + lottie overlay end-to-end render *(renderer)*
 
 ## [0.49.1] - 2026-04-19
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -37,10 +37,11 @@ To use GPT-5.4 in agent mode: `vibe agent -p openai --model gpt-5.4`
 | Model ID | Variant | Notes |
 |----------|---------|-------|
 | `claude-sonnet-4-6` | Sonnet 4.6 | **Default**. Best cost-performance for agent loops. $3/M input, $15/M output |
-| `claude-opus-4-6` | Opus 4.6 | Highest capability, best for complex reasoning. $15/M input, $75/M output |
-| `claude-haiku-4-5-20251001` | Haiku 4.5 | Fastest, lowest cost. $0.80/M input, $4/M output |
+| `claude-opus-4-7` | Opus 4.7 | Highest capability, step-change in agentic coding, 1M context. $5/M input, $25/M output |
+| `claude-haiku-4-5-20251001` | Haiku 4.5 | Fastest, lowest cost. $1/M input, $5/M output |
+| `claude-opus-4-6` | Opus 4.6 (legacy) | Previous Opus tier — same price as 4.7. Still supported. |
 
-To use Opus in agent mode: `vibe agent -p claude --model claude-opus-4-6`
+To use Opus in agent mode: `vibe agent -p claude --model claude-opus-4-7`
 
 **xAI model options:**
 
@@ -103,7 +104,8 @@ Used for Remotion component code generation (`vibe generate motion`).
 | Alias | Model | Provider | Env Key | CLI Option | Notes |
 |-------|-------|----------|---------|------------|-------|
 | `sonnet` | `claude-sonnet-4-6` | Claude | `ANTHROPIC_API_KEY` | `-m sonnet` | **Default** |
-| `opus` | `claude-opus-4-6` | Claude | `ANTHROPIC_API_KEY` | `-m opus` | Best quality |
+| `opus` | `claude-opus-4-7` | Claude | `ANTHROPIC_API_KEY` | `-m opus` | Best quality (step-change agentic coding) |
+| `opus-4-6` | `claude-opus-4-6` | Claude | `ANTHROPIC_API_KEY` | `-m opus-4-6` | Previous Opus tier (legacy) |
 | `gemini` | `gemini-2.5-pro` | Gemini | `GOOGLE_API_KEY` | `-m gemini` | Fast alternative |
 | `gemini-3.1-pro` | `gemini-3.1-pro-preview` | Gemini | `GOOGLE_API_KEY` | `-m gemini-3.1-pro` | Gemini 3.1 Pro |
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/src/claude/ClaudeProvider.ts
+++ b/packages/ai-providers/src/claude/ClaudeProvider.ts
@@ -136,7 +136,8 @@ export class ClaudeProvider implements AIProvider {
   /** Supported model aliases for motion graphic generation */
   static readonly MOTION_MODELS = {
     sonnet: "claude-sonnet-4-6",
-    opus: "claude-opus-4-6",
+    opus: "claude-opus-4-7",
+    "opus-4-6": "claude-opus-4-6",
   } as const;
 
   async initialize(config: ProviderConfig): Promise<void> {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/ai-motion.ts
+++ b/packages/cli/src/commands/ai-motion.ts
@@ -59,7 +59,8 @@ export interface MotionCommandResult {
 // Map model alias → { provider, modelId }
 const MODEL_MAP: Record<string, { provider: "claude" | "gemini"; modelId: string }> = {
   sonnet:          { provider: "claude",  modelId: "claude-sonnet-4-6" },
-  opus:            { provider: "claude",  modelId: "claude-opus-4-6" },
+  opus:            { provider: "claude",  modelId: "claude-opus-4-7" },
+  "opus-4-6":      { provider: "claude",  modelId: "claude-opus-4-6" },
   gemini:          { provider: "gemini",  modelId: "gemini-2.5-pro" },
   "gemini-3.1-pro": { provider: "gemini", modelId: "gemini-3.1-pro-preview" },
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Phase 1 of the new-model rollout — **Opus 4.7 only** for now.

- `vibe generate motion -m opus` now maps to `claude-opus-4-7` (was `claude-opus-4-6`)
- Previous Opus tier reachable via new explicit alias: `-m opus-4-6`
- Pricing is **identical** ($5/M in, $25/M out) — no billing impact for users on the `opus` alias
- `ClaudeProvider.MOTION_MODELS` updated to match
- `MODELS.md` corrected: 4.6 was listed at $15/$75 (outdated Anthropic pricing), now $5/$25; Haiku 4.5 also corrected ($0.80/$4 → $1/$5)

## Why not GPT-5.5 / GPT-Image-2?

Originally scoped together. Verification found both aren't live on the public API yet:

- **GPT-5.5**: "not launching to the API today" — OpenAI, 2026-04-23. ChatGPT/Codex only, Chat Completions "very soon"
- **GPT-Image-2**: API opens "early May" — docs live, endpoint not

Deferring until each OpenAI API flips on, otherwise we'd ship options that 404. Phase 2 PR will handle both.

## Files

- `packages/cli/src/commands/ai-motion.ts` — `MODEL_MAP` opus alias
- `packages/ai-providers/src/claude/ClaudeProvider.ts` — `MOTION_MODELS` declaration
- `MODELS.md` — agent table + motion table + pricing fix
- Version bump 0.50.0 → 0.51.0 across 7 package.json + CHANGELOG.md

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm -F @vibeframe/cli test` — 286 passed, 11 skipped, 0 failed
- [x] `pnpm -F @vibeframe/cli lint` — 0 errors (8 pre-existing warnings)
- [ ] CI green on push
- [ ] Smoke: `vibe generate motion -m opus "spinning logo" --dry-run`

Source for Opus 4.7 pricing + model ID: https://platform.claude.com/docs/en/docs/about-claude/models

🤖 Generated with [Claude Code](https://claude.com/claude-code)