### PR TITLE
feat(openai-image): add GPT-Image-2 opt-in support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.0] - 2026-04-24
+
+### Added
+
+- allow gpt-image-2 in generate image *(openai-image)*
+
+### Documentation
+
+- add GPT-Image-2 rows for generate + edit *(MODELS)*
+
 ## [0.51.0] - 2026-04-24
 
 ### Added
 
-- bump opus alias to claude-opus-4-7 *(motion)*
-
-### Documentation
-
-- add Claude Opus 4.7, mark 4.6 as legacy, correct pricing *(MODELS)*
+- bump opus alias to Claude Opus 4.7 (#55) *(motion)*
 
 ## [0.50.0] - 2026-04-24
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -115,7 +115,8 @@ Used for Remotion component code generation (`vibe generate motion`).
 
 | Provider | Model | Env Key | CLI Option | Notes |
 |----------|-------|---------|------------|-------|
-| OpenAI | `gpt-image-1.5` | `OPENAI_API_KEY` | `-p openai` | Quality tiers: low ($0.009), medium ($0.035), high ($0.133) |
+| OpenAI | `gpt-image-1.5` | `OPENAI_API_KEY` | `-p openai` | **Default (OpenAI)**. Quality tiers: low ($0.009), medium ($0.035), high ($0.133) |
+| OpenAI | `gpt-image-2` | `OPENAI_API_KEY` | `-p openai -m 2` | Flagship, 2026-04-21 GA. Higher fidelity. ~$0.04–$0.35/image |
 | Gemini | `gemini-2.5-flash-image` | `GOOGLE_API_KEY` | `-p gemini` | Default. Nano Banana Flash - **GA**, fast |
 | Gemini | `gemini-3.1-flash-image-preview` | `GOOGLE_API_KEY` | `-p gemini -m 3.1-flash` | Nano Banana 2 - Image Search grounding, 512px |
 | Gemini | `gemini-3-pro-image-preview` | `GOOGLE_API_KEY` | `-p gemini -m pro` | Nano Banana Pro - higher quality, up to 4K |
@@ -138,6 +139,7 @@ Grok Imagine supports 14 aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:
 | Gemini | 3.1 Flash | 3 | `-p gemini -m 3.1-flash` | Image Search grounding, 512px-1K output |
 | Gemini | Pro | 14 | `-p gemini -m pro` | Multi-image composition, up to 4K output |
 | OpenAI | `gpt-image-1.5` | 16 | `-p openai` | Instruction-based editing, multipart upload |
+| OpenAI | `gpt-image-2` | 16 | `-p openai -m 2` | Flagship editor, 2026-04-21 GA |
 | xAI Grok | `grok-imagine-image` | 1 | `-p grok` | Single image editing, $0.02/edit |
 
 ---

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/src/openai-image/OpenAIImageProvider.ts
+++ b/packages/ai-providers/src/openai-image/OpenAIImageProvider.ts
@@ -6,10 +6,11 @@ import type {
 
 /**
  * GPT Image model types
- * - gpt-image-1.5: Latest model (fastest, best quality)
+ * - gpt-image-1.5: Default model (best cost/quality ratio)
+ * - gpt-image-2: Flagship model released 2026-04-21 (higher fidelity, pricier)
  * - dall-e-3: Legacy model
  */
-export type GPTImageModel = "gpt-image-1.5" | "dall-e-3";
+export type GPTImageModel = "gpt-image-1.5" | "gpt-image-2" | "dall-e-3";
 
 /**
  * GPT Image 1.5 quality tiers
@@ -27,7 +28,7 @@ export interface ImageOptions {
   model?: GPTImageModel;
   /** Image size */
   size?: "1024x1024" | "1536x1024" | "1024x1536" | "auto";
-  /** Quality tier (gpt-image-1.5) or standard/hd (dall-e-3) */
+  /** Quality tier (gpt-image-1.5 / gpt-image-2) or standard/hd (dall-e-3) */
   quality?: GPTImageQuality | "standard" | "hd";
   /** Style (dall-e-3 only) */
   style?: "vivid" | "natural";
@@ -60,22 +61,22 @@ export interface ImageEditOptions {
   size?: "1024x1024" | "512x512" | "256x256";
   /** Number of variations */
   n?: number;
-  /** Model for editing (default: gpt-image-1.5) */
+  /** Model for editing (default: gpt-image-1.5; gpt-image-2 also supported) */
   model?: GPTImageModel;
   /** Quality tier for editing */
   quality?: GPTImageQuality;
 }
 
-/** Default model - GPT Image 1.5 is fastest and best quality */
+/** Default model — GPT Image 1.5 for best cost/quality. gpt-image-2 is opt-in (pricier). */
 const DEFAULT_MODEL: GPTImageModel = "gpt-image-1.5";
 
 /**
- * OpenAI Image provider (GPT Image 1.5 / DALL-E)
+ * OpenAI Image provider (GPT Image 1.5 / GPT Image 2 / DALL-E)
  */
 export class OpenAIImageProvider implements AIProvider {
   id = "openai-image";
   name = "OpenAI GPT Image";
-  description = "AI image generation with GPT Image 1.5 (fastest, best quality)";
+  description = "AI image generation with GPT Image 1.5 (default) and GPT Image 2 (opt-in)";
   capabilities: AICapability[] = ["text-to-image", "background-removal", "image-editing"];
   iconUrl = "/icons/openai.svg";
   isAvailable = true;
@@ -110,7 +111,7 @@ export class OpenAIImageProvider implements AIProvider {
     }
 
     const model = options.model || DEFAULT_MODEL;
-    const isGPTImage = model === "gpt-image-1.5";
+    const isGPTImage = model === "gpt-image-1.5" || model === "gpt-image-2";
 
     try {
       // Build request body based on model
@@ -121,7 +122,7 @@ export class OpenAIImageProvider implements AIProvider {
       };
 
       if (isGPTImage) {
-        // GPT Image 1.5 options - does NOT support response_format
+        // GPT Image 1.5 / 2 options - do NOT support response_format
         // Quality values: low, medium, high, auto
         const qualityMap: Record<string, string> = {
           standard: "medium",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/ai-image.ts
+++ b/packages/cli/src/commands/ai-image.ts
@@ -41,7 +41,7 @@ aiCommand
   .option("-q, --quality <quality>", "Quality: standard, hd (openai only)", "standard")
   .option("--style <style>", "Style: vivid, natural (openai only)", "vivid")
   .option("-n, --count <n>", "Number of images to generate", "1")
-  .option("-m, --model <model>", "Gemini model: flash, 3.1-flash, latest (Nano Banana 2), pro (4K)")
+  .option("-m, --model <model>", "Model. Gemini: flash, 3.1-flash, latest, pro. OpenAI: 1.5 (default), 2 (gpt-image-2)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (prompt: string, options) => {
     try {
@@ -92,7 +92,14 @@ aiCommand
         const openaiImage = new OpenAIImageProvider();
         await openaiImage.initialize({ apiKey });
 
+        const modelAlias = options.model;
+        const openaiModel =
+          modelAlias === "2" || modelAlias === "gpt-image-2"
+            ? "gpt-image-2"
+            : undefined;
+
         const result = await openaiImage.generateImage(prompt, {
+          model: openaiModel,
           size: options.size,
           quality: options.quality,
           style: options.style,
@@ -104,7 +111,8 @@ aiCommand
           exitWithError(apiError(result.error || "Image generation failed", true));
         }
 
-        spinner.succeed(chalk.green(`Generated ${result.images.length} image(s) with OpenAI GPT Image 1.5`));
+        const modelLabel = openaiModel === "gpt-image-2" ? "GPT Image 2" : "GPT Image 1.5";
+        spinner.succeed(chalk.green(`Generated ${result.images.length} image(s) with OpenAI ${modelLabel}`));
 
         console.log();
         console.log(chalk.bold.cyan("Generated Images"));

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Adds **GPT-Image-2** (OpenAI, GA 2026-04-21) as an opt-in alternative to `gpt-image-1.5` for the image generate + edit commands.

- `GPTImageModel` union extended: `"gpt-image-1.5" | "gpt-image-2" | "dall-e-3"`
- `OpenAIImageProvider.generateImage` accepts gpt-image-2 through the same code path (same request shape, quality tiers low/medium/high)
- CLI opt-in: `vibe generate image -p openai -m 2` (or `-m gpt-image-2`)
- **Default unchanged** — `gpt-image-1.5` stays as OpenAI default since gpt-image-2 is pricier (~\$0.04–\$0.35/image vs 1.5 high \$0.133)

## Why not GPT-5.5 in this PR?

Originally planned to ship GPT-5.5 + GPT-Image-2 together. Re-verified against OpenAI's official sources today:

- **GPT-5.5**: Only a "coming soon" header banner on [developers.openai.com/api/docs/models](https://developers.openai.com/api/docs/models). The actual chat model list still tops out at `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.4-nano`. **No committed model ID yet** — shipping speculative IDs risks a rename when OpenAI finalizes.
- **GPT-Image-2**: Officially listed at [developers.openai.com/api/docs/models/gpt-image-2](https://developers.openai.com/api/docs/models/gpt-image-2). Model ID confirmed: `gpt-image-2` (snapshot: `gpt-image-2-2026-04-21`). API endpoints: `v1/images/generations`, `v1/images/edits`, `v1/batch`. Live in OpenAI's changelog since 2026-04-21.

Phase 2b (GPT-5.5) ships separately once it hits the official model list.

## Files

- `packages/ai-providers/src/openai-image/OpenAIImageProvider.ts` — type union + branch check + description
- `packages/cli/src/commands/ai-image.ts` — `-m 2` / `-m gpt-image-2` alias mapping, dynamic success-message label
- `MODELS.md` — new row in generate + edit tables with pricing
- Version bump 0.51.0 → 0.52.0 across 7 package.json + CHANGELOG.md

## Test plan

- [x] `pnpm -F @vibeframe/cli build` — clean
- [x] `pnpm -F @vibeframe/ai-providers build` — clean
- [x] CLI tests — 286 passed, 11 skipped, 0 failed
- [x] ai-providers tests — 20 passed
- [x] `pnpm lint` — 0 errors (pre-existing warnings unchanged)
- [ ] CI green on push
- [ ] Smoke: `vibe generate image -p openai -m 2 "a cat on a skateboard" -o cat.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)