### PR TITLE
fix(generate): wire gpt-image-2 alias in "vibe generate image"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.1] - 2026-04-24
+
+### Fixed
+
+- wire gpt-image-2 alias in "vibe generate image" *(generate)*
+
 ## [0.52.0] - 2026-04-24
 
 ### Added
 
-- allow gpt-image-2 in generate image *(openai-image)*
-
-### Documentation
-
-- add GPT-Image-2 rows for generate + edit *(MODELS)*
+- add GPT-Image-2 opt-in support (#56) *(openai-image)*
 
 ## [0.51.0] - 2026-04-24
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -121,7 +121,7 @@ generateCommand
   .option("-q, --quality <quality>", "Quality: standard, hd (openai only)", "standard")
   .option("--style <style>", "Style: vivid, natural (openai only)", "vivid")
   .option("-n, --count <n>", "Number of images to generate", "1")
-  .option("-m, --model <model>", "Gemini model: flash, 3.1-flash, latest (Nano Banana 2), pro (4K)")
+  .option("-m, --model <model>", "Model. Gemini: flash, 3.1-flash, latest, pro. OpenAI: 1.5 (default), 2 (gpt-image-2)")
   .option("--dry-run", "Preview parameters without executing")
   .addHelpText("after", `
 Examples:
@@ -203,7 +203,14 @@ Examples:
         const openaiImage = new OpenAIImageProvider();
         await openaiImage.initialize({ apiKey });
 
+        const modelAlias = options.model;
+        const openaiModel =
+          modelAlias === "2" || modelAlias === "gpt-image-2"
+            ? "gpt-image-2"
+            : undefined;
+
         const result = await openaiImage.generateImage(prompt, {
+          model: openaiModel,
           size: options.size,
           quality: options.quality,
           style: options.style,
@@ -215,7 +222,8 @@ Examples:
           exitWithError(apiError(result.error || "Image generation failed", true));
         }
 
-        spinner.succeed(chalk.green(`Generated ${result.images.length} image(s) with OpenAI GPT Image 1.5`));
+        const modelLabel = openaiModel === "gpt-image-2" ? "GPT Image 2" : "GPT Image 1.5";
+        spinner.succeed(chalk.green(`Generated ${result.images.length} image(s) with OpenAI ${modelLabel}`));
 
         if (isJsonMode()) {
           const outputPath = options.output ? resolve(process.cwd(), options.output) : undefined;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

v0.52.0 shipped `gpt-image-2` support but only wired it into the **`vibe ai image`** path (`ai-image.ts`). The separate **`vibe generate image`** path (`generate.ts`) hardcoded `"gpt-image-1.5"` in its success label and, more importantly, never passed `options.model` through to `OpenAIImageProvider.generateImage()`. So `vibe generate image -p openai -m 2` silently fell back to gpt-image-1.5.

## Evidence (smoke test)

**Before:**
```
$ vibe generate image -p openai --model gpt-image-2 -q low "tiny red dot" -o test.png
✔ Generated 1 image(s) with OpenAI GPT Image 1.5   ← WRONG
```

**After:**
```
$ vibe generate image -p openai --model gpt-image-2 -q low "tiny red dot" -o test.png
✔ Generated 1 image(s) with OpenAI GPT Image 2     ← correct, 501KB PNG delivered
```

OpenAI API confirms `gpt-image-2` model ID is accepted end-to-end.

## Files

- `packages/cli/src/commands/generate.ts` — add `modelAlias` mapping + pass `model` to provider + dynamic success label + update `-m` help text
- Version bump 0.52.0 → 0.52.1 across 7 package.json + CHANGELOG.md

## Test plan

- [x] `pnpm -F @vibeframe/cli build` — clean
- [x] CLI tests — 286 passed, 11 skipped
- [x] Smoke test (see above) — OpenAI API accepts gpt-image-2
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)