### PR TITLE
feat(ci): auto-tag main on version bump (closes #51)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,64 @@
+name: Auto-tag on version bump
+
+# Creates vX.Y.Z tag whenever main's root package.json version is
+# ahead of the latest v* tag, then dispatches publish.yml.
+#
+# Closes the gap #51 describes: the manual `git tag && git push --tags`
+# step in the release workflow was occasionally skipped (e.g. v0.49.0,
+# v0.50.0) causing npm publishes to silently not happen.
+#
+# Note: a tag pushed by the default GITHUB_TOKEN does NOT trigger
+# workflows keyed on `push: tags` (GitHub anti-recursion rule), so we
+# explicitly dispatch publish.yml afterwards.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - package.json
+      - packages/*/package.json
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine target tag
+        id: check
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists — nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $TAG missing — will create."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.check.outputs.tag }}" \
+            -m "Release ${{ steps.check.outputs.tag }}"
+          git push origin "${{ steps.check.outputs.tag }}"
+
+      - name: Dispatch publish.yml
+        if: steps.check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish.yml


### PR DESCRIPTION
## Summary

Closes #51. Replaces the manual `git tag && git push --tags` step in the release workflow with a GitHub Action that:

1. Fires on push to `main` (filtered to package.json changes)
2. Reads root package.json version
3. If `v$VERSION` tag already exists → skip (idempotent)
4. Otherwise: create annotated tag, push, then dispatch `publish.yml`

## Why the dispatch step

GitHub's [anti-recursion rule](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) means a tag pushed by the default `GITHUB_TOKEN` does **not** fire workflows keyed on `push: tags`. So we push the tag (for historical record / release visibility) and then explicitly `gh workflow run publish.yml` to trigger the existing npm publish flow.

No new secret needed — `GITHUB_TOKEN` with `actions: write` can dispatch workflows.

## What this prevents

Per #51: v0.49.0 and v0.50.0 both shipped to main as version-bump PRs but never got tagged, so `publish.yml` (trigger: `push: tags: 'v*'`) never fired. npm stayed on an older version until the miss was spotted and tagged retroactively. With this workflow, the tag + publish happen deterministically from `package.json`.

## Safety properties

- **Idempotent**: already-existing tags are skipped, so re-pushing the same commit is safe.
- **Initial deployment is a no-op**: current repo state is `main@0.52.1`, and `v0.52.1` tag already exists — first push after merge detects match and exits.
- **Path filter scoped to `package.json`**: doc-only / source-only commits don't trigger the workflow.
- **Manual trigger retained**: `workflow_dispatch` kept for testing / recovery.

## Not in this PR

Option C from #51 (CI-level safety net that fails when main is ahead of latest tag) — deferred. This workflow replaces the manual step deterministically; if it ever fails it'll surface in the Actions tab.

## Test plan

- [ ] CI green
- [ ] After merge: verify workflow visible in Actions tab
- [ ] Dispatch manually once via `workflow_dispatch` to confirm "skip" path on current state (tag v0.52.1 exists)
- [ ] Next version bump PR: confirm auto-tag + publish fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)