### PR TITLE
feat(scene): scaffold vibe scene init + bilingual project layout (MVP 1 c1/8)

### DIFF
--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, writeFile, mkdir, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { parse as yamlParse } from "yaml";
+
+import {
+  aspectToDims,
+  buildEmptyRootHtml,
+  buildHyperframesConfig,
+  buildHyperframesMeta,
+  buildProjectClaudeMd,
+  buildSceneGitignore,
+  defaultVibeProjectConfig,
+  mergeHyperframesConfig,
+  scaffoldSceneProject,
+  type HyperframesConfig,
+} from "./scene-project.js";
+
+async function makeTmp(label = "vibe-scene-test-"): Promise<string> {
+  return mkdtemp(join(tmpdir(), label));
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+describe("aspectToDims", () => {
+  it.each([
+    ["16:9", 1920, 1080],
+    ["9:16", 1080, 1920],
+    ["1:1",  1080, 1080],
+    ["4:5",  1080, 1350],
+  ] as const)("%s → %dx%d", (ratio, w, h) => {
+    expect(aspectToDims(ratio)).toEqual({ width: w, height: h });
+  });
+});
+
+describe("buildHyperframesConfig", () => {
+  it("produces the shape expected by hyperframes CLI", () => {
+    const cfg = buildHyperframesConfig();
+    expect(cfg.$schema).toContain("hyperframes.json");
+    expect(cfg.paths).toEqual({
+      blocks: "compositions",
+      components: "compositions/components",
+      assets: "assets",
+    });
+  });
+});
+
+describe("buildHyperframesMeta", () => {
+  it("uses project name as both id and name", () => {
+    const meta = buildHyperframesMeta("my-video", new Date("2026-04-25T00:00:00Z"));
+    expect(meta).toEqual({
+      id: "my-video",
+      name: "my-video",
+      createdAt: "2026-04-25T00:00:00.000Z",
+    });
+  });
+});
+
+describe("mergeHyperframesConfig", () => {
+  it("preserves existing top-level keys", () => {
+    const existing: HyperframesConfig = {
+      $schema: "custom-schema",
+      registry: "https://my.registry/",
+      customField: "user-value",
+    };
+    const merged = mergeHyperframesConfig(existing, buildHyperframesConfig());
+    expect(merged.$schema).toBe("custom-schema");
+    expect(merged.registry).toBe("https://my.registry/");
+    expect(merged.customField).toBe("user-value");
+  });
+
+  it("shallow-merges nested paths preserving user keys", () => {
+    const existing: HyperframesConfig = {
+      paths: { blocks: "custom-blocks", assets: "media" },
+    };
+    const merged = mergeHyperframesConfig(existing, buildHyperframesConfig());
+    expect(merged.paths).toEqual({
+      blocks: "custom-blocks",         // preserved
+      components: "compositions/components", // from defaults
+      assets: "media",                 // preserved
+    });
+  });
+
+  it("falls back to defaults when existing is empty", () => {
+    const merged = mergeHyperframesConfig({}, buildHyperframesConfig());
+    expect(merged).toEqual(buildHyperframesConfig());
+  });
+});
+
+describe("buildEmptyRootHtml", () => {
+  it("embeds aspect-correct canvas dimensions", () => {
+    const html = buildEmptyRootHtml({ aspect: "9:16", duration: 12 });
+    expect(html).toContain("width: 1080px");
+    expect(html).toContain("height: 1920px");
+    expect(html).toContain('data-duration="12"');
+    expect(html).toContain('data-composition-id="main"');
+  });
+
+  it("registers a paused main timeline", () => {
+    const html = buildEmptyRootHtml({ aspect: "16:9", duration: 5 });
+    expect(html).toContain('window.__timelines["main"] = gsap.timeline({ paused: true });');
+  });
+});
+
+describe("buildProjectClaudeMd", () => {
+  it("names the project and references both toolchains", () => {
+    const md = buildProjectClaudeMd("my-promo");
+    expect(md).toContain("# my-promo");
+    expect(md).toContain("/vibe-scene");
+    expect(md).toContain("/hyperframes");
+    expect(md).toContain("vibe scene add");
+    expect(md).toContain("npx hyperframes");
+  });
+});
+
+describe("buildSceneGitignore", () => {
+  it("excludes caches and rendered outputs", () => {
+    const out = buildSceneGitignore();
+    expect(out).toContain(".vibeframe/cache/");
+    expect(out).toContain("renders/*.mp4");
+  });
+});
+
+describe("defaultVibeProjectConfig", () => {
+  it("produces sane defaults", () => {
+    const cfg = defaultVibeProjectConfig("promo");
+    expect(cfg.name).toBe("promo");
+    expect(cfg.aspect).toBe("16:9");
+    expect(cfg.defaultSceneDuration).toBe(5);
+    expect(cfg.providers).toEqual({ image: null, tts: null, transcribe: null });
+    expect(cfg.budget.maxUsd).toBe(0);
+  });
+});
+
+describe("scaffoldSceneProject", () => {
+  it("creates all expected files in an empty directory", async () => {
+    const dir = await makeTmp();
+    const result = await scaffoldSceneProject({
+      dir,
+      name: "fixture",
+      aspect: "16:9",
+      duration: 8,
+      now: new Date("2026-04-25T00:00:00Z"),
+    });
+
+    const expected = [
+      "hyperframes.json",
+      "meta.json",
+      "index.html",
+      "vibe.project.yaml",
+      "CLAUDE.md",
+      ".gitignore",
+    ];
+    for (const f of expected) {
+      expect(await pathExists(resolve(dir, f))).toBe(true);
+    }
+    expect(await pathExists(resolve(dir, "compositions"))).toBe(true);
+    expect(await pathExists(resolve(dir, "assets"))).toBe(true);
+
+    expect(result.created.length).toBe(expected.length);
+    expect(result.merged).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it("vibe.project.yaml parses as valid YAML and carries the chosen aspect", async () => {
+    const dir = await makeTmp();
+    await scaffoldSceneProject({ dir, name: "fixture", aspect: "9:16", duration: 10 });
+    const raw = await readFile(resolve(dir, "vibe.project.yaml"), "utf-8");
+    const parsed = yamlParse(raw);
+    expect(parsed).toMatchObject({
+      name: "fixture",
+      aspect: "9:16",
+      defaultSceneDuration: 5,
+      providers: { image: null, tts: null, transcribe: null },
+    });
+  });
+
+  it("is idempotent: running twice is a no-op (no overwrites of user-editable files)", async () => {
+    const dir = await makeTmp();
+    const first = await scaffoldSceneProject({ dir, name: "fixture" });
+    const claudeBefore = await readFile(resolve(dir, "CLAUDE.md"), "utf-8");
+
+    // User edits CLAUDE.md
+    await writeFile(resolve(dir, "CLAUDE.md"), claudeBefore + "\n\n## My notes\n\nHand-written.\n", "utf-8");
+
+    const second = await scaffoldSceneProject({ dir, name: "fixture" });
+    const claudeAfter = await readFile(resolve(dir, "CLAUDE.md"), "utf-8");
+
+    // CLAUDE.md edit survives.
+    expect(claudeAfter).toContain("Hand-written.");
+    // Second run reports every non-hyperframes.json file as skipped.
+    expect(second.created).toEqual([]);
+    expect(second.skipped.length).toBeGreaterThan(0);
+    // hyperframes.json is always merge-updated (idempotent shape).
+    expect(second.merged.map((p) => p.split("/").pop())).toContain("hyperframes.json");
+    // First run created hyperframes.json; second merged it.
+    expect(first.created.map((p) => p.split("/").pop())).toContain("hyperframes.json");
+  });
+
+  it("preserves user keys in existing hyperframes.json (merge, not overwrite)", async () => {
+    const dir = await makeTmp();
+    await mkdir(dir, { recursive: true });
+    // Pre-seed a Hyperframes project with custom paths + user field.
+    const preExisting = {
+      $schema: "https://hyperframes.heygen.com/schema/hyperframes.json",
+      paths: { blocks: "custom-blocks", assets: "media" },
+      userField: "kept",
+    };
+    await writeFile(resolve(dir, "hyperframes.json"), JSON.stringify(preExisting, null, 2) + "\n", "utf-8");
+
+    const result = await scaffoldSceneProject({ dir, name: "fixture" });
+
+    const merged = JSON.parse(await readFile(resolve(dir, "hyperframes.json"), "utf-8"));
+    expect(merged.userField).toBe("kept");
+    expect(merged.paths.blocks).toBe("custom-blocks");
+    expect(merged.paths.assets).toBe("media");
+    // Default key backfilled:
+    expect(merged.paths.components).toBe("compositions/components");
+
+    expect(result.merged.some((p) => p.endsWith("hyperframes.json"))).toBe(true);
+  });
+
+  it("creates index.html with the correct aspect", async () => {
+    const dir = await makeTmp();
+    await scaffoldSceneProject({ dir, name: "fixture", aspect: "1:1", duration: 6 });
+    const html = await readFile(resolve(dir, "index.html"), "utf-8");
+    expect(html).toContain("width: 1080px");
+    expect(html).toContain("height: 1080px");
+    expect(html).toContain('data-duration="6"');
+  });
+});

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -1,0 +1,357 @@
+/**
+ * @module _shared/scene-project
+ *
+ * Helpers for scaffolding a "scene project" — a directory that works as both
+ * a VibeFrame project (via `vibe.project.yaml`) AND a HeyGen Hyperframes
+ * project (via `hyperframes.json` + `meta.json` + `index.html`). Either
+ * toolchain can be run inside the directory.
+ *
+ * Pure functions; no I/O beyond `scaffoldSceneProject()` which orchestrates
+ * file writes. Everything else returns strings or JSON-serializable objects
+ * so it can be unit-tested without touching the filesystem.
+ */
+
+import { mkdir, readFile, writeFile, access } from "node:fs/promises";
+import { resolve, basename } from "node:path";
+import { stringify as yamlStringify } from "yaml";
+
+/** Supported aspect ratios for scene projects (maps to CSS canvas dims). */
+export type SceneAspect = "16:9" | "9:16" | "1:1" | "4:5";
+
+const ASPECT_DIMS: Record<SceneAspect, { width: number; height: number }> = {
+  "16:9": { width: 1920, height: 1080 },
+  "9:16": { width: 1080, height: 1920 },
+  "1:1":  { width: 1080, height: 1080 },
+  "4:5":  { width: 1080, height: 1350 },
+};
+
+export function aspectToDims(aspect: SceneAspect): { width: number; height: number } {
+  return ASPECT_DIMS[aspect];
+}
+
+/** Shape of the Hyperframes project config file. */
+export interface HyperframesConfig {
+  $schema?: string;
+  registry?: string;
+  paths?: {
+    blocks?: string;
+    components?: string;
+    assets?: string;
+  };
+  // Preserve unknown keys on merge so we don't clobber user edits.
+  [key: string]: unknown;
+}
+
+/** Shape of the Hyperframes meta file. */
+export interface HyperframesMeta {
+  id: string;
+  name: string;
+  createdAt: string;
+  [key: string]: unknown;
+}
+
+/** Shape of the new VibeFrame-specific project config. */
+export interface VibeProjectConfig {
+  name: string;
+  aspect: SceneAspect;
+  /** Default scene duration in seconds when none is inferred from narration. */
+  defaultSceneDuration: number;
+  /** Default providers per capability. `null` means "auto-resolve from env". */
+  providers: {
+    image: "openai" | "gemini" | "grok" | null;
+    tts: "elevenlabs" | null;
+    transcribe: "whisper" | null;
+  };
+  /** Cost ceiling for `vibe pipeline` runs in this project. 0 disables. */
+  budget: { maxUsd: number };
+}
+
+/** Defaults for a fresh scene project. */
+export function defaultVibeProjectConfig(name: string): VibeProjectConfig {
+  return {
+    name,
+    aspect: "16:9",
+    defaultSceneDuration: 5,
+    providers: { image: null, tts: null, transcribe: null },
+    budget: { maxUsd: 0 },
+  };
+}
+
+/** The Hyperframes config we write on init. Matches the format at
+ *  hyperframe-learn/my-first-video/hyperframes.json.
+ */
+export function buildHyperframesConfig(): HyperframesConfig {
+  return {
+    $schema: "https://hyperframes.heygen.com/schema/hyperframes.json",
+    registry: "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+    paths: {
+      blocks: "compositions",
+      components: "compositions/components",
+      assets: "assets",
+    },
+  };
+}
+
+export function buildHyperframesMeta(name: string, now: Date = new Date()): HyperframesMeta {
+  return { id: name, name, createdAt: now.toISOString() };
+}
+
+/**
+ * Merge an existing Hyperframes config with our defaults, preserving any
+ * user-authored keys and nested values. `vibe scene init` is idempotent:
+ * running it on a directory that already has `hyperframes.json` must never
+ * lose user config.
+ */
+export function mergeHyperframesConfig(
+  existing: HyperframesConfig,
+  defaults: HyperframesConfig,
+): HyperframesConfig {
+  const out: HyperframesConfig = { ...defaults, ...existing };
+  // Preserve nested `paths` by shallow-merging.
+  if (existing.paths || defaults.paths) {
+    out.paths = { ...(defaults.paths ?? {}), ...(existing.paths ?? {}) };
+  }
+  return out;
+}
+
+/**
+ * Minimal valid Hyperframes root composition — empty (no sub-compositions
+ * yet). A later `vibe scene add` inserts `<div class="clip" ...>` children.
+ */
+export function buildEmptyRootHtml(opts: { aspect: SceneAspect; duration: number }): string {
+  const { width, height } = ASPECT_DIMS[opts.aspect];
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=${width}, height=${height}" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        margin: 0;
+        width: ${width}px;
+        height: ${height}px;
+        overflow: hidden;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="main"
+      data-start="0"
+      data-duration="${opts.duration}"
+      data-width="${width}"
+      data-height="${height}"
+    >
+      <!-- Scenes will be inserted here by \`vibe scene add\`.
+           Each scene is a <div class="clip" data-composition-src="compositions/*.html"
+           data-start="..." data-duration="..." data-track-index="1"></div>. -->
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      window.__timelines["main"] = gsap.timeline({ paused: true });
+    </script>
+  </body>
+</html>
+`;
+}
+
+/** Project-local CLAUDE.md that orients an AI agent to both toolchains. */
+export function buildProjectClaudeMd(name: string): string {
+  return `# ${name} — Scene Authoring Project
+
+This project is **bilingual**: it works with both VibeFrame (\`vibe\`) and
+HeyGen Hyperframes (\`hyperframes\`). You can run either CLI inside this
+directory.
+
+## Skills — USE THESE FIRST
+
+**Always invoke the relevant skill before authoring scenes.** Skills encode
+framework-specific patterns (GSAP timeline registration, data-attribute
+semantics, VibeFrame pipeline conventions) that are NOT in generic web docs.
+
+| Skill             | Command          | When to use                                                                           |
+| ----------------- | ---------------- | ------------------------------------------------------------------------------------- |
+| **vibe-scene**    | \`/vibe-scene\`    | Authoring / editing per-scene HTML in this project — preferred                        |
+| **hyperframes**   | \`/hyperframes\`   | Fallback: direct HF authoring (install via \`npx skills add heygen-com/hyperframes\`) |
+| **gsap**          | \`/gsap\`          | GSAP tweens, timelines, easing                                                        |
+
+If the skill is not available, follow the **Key Rules** below.
+
+## Project structure
+
+- \`index.html\` — root composition (timeline)
+- \`compositions/scene-*.html\` — per-scene HTML authored by you or the agent
+- \`assets/\` — shared media (narration audio, images, video)
+- \`transcript.json\` — Whisper word-level transcript (if narration exists)
+- \`hyperframes.json\` — HF registry config (speak to both toolchains)
+- \`vibe.project.yaml\` — VibeFrame config (providers, budget)
+- \`renders/\` — output MP4s
+
+## Commands
+
+\`\`\`bash
+vibe scene add <name> --narration "..." --visuals "..."   # Author a new scene via AI
+vibe scene lint                                             # Validate scenes (in-process HF linter)
+vibe scene render                                           # Render to MP4
+
+# Hyperframes CLI (if installed — works in this project too)
+npx hyperframes preview
+npx hyperframes render
+\`\`\`
+
+## Key Rules (for hand-authored scene HTML)
+
+1. Every timed element needs \`data-start\`, \`data-duration\`, and \`data-track-index\`.
+2. Elements with timing **MUST** have \`class="clip"\` — the framework uses this for visibility control.
+3. Timelines must be paused and registered on \`window.__timelines\`:
+   \`\`\`js
+   window.__timelines = window.__timelines || {};
+   window.__timelines["composition-id"] = gsap.timeline({ paused: true });
+   \`\`\`
+4. Videos use \`muted\` with a separate \`<audio>\` element for the audio track.
+5. Sub-compositions use \`data-composition-src="compositions/file.html"\`.
+6. Only deterministic logic — no \`Date.now()\`, \`Math.random()\`, or network fetches.
+
+## Linting — run after changes
+
+\`\`\`bash
+vibe scene lint           # preferred — in-process, no network
+vibe scene lint --fix     # auto-fix mechanical issues
+vibe scene lint --json    # structured output for agent loops
+\`\`\`
+`;
+}
+
+/** Minimal .gitignore for a scene project. */
+export function buildSceneGitignore(): string {
+  return `# VibeFrame caches
+.vibeframe/cache/
+.vibeframe/checkpoints/
+
+# Render outputs
+renders/*.mp4
+tmp/
+
+# OS / editor
+.DS_Store
+*.log
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem orchestration
+// ---------------------------------------------------------------------------
+
+export interface ScaffoldOptions {
+  dir: string;
+  name?: string;
+  aspect?: SceneAspect;
+  duration?: number;
+  now?: Date;
+}
+
+export interface ScaffoldResult {
+  /** Files written (absolute paths). */
+  created: string[];
+  /** Files that already existed and were NOT overwritten. */
+  skipped: string[];
+  /** Files that were merge-updated (currently only hyperframes.json). */
+  merged: string[];
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Scaffold (or update) a scene project at `dir`. Idempotent: running twice is
+ * a no-op; running on an existing Hyperframes project merges `hyperframes.json`
+ * instead of overwriting.
+ */
+export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<ScaffoldResult> {
+  const dir = resolve(opts.dir);
+  const name = opts.name ?? basename(dir);
+  const aspect: SceneAspect = opts.aspect ?? "16:9";
+  const duration = opts.duration ?? 10;
+  const now = opts.now ?? new Date();
+
+  await mkdir(dir, { recursive: true });
+  await mkdir(resolve(dir, "compositions"), { recursive: true });
+  await mkdir(resolve(dir, "assets"), { recursive: true });
+
+  const created: string[] = [];
+  const skipped: string[] = [];
+  const merged: string[] = [];
+
+  // hyperframes.json — merge if exists, else create.
+  const hfPath = resolve(dir, "hyperframes.json");
+  const hfDefaults = buildHyperframesConfig();
+  if (await pathExists(hfPath)) {
+    const existingRaw = await readFile(hfPath, "utf-8");
+    const existing = JSON.parse(existingRaw) as HyperframesConfig;
+    const mergedConfig = mergeHyperframesConfig(existing, hfDefaults);
+    await writeFile(hfPath, JSON.stringify(mergedConfig, null, 2) + "\n", "utf-8");
+    merged.push(hfPath);
+  } else {
+    await writeFile(hfPath, JSON.stringify(hfDefaults, null, 2) + "\n", "utf-8");
+    created.push(hfPath);
+  }
+
+  // meta.json — preserve existing (id shouldn't change).
+  const metaPath = resolve(dir, "meta.json");
+  if (await pathExists(metaPath)) {
+    skipped.push(metaPath);
+  } else {
+    await writeFile(metaPath, JSON.stringify(buildHyperframesMeta(name, now), null, 2) + "\n", "utf-8");
+    created.push(metaPath);
+  }
+
+  // index.html — preserve existing (user may have edited root).
+  const rootPath = resolve(dir, "index.html");
+  if (await pathExists(rootPath)) {
+    skipped.push(rootPath);
+  } else {
+    await writeFile(rootPath, buildEmptyRootHtml({ aspect, duration }), "utf-8");
+    created.push(rootPath);
+  }
+
+  // vibe.project.yaml — preserve existing; this is VibeFrame's own config.
+  const vibePath = resolve(dir, "vibe.project.yaml");
+  if (await pathExists(vibePath)) {
+    skipped.push(vibePath);
+  } else {
+    const cfg = { ...defaultVibeProjectConfig(name), aspect };
+    await writeFile(vibePath, yamlStringify(cfg), "utf-8");
+    created.push(vibePath);
+  }
+
+  // CLAUDE.md — preserve existing.
+  const claudePath = resolve(dir, "CLAUDE.md");
+  if (await pathExists(claudePath)) {
+    skipped.push(claudePath);
+  } else {
+    await writeFile(claudePath, buildProjectClaudeMd(name), "utf-8");
+    created.push(claudePath);
+  }
+
+  // .gitignore — preserve existing.
+  const gitignorePath = resolve(dir, ".gitignore");
+  if (await pathExists(gitignorePath)) {
+    skipped.push(gitignorePath);
+  } else {
+    await writeFile(gitignorePath, buildSceneGitignore(), "utf-8");
+    created.push(gitignorePath);
+  }
+
+  return { created, skipped, merged };
+}

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -1,0 +1,114 @@
+/**
+ * @module scene
+ *
+ * `vibe scene <sub>` — author, lint, and render per-scene HTML projects that
+ * target the Hyperframes render backend. A scene project is bilingual: it's
+ * also a valid Hyperframes project (hyperframes.json + meta.json +
+ * index.html + compositions/). Users and AI agents can hand-author rich per-
+ * scene animation instead of relying on flat YAML steps or opaque MP4s.
+ *
+ * Subcommands land incrementally across MVP 1:
+ *   - init      [C1, this commit] — scaffold project directory
+ *   - add       [C2]
+ *   - lint      [C3]
+ *   - render    [C4]
+ */
+
+import { Command } from "commander";
+import { basename } from "node:path";
+import chalk from "chalk";
+import ora from "ora";
+import {
+  scaffoldSceneProject,
+  type SceneAspect,
+} from "./_shared/scene-project.js";
+import { exitWithError, generalError, usageError, outputResult, isJsonMode } from "./output.js";
+
+const VALID_ASPECTS: SceneAspect[] = ["16:9", "9:16", "1:1", "4:5"];
+
+function validateAspect(value: string): SceneAspect {
+  if (!VALID_ASPECTS.includes(value as SceneAspect)) {
+    exitWithError(usageError(`Invalid aspect ratio: ${value}`, `Valid: ${VALID_ASPECTS.join(", ")}`));
+  }
+  return value as SceneAspect;
+}
+
+function validateDuration(value: string): number {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n) || n <= 0 || n > 3600) {
+    exitWithError(usageError(`Invalid duration: ${value}`, "Duration must be a positive number of seconds (≤3600)"));
+  }
+  return n;
+}
+
+export const sceneCommand = new Command("scene")
+  .description("Author and render per-scene HTML compositions (Hyperframes backend)")
+  .addHelpText("after", `
+Examples:
+  $ vibe scene init my-video                       # Scaffold a new scene project
+  $ vibe scene init my-video -r 9:16 -d 30         # Vertical 30s project
+  $ vibe scene init existing-hf-project            # Safe — merges with existing hyperframes.json
+
+A scene project is bilingual: it works with both \`vibe\` and \`npx hyperframes\`.
+Run 'vibe schema scene.<command>' for structured parameter info.`);
+
+sceneCommand
+  .command("init")
+  .description("Scaffold a new scene project (or safely augment an existing Hyperframes project)")
+  .argument("<dir>", "Project directory (created if it doesn't exist)")
+  .option("-n, --name <name>", "Project name (defaults to directory basename)")
+  .option("-r, --ratio <ratio>", "Aspect ratio: 16:9, 9:16, 1:1, 4:5", "16:9")
+  .option("-d, --duration <sec>", "Default root composition duration (seconds)", "10")
+  .option("--dry-run", "Preview parameters without writing files")
+  .action(async (dir: string, options) => {
+    const aspect = validateAspect(options.ratio);
+    const duration = validateDuration(options.duration);
+    const name = (options.name as string | undefined) ?? basename(dir.replace(/\/+$/, ""));
+
+    if (options.dryRun) {
+      outputResult({
+        dryRun: true,
+        command: "scene init",
+        params: { dir, name, aspect, duration },
+      });
+      return;
+    }
+
+    const spinner = isJsonMode() ? null : ora(`Scaffolding scene project at ${dir}...`).start();
+    try {
+      const result = await scaffoldSceneProject({ dir, name, aspect, duration });
+
+      if (isJsonMode()) {
+        outputResult({
+          success: true,
+          command: "scene init",
+          dir,
+          name,
+          aspect,
+          duration,
+          created: result.created,
+          merged: result.merged,
+          skipped: result.skipped,
+        });
+        return;
+      }
+
+      spinner?.succeed(chalk.green(`Scene project ready: ${dir}`));
+      console.log();
+      console.log(chalk.bold.cyan("Files"));
+      console.log(chalk.dim("─".repeat(60)));
+      for (const f of result.created) console.log(chalk.green("  +"), f);
+      for (const f of result.merged)  console.log(chalk.yellow("  ~"), f, chalk.dim("(merged)"));
+      for (const f of result.skipped) console.log(chalk.dim("  ·"), f, chalk.dim("(kept existing)"));
+      console.log();
+      console.log(chalk.bold.cyan("Next steps"));
+      console.log(chalk.dim("─".repeat(60)));
+      console.log(`  ${chalk.cyan("vibe scene add")} <name>    ${chalk.dim("# author a scene via AI")}`);
+      console.log(`  ${chalk.cyan("vibe scene lint")}          ${chalk.dim("# validate HTML")}`);
+      console.log(`  ${chalk.cyan("vibe scene render")}        ${chalk.dim("# render to MP4")}`);
+    } catch (error) {
+      spinner?.fail("Failed to scaffold scene project");
+      const msg = error instanceof Error ? error.message : String(error);
+      exitWithError(generalError(`Failed to scaffold: ${msg}`));
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ const pkg = require("../package.json");
 // Re-export engine for library usage
 export { Project, generateId, type ProjectFile } from "./engine/index.js";
 import { projectCommand } from "./commands/project.js";
+import { sceneCommand } from "./commands/scene.js";
 import { timelineCommand } from "./commands/timeline.js";
 import { generateCommand } from "./commands/generate.js";
 import { editCommand } from "./commands/edit-cmd.js";
@@ -197,6 +198,7 @@ program.addCommand(agentCommand);
 
 // Workflow commands
 program.addCommand(projectCommand);
+program.addCommand(sceneCommand);
 program.addCommand(timelineCommand);
 program.addCommand(exportCommand);
 program.addCommand(detectCommand);


### PR DESCRIPTION
## Summary

First installment of the **scene-authoring MVP 1** from the Hyperframes integration plan. Lands `vibe scene init <dir>` — a scaffolder for a project directory that works as **both** a VibeFrame project (`vibe.project.yaml`) and a HeyGen Hyperframes project (`hyperframes.json` + `meta.json` + `index.html` + `compositions/`).

This is the foundation. No release in this PR — `v0.52.1` stays current. Version bump waits for MVP 1 c8.

## What ships

- `vibe scene init <dir>` (Commander subcommand under new `scene` group)
  - Flags: `-r/--ratio` (16:9, 9:16, 1:1, 4:5), `-d/--duration`, `-n/--name`, `--dry-run`
  - Creates 6 files + 2 directories, idempotent on re-run
  - Merges, never overwrites, an existing `hyperframes.json` (preserves user keys + nested `paths`)
  - Keeps any user edits to `index.html`, `CLAUDE.md`, `vibe.project.yaml` on subsequent runs

- New shared module `packages/cli/src/commands/_shared/scene-project.ts` — pure helpers (no I/O except the orchestrating `scaffoldSceneProject`):
  - `aspectToDims`, `buildHyperframesConfig`, `buildHyperframesMeta`, `mergeHyperframesConfig`, `buildEmptyRootHtml`, `buildProjectClaudeMd`, `buildSceneGitignore`, `defaultVibeProjectConfig`

- 19 unit tests covering: aspect dims, HF config shape, merge invariants (top-level keys, nested paths, empty fallback), HTML aspect/duration embedding, idempotence (CLAUDE.md edit survives re-run), pre-existing HF project merge.

## What does NOT ship in this PR

The remaining 7 commits of MVP 1 (`scene add` / `lint` / `render`, `--format scenes` script-to-video, agent+MCP tools, `/vibe-scene` skill, example, version bump). They follow in subsequent PRs on this branch or as separate PRs.

Each will be bisectable on its own.

## Smoke test

```
$ pnpm vibe scene init /tmp/vibe-scene-smoke -r 9:16 -d 8
{
  "success": true, "command": "scene init", "dir": "/tmp/vibe-scene-smoke",
  "name": "vibe-scene-smoke", "aspect": "9:16", "duration": 8,
  "created": [".../hyperframes.json", ".../meta.json", ".../index.html",
              ".../vibe.project.yaml", ".../CLAUDE.md", ".../.gitignore"]
}

$ pnpm vibe scene init /tmp/vibe-scene-smoke   # re-run
{
  "success": true, "created": [],
  "merged":  ["/tmp/vibe-scene-smoke/hyperframes.json"],
  "skipped": [".../meta.json", ".../index.html", ".../vibe.project.yaml",
              ".../CLAUDE.md", ".../.gitignore"]
}
```

`index.html` shape (vertical 9:16 example):
```html
<meta name="viewport" content="width=1080, height=1920" />
...
<div id="root" data-composition-id="main" data-start="0" data-duration="8"
     data-width="1080" data-height="1920">
  <!-- Scenes will be inserted here by `vibe scene add`. -->
</div>
<script>
  window.__timelines = window.__timelines || {};
  window.__timelines["main"] = gsap.timeline({ paused: true });
</script>
```

## Plan reference

Full plan including the remaining 7-commit sequence and Phase A follow-up: `/Users/kiyeonjeon/.claude/plans/magical-booping-blossom.md` (local).

## Test plan

- [x] `pnpm -F @vibeframe/cli build` — clean
- [x] `pnpm -F @vibeframe/cli test` — 305 passed (19 new + 286 existing), 11 skipped
- [x] Smoke: scaffold + idempotent re-run
- [x] Smoke: scaffold over a pre-seeded `hyperframes.json` preserves user keys (test in suite)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)