### PR TITLE
feat(scene): add template-based vibe scene add (MVP 1 c2/8)

### DIFF
--- a/packages/cli/src/commands/_shared/scene-html-emit.test.ts
+++ b/packages/cli/src/commands/_shared/scene-html-emit.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildClipReference,
+  emitSceneHtml,
+  insertClipIntoRoot,
+  nextSceneStart,
+  readRootDims,
+  slugifySceneName,
+  SCENE_PRESETS,
+  type ScenePreset,
+} from "./scene-html-emit.js";
+import { buildEmptyRootHtml } from "./scene-project.js";
+
+// ── slugifySceneName ────────────────────────────────────────────────────────
+
+describe("slugifySceneName", () => {
+  it.each([
+    ["intro",          "intro"],
+    ["My Intro",       "my-intro"],
+    ["Product Shot!",  "product-shot"],
+    ["scene  3 hello", "scene-3-hello"],
+    ["__weird__name", "weird-name"],
+    ["",              "scene"],
+    ["!!!",           "scene"],
+  ])("%j → %j", (input, expected) => {
+    expect(slugifySceneName(input)).toBe(expected);
+  });
+});
+
+// ── nextSceneStart ──────────────────────────────────────────────────────────
+
+describe("nextSceneStart", () => {
+  it("returns 0 for an empty root", () => {
+    const root = buildEmptyRootHtml({ aspect: "16:9", duration: 10 });
+    expect(nextSceneStart(root)).toBe(0);
+  });
+
+  it("returns the max end-time of existing clips", () => {
+    const root = `
+      <div class="clip" data-composition-src="a.html" data-start="0" data-duration="3" data-track-index="1"></div>
+      <div class="clip" data-composition-src="b.html" data-start="3" data-duration="2.5" data-track-index="1"></div>
+    `;
+    expect(nextSceneStart(root)).toBeCloseTo(5.5, 5);
+  });
+
+  it("ignores clips with malformed data-start", () => {
+    const root = `<div class="clip" data-composition-src="x.html" data-start="oops" data-duration="2" data-track-index="1"></div>`;
+    expect(nextSceneStart(root)).toBe(0);
+  });
+});
+
+// ── buildClipReference ──────────────────────────────────────────────────────
+
+describe("buildClipReference", () => {
+  it("builds a Hyperframes-compatible clip div", () => {
+    const out = buildClipReference({ id: "intro", start: 0, duration: 4 });
+    expect(out).toContain('class="clip"');
+    expect(out).toContain('data-composition-src="compositions/scene-intro.html"');
+    expect(out).toContain('data-start="0"');
+    expect(out).toContain('data-duration="4"');
+    expect(out).toContain('data-track-index="1"');
+  });
+
+  it("respects an explicit track and src override", () => {
+    const out = buildClipReference({ id: "x", start: 1.234, duration: 2.345, trackIndex: 3, src: "custom/path.html" });
+    expect(out).toContain('data-composition-src="custom/path.html"');
+    expect(out).toContain('data-track-index="3"');
+    expect(out).toContain('data-start="1.234"');
+    expect(out).toContain('data-duration="2.345"');
+  });
+});
+
+// ── insertClipIntoRoot ──────────────────────────────────────────────────────
+
+describe("insertClipIntoRoot", () => {
+  it("inserts a clip before the root closing div", () => {
+    const root = buildEmptyRootHtml({ aspect: "16:9", duration: 10 });
+    const updated = insertClipIntoRoot(root, { id: "intro", start: 0, duration: 4 });
+    expect(updated).toContain('<div class="clip" data-composition-src="compositions/scene-intro.html"');
+    // The new clip must appear *before* the root's closing </div>
+    const clipIdx = updated.indexOf("compositions/scene-intro.html");
+    const rootCloseIdx = updated.lastIndexOf("</div>\n\n    <script>");
+    expect(clipIdx).toBeGreaterThan(0);
+    expect(rootCloseIdx).toBeGreaterThan(clipIdx);
+  });
+
+  it("grows root data-duration when clip end exceeds it but never shrinks", () => {
+    const root = buildEmptyRootHtml({ aspect: "16:9", duration: 10 });
+    const grown = insertClipIntoRoot(root, { id: "long", start: 0, duration: 14 });
+    expect(grown).toContain('data-duration="14"');
+
+    const stillShort = insertClipIntoRoot(root, { id: "short", start: 0, duration: 4 });
+    expect(stillShort).toContain('data-duration="10"');
+  });
+
+  it("appends sequentially and tracks the new start via nextSceneStart", () => {
+    let root = buildEmptyRootHtml({ aspect: "16:9", duration: 0 });
+
+    root = insertClipIntoRoot(root, { id: "a", start: 0, duration: 3 });
+    expect(nextSceneStart(root)).toBe(3);
+
+    root = insertClipIntoRoot(root, { id: "b", start: 3, duration: 2 });
+    expect(nextSceneStart(root)).toBe(5);
+
+    expect(root).toContain('data-composition-src="compositions/scene-a.html"');
+    expect(root).toContain('data-composition-src="compositions/scene-b.html"');
+  });
+
+  it("throws on a root that lacks the expected closing tag", () => {
+    const broken = "<html><body>no root</body></html>";
+    expect(() => insertClipIntoRoot(broken, { id: "x", start: 0, duration: 1 })).toThrow(/closing/);
+  });
+});
+
+// ── readRootDims ────────────────────────────────────────────────────────────
+
+describe("readRootDims", () => {
+  it("reads dims from the standard scaffold", () => {
+    const root = buildEmptyRootHtml({ aspect: "9:16", duration: 8 });
+    expect(readRootDims(root)).toEqual({ width: 1080, height: 1920 });
+  });
+
+  it("returns null when dims are missing", () => {
+    expect(readRootDims('<div id="root"></div>')).toBeNull();
+  });
+});
+
+// ── emitSceneHtml — shared invariants ───────────────────────────────────────
+
+const baseInput = {
+  id: "intro",
+  width: 1920,
+  height: 1080,
+  duration: 4,
+  headline: "Welcome to VibeFrame",
+};
+
+describe.each(SCENE_PRESETS)("emitSceneHtml(%s)", (preset: ScenePreset) => {
+  it("emits a Hyperframes-compatible composition", () => {
+    const html = emitSceneHtml({ ...baseInput, preset });
+    expect(html).toContain('<template id="scene-intro-template">');
+    expect(html).toContain('data-composition-id="intro"');
+    expect(html).toContain('data-start="0"');
+    expect(html).toContain('data-duration="4"');
+    expect(html).toContain('data-width="1920"');
+    expect(html).toContain('data-height="1080"');
+  });
+
+  it("registers a paused timeline keyed by the scene id", () => {
+    const html = emitSceneHtml({ ...baseInput, preset });
+    expect(html).toContain("gsap.timeline({ paused: true })");
+    expect(html).toContain('window.__timelines["intro"] = tl');
+  });
+
+  it("includes the audio element only when audioPath is given", () => {
+    const without = emitSceneHtml({ ...baseInput, preset });
+    expect(without).not.toContain("<audio");
+
+    const withAudio = emitSceneHtml({ ...baseInput, preset, audioPath: "assets/narration-intro.mp3" });
+    expect(withAudio).toContain('<audio');
+    expect(withAudio).toContain('src="assets/narration-intro.mp3"');
+    expect(withAudio).toContain('data-track-index="2"');
+  });
+
+  it("includes the backdrop image only when imagePath is given", () => {
+    const without = emitSceneHtml({ ...baseInput, preset });
+    expect(without).not.toContain("background-image: url(");
+
+    const withImage = emitSceneHtml({ ...baseInput, preset, imagePath: "assets/scene-intro.png" });
+    expect(withImage).toContain('background-image: url("assets/scene-intro.png")');
+  });
+});
+
+// ── emitSceneHtml — preset specifics ────────────────────────────────────────
+
+describe("emitSceneHtml — preset specifics", () => {
+  it("simple: shows narration as the caption", () => {
+    const html = emitSceneHtml({ ...baseInput, preset: "simple", subhead: "Hello world" });
+    expect(html).toContain("Hello world");
+    expect(html).toContain('id="caption"');
+  });
+
+  it("announcement: renders headline as the centered h1", () => {
+    const html = emitSceneHtml({ ...baseInput, preset: "announcement" });
+    expect(html).toMatch(/<h1[^>]*id="headline">\s*Welcome to VibeFrame\s*<\/h1>/);
+  });
+
+  it("explainer: renders kicker + title and includes subtitle when subhead is set", () => {
+    const html = emitSceneHtml({
+      ...baseInput,
+      preset: "explainer",
+      kicker: "Episode 1",
+      subhead: "Authoring videos with code",
+    });
+    expect(html).toContain('id="kicker"');
+    expect(html).toContain("Episode 1");
+    expect(html).toContain('id="subtitle"');
+    expect(html).toContain("Authoring videos with code");
+  });
+
+  it("explainer: omits the subtitle div when no subhead is provided", () => {
+    const html = emitSceneHtml({ ...baseInput, preset: "explainer" });
+    expect(html).not.toContain('id="subtitle"');
+  });
+
+  it("kinetic-type: emits one span per word", () => {
+    const html = emitSceneHtml({ ...baseInput, preset: "kinetic-type" });
+    // baseInput.headline = "Welcome to VibeFrame" → 3 words
+    expect(html).toContain('id="w-0"');
+    expect(html).toContain('id="w-1"');
+    expect(html).toContain('id="w-2"');
+    expect(html).not.toContain('id="w-3"');
+  });
+
+  it("product-shot: applies a Ken-Burns scale tween over the full duration", () => {
+    const html = emitSceneHtml({ ...baseInput, preset: "product-shot", duration: 6 });
+    expect(html).toContain("scale: 1.08, duration: 6.00");
+  });
+
+  it("escapes HTML metacharacters in headline + subhead", () => {
+    const html = emitSceneHtml({
+      id: "x",
+      preset: "simple",
+      width: 1920,
+      height: 1080,
+      duration: 3,
+      subhead: '<script>alert("xss")</script>',
+    });
+    expect(html).not.toContain("<script>alert");
+    expect(html).toContain("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;");
+  });
+
+  it("rejects non-positive durations", () => {
+    expect(() => emitSceneHtml({ ...baseInput, preset: "simple", duration: 0 })).toThrow(/duration/);
+    expect(() => emitSceneHtml({ ...baseInput, preset: "simple", duration: -1 })).toThrow(/duration/);
+  });
+
+  it("falls back to humanised id when no headline is provided", () => {
+    const html = emitSceneHtml({
+      id: "product-shot",
+      preset: "announcement",
+      width: 1920,
+      height: 1080,
+      duration: 4,
+    });
+    expect(html).toContain("Product Shot");
+  });
+});

--- a/packages/cli/src/commands/_shared/scene-html-emit.ts
+++ b/packages/cli/src/commands/_shared/scene-html-emit.ts
@@ -1,0 +1,445 @@
+/**
+ * @module _shared/scene-html-emit
+ *
+ * Pure HTML emitters for `vibe scene add`. Each preset produces a self-contained
+ * Hyperframes-compatible scene composition: a `<template>`-wrapped `<div
+ * data-composition-id>` with scoped CSS, optional audio/image, and a paused
+ * GSAP timeline registered on `window.__timelines`.
+ *
+ * Also exposes helpers that mutate the root index.html:
+ * - `nextSceneStart()` — sum existing clip end-times to choose the new start
+ * - `insertClipIntoRoot()` — splice a `<div class="clip">` reference before the
+ *   root's closing div, preserving the user's hand-edited markup
+ * - `slugifySceneName()` — name → kebab-case scene id
+ *
+ * Pure functions only — no I/O. The orchestrating command (`scene add`) wires
+ * these to the filesystem.
+ */
+export type ScenePreset =
+  | "simple"
+  | "announcement"
+  | "explainer"
+  | "kinetic-type"
+  | "product-shot";
+
+export const SCENE_PRESETS: readonly ScenePreset[] = [
+  "simple",
+  "announcement",
+  "explainer",
+  "kinetic-type",
+  "product-shot",
+] as const;
+
+export interface EmitSceneInput {
+  /** Kebab-case scene id; appears in `data-composition-id` and template id. */
+  id: string;
+  preset: ScenePreset;
+  /** Canvas width in px (must match the root composition). */
+  width: number;
+  /** Canvas height in px (must match the root composition). */
+  height: number;
+  /** Visible composition duration in seconds. */
+  duration: number;
+  /** Headline text — required for non-simple presets; defaulted from id. */
+  headline?: string;
+  /** Secondary text (subhead/caption). Often the narration. */
+  subhead?: string;
+  /** Optional small label above the headline (explainer / product-shot). */
+  kicker?: string;
+  /** Project-relative image path (e.g. "assets/scene-intro.png"). */
+  imagePath?: string;
+  /** Project-relative narration audio path (e.g. "assets/narration-intro.mp3"). */
+  audioPath?: string;
+}
+
+const GSAP_CDN = "https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js";
+
+/** Minimal HTML escaper for text we inline into elements/attributes. */
+function esc(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** Normalise whitespace and trim — used on user-supplied headlines/subheads. */
+function clean(text: string | undefined): string {
+  return (text ?? "").replace(/\s+/g, " ").trim();
+}
+
+/** Humanise a scene id — "product-shot" → "Product Shot". */
+function humanise(id: string): string {
+  return id
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Slugify a free-form scene name to a kebab-case id usable in HTML attributes
+ * and filenames. Strips diacritics, collapses whitespace, lowercases.
+ */
+export function slugifySceneName(name: string): string {
+  const normalised = name
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "");
+  const slug = normalised
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "scene";
+}
+
+// ---------------------------------------------------------------------------
+// Per-preset content + animation
+// ---------------------------------------------------------------------------
+
+interface PresetParts {
+  /** CSS rules scoped via `[data-composition-id="<id>"] ...`. */
+  css: string;
+  /** Body markup inside the composition root div (no trailing newline). */
+  body: string;
+  /** GSAP tween statements, each terminated with a semicolon. */
+  timeline: string;
+}
+
+function buildPreset(input: Required<Pick<EmitSceneInput, "id" | "preset" | "duration">> & EmitSceneInput): PresetParts {
+  const id = input.id;
+  const scope = `[data-composition-id="${id}"]`;
+  const headline = clean(input.headline) || humanise(id);
+  const subhead = clean(input.subhead);
+  const kicker = clean(input.kicker);
+  const dur = input.duration;
+  const hasImage = !!input.imagePath;
+
+  const backdrop = hasImage
+    ? `${scope} .backdrop {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        background-image: url("${esc(input.imagePath as string)}");
+        background-size: cover;
+        background-position: center;
+      }
+      ${scope} .backdrop::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(180deg, rgba(0,0,0,0.0) 30%, rgba(0,0,0,0.55) 100%);
+      }`
+    : `${scope} .backdrop {
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(ellipse at center, #1a1a2e 0%, #000 70%);
+      }`;
+  const backdropMarkup = `<div class="backdrop"></div>`;
+
+  switch (input.preset) {
+    case "simple": {
+      const caption = subhead || headline;
+      return {
+        css: `${scope} {
+        position: absolute; inset: 0; width: 100%; height: 100%;
+        font-family: -apple-system, "Helvetica Neue", Arial, sans-serif;
+        color: #fff; overflow: hidden; background: #000;
+      }
+      ${backdrop}
+      ${scope} .caption {
+        position: absolute;
+        left: 8%; right: 8%; bottom: 12%;
+        text-align: center;
+        font-size: 56px;
+        font-weight: 700;
+        line-height: 1.2;
+        text-shadow: 0 4px 20px rgba(0,0,0,0.65);
+      }`,
+        body: `${backdropMarkup}
+    <div class="caption" id="caption">${esc(caption)}</div>`,
+        timeline: `tl.from('${scope} .caption', { opacity: 0, y: 28, duration: 0.6, ease: 'power2.out' }, 0.1);
+      tl.to('${scope} .caption', { opacity: 0, duration: 0.4, ease: 'power2.in' }, ${(dur - 0.4).toFixed(2)});`,
+      };
+    }
+    case "announcement": {
+      return {
+        css: `${scope} {
+        position: absolute; inset: 0; width: 100%; height: 100%;
+        font-family: -apple-system, "Helvetica Neue", Arial, sans-serif;
+        color: #fff; overflow: hidden; background: #000;
+      }
+      ${backdrop}
+      ${scope} .announce {
+        position: absolute; inset: 0;
+        display: flex; align-items: center; justify-content: center;
+        text-align: center;
+        padding: 0 8%;
+      }
+      ${scope} .announce h1 {
+        margin: 0;
+        font-size: 160px;
+        font-weight: 900;
+        letter-spacing: -4px;
+        line-height: 1;
+        background: linear-gradient(90deg, #8e2de2, #00c9ff);
+        -webkit-background-clip: text; background-clip: text; color: transparent;
+        text-shadow: 0 8px 40px rgba(142,45,226,0.35);
+      }`,
+        body: `${backdropMarkup}
+    <div class="announce"><h1 id="headline">${esc(headline)}</h1></div>`,
+        timeline: `tl.from('${scope} #headline', { opacity: 0, scale: 0.8, duration: 0.9, ease: 'back.out(1.6)' }, 0.15);
+      tl.to('${scope} #headline', { opacity: 0, duration: 0.4, ease: 'power2.in' }, ${(dur - 0.4).toFixed(2)});`,
+      };
+    }
+    case "explainer": {
+      const k = kicker || humanise(id).toUpperCase();
+      const sub = subhead || "";
+      return {
+        css: `${scope} {
+        position: absolute; inset: 0; width: 100%; height: 100%;
+        font-family: -apple-system, "Helvetica Neue", Arial, sans-serif;
+        color: #fff; overflow: hidden; background: #000;
+      }
+      ${backdrop}
+      ${scope} .stage {
+        position: absolute; inset: 0;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 24px; padding: 0 10%;
+      }
+      ${scope} .kicker {
+        font-size: 28px; letter-spacing: 6px; text-transform: uppercase;
+        color: #00c9ff; font-weight: 600;
+      }
+      ${scope} .title {
+        font-size: 110px; font-weight: 800; letter-spacing: -2px;
+        line-height: 1.05; margin: 0;
+      }
+      ${scope} .subtitle {
+        font-size: 38px; font-weight: 300; color: #c0c0d0; max-width: 80%;
+      }`,
+        body: `${backdropMarkup}
+    <div class="stage">
+      <div class="kicker" id="kicker">${esc(k)}</div>
+      <h1 class="title" id="title">${esc(headline)}</h1>${sub ? `
+      <div class="subtitle" id="subtitle">${esc(sub)}</div>` : ""}
+    </div>`,
+        timeline: `tl.from('${scope} #kicker', { opacity: 0, y: 16, duration: 0.4, ease: 'power2.out' }, 0.1);
+      tl.from('${scope} #title', { opacity: 0, y: 60, duration: 0.7, ease: 'power3.out' }, 0.25);
+      ${sub ? `tl.from('${scope} #subtitle', { opacity: 0, y: 30, duration: 0.55, ease: 'power3.out' }, 0.55);` : ""}`,
+      };
+    }
+    case "kinetic-type": {
+      const words = headline.split(/\s+/).filter(Boolean);
+      const wordSpans = words
+        .map((w, i) => `<span class="word" id="w-${i}">${esc(w)}</span>`)
+        .join(" ");
+      const stagger = Math.max(0.08, Math.min(0.3, (dur - 0.6) / Math.max(words.length, 1)));
+      const tweens = words
+        .map((_, i) => {
+          const start = (0.05 + i * stagger).toFixed(2);
+          return `tl.from('${scope} #w-${i}', { opacity: 0, y: 80, scale: 0.8, duration: 0.45, ease: 'back.out(1.8)' }, ${start});`;
+        })
+        .join("\n      ");
+      return {
+        css: `${scope} {
+        position: absolute; inset: 0; width: 100%; height: 100%;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        color: #fff; overflow: hidden; background: #000;
+      }
+      ${backdrop}
+      ${scope} .kinetic {
+        position: absolute; inset: 0;
+        display: flex; align-items: center; justify-content: center;
+        text-align: center; padding: 0 6%;
+        font-size: 180px; font-weight: 900; letter-spacing: -6px;
+        line-height: 1; text-shadow: 0 6px 30px rgba(0,0,0,0.6);
+      }
+      ${scope} .kinetic .word { display: inline-block; margin: 0 12px; }`,
+        body: `${backdropMarkup}
+    <div class="kinetic">${wordSpans}</div>`,
+        timeline: tweens,
+      };
+    }
+    case "product-shot": {
+      const label = kicker || humanise(id);
+      return {
+        css: `${scope} {
+        position: absolute; inset: 0; width: 100%; height: 100%;
+        font-family: -apple-system, "Helvetica Neue", Arial, sans-serif;
+        color: #fff; overflow: hidden; background: #000;
+      }
+      ${backdrop}
+      ${scope} .backdrop { transform-origin: center; }
+      ${scope} .label {
+        position: absolute; top: 8%; left: 8%;
+        padding: 12px 24px; border-radius: 999px;
+        background: rgba(0,0,0,0.55); backdrop-filter: blur(6px);
+        font-size: 24px; font-weight: 600; letter-spacing: 2px;
+        text-transform: uppercase;
+      }
+      ${scope} .product-headline {
+        position: absolute; left: 8%; right: 8%; bottom: 14%;
+        font-size: 72px; font-weight: 800; letter-spacing: -1px;
+        line-height: 1.1; text-shadow: 0 4px 20px rgba(0,0,0,0.7);
+      }${subhead ? `
+      ${scope} .product-sub {
+        position: absolute; left: 8%; right: 8%; bottom: 8%;
+        font-size: 28px; font-weight: 400; color: #d0d0e0;
+        text-shadow: 0 2px 10px rgba(0,0,0,0.7);
+      }` : ""}`,
+        body: `${backdropMarkup}
+    <div class="label" id="label">${esc(label)}</div>
+    <div class="product-headline" id="headline">${esc(headline)}</div>${subhead ? `
+    <div class="product-sub" id="subhead">${esc(subhead)}</div>` : ""}`,
+        timeline: `tl.fromTo('${scope} .backdrop', { scale: 1.0 }, { scale: 1.08, duration: ${dur.toFixed(2)}, ease: 'none' }, 0);
+      tl.from('${scope} #label', { opacity: 0, x: -30, duration: 0.5, ease: 'power3.out' }, 0.2);
+      tl.from('${scope} #headline', { opacity: 0, y: 40, duration: 0.6, ease: 'power3.out' }, 0.4);${subhead ? `
+      tl.from('${scope} #subhead', { opacity: 0, y: 20, duration: 0.5, ease: 'power3.out' }, 0.65);` : ""}`,
+      };
+    }
+  }
+}
+
+/**
+ * Emit the full per-scene HTML. Returns a complete `<template>`-wrapped
+ * composition ready to write to `compositions/scene-<id>.html`.
+ */
+export function emitSceneHtml(input: EmitSceneInput): string {
+  if (input.duration <= 0) {
+    throw new Error(`Scene duration must be > 0, got ${input.duration}`);
+  }
+  if (input.width <= 0 || input.height <= 0) {
+    throw new Error(`Invalid canvas dims: ${input.width}x${input.height}`);
+  }
+
+  const id = input.id;
+  const dur = Number(input.duration.toFixed(3));
+  const parts = buildPreset({ ...input, id, duration: dur });
+
+  const audioBlock = input.audioPath
+    ? `\n    <audio
+      id="narration"
+      data-start="0"
+      data-duration="auto"
+      data-track-index="2"
+      src="${esc(input.audioPath)}"
+      data-volume="1"
+    ></audio>\n`
+    : "";
+
+  return `<template id="scene-${id}-template">
+  <div data-composition-id="${id}" data-start="0" data-duration="${dur}" data-width="${input.width}" data-height="${input.height}">
+    <style>
+      ${parts.css}
+    </style>
+
+    ${parts.body}
+${audioBlock}
+    <script src="${GSAP_CDN}"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+
+      ${parts.timeline}
+
+      window.__timelines["${id}"] = tl;
+    </script>
+  </div>
+</template>
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Root index.html mutation
+// ---------------------------------------------------------------------------
+
+/**
+ * Sum existing `<div class="clip">` end-times to find where the next scene
+ * should start. Returns 0 for an empty root.
+ */
+export function nextSceneStart(rootHtml: string): number {
+  const clipRegex = /<div\s+class="clip"[^>]*?\sdata-start="([\d.]+)"[^>]*?\sdata-duration="([\d.]+)"/gi;
+  let maxEnd = 0;
+  let match: RegExpExecArray | null;
+  while ((match = clipRegex.exec(rootHtml)) !== null) {
+    const end = parseFloat(match[1]) + parseFloat(match[2]);
+    if (Number.isFinite(end) && end > maxEnd) maxEnd = end;
+  }
+  return maxEnd;
+}
+
+export interface ClipReferenceInput {
+  /** Scene id — used to derive the composition src path. */
+  id: string;
+  start: number;
+  duration: number;
+  trackIndex?: number;
+  /** Override the default `compositions/scene-<id>.html` src. */
+  src?: string;
+}
+
+/** Build the `<div class="clip" data-composition-src=...>` reference string. */
+export function buildClipReference(opts: ClipReferenceInput): string {
+  const start = Number(opts.start.toFixed(3));
+  const duration = Number(opts.duration.toFixed(3));
+  const track = opts.trackIndex ?? 1;
+  const src = opts.src ?? `compositions/scene-${opts.id}.html`;
+  return `<div class="clip" data-composition-src="${esc(src)}" data-start="${start}" data-duration="${duration}" data-track-index="${track}"></div>`;
+}
+
+/**
+ * Insert a clip reference inside the root composition's `#root` div, just
+ * before its closing `</div>`. Throws if the expected closing tag isn't
+ * found — callers should surface this as a structured error so users know
+ * to inspect a hand-edited root.
+ *
+ * Also grows the root's `data-duration` to fit the new clip's end-time.
+ */
+export function insertClipIntoRoot(rootHtml: string, clip: ClipReferenceInput): string {
+  const clipDiv = buildClipReference(clip);
+
+  // Find the root closing tag. Match `</div>` followed by blank line + `<script>`,
+  // which matches `buildEmptyRootHtml` and any user-edited root that keeps the
+  // standard structure.
+  const closeMatch = rootHtml.match(/\n(\s*)<\/div>(\s*\n\s*<script>)/);
+  if (!closeMatch) {
+    throw new Error(
+      "Could not find root composition closing </div>. Ensure index.html follows the layout from `vibe scene init`."
+    );
+  }
+  const closeIdx = closeMatch.index!;
+  const closeIndent = closeMatch[1];
+  const childIndent = closeIndent + "  ";
+
+  // Splice the clip just above the closing div, indented one level deeper.
+  const insertion = `\n${childIndent}${clipDiv}`;
+  let updated = rootHtml.slice(0, closeIdx) + insertion + rootHtml.slice(closeIdx);
+
+  // Grow root data-duration to fit the new clip end (never shrink — preserves
+  // user-set padding).
+  const newEnd = clip.start + clip.duration;
+  updated = updated.replace(
+    /(<div\b[^>]*\bid="root"[^>]*\bdata-duration=")([\d.]+)(")/,
+    (_full, prefix: string, value: string, suffix: string) => {
+      const current = parseFloat(value);
+      const next = Math.max(current, newEnd);
+      return `${prefix}${Number(next.toFixed(3))}${suffix}`;
+    },
+  );
+
+  return updated;
+}
+
+/**
+ * Read the root composition's canvas dims by parsing `data-width`/`data-height`
+ * on the `#root` div. Returns null if either is missing — caller should fall
+ * back to the project's aspect config.
+ */
+export function readRootDims(rootHtml: string): { width: number; height: number } | null {
+  const widthMatch = rootHtml.match(/<div\b[^>]*\bid="root"[^>]*\bdata-width="(\d+)"/);
+  const heightMatch = rootHtml.match(/<div\b[^>]*\bid="root"[^>]*\bdata-height="(\d+)"/);
+  if (!widthMatch || !heightMatch) return null;
+  return { width: parseInt(widthMatch[1], 10), height: parseInt(heightMatch[1], 10) };
+}

--- a/packages/cli/src/commands/scene.test.ts
+++ b/packages/cli/src/commands/scene.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { scaffoldSceneProject } from "./_shared/scene-project.js";
+import { executeSceneAdd } from "./scene.js";
+
+async function pathExists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+async function makeProject(label = "vibe-scene-add-test-"): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), label));
+  await scaffoldSceneProject({ dir, name: "fixture", aspect: "16:9", duration: 10 });
+  return dir;
+}
+
+describe("executeSceneAdd — offline (--no-audio --no-image)", () => {
+  it("emits scene HTML and inserts a clip into the root", async () => {
+    const projectDir = await makeProject();
+
+    const result = await executeSceneAdd({
+      name: "Intro Scene",
+      preset: "announcement",
+      headline: "Welcome",
+      duration: 4,
+      projectDir,
+      skipAudio: true,
+      skipImage: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.id).toBe("intro-scene");
+    expect(result.start).toBe(0);
+    expect(result.duration).toBe(4);
+    expect(result.audioPath).toBeUndefined();
+    expect(result.imagePath).toBeUndefined();
+
+    // Scene file written
+    const scenePath = resolve(projectDir, "compositions/scene-intro-scene.html");
+    expect(await pathExists(scenePath)).toBe(true);
+    const sceneHtml = await readFile(scenePath, "utf-8");
+    expect(sceneHtml).toContain('data-composition-id="intro-scene"');
+    expect(sceneHtml).toContain("Welcome");
+    expect(sceneHtml).not.toContain("<audio");
+    expect(sceneHtml).not.toContain("background-image: url(");
+
+    // Root updated with the clip ref
+    const rootHtml = await readFile(resolve(projectDir, "index.html"), "utf-8");
+    expect(rootHtml).toContain('data-composition-src="compositions/scene-intro-scene.html"');
+    expect(rootHtml).toContain('data-start="0"');
+    expect(rootHtml).toContain('data-duration="4"');
+  });
+
+  it("appends multiple scenes sequentially with running start times", async () => {
+    const projectDir = await makeProject();
+
+    const a = await executeSceneAdd({
+      name: "intro", preset: "simple", duration: 3, projectDir, skipAudio: true, skipImage: true,
+    });
+    expect(a.success).toBe(true);
+    expect(a.start).toBe(0);
+
+    const b = await executeSceneAdd({
+      name: "outro", preset: "simple", duration: 2, projectDir, skipAudio: true, skipImage: true,
+    });
+    expect(b.success).toBe(true);
+    expect(b.start).toBe(3);
+
+    const root = await readFile(resolve(projectDir, "index.html"), "utf-8");
+    expect(root).toContain('data-composition-src="compositions/scene-intro.html"');
+    expect(root).toContain('data-composition-src="compositions/scene-outro.html"');
+  });
+
+  it("uses the narration text as the subhead even when --no-audio is set", async () => {
+    const projectDir = await makeProject();
+
+    const result = await executeSceneAdd({
+      name: "explain",
+      preset: "explainer",
+      narration: "VibeFrame turns YAML into MP4s.",
+      duration: 5,
+      projectDir,
+      skipAudio: true,
+      skipImage: true,
+    });
+
+    expect(result.success).toBe(true);
+    const html = await readFile(resolve(projectDir, "compositions/scene-explain.html"), "utf-8");
+    expect(html).toContain("VibeFrame turns YAML into MP4s.");
+    expect(html).not.toContain("<audio"); // skipAudio honored
+  });
+
+  it("falls back to vibe.project.yaml defaultSceneDuration when neither --duration nor narration audio is available", async () => {
+    const projectDir = await makeProject();
+
+    const result = await executeSceneAdd({
+      name: "default-dur",
+      preset: "simple",
+      projectDir,
+      skipAudio: true,
+      skipImage: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.duration).toBe(5); // defaultSceneDuration in defaultVibeProjectConfig
+  });
+
+  it("refuses to overwrite an existing scene unless --force is passed", async () => {
+    const projectDir = await makeProject();
+
+    const first = await executeSceneAdd({
+      name: "intro", preset: "simple", duration: 3, projectDir, skipAudio: true, skipImage: true,
+    });
+    expect(first.success).toBe(true);
+
+    const second = await executeSceneAdd({
+      name: "intro", preset: "simple", duration: 3, projectDir, skipAudio: true, skipImage: true,
+    });
+    expect(second.success).toBe(false);
+    expect(second.error).toMatch(/already exists/);
+
+    const forced = await executeSceneAdd({
+      name: "intro", preset: "simple", duration: 3, projectDir, skipAudio: true, skipImage: true, force: true,
+    });
+    expect(forced.success).toBe(true);
+  });
+
+  it("returns a structured error when the root composition is missing", async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), "vibe-scene-noroot-"));
+
+    const result = await executeSceneAdd({
+      name: "x", preset: "simple", duration: 3, projectDir, skipAudio: true, skipImage: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Root composition not found/);
+  });
+
+  it("emits canvas dims that match the project aspect", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vibe-scene-vertical-"));
+    await scaffoldSceneProject({ dir, name: "vert", aspect: "9:16", duration: 8 });
+
+    const result = await executeSceneAdd({
+      name: "hook", preset: "simple", duration: 3, projectDir: dir, skipAudio: true, skipImage: true,
+    });
+    expect(result.success).toBe(true);
+    const html = await readFile(resolve(dir, "compositions/scene-hook.html"), "utf-8");
+    expect(html).toContain('data-width="1080"');
+    expect(html).toContain('data-height="1920"');
+  });
+});

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -8,21 +8,48 @@
  * scene animation instead of relying on flat YAML steps or opaque MP4s.
  *
  * Subcommands land incrementally across MVP 1:
- *   - init      [C1, this commit] — scaffold project directory
- *   - add       [C2]
+ *   - init      [C1] — scaffold project directory
+ *   - add       [C2, this commit] — author one scene (template + assets)
  *   - lint      [C3]
  *   - render    [C4]
  */
 
 import { Command } from "commander";
-import { basename } from "node:path";
+import { basename, resolve, relative, dirname } from "node:path";
+import { mkdir, readFile, writeFile, access } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import chalk from "chalk";
 import ora from "ora";
+import { parse as yamlParse } from "yaml";
+import {
+  ElevenLabsProvider,
+  GeminiProvider,
+  OpenAIImageProvider,
+} from "@vibeframe/ai-providers";
 import {
   scaffoldSceneProject,
+  aspectToDims,
   type SceneAspect,
+  type VibeProjectConfig,
 } from "./_shared/scene-project.js";
-import { exitWithError, generalError, usageError, outputResult, isJsonMode } from "./output.js";
+import {
+  emitSceneHtml,
+  insertClipIntoRoot,
+  nextSceneStart,
+  readRootDims,
+  slugifySceneName,
+  SCENE_PRESETS,
+  type ScenePreset,
+} from "./_shared/scene-html-emit.js";
+import {
+  exitWithError,
+  generalError,
+  usageError,
+  outputResult,
+  isJsonMode,
+} from "./output.js";
+import { getApiKey } from "../utils/api-key.js";
+import { getAudioDuration } from "../utils/audio.js";
 
 const VALID_ASPECTS: SceneAspect[] = ["16:9", "9:16", "1:1", "4:5"];
 
@@ -41,13 +68,23 @@ function validateDuration(value: string): number {
   return n;
 }
 
+function validatePreset(value: string): ScenePreset {
+  if (!SCENE_PRESETS.includes(value as ScenePreset)) {
+    exitWithError(usageError(`Invalid style: ${value}`, `Valid: ${SCENE_PRESETS.join(", ")}`));
+  }
+  return value as ScenePreset;
+}
+
 export const sceneCommand = new Command("scene")
   .description("Author and render per-scene HTML compositions (Hyperframes backend)")
   .addHelpText("after", `
 Examples:
-  $ vibe scene init my-video                       # Scaffold a new scene project
-  $ vibe scene init my-video -r 9:16 -d 30         # Vertical 30s project
-  $ vibe scene init existing-hf-project            # Safe — merges with existing hyperframes.json
+  $ vibe scene init my-video                              # Scaffold a new project
+  $ vibe scene init my-video -r 9:16 -d 30                # Vertical 30s project
+  $ vibe scene add intro --style announcement \\
+      --headline "Welcome to VibeFrame"                   # Headline-only scene
+  $ vibe scene add overview --narration "VibeFrame turns scripts into video." \\
+      --visuals "studio desk, soft lighting"              # AI narration + image
 
 A scene project is bilingual: it works with both \`vibe\` and \`npx hyperframes\`.
 Run 'vibe schema scene.<command>' for structured parameter info.`);
@@ -112,3 +149,369 @@ sceneCommand
       exitWithError(generalError(`Failed to scaffold: ${msg}`));
     }
   });
+
+// ---------------------------------------------------------------------------
+// `vibe scene add`
+// ---------------------------------------------------------------------------
+
+sceneCommand
+  .command("add")
+  .description("Add a new scene to a project: AI narration + image + per-scene HTML")
+  .argument("<name>", "Scene name (slugified into the composition id)")
+  .option("--style <preset>", `Style preset: ${SCENE_PRESETS.join(", ")}`, "simple")
+  .option("--narration <text>", "Narration text (or path to a .txt file). Drives TTS + scene duration.")
+  .option("-d, --duration <sec>", "Explicit scene duration in seconds (overrides narration audio)")
+  .option("--visuals <prompt>", "Image prompt — generates assets/scene-<id>.png via the configured image provider")
+  .option("--headline <text>", "Visible headline (defaults to the humanised scene name)")
+  .option("--kicker <text>", "Small label above the headline (explainer / product-shot)")
+  .option("--insert-into <path>", "Root composition file to update", "index.html")
+  .option("--project <dir>", "Project directory", ".")
+  .option("--image-provider <name>", "Image provider: gemini, openai", "gemini")
+  .option("--voice <id>", "ElevenLabs voice id or name")
+  .option("--no-audio", "Skip TTS even when --narration is provided (useful for tests/agent dry runs)")
+  .option("--no-image", "Skip image generation even when --visuals is provided")
+  .option("--force", "Overwrite an existing compositions/scene-<id>.html")
+  .option("--dry-run", "Preview parameters without writing files or calling APIs")
+  .action(async (name: string, options) => {
+    if (options.style) options.style = validatePreset(options.style);
+    if (options.duration !== undefined) options.duration = validateDuration(options.duration);
+
+    if (options.dryRun) {
+      const id = slugifySceneName(name);
+      outputResult({
+        dryRun: true,
+        command: "scene add",
+        params: {
+          name,
+          id,
+          preset: options.style,
+          narration: !!options.narration,
+          visuals: !!options.visuals,
+          duration: options.duration,
+          headline: options.headline,
+          kicker: options.kicker,
+          project: options.project,
+          insertInto: options.insertInto,
+          imageProvider: options.imageProvider,
+          audio: options.audio,   // commander sets `audio: false` when --no-audio is passed
+          image: options.image,
+        },
+      });
+      return;
+    }
+
+    const spinner = isJsonMode() ? null : ora(`Adding scene "${name}"...`).start();
+
+    try {
+      const result = await executeSceneAdd({
+        name,
+        preset: options.style as ScenePreset,
+        narration: options.narration,
+        duration: options.duration,
+        visuals: options.visuals,
+        headline: options.headline,
+        kicker: options.kicker,
+        projectDir: options.project,
+        insertInto: options.insertInto,
+        imageProvider: options.imageProvider,
+        voice: options.voice,
+        skipAudio: options.audio === false,
+        skipImage: options.image === false,
+        force: !!options.force,
+        onProgress: (msg) => {
+          if (spinner) spinner.text = msg;
+        },
+      });
+
+      if (!result.success) {
+        spinner?.fail(`Failed to add scene "${name}"`);
+        exitWithError(generalError(result.error ?? "Scene add failed"));
+      }
+
+      if (isJsonMode()) {
+        outputResult({
+          command: "scene add",
+          ...result,
+        });
+        return;
+      }
+
+      spinner?.succeed(chalk.green(`Scene added: ${result.id}`));
+      console.log();
+      console.log(chalk.bold.cyan("Files"));
+      console.log(chalk.dim("─".repeat(60)));
+      console.log(chalk.green("  +"), result.scenePath);
+      if (result.audioPath) console.log(chalk.green("  +"), result.audioPath);
+      if (result.imagePath) console.log(chalk.green("  +"), result.imagePath);
+      console.log(chalk.yellow("  ~"), result.rootPath, chalk.dim("(updated)"));
+      console.log();
+      console.log(chalk.bold.cyan("Composition"));
+      console.log(chalk.dim("─".repeat(60)));
+      console.log(`  id        ${chalk.bold(result.id)}`);
+      console.log(`  preset    ${result.preset}`);
+      console.log(`  start     ${result.start.toFixed(2)}s`);
+      console.log(`  duration  ${result.duration.toFixed(2)}s`);
+      console.log();
+      console.log(chalk.bold.cyan("Next steps"));
+      console.log(chalk.dim("─".repeat(60)));
+      console.log(`  ${chalk.cyan("vibe scene lint")}      ${chalk.dim("# validate HTML")}`);
+      console.log(`  ${chalk.cyan("vibe scene render")}    ${chalk.dim("# render to MP4")}`);
+    } catch (error) {
+      spinner?.fail(`Failed to add scene "${name}"`);
+      const msg = error instanceof Error ? error.message : String(error);
+      exitWithError(generalError(msg));
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// executeSceneAdd — testable orchestration (also targeted by C6 agent tool)
+// ---------------------------------------------------------------------------
+
+export interface SceneAddOptions {
+  name: string;
+  preset: ScenePreset;
+  /** Narration text. If the value is an existing file path, its content is used. */
+  narration?: string;
+  /** Explicit duration in seconds. Overrides narration-derived duration. */
+  duration?: number;
+  /** Image generation prompt. */
+  visuals?: string;
+  headline?: string;
+  kicker?: string;
+  /** Project directory. Defaults to cwd. */
+  projectDir?: string;
+  /** Filename of the root composition (relative to projectDir). */
+  insertInto?: string;
+  /** "gemini" | "openai". */
+  imageProvider?: string;
+  /** ElevenLabs voice id/name. */
+  voice?: string;
+  /** When true, skip TTS even if narration is provided. */
+  skipAudio?: boolean;
+  /** When true, skip image generation even if visuals is provided. */
+  skipImage?: boolean;
+  /** Overwrite existing compositions/scene-<id>.html. */
+  force?: boolean;
+  /** Progress sink (CLI spinner / agent stream). */
+  onProgress?: (msg: string) => void;
+}
+
+export interface SceneAddResult {
+  success: boolean;
+  id: string;
+  preset: ScenePreset;
+  start: number;
+  duration: number;
+  scenePath: string;
+  rootPath: string;
+  audioPath?: string;
+  imagePath?: string;
+  error?: string;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+async function loadVibeProjectConfig(projectDir: string): Promise<VibeProjectConfig | null> {
+  const cfgPath = resolve(projectDir, "vibe.project.yaml");
+  if (!(await pathExists(cfgPath))) return null;
+  const raw = await readFile(cfgPath, "utf-8");
+  return yamlParse(raw) as VibeProjectConfig;
+}
+
+/** Resolve narration text — value may be inline text or a path to a `.txt`/`.md` file. */
+async function resolveNarrationText(value: string | undefined): Promise<string | undefined> {
+  if (!value) return undefined;
+  // Treat as a file path only when it actually exists AND looks like one. This
+  // avoids accidentally interpreting a sentence with a slash as a path.
+  const looksLikePath = /\.[a-z]{2,4}$/i.test(value) || value.includes("/") || value.includes("\\");
+  if (looksLikePath && existsSync(value)) {
+    return (await readFile(value, "utf-8")).trim();
+  }
+  return value.trim();
+}
+
+/** Map a project aspect to the OpenAI image API size string. */
+function openAiSizeForAspect(width: number, height: number): "1024x1024" | "1536x1024" | "1024x1536" {
+  if (width === height) return "1024x1024";
+  return width > height ? "1536x1024" : "1024x1536";
+}
+
+/** Best-effort aspect-ratio string for the image provider. */
+function aspectStringFromDims(width: number, height: number): string {
+  if (width === height) return "1:1";
+  if (width === 1920 && height === 1080) return "16:9";
+  if (width === 1080 && height === 1920) return "9:16";
+  if (width === 1080 && height === 1350) return "4:5";
+  return width > height ? "16:9" : "9:16";
+}
+
+export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddResult> {
+  const projectDir = resolve(opts.projectDir ?? ".");
+  const rootRel = opts.insertInto ?? "index.html";
+  const rootPath = resolve(projectDir, rootRel);
+  const id = slugifySceneName(opts.name);
+  const sceneRel = `compositions/scene-${id}.html`;
+  const scenePath = resolve(projectDir, sceneRel);
+
+  // -- Validate project ----------------------------------------------------
+  const errResult = (error: string): SceneAddResult => ({
+    success: false,
+    id,
+    preset: opts.preset,
+    start: 0,
+    duration: 0,
+    scenePath,
+    rootPath,
+    error,
+  });
+
+  if (!(await pathExists(rootPath))) {
+    return errResult(`Root composition not found: ${rootPath}. Run \`vibe scene init\` first.`);
+  }
+  if (!opts.force && (await pathExists(scenePath))) {
+    return errResult(`Scene already exists: ${sceneRel}. Re-run with --force to overwrite.`);
+  }
+
+  // -- Resolve canvas dims (root takes precedence over project config) -----
+  const rootHtmlBefore = await readFile(rootPath, "utf-8");
+  let dims = readRootDims(rootHtmlBefore);
+  if (!dims) {
+    const cfg = await loadVibeProjectConfig(projectDir);
+    if (cfg?.aspect) dims = aspectToDims(cfg.aspect);
+  }
+  if (!dims) {
+    return errResult("Could not determine canvas dimensions from index.html or vibe.project.yaml.");
+  }
+
+  // -- Resolve narration text ---------------------------------------------
+  const narrationText = await resolveNarrationText(opts.narration);
+
+  // -- Asset generation: narration audio -----------------------------------
+  let audioRelPath: string | undefined;
+  let audioAbsPath: string | undefined;
+  let narrationDuration: number | undefined;
+
+  if (narrationText && !opts.skipAudio) {
+    const elevenlabsKey = await getApiKey("ELEVENLABS_API_KEY", "ElevenLabs");
+    if (!elevenlabsKey) {
+      return errResult("ElevenLabs API key required for --narration. Set ELEVENLABS_API_KEY, run 'vibe setup', or pass --no-audio.");
+    }
+    opts.onProgress?.("Generating narration with ElevenLabs...");
+    const elevenlabs = new ElevenLabsProvider();
+    await elevenlabs.initialize({ apiKey: elevenlabsKey });
+    const tts = await elevenlabs.textToSpeech(narrationText, { voiceId: opts.voice });
+    if (!tts.success || !tts.audioBuffer) {
+      return errResult(`ElevenLabs TTS failed: ${tts.error ?? "unknown error"}`);
+    }
+    audioRelPath = `assets/narration-${id}.mp3`;
+    audioAbsPath = resolve(projectDir, audioRelPath);
+    await mkdir(dirname(audioAbsPath), { recursive: true });
+    await writeFile(audioAbsPath, tts.audioBuffer);
+    try {
+      narrationDuration = await getAudioDuration(audioAbsPath);
+    } catch {
+      narrationDuration = undefined;
+    }
+  }
+
+  // -- Asset generation: backdrop image -----------------------------------
+  let imageRelPath: string | undefined;
+  let imageAbsPath: string | undefined;
+
+  if (opts.visuals && !opts.skipImage) {
+    const provider = (opts.imageProvider ?? "gemini").toLowerCase();
+    if (provider !== "gemini" && provider !== "openai") {
+      return errResult(`Unsupported --image-provider: ${provider}. Valid: gemini, openai.`);
+    }
+    opts.onProgress?.(`Generating image with ${provider}...`);
+
+    if (provider === "openai") {
+      const openaiKey = await getApiKey("OPENAI_API_KEY", "OpenAI");
+      if (!openaiKey) {
+        return errResult("OpenAI API key required for --visuals --image-provider openai. Set OPENAI_API_KEY or pass --no-image.");
+      }
+      const openai = new OpenAIImageProvider();
+      await openai.initialize({ apiKey: openaiKey });
+      const imageResult = await openai.generateImage(opts.visuals, {
+        size: openAiSizeForAspect(dims.width, dims.height),
+        quality: "standard",
+      });
+      if (!imageResult.success || !imageResult.images?.[0]) {
+        return errResult(`OpenAI image generation failed: ${imageResult.error ?? "unknown error"}`);
+      }
+      const img = imageResult.images[0];
+      imageRelPath = `assets/scene-${id}.png`;
+      imageAbsPath = resolve(projectDir, imageRelPath);
+      await mkdir(dirname(imageAbsPath), { recursive: true });
+      let buffer: Buffer;
+      if (img.base64) {
+        buffer = Buffer.from(img.base64, "base64");
+      } else if (img.url) {
+        const response = await fetch(img.url);
+        buffer = Buffer.from(await response.arrayBuffer());
+      } else {
+        return errResult("OpenAI returned no image data");
+      }
+      await writeFile(imageAbsPath, buffer);
+    } else {
+      const googleKey = await getApiKey("GOOGLE_API_KEY", "Google");
+      if (!googleKey) {
+        return errResult("Google API key required for Gemini image generation. Set GOOGLE_API_KEY or pass --no-image.");
+      }
+      const gemini = new GeminiProvider();
+      await gemini.initialize({ apiKey: googleKey });
+      const aspectRatio = aspectStringFromDims(dims.width, dims.height) as "1:1" | "16:9" | "9:16" | "4:5";
+      const imageResult = await gemini.generateImage(opts.visuals, { aspectRatio });
+      if (!imageResult.success || !imageResult.images?.[0]?.base64) {
+        return errResult(`Gemini image generation failed: ${imageResult.error ?? "unknown error"}`);
+      }
+      imageRelPath = `assets/scene-${id}.png`;
+      imageAbsPath = resolve(projectDir, imageRelPath);
+      await mkdir(dirname(imageAbsPath), { recursive: true });
+      const buffer = Buffer.from(imageResult.images[0].base64!, "base64");
+      await writeFile(imageAbsPath, buffer);
+    }
+  }
+
+  // -- Decide scene duration -----------------------------------------------
+  const cfg = await loadVibeProjectConfig(projectDir);
+  const fallback = cfg?.defaultSceneDuration ?? 5;
+  const duration = opts.duration ?? narrationDuration ?? fallback;
+
+  // -- Emit scene HTML -----------------------------------------------------
+  opts.onProgress?.("Emitting scene HTML...");
+  const sceneHtml = emitSceneHtml({
+    id,
+    preset: opts.preset,
+    width: dims.width,
+    height: dims.height,
+    duration,
+    headline: opts.headline,
+    subhead: narrationText,
+    kicker: opts.kicker,
+    imagePath: imageRelPath,
+    audioPath: audioRelPath,
+  });
+  await mkdir(dirname(scenePath), { recursive: true });
+  await writeFile(scenePath, sceneHtml, "utf-8");
+
+  // -- Update root index.html ---------------------------------------------
+  opts.onProgress?.("Updating root composition...");
+  const start = nextSceneStart(rootHtmlBefore);
+  const updated = insertClipIntoRoot(rootHtmlBefore, { id, start, duration });
+  await writeFile(rootPath, updated, "utf-8");
+
+  return {
+    success: true,
+    id,
+    preset: opts.preset,
+    start,
+    duration,
+    scenePath: relative(process.cwd(), scenePath) || scenePath,
+    rootPath: relative(process.cwd(), rootPath) || rootPath,
+    audioPath: audioAbsPath ? (relative(process.cwd(), audioAbsPath) || audioAbsPath) : undefined,
+    imagePath: imageAbsPath ? (relative(process.cwd(), imageAbsPath) || imageAbsPath) : undefined,
+  };
+}


### PR DESCRIPTION
## Summary

Lands C2 of the Hyperframes scene-authoring MVP: `vibe scene add <name>` authors a single scene HTML, optionally generates narration + backdrop image, and splices a `<div class="clip" data-composition-src=...>` reference into the root composition.

- 5 style presets (`simple`, `announcement`, `explainer`, `kinetic-type`, `product-shot`) — each emits Hyperframes-compatible markup with a paused GSAP timeline registered on `window.__timelines`.
- Pure helpers in `_shared/scene-html-emit.ts` (`emitSceneHtml`, `insertClipIntoRoot`, `nextSceneStart`, `slugifySceneName`, `readRootDims`) — no I/O, fully unit-tested.
- `executeSceneAdd()` returns structured results (no `process.exit`) so it's safe to call from the agent + MCP tools landing in c6.
- Root index.html `data-duration` auto-grows to fit each new clip's end-time but never shrinks (preserves user-set padding).
- `--no-audio` / `--no-image` give an offline path for tests and lint-driven authoring loops.
- Reuses `ElevenLabsProvider`, `OpenAIImageProvider`, `GeminiProvider`, `getApiKey`, and `getAudioDuration` from existing infrastructure.

No version bump — stays `0.52.1` until c8.

## Test plan

- [x] `pnpm -F @vibeframe/cli build` clean (tsc strict)
- [x] `pnpm -F @vibeframe/cli lint` — 0 errors (8 pre-existing warnings unrelated)
- [x] 54 new unit tests pass: 47 `_shared/scene-html-emit.test.ts` + 7 `commands/scene.test.ts`
- [x] Full CLI suite: 358 passed, 11 skipped (1 pre-existing parallel-flake in `ai.test.ts > generate music` — passes in isolation, not introduced by this PR)
- [x] Smoke: `vibe scene init /tmp/x` → `vibe scene add intro --style announcement --headline "..." --duration 4 --no-audio --no-image` → `vibe scene add outro --style explainer --duration 5 --no-audio --no-image` produces sequential clips at start=0/4 and grows root data-duration from 8 → 9.

## MVP 1 sequence

- [x] c1 — `vibe scene init` + bilingual layout (#60)
- [x] **c2 — `vibe scene add` (this PR)**
- [ ] c3 — `vibe scene lint` via `runHyperframeLint`
- [ ] c4 — `vibe scene render`
- [ ] c5 — `pipeline script-to-video --format scenes`
- [ ] c6 — agent + MCP tool sync
- [ ] c7 — `/vibe-scene` skill + example + README
- [ ] c8 — bump 0.53.0 + CHANGELOG