### PR TITLE
feat(scene): vibe scene lint via runHyperframeLint (MVP 1 c3/8)

### DIFF
--- a/packages/cli/src/commands/_shared/scene-html-emit.test.ts
+++ b/packages/cli/src/commands/_shared/scene-html-emit.test.ts
@@ -52,17 +52,19 @@ describe("nextSceneStart", () => {
 // ── buildClipReference ──────────────────────────────────────────────────────
 
 describe("buildClipReference", () => {
-  it("builds a Hyperframes-compatible clip div", () => {
+  it("builds a Hyperframes-compatible clip div with data-composition-id", () => {
     const out = buildClipReference({ id: "intro", start: 0, duration: 4 });
     expect(out).toContain('class="clip"');
+    expect(out).toContain('data-composition-id="intro"');
     expect(out).toContain('data-composition-src="compositions/scene-intro.html"');
     expect(out).toContain('data-start="0"');
     expect(out).toContain('data-duration="4"');
     expect(out).toContain('data-track-index="1"');
   });
 
-  it("respects an explicit track and src override", () => {
+  it("respects an explicit track and src override and still emits data-composition-id", () => {
     const out = buildClipReference({ id: "x", start: 1.234, duration: 2.345, trackIndex: 3, src: "custom/path.html" });
+    expect(out).toContain('data-composition-id="x"');
     expect(out).toContain('data-composition-src="custom/path.html"');
     expect(out).toContain('data-track-index="3"');
     expect(out).toContain('data-start="1.234"');
@@ -76,7 +78,7 @@ describe("insertClipIntoRoot", () => {
   it("inserts a clip before the root closing div", () => {
     const root = buildEmptyRootHtml({ aspect: "16:9", duration: 10 });
     const updated = insertClipIntoRoot(root, { id: "intro", start: 0, duration: 4 });
-    expect(updated).toContain('<div class="clip" data-composition-src="compositions/scene-intro.html"');
+    expect(updated).toContain('<div class="clip" data-composition-id="intro" data-composition-src="compositions/scene-intro.html"');
     // The new clip must appear *before* the root's closing </div>
     const clipIdx = updated.indexOf("compositions/scene-intro.html");
     const rootCloseIdx = updated.lastIndexOf("</div>\n\n    <script>");

--- a/packages/cli/src/commands/_shared/scene-html-emit.ts
+++ b/packages/cli/src/commands/_shared/scene-html-emit.ts
@@ -380,13 +380,13 @@ export interface ClipReferenceInput {
   src?: string;
 }
 
-/** Build the `<div class="clip" data-composition-src=...>` reference string. */
+/** Build the `<div class="clip" data-composition-id=... data-composition-src=...>` reference string. */
 export function buildClipReference(opts: ClipReferenceInput): string {
   const start = Number(opts.start.toFixed(3));
   const duration = Number(opts.duration.toFixed(3));
   const track = opts.trackIndex ?? 1;
   const src = opts.src ?? `compositions/scene-${opts.id}.html`;
-  return `<div class="clip" data-composition-src="${esc(src)}" data-start="${start}" data-duration="${duration}" data-track-index="${track}"></div>`;
+  return `<div class="clip" data-composition-id="${esc(opts.id)}" data-composition-src="${esc(src)}" data-start="${start}" data-duration="${duration}" data-track-index="${track}"></div>`;
 }
 
 /**

--- a/packages/cli/src/commands/_shared/scene-lint.test.ts
+++ b/packages/cli/src/commands/_shared/scene-lint.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  applyMechanicalFixes,
+  discoverSceneFiles,
+  filterSubCompFalsePositives,
+  rootExists,
+  runProjectLint,
+  SUB_COMP_FALSE_POSITIVES,
+  type LintFinding,
+} from "./scene-lint.js";
+import {
+  buildEmptyRootHtml,
+  scaffoldSceneProject,
+} from "./scene-project.js";
+import {
+  buildClipReference,
+  emitSceneHtml,
+  insertClipIntoRoot,
+} from "./scene-html-emit.js";
+
+async function makeTmp(label = "vibe-scene-lint-"): Promise<string> {
+  return mkdtemp(join(tmpdir(), label));
+}
+
+// ── filterSubCompFalsePositives ─────────────────────────────────────────────
+
+describe("filterSubCompFalsePositives", () => {
+  const findings: LintFinding[] = [
+    { code: "standalone_composition_wrapped_in_template", severity: "warning", message: "x" },
+    { code: "root_composition_missing_html_wrapper",      severity: "warning", message: "x" },
+    { code: "missing_timeline_registry",                  severity: "error",   message: "real" },
+  ];
+
+  it("drops the two known false positives for sub-compositions", () => {
+    const out = filterSubCompFalsePositives(findings, true);
+    expect(out).toHaveLength(1);
+    expect(out[0].code).toBe("missing_timeline_registry");
+  });
+
+  it("returns root-composition findings unchanged", () => {
+    const out = filterSubCompFalsePositives(findings, false);
+    expect(out).toHaveLength(3);
+  });
+
+  it("exposes the filtered codes via SUB_COMP_FALSE_POSITIVES", () => {
+    expect(SUB_COMP_FALSE_POSITIVES.has("standalone_composition_wrapped_in_template")).toBe(true);
+    expect(SUB_COMP_FALSE_POSITIVES.has("root_composition_missing_html_wrapper")).toBe(true);
+    expect(SUB_COMP_FALSE_POSITIVES.size).toBe(2);
+  });
+});
+
+// ── applyMechanicalFixes ────────────────────────────────────────────────────
+
+describe("applyMechanicalFixes — timed_element_missing_clip_class", () => {
+  const finding: LintFinding = {
+    code: "timed_element_missing_clip_class",
+    severity: "error",
+    message: "missing class=\"clip\"",
+  };
+
+  it("adds class=\"clip\" to elements with timing attributes and no class", () => {
+    const html = `<div data-start="0" data-duration="3" data-track-index="1">x</div>`;
+    const { html: out, fixedCodes } = applyMechanicalFixes(html, [finding]);
+    expect(out).toContain('<div class="clip" data-start="0" data-duration="3"');
+    expect(fixedCodes).toEqual(["timed_element_missing_clip_class"]);
+  });
+
+  it("merges into an existing class list rather than overwriting", () => {
+    const html = `<div class="card glow" data-start="0" data-duration="3" data-track-index="1">x</div>`;
+    const { html: out } = applyMechanicalFixes(html, [finding]);
+    expect(out).toContain('class="card glow clip"');
+  });
+
+  it("is idempotent — already-clipped elements aren't modified", () => {
+    const html = `<div class="clip card" data-start="0" data-duration="3" data-track-index="1">x</div>`;
+    const { html: out, fixedCodes } = applyMechanicalFixes(html, [finding]);
+    expect(out).toBe(html);
+    expect(fixedCodes).toEqual([]);
+  });
+
+  it("skips <audio> and <video> (their lint rule already exempts them)", () => {
+    const html = `<audio data-start="0" data-duration="3" src="x.mp3"></audio>
+<video data-start="0" data-duration="3" src="x.mp4"></video>`;
+    const { html: out, fixedCodes } = applyMechanicalFixes(html, [finding]);
+    expect(out).toBe(html);
+    expect(fixedCodes).toEqual([]);
+  });
+
+  it("does not fix codes outside the auto-fix allow-list", () => {
+    const html = `<div data-start="0" data-duration="3">x</div>`;
+    const other: LintFinding = { code: "missing_timeline_registry", severity: "error", message: "x" };
+    const { html: out, fixedCodes } = applyMechanicalFixes(html, [other]);
+    expect(out).toBe(html);
+    expect(fixedCodes).toEqual([]);
+  });
+});
+
+// ── discoverSceneFiles + rootExists ─────────────────────────────────────────
+
+describe("discoverSceneFiles", () => {
+  it("returns null root when index.html is missing", async () => {
+    const dir = await makeTmp();
+    const out = await discoverSceneFiles({ projectDir: dir });
+    expect(out.root).toBeNull();
+    expect(out.subs).toEqual([]);
+  });
+
+  it("walks compositions/ recursively and sorts results", async () => {
+    const dir = await makeTmp();
+    await scaffoldSceneProject({ dir, name: "fix", aspect: "16:9", duration: 6 });
+    await mkdir(resolve(dir, "compositions/nested"), { recursive: true });
+    await writeFile(resolve(dir, "compositions/scene-b.html"), "x", "utf-8");
+    await writeFile(resolve(dir, "compositions/scene-a.html"), "x", "utf-8");
+    await writeFile(resolve(dir, "compositions/nested/deep.html"), "x", "utf-8");
+    await writeFile(resolve(dir, "compositions/notes.txt"), "ignored", "utf-8");
+
+    const out = await discoverSceneFiles({ projectDir: dir });
+    expect(out.root).toBe(resolve(dir, "index.html"));
+    expect(out.subs).toEqual([
+      resolve(dir, "compositions/nested/deep.html"),
+      resolve(dir, "compositions/scene-a.html"),
+      resolve(dir, "compositions/scene-b.html"),
+    ]);
+  });
+});
+
+describe("rootExists", () => {
+  it("true when index.html exists, false otherwise", async () => {
+    const dir = await makeTmp();
+    expect(await rootExists(dir)).toBe(false);
+    await scaffoldSceneProject({ dir, name: "x", aspect: "16:9", duration: 4 });
+    expect(await rootExists(dir)).toBe(true);
+  });
+});
+
+// ── runProjectLint — integration against scaffolded projects ────────────────
+
+describe("runProjectLint — integration", () => {
+  async function scaffoldWithScenes(): Promise<string> {
+    const dir = await makeTmp("vibe-lint-int-");
+    await scaffoldSceneProject({ dir, name: "fixture", aspect: "16:9", duration: 8 });
+
+    // Add two scenes by hand using the C2 emit helpers (avoids spawning the CLI).
+    let root = await readFile(resolve(dir, "index.html"), "utf-8");
+
+    const intro = emitSceneHtml({
+      id: "intro", preset: "announcement", width: 1920, height: 1080,
+      duration: 4, headline: "Hello",
+    });
+    await writeFile(resolve(dir, "compositions/scene-intro.html"), intro, "utf-8");
+    root = insertClipIntoRoot(root, { id: "intro", start: 0, duration: 4 });
+
+    const outro = emitSceneHtml({
+      id: "outro", preset: "simple", width: 1920, height: 1080,
+      duration: 3, subhead: "Thanks",
+    });
+    await writeFile(resolve(dir, "compositions/scene-outro.html"), outro, "utf-8");
+    root = insertClipIntoRoot(root, { id: "outro", start: 4, duration: 3 });
+
+    await writeFile(resolve(dir, "index.html"), root, "utf-8");
+    return dir;
+  }
+
+  it("produces ok=true on a freshly scaffolded project with valid scenes", async () => {
+    const dir = await scaffoldWithScenes();
+    const result = await runProjectLint({ projectDir: dir });
+
+    expect(result.ok).toBe(true);
+    expect(result.errorCount).toBe(0);
+    // 1 root + 2 sub-comps inspected
+    expect(result.files.map((f) => f.file).sort()).toEqual([
+      "compositions/scene-intro.html",
+      "compositions/scene-outro.html",
+      "index.html",
+    ]);
+    // Sub-comp false positives must not appear
+    for (const file of result.files) {
+      for (const f of file.findings) {
+        expect(SUB_COMP_FALSE_POSITIVES.has(f.code)).toBe(false);
+      }
+    }
+  });
+
+  it("flags a sub-comp that has timing attributes but no class=\"clip\"", async () => {
+    const dir = await scaffoldWithScenes();
+    // Mutate scene-intro.html: drop `class="clip"` from a timed element.
+    const broken = `<template id="bad-template">
+  <div data-composition-id="bad" data-start="0" data-duration="3" data-width="1920" data-height="1080">
+    <div data-start="0" data-duration="2" data-track-index="1">no class</div>
+  </div>
+</template>`;
+    await writeFile(resolve(dir, "compositions/scene-bad.html"), broken, "utf-8");
+
+    const result = await runProjectLint({ projectDir: dir });
+    const badFile = result.files.find((f) => f.file.endsWith("scene-bad.html"))!;
+    expect(badFile).toBeDefined();
+    expect(badFile.findings.some((f) => f.code === "timed_element_missing_clip_class")).toBe(true);
+  });
+
+  it("--fix repairs timed_element_missing_clip_class and re-lint shows it gone", async () => {
+    const dir = await scaffoldWithScenes();
+    const broken = `<template id="bad-template">
+  <div data-composition-id="bad" data-start="0" data-duration="3" data-width="1920" data-height="1080">
+    <div data-start="0" data-duration="2" data-track-index="1">no class</div>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      window.__timelines["bad"] = tl;
+    </script>
+  </div>
+</template>`;
+    const badPath = resolve(dir, "compositions/scene-bad.html");
+    await writeFile(badPath, broken, "utf-8");
+
+    const result = await runProjectLint({ projectDir: dir, fix: true });
+
+    // Fix tracked
+    const fix = result.fixed.find((f) => f.file.endsWith("scene-bad.html"));
+    expect(fix).toBeDefined();
+    expect(fix!.codes).toContain("timed_element_missing_clip_class");
+
+    // File on disk is updated
+    const after = await readFile(badPath, "utf-8");
+    expect(after).toContain('<div class="clip" data-start="0" data-duration="2"');
+
+    // Re-lint result no longer reports it for that file
+    const badFile = result.files.find((f) => f.file.endsWith("scene-bad.html"))!;
+    expect(badFile.findings.some((f) => f.code === "timed_element_missing_clip_class")).toBe(false);
+  });
+
+  it("returns ok=true and empty findings on an empty root with no compositions/ dir", async () => {
+    const dir = await makeTmp();
+    await writeFile(resolve(dir, "index.html"), buildEmptyRootHtml({ aspect: "16:9", duration: 5 }), "utf-8");
+    const result = await runProjectLint({ projectDir: dir });
+    expect(result.ok).toBe(true);
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0].file).toBe("index.html");
+  });
+
+  it("does not flag a buildClipReference()-built clip in the root", async () => {
+    const dir = await scaffoldWithScenes();
+    // Produce one extra clip via the C2 helper just to be sure the produced
+    // markup keeps lint clean.
+    const root = await readFile(resolve(dir, "index.html"), "utf-8");
+    const augmented = root.replace(
+      "</div>\n\n    <script>",
+      `  ${buildClipReference({ id: "extra", start: 7, duration: 2 })}\n    </div>\n\n    <script>`,
+    );
+    await writeFile(resolve(dir, "index.html"), augmented, "utf-8");
+    // The extra clip references a non-existent composition file — that's a
+    // semantic/runtime concern, not a lint rule. So lint should still pass.
+    const result = await runProjectLint({ projectDir: dir });
+    const rootFile = result.files.find((f) => f.file === "index.html")!;
+    expect(rootFile.findings.some((f) => f.code === "timed_element_missing_clip_class")).toBe(false);
+  });
+});
+

--- a/packages/cli/src/commands/_shared/scene-lint.ts
+++ b/packages/cli/src/commands/_shared/scene-lint.ts
@@ -1,0 +1,280 @@
+/**
+ * @module _shared/scene-lint
+ *
+ * In-process Hyperframes lint pipeline for VibeFrame scene projects. Wraps
+ * `runHyperframeLint` from `@hyperframes/producer` (its public lint entry
+ * point) and adapts the output to VibeFrame's two-tier file structure:
+ *
+ *   project/
+ *     index.html              # root composition  → linted as-is
+ *     compositions/*.html     # sub-compositions  → producer's lint emits two
+ *                                                   spurious findings here, so
+ *                                                   we filter them out.
+ *
+ * Two findings are filtered for sub-compositions because they encode the
+ * inverse rule (sub-comps SHOULD be wrapped in `<template>` and SHOULD NOT
+ * have an `<html>` wrapper):
+ *   - `standalone_composition_wrapped_in_template`
+ *   - `root_composition_missing_html_wrapper`
+ *
+ * Pure helpers are exported for unit testing; `runProjectLint` does the
+ * filesystem walk + lint orchestration. Mechanical `--fix` is intentionally
+ * conservative — only `timed_element_missing_clip_class` is auto-fixed in
+ * MVP 1.
+ */
+
+import { readdir, readFile, writeFile, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve, relative, join } from "node:path";
+import {
+  runHyperframeLint,
+  type PreparedHyperframeLintInput,
+} from "@hyperframes/producer";
+
+// ── Re-exported shape of producer's HyperframeLintResult ───────────────────
+//
+// We re-declare here (vs importing from `@hyperframes/core`) so VibeFrame
+// only depends on the producer's public surface.
+
+export type LintSeverity = "error" | "warning" | "info";
+
+export interface LintFinding {
+  code: string;
+  severity: LintSeverity;
+  message: string;
+  file?: string;
+  selector?: string;
+  elementId?: string;
+  fixHint?: string;
+  snippet?: string;
+}
+
+export interface FileLintResult {
+  /** Path relative to the project directory. */
+  file: string;
+  /** True for files under `compositions/` — used to filter false positives. */
+  isSubComposition: boolean;
+  findings: LintFinding[];
+}
+
+export interface FileFixResult {
+  file: string;
+  /** Codes that were mechanically fixed. */
+  codes: string[];
+}
+
+export interface ProjectLintResult {
+  ok: boolean;
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+  files: FileLintResult[];
+  fixed: FileFixResult[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Producer's two findings that are inverse-rules for sub-compositions. */
+export const SUB_COMP_FALSE_POSITIVES: ReadonlySet<string> = new Set([
+  "standalone_composition_wrapped_in_template",
+  "root_composition_missing_html_wrapper",
+]);
+
+/**
+ * Discover scene files in a project. Returns the root composition (or null
+ * if missing) plus every `*.html` file under `compositions/` recursively.
+ *
+ * Paths returned are absolute. The caller derives project-relative paths via
+ * `relative(projectDir, path)`.
+ */
+export async function discoverSceneFiles(opts: {
+  projectDir: string;
+  rootRel?: string;
+}): Promise<{ root: string | null; subs: string[] }> {
+  const projectDir = resolve(opts.projectDir);
+  const rootAbs = resolve(projectDir, opts.rootRel ?? "index.html");
+  const root = existsSync(rootAbs) ? rootAbs : null;
+
+  const compsDir = resolve(projectDir, "compositions");
+  const subs: string[] = [];
+  if (existsSync(compsDir)) {
+    await collectHtmlRecursive(compsDir, subs);
+    subs.sort();
+  }
+
+  return { root, subs };
+}
+
+async function collectHtmlRecursive(dir: string, into: string[]): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectHtmlRecursive(full, into);
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".html")) {
+      into.push(full);
+    }
+  }
+}
+
+/**
+ * Drop findings that producer's lint emits as inverse-rules for sub-comp
+ * files. Other findings pass through unchanged.
+ */
+export function filterSubCompFalsePositives(
+  findings: LintFinding[],
+  isSubComposition: boolean,
+): LintFinding[] {
+  if (!isSubComposition) return findings;
+  return findings.filter((f) => !SUB_COMP_FALSE_POSITIVES.has(f.code));
+}
+
+/**
+ * Apply mechanical `--fix` rewrites for known-safe finding codes. Returns the
+ * (possibly unchanged) HTML and the list of codes that were fixed at least
+ * once.
+ *
+ * MVP 1 only auto-fixes `timed_element_missing_clip_class` — adding the
+ * `clip` class to elements that already carry timing attributes.
+ *
+ * Other "registration"/"paused" fixes are intentionally NOT mechanical —
+ * they require structural reasoning (where to insert the `window.__timelines`
+ * block, how to convert an unpaused timeline) that goes beyond a regex.
+ * The lint output still surfaces them with `fixHint` for the agent or human
+ * to apply.
+ */
+export function applyMechanicalFixes(
+  html: string,
+  findings: LintFinding[],
+): { html: string; fixedCodes: string[] } {
+  const fixedCodes = new Set<string>();
+  let updated = html;
+
+  if (findings.some((f) => f.code === "timed_element_missing_clip_class")) {
+    const next = addClipClassToTimedElements(updated);
+    if (next !== updated) {
+      updated = next;
+      fixedCodes.add("timed_element_missing_clip_class");
+    }
+  }
+
+  return { html: updated, fixedCodes: [...fixedCodes] };
+}
+
+/**
+ * Add `class="clip"` (or merge into an existing `class="..."`) on every
+ * element that has both `data-start` and `data-duration` but no `clip` class.
+ *
+ * Skips `<audio>` and `<video>` elements — those have timing attributes but
+ * use their own track-management semantics, and the lint rule already exempts
+ * them.
+ */
+function addClipClassToTimedElements(html: string): string {
+  return html.replace(/<([a-z][a-z0-9-]*)([^>]*)>/gi, (full, tag: string, attrs: string) => {
+    const lower = tag.toLowerCase();
+    if (lower === "audio" || lower === "video") return full;
+    if (!/\sdata-start="/.test(attrs)) return full;
+    if (!/\sdata-duration="/.test(attrs)) return full;
+    const classMatch = attrs.match(/\sclass="([^"]*)"/);
+    if (classMatch) {
+      const classes = classMatch[1].split(/\s+/).filter(Boolean);
+      if (classes.includes("clip")) return full;
+      const merged = [...classes, "clip"].join(" ");
+      return `<${tag}${attrs.replace(/\sclass="[^"]*"/, ` class="${merged}"`)}>`;
+    }
+    return `<${tag} class="clip"${attrs}>`;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// File-system orchestration
+// ---------------------------------------------------------------------------
+
+export interface RunProjectLintOptions {
+  projectDir: string;
+  rootRel?: string;
+  /** Apply mechanical fixes and write files back. */
+  fix?: boolean;
+}
+
+/**
+ * Walk the project, lint every HTML file, optionally apply mechanical fixes,
+ * and return aggregated counts. Throws only on FS errors; lint errors are
+ * surfaced as findings, not exceptions.
+ */
+export async function runProjectLint(opts: RunProjectLintOptions): Promise<ProjectLintResult> {
+  const projectDir = resolve(opts.projectDir);
+  const { root, subs } = await discoverSceneFiles({ projectDir, rootRel: opts.rootRel });
+
+  const files: FileLintResult[] = [];
+  const fixed: FileFixResult[] = [];
+
+  const targets: Array<{ abs: string; isSub: boolean }> = [];
+  if (root) targets.push({ abs: root, isSub: false });
+  for (const sub of subs) targets.push({ abs: sub, isSub: true });
+
+  for (const { abs, isSub } of targets) {
+    const rel = relative(projectDir, abs) || abs;
+    const html = await readFile(abs, "utf-8");
+
+    const prepared: PreparedHyperframeLintInput = {
+      html,
+      entryFile: rel,
+      source: "projectDir",
+    };
+    const raw = runHyperframeLint(prepared);
+    const findings = filterSubCompFalsePositives(raw.findings as LintFinding[], isSub);
+
+    if (opts.fix && findings.length > 0) {
+      const { html: nextHtml, fixedCodes } = applyMechanicalFixes(html, findings);
+      if (fixedCodes.length > 0) {
+        await writeFile(abs, nextHtml, "utf-8");
+        fixed.push({ file: rel, codes: fixedCodes });
+        // Re-lint after fix so the result reflects what's left.
+        const reLinted = runHyperframeLint({ ...prepared, html: nextHtml });
+        files.push({
+          file: rel,
+          isSubComposition: isSub,
+          findings: filterSubCompFalsePositives(reLinted.findings as LintFinding[], isSub),
+        });
+        continue;
+      }
+    }
+
+    files.push({ file: rel, isSubComposition: isSub, findings });
+  }
+
+  let errorCount = 0;
+  let warningCount = 0;
+  let infoCount = 0;
+  for (const f of files) {
+    for (const finding of f.findings) {
+      if (finding.severity === "error") errorCount++;
+      else if (finding.severity === "warning") warningCount++;
+      else infoCount++;
+    }
+  }
+
+  return {
+    ok: errorCount === 0,
+    errorCount,
+    warningCount,
+    infoCount,
+    files,
+    fixed,
+  };
+}
+
+/** True if `root` exists and is a regular file. Used by callers that want to
+ *  pre-validate before invoking `runProjectLint`. */
+export async function rootExists(projectDir: string, rootRel = "index.html"): Promise<boolean> {
+  const abs = resolve(projectDir, rootRel);
+  try {
+    const s = await stat(abs);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -146,9 +146,10 @@ export function buildEmptyRootHtml(opts: { aspect: SceneAspect; duration: number
       data-width="${width}"
       data-height="${height}"
     >
-      <!-- Scenes will be inserted here by \`vibe scene add\`.
-           Each scene is a <div class="clip" data-composition-src="compositions/*.html"
-           data-start="..." data-duration="..." data-track-index="1"></div>. -->
+      <!-- Scenes added via \`vibe scene add\` are inserted here. -->
+      <!-- Each scene reference: data-composition-id, data-composition-src, data-start, data-duration, data-track-index. -->
+      <!-- See compositions/*.html for sub-composition contents. -->
+
     </div>
 
     <script>

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -9,8 +9,8 @@
  *
  * Subcommands land incrementally across MVP 1:
  *   - init      [C1] — scaffold project directory
- *   - add       [C2, this commit] — author one scene (template + assets)
- *   - lint      [C3]
+ *   - add       [C2] — author one scene (template + assets)
+ *   - lint      [C3, this commit] — in-process Hyperframes lint + --fix
  *   - render    [C4]
  */
 
@@ -41,6 +41,11 @@ import {
   SCENE_PRESETS,
   type ScenePreset,
 } from "./_shared/scene-html-emit.js";
+import {
+  runProjectLint,
+  rootExists,
+  type ProjectLintResult,
+} from "./_shared/scene-lint.js";
 import {
   exitWithError,
   generalError,
@@ -85,6 +90,9 @@ Examples:
       --headline "Welcome to VibeFrame"                   # Headline-only scene
   $ vibe scene add overview --narration "VibeFrame turns scripts into video." \\
       --visuals "studio desk, soft lighting"              # AI narration + image
+  $ vibe scene lint                                       # Validate every scene against Hyperframes rules
+  $ vibe scene lint --fix                                 # Auto-fix mechanical issues (e.g. missing class="clip")
+  $ vibe scene lint --json                                # Structured output for agent loops
 
 A scene project is bilingual: it works with both \`vibe\` and \`npx hyperframes\`.
 Run 'vibe schema scene.<command>' for structured parameter info.`);
@@ -514,4 +522,85 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
     audioPath: audioAbsPath ? (relative(process.cwd(), audioAbsPath) || audioAbsPath) : undefined,
     imagePath: imageAbsPath ? (relative(process.cwd(), imageAbsPath) || imageAbsPath) : undefined,
   };
+}
+
+// ---------------------------------------------------------------------------
+// `vibe scene lint`
+// ---------------------------------------------------------------------------
+
+sceneCommand
+  .command("lint")
+  .description("Validate scene HTML against Hyperframes rules (in-process, no Chrome required)")
+  .argument("[root]", "Root composition file relative to --project", "index.html")
+  .option("--project <dir>", "Project directory", ".")
+  .option("--fix", "Apply mechanical auto-fixes (currently: missing class=\"clip\")")
+  .action(async (root: string, options) => {
+    const projectDir = resolve(options.project as string);
+    if (!(await rootExists(projectDir, root))) {
+      exitWithError(generalError(
+        `Root composition not found: ${resolve(projectDir, root)}`,
+        "Run `vibe scene init` first, or pass --project <dir>.",
+      ));
+    }
+
+    const spinner = isJsonMode() ? null : ora("Linting scenes...").start();
+    let result: ProjectLintResult;
+    try {
+      result = await runProjectLint({ projectDir, rootRel: root, fix: !!options.fix });
+    } catch (error) {
+      spinner?.fail("Lint failed");
+      const msg = error instanceof Error ? error.message : String(error);
+      exitWithError(generalError(`Lint failed: ${msg}`));
+    }
+
+    if (isJsonMode()) {
+      outputResult({
+        command: "scene lint",
+        ...result,
+      });
+      if (!result.ok) process.exit(1);
+      return;
+    }
+
+    if (result.ok && result.warningCount === 0 && result.infoCount === 0) {
+      spinner?.succeed(chalk.green(`Lint clean — ${result.files.length} file(s) checked`));
+    } else if (result.ok) {
+      spinner?.warn(chalk.yellow(
+        `${result.warningCount} warning(s), ${result.infoCount} info — ${result.errorCount} error(s)`,
+      ));
+    } else {
+      spinner?.fail(chalk.red(
+        `${result.errorCount} error(s), ${result.warningCount} warning(s), ${result.infoCount} info`,
+      ));
+    }
+
+    for (const file of result.files) {
+      if (file.findings.length === 0) continue;
+      console.log();
+      console.log(chalk.bold.cyan(file.file));
+      console.log(chalk.dim("─".repeat(60)));
+      for (const f of file.findings) {
+        const tag = severityTag(f.severity);
+        const loc = f.elementId ? chalk.dim(` #${f.elementId}`) : f.selector ? chalk.dim(` ${f.selector}`) : "";
+        console.log(`  ${tag} ${chalk.dim(`[${f.code}]`)}${loc}  ${f.message}`);
+        if (f.fixHint) console.log(`     ${chalk.dim("→ " + f.fixHint)}`);
+      }
+    }
+
+    if (result.fixed.length > 0) {
+      console.log();
+      console.log(chalk.bold.cyan("Auto-fixed"));
+      console.log(chalk.dim("─".repeat(60)));
+      for (const fx of result.fixed) {
+        console.log(`  ${chalk.green("✔")} ${fx.file}  ${chalk.dim(fx.codes.join(", "))}`);
+      }
+    }
+
+    if (!result.ok) process.exit(1);
+  });
+
+function severityTag(severity: "error" | "warning" | "info"): string {
+  if (severity === "error") return chalk.red("✘ error  ");
+  if (severity === "warning") return chalk.yellow("⚠ warn   ");
+  return chalk.blue("ℹ info   ");
 }


### PR DESCRIPTION
## Summary

Lands C3 of the Hyperframes scene-authoring MVP: `vibe scene lint [<root>]` walks the project, lints `index.html` plus every `compositions/**/*.html` against the public Hyperframes lint API (`runHyperframeLint` from `@hyperframes/producer`), and reports findings either pretty-printed or as JSON for agent loops.

- Pure helpers in `_shared/scene-lint.ts` (`discoverSceneFiles`, `filterSubCompFalsePositives`, `applyMechanicalFixes`) plus a single `runProjectLint()` orchestrator. Helpers are unit-tested independently.
- Producer's lint emits two findings as inverse rules for sub-compositions (`standalone_composition_wrapped_in_template`, `root_composition_missing_html_wrapper`). We filter those for paths under `compositions/`.
- `--fix` mechanically repairs `timed_element_missing_clip_class` only (adds `class="clip"` to elements that already carry timing attrs, merging into existing class lists, idempotent, skips audio/video). Other "registration"/"paused" issues surface with `fixHint` for the agent or human to apply.
- Exit code 1 when any error finding remains; warnings/info exit 0.
- Re-uses the public producer API only — no direct dependency on `@hyperframes/core` introduced.

### C2 fixes surfaced by the new linter (shipped in this PR)

Running the new linter against a freshly scaffolded project surfaced two real bugs in C2 that this PR also fixes:

1. `buildClipReference` did not emit `data-composition-id="<id>"`, so every clip host failed `host_missing_composition_id`. Now emitted.
2. `buildEmptyRootHtml`'s placeholder comment embedded example clip markup (`<div class=\"clip\" data-composition-src=\"compositions/*.html\" ...>`); the lint regex parsed this as a real host and flagged it. Comment is now plain text.

No version bump — stays `0.52.1` until c8.

## Test plan

- [x] `pnpm -F @vibeframe/cli build` clean (tsc strict)
- [x] `pnpm -F @vibeframe/cli lint` — 0 errors (8 pre-existing warnings unrelated)
- [x] 16 new tests pass: 5 pure-helper + 6 fix/discover/path + 5 integration scenarios in `_shared/scene-lint.test.ts`
- [x] Full CLI suite: 375 passed, 11 skipped, 1 file skipped — no regressions
- [x] Smoke (clean): `vibe scene init /tmp/x && vibe scene add intro --no-audio --no-image && vibe scene lint --project /tmp/x` → ok=true, exit 0
- [x] Smoke (broken): mutate a scene to drop `class=\"clip\"` from a timed `<div>` → lint reports `timed_element_missing_clip_class` warning; `--fix` rewrites the file and re-lint shows it gone
- [x] Pretty + JSON output paths both exercised; `--json` returns the full `ProjectLintResult`

## MVP 1 sequence

- [x] c1 — `vibe scene init` + bilingual layout (#60)
- [x] c2 — `vibe scene add` (#61)
- [x] **c3 — `vibe scene lint` (this PR)**
- [ ] c4 — `vibe scene render`
- [ ] c5 — `pipeline script-to-video --format scenes`
- [ ] c6 — agent + MCP tool sync
- [ ] c7 — `/vibe-scene` skill + example + README
- [ ] c8 — bump 0.53.0 + CHANGELOG