### PR TITLE
feat(scene): vibe scene render via Hyperframes producer (MVP 1 c4/8)

### DIFF
--- a/packages/cli/src/commands/_shared/scene-render.test.ts
+++ b/packages/cli/src/commands/_shared/scene-render.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  buildRenderConfig,
+  defaultOutputPath,
+  executeSceneRender,
+  qualityToCrf,
+} from "./scene-render.js";
+import { scaffoldSceneProject } from "./scene-project.js";
+import { emitSceneHtml, insertClipIntoRoot } from "./scene-html-emit.js";
+import { preflightChrome } from "../../pipeline/renderers/chrome.js";
+
+async function makeTmp(label = "vibe-scene-render-"): Promise<string> {
+  return mkdtemp(join(tmpdir(), label));
+}
+
+// ── qualityToCrf ────────────────────────────────────────────────────────────
+
+describe("qualityToCrf", () => {
+  it.each([
+    ["draft", 28],
+    ["standard", 23],
+    ["high", 18],
+  ] as const)("%s → %d", (q, expected) => {
+    expect(qualityToCrf(q)).toBe(expected);
+  });
+
+  it("defaults to standard when no preset is given", () => {
+    expect(qualityToCrf()).toBe(23);
+  });
+});
+
+// ── buildRenderConfig ───────────────────────────────────────────────────────
+
+describe("buildRenderConfig", () => {
+  it("supplies producer-compatible defaults", () => {
+    const cfg = buildRenderConfig({});
+    expect(cfg).toEqual({
+      fps: 30,
+      quality: "standard",
+      format: "mp4",
+      entryFile: "index.html",
+      crf: 23,
+      workers: 1,
+    });
+  });
+
+  it("propagates overrides and recomputes crf from quality", () => {
+    const cfg = buildRenderConfig({ fps: 60, quality: "high", format: "webm", workers: 4, entryFile: "alt.html" });
+    expect(cfg).toEqual({
+      fps: 60,
+      quality: "high",
+      format: "webm",
+      entryFile: "alt.html",
+      crf: 18,
+      workers: 4,
+    });
+  });
+});
+
+// ── defaultOutputPath ───────────────────────────────────────────────────────
+
+describe("defaultOutputPath", () => {
+  it("places output under <projectDir>/renders with project name + iso stamp", () => {
+    const out = defaultOutputPath({
+      projectDir: "/tmp/proj",
+      projectName: "promo",
+      format: "mp4",
+      now: new Date("2026-04-25T12:34:56Z"),
+    });
+    expect(out).toBe("/tmp/proj/renders/promo-2026-04-25-12-34-56.mp4");
+  });
+
+  it("falls back to projectDir basename when no name is given", () => {
+    const out = defaultOutputPath({
+      projectDir: "/tmp/my-video",
+      format: "webm",
+      now: new Date("2026-04-25T00:00:00Z"),
+    });
+    expect(out).toBe("/tmp/my-video/renders/my-video-2026-04-25-00-00-00.webm");
+  });
+
+  it("defaults to mp4 when no format is given", () => {
+    const out = defaultOutputPath({
+      projectDir: "/tmp/p",
+      projectName: "n",
+      now: new Date("2026-04-25T00:00:00Z"),
+    });
+    expect(out.endsWith(".mp4")).toBe(true);
+  });
+});
+
+// ── executeSceneRender — pre-Chrome failure paths ───────────────────────────
+//
+// These tests exercise the validation surface (project dir, root file, Chrome
+// preflight) WITHOUT requiring Chrome to be installed.
+
+describe("executeSceneRender — validation", () => {
+  it("returns a structured error when the project directory doesn't exist", async () => {
+    const r = await executeSceneRender({ projectDir: "/tmp/__vibe_does_not_exist__" });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/Project directory not found/);
+  });
+
+  it("returns a structured error when index.html is missing", async () => {
+    const dir = await makeTmp();
+    const r = await executeSceneRender({ projectDir: dir });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/Root composition not found/);
+  });
+
+  it("(without Chrome) returns the Chrome preflight reason", async () => {
+    const pre = await preflightChrome();
+    if (pre.ok) return; // Chrome present — Chrome-gated integration test covers the success path.
+
+    const dir = await makeTmp();
+    await scaffoldSceneProject({ dir, name: "fixture", aspect: "16:9", duration: 4 });
+    const r = await executeSceneRender({ projectDir: dir });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/Chrome not found/);
+  });
+});
+
+// ── executeSceneRender — Chrome-gated integration ───────────────────────────
+
+describe("executeSceneRender — Chrome-gated render", () => {
+  let chromeAvailable = false;
+
+  beforeAll(async () => {
+    chromeAvailable = (await preflightChrome()).ok;
+    if (!chromeAvailable) {
+      console.warn("[scene-render] Chrome not found — skipping render integration test");
+    }
+  });
+
+  it("renders a 1-scene project to MP4 (requires Chrome, skipped in CI)", async () => {
+    if (!chromeAvailable || process.env.CI) return;
+
+    // Build a minimal scene project: root + one announcement scene.
+    const dir = await makeTmp("vibe-scene-render-int-");
+    await scaffoldSceneProject({ dir, name: "fixture", aspect: "16:9", duration: 2 });
+
+    let root = await readFile(resolve(dir, "index.html"), "utf-8");
+    const intro = emitSceneHtml({
+      id: "intro", preset: "announcement", width: 1920, height: 1080,
+      duration: 1.5, headline: "Render OK",
+    });
+    await writeFile(resolve(dir, "compositions/scene-intro.html"), intro, "utf-8");
+    root = insertClipIntoRoot(root, { id: "intro", start: 0, duration: 1.5 });
+    await writeFile(resolve(dir, "index.html"), root, "utf-8");
+
+    const out = resolve(dir, "renders", "out.mp4");
+    const result = await executeSceneRender({
+      projectDir: dir,
+      output: "renders/out.mp4",
+      fps: 30,
+      quality: "draft",
+      format: "mp4",
+    });
+
+    expect(result.success).toBe(true);
+    expect(existsSync(out)).toBe(true);
+    expect(result.fps).toBe(30);
+    expect(result.quality).toBe("draft");
+    expect(result.format).toBe("mp4");
+    expect((result.framesRendered ?? 0)).toBeGreaterThan(0);
+  }, 90_000);
+});

--- a/packages/cli/src/commands/_shared/scene-render.ts
+++ b/packages/cli/src/commands/_shared/scene-render.ts
@@ -1,0 +1,201 @@
+/**
+ * @module _shared/scene-render
+ *
+ * Render a VibeFrame scene project to MP4/WebM/MOV using the Hyperframes
+ * producer directly. Unlike the FFmpeg-bridge backend in
+ * `pipeline/renderers/hyperframes.ts` which has to convert a `TimelineState`
+ * into a temp Hyperframes project, scene projects already ARE Hyperframes
+ * projects — so we hand the producer the user's project dir and entry file
+ * verbatim.
+ *
+ * `executeSceneRender()` is decoupled from CLI flags so that the C6 agent
+ * tool and the C5 `--format scenes` pipeline can call it the same way. It
+ * returns a structured result instead of throwing or exiting.
+ */
+
+import { mkdir, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve, relative, dirname, basename } from "node:path";
+import { parse as yamlParse } from "yaml";
+import {
+  createRenderJob,
+  executeRenderJob,
+  type RenderConfig,
+} from "@hyperframes/producer";
+import { preflightChrome } from "../../pipeline/renderers/chrome.js";
+import { rootExists } from "./scene-lint.js";
+
+export type RenderFps = 24 | 30 | 60;
+export type RenderQuality = "draft" | "standard" | "high";
+export type RenderFormat = "mp4" | "webm" | "mov";
+
+export interface SceneRenderOptions {
+  /** Project directory (defaults to cwd). */
+  projectDir?: string;
+  /** Root composition file relative to projectDir (default: "index.html"). */
+  root?: string;
+  /** Output file. When relative, resolved against projectDir. Default:
+   *  `renders/<projectName>-<isoStamp>.<format>`. */
+  output?: string;
+  fps?: RenderFps;
+  quality?: RenderQuality;
+  format?: RenderFormat;
+  /** Hyperframes capture worker count. Default 1 (the existing backend's
+   *  default — auto-worker mode times out on small comps). */
+  workers?: number;
+  signal?: AbortSignal;
+  onProgress?: (pct: number, stage: string) => void;
+}
+
+export interface SceneRenderResult {
+  success: boolean;
+  outputPath?: string;
+  durationMs?: number;
+  framesRendered?: number;
+  totalFrames?: number;
+  fps?: RenderFps;
+  quality?: RenderQuality;
+  format?: RenderFormat;
+  error?: string;
+}
+
+/** Map a quality preset to an x264 CRF (lower = higher quality). */
+export function qualityToCrf(quality: RenderQuality = "standard"): number {
+  return quality === "draft" ? 28 : quality === "high" ? 18 : 23;
+}
+
+/**
+ * Compute the default output path for a render. Pure — does no I/O. Returns
+ * an absolute path under `<projectDir>/renders/`.
+ *
+ * `now` is injectable so tests get deterministic output.
+ */
+export function defaultOutputPath(opts: {
+  projectDir: string;
+  projectName?: string;
+  format?: RenderFormat;
+  now?: Date;
+}): string {
+  const fmt = opts.format ?? "mp4";
+  const now = opts.now ?? new Date();
+  const stamp = now
+    .toISOString()
+    .replace(/[:T]/g, "-")
+    .replace(/\..+$/, "");
+  const name = (opts.projectName ?? basename(resolve(opts.projectDir))) || "scene";
+  return resolve(opts.projectDir, "renders", `${name}-${stamp}.${fmt}`);
+}
+
+/** Minimal subset of `vibe.project.yaml` we care about for render. */
+interface VibeProjectShape {
+  name?: string;
+}
+
+async function readProjectName(projectDir: string): Promise<string | undefined> {
+  const cfgPath = resolve(projectDir, "vibe.project.yaml");
+  if (!existsSync(cfgPath)) return undefined;
+  try {
+    const raw = await (await import("node:fs/promises")).readFile(cfgPath, "utf-8");
+    const parsed = yamlParse(raw) as VibeProjectShape | null;
+    return parsed?.name ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build the producer's `RenderConfig` from caller options. Pure — useful for
+ * unit tests that want to assert defaults without touching Chrome.
+ */
+export function buildRenderConfig(opts: {
+  fps?: RenderFps;
+  quality?: RenderQuality;
+  format?: RenderFormat;
+  workers?: number;
+  entryFile?: string;
+}): RenderConfig {
+  const quality = opts.quality ?? "standard";
+  return {
+    fps: opts.fps ?? 30,
+    quality,
+    format: opts.format ?? "mp4",
+    entryFile: opts.entryFile ?? "index.html",
+    crf: qualityToCrf(quality),
+    workers: opts.workers ?? 1,
+  };
+}
+
+/**
+ * Render a scene project. Mirrors the contract of the existing Hyperframes
+ * backend (preflight → execute → structured result), but skips the
+ * `TimelineState` → temp project conversion because the user's project is
+ * already a valid Hyperframes project.
+ */
+export async function executeSceneRender(opts: SceneRenderOptions = {}): Promise<SceneRenderResult> {
+  const projectDir = resolve(opts.projectDir ?? ".");
+  const root = opts.root ?? "index.html";
+
+  // -- Preflight: project + Chrome ---------------------------------------
+  const projectStat = await safeStat(projectDir);
+  if (!projectStat || !projectStat.isDirectory()) {
+    return { success: false, error: `Project directory not found: ${projectDir}` };
+  }
+  if (!(await rootExists(projectDir, root))) {
+    return {
+      success: false,
+      error: `Root composition not found: ${resolve(projectDir, root)}. Run \`vibe scene init\` first.`,
+    };
+  }
+  const chrome = await preflightChrome();
+  if (!chrome.ok) {
+    return { success: false, error: chrome.reason };
+  }
+
+  // -- Resolve output path -----------------------------------------------
+  const projectName = await readProjectName(projectDir);
+  const outputPath = opts.output
+    ? resolve(projectDir, opts.output)
+    : defaultOutputPath({ projectDir, projectName, format: opts.format });
+  await mkdir(dirname(outputPath), { recursive: true });
+
+  // -- Execute render ----------------------------------------------------
+  const config = buildRenderConfig({
+    fps: opts.fps,
+    quality: opts.quality,
+    format: opts.format,
+    workers: opts.workers,
+    entryFile: root,
+  });
+  const job = createRenderJob(config);
+  const start = Date.now();
+
+  try {
+    await executeRenderJob(
+      job,
+      projectDir,
+      outputPath,
+      (j, msg) => opts.onProgress?.(j.progress, j.currentStage ?? msg),
+      opts.signal,
+    );
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  return {
+    success: true,
+    outputPath: relative(process.cwd(), outputPath) || outputPath,
+    durationMs: Date.now() - start,
+    framesRendered: job.framesRendered,
+    totalFrames: job.totalFrames,
+    fps: config.fps,
+    quality: config.quality,
+    format: config.format,
+  };
+}
+
+async function safeStat(p: string): Promise<{ isDirectory: () => boolean } | null> {
+  try { return await stat(p); } catch { return null; }
+}

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -10,8 +10,8 @@
  * Subcommands land incrementally across MVP 1:
  *   - init      [C1] — scaffold project directory
  *   - add       [C2] — author one scene (template + assets)
- *   - lint      [C3, this commit] — in-process Hyperframes lint + --fix
- *   - render    [C4]
+ *   - lint      [C3] — in-process Hyperframes lint + --fix
+ *   - render    [C4, this commit] — render scene project to MP4/WebM/MOV
  */
 
 import { Command } from "commander";
@@ -46,6 +46,12 @@ import {
   rootExists,
   type ProjectLintResult,
 } from "./_shared/scene-lint.js";
+import {
+  executeSceneRender,
+  type RenderFps,
+  type RenderFormat,
+  type RenderQuality,
+} from "./_shared/scene-render.js";
 import {
   exitWithError,
   generalError,
@@ -93,6 +99,9 @@ Examples:
   $ vibe scene lint                                       # Validate every scene against Hyperframes rules
   $ vibe scene lint --fix                                 # Auto-fix mechanical issues (e.g. missing class="clip")
   $ vibe scene lint --json                                # Structured output for agent loops
+  $ vibe scene render                                     # Render to renders/<name>-<timestamp>.mp4
+  $ vibe scene render -o demo.mp4 --quality high          # Custom output path + quality
+  $ vibe scene render --fps 60 --format webm              # 60fps WebM render
 
 A scene project is bilingual: it works with both \`vibe\` and \`npx hyperframes\`.
 Run 'vibe schema scene.<command>' for structured parameter info.`);
@@ -604,3 +613,115 @@ function severityTag(severity: "error" | "warning" | "info"): string {
   if (severity === "warning") return chalk.yellow("⚠ warn   ");
   return chalk.blue("ℹ info   ");
 }
+
+// ---------------------------------------------------------------------------
+// `vibe scene render`
+// ---------------------------------------------------------------------------
+
+const VALID_FPS: ReadonlyArray<RenderFps> = [24, 30, 60];
+const VALID_QUALITIES: ReadonlyArray<RenderQuality> = ["draft", "standard", "high"];
+const VALID_FORMATS: ReadonlyArray<RenderFormat> = ["mp4", "webm", "mov"];
+
+function validateFps(value: string): RenderFps {
+  const n = parseInt(value, 10);
+  if (!VALID_FPS.includes(n as RenderFps)) {
+    exitWithError(usageError(`Invalid --fps: ${value}`, `Valid: ${VALID_FPS.join(", ")}`));
+  }
+  return n as RenderFps;
+}
+
+function validateQuality(value: string): RenderQuality {
+  if (!VALID_QUALITIES.includes(value as RenderQuality)) {
+    exitWithError(usageError(`Invalid --quality: ${value}`, `Valid: ${VALID_QUALITIES.join(", ")}`));
+  }
+  return value as RenderQuality;
+}
+
+function validateFormat(value: string): RenderFormat {
+  if (!VALID_FORMATS.includes(value as RenderFormat)) {
+    exitWithError(usageError(`Invalid --format: ${value}`, `Valid: ${VALID_FORMATS.join(", ")}`));
+  }
+  return value as RenderFormat;
+}
+
+function validateWorkers(value: string): number {
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n) || n < 1 || n > 16) {
+    exitWithError(usageError(`Invalid --workers: ${value}`, "Must be an integer between 1 and 16"));
+  }
+  return n;
+}
+
+sceneCommand
+  .command("render")
+  .description("Render a scene project to MP4/WebM/MOV via the Hyperframes producer (requires Chrome)")
+  .argument("[root]", "Root composition file relative to --project", "index.html")
+  .option("--project <dir>", "Project directory", ".")
+  .option("-o, --out <path>", "Output file (default: renders/<name>-<timestamp>.<format>)")
+  .option("--fps <n>", `Frames per second: ${VALID_FPS.join("|")}`, "30")
+  .option("--quality <q>", `Quality preset: ${VALID_QUALITIES.join("|")}`, "standard")
+  .option("--format <f>", `Output container: ${VALID_FORMATS.join("|")}`, "mp4")
+  .option("--workers <n>", "Capture workers (1-16, default 1)", "1")
+  .option("--dry-run", "Preview parameters without rendering")
+  .action(async (root: string, options) => {
+    const fps = validateFps(options.fps);
+    const quality = validateQuality(options.quality);
+    const format = validateFormat(options.format);
+    const workers = validateWorkers(options.workers);
+    const projectDir = resolve(options.project as string);
+
+    if (options.dryRun) {
+      outputResult({
+        dryRun: true,
+        command: "scene render",
+        params: {
+          projectDir,
+          root,
+          output: options.out,
+          fps,
+          quality,
+          format,
+          workers,
+        },
+      });
+      return;
+    }
+
+    const spinner = isJsonMode() ? null : ora("Rendering scene project...").start();
+
+    const result = await executeSceneRender({
+      projectDir,
+      root,
+      output: options.out,
+      fps,
+      quality,
+      format,
+      workers,
+      onProgress: (pct, stage) => {
+        if (spinner) spinner.text = `Rendering [${Math.round(pct * 100)}%] ${stage}`;
+      },
+    });
+
+    if (!result.success) {
+      spinner?.fail("Render failed");
+      if (isJsonMode()) {
+        outputResult({ command: "scene render", ...result });
+        process.exit(1);
+      }
+      exitWithError(generalError(result.error ?? "Render failed"));
+    }
+
+    if (isJsonMode()) {
+      outputResult({ command: "scene render", ...result });
+      return;
+    }
+
+    spinner?.succeed(chalk.green(`Render complete: ${result.outputPath}`));
+    console.log();
+    console.log(chalk.bold.cyan("Render"));
+    console.log(chalk.dim("─".repeat(60)));
+    console.log(`  output    ${chalk.bold(result.outputPath)}`);
+    console.log(`  duration  ${(((result.durationMs ?? 0) / 1000)).toFixed(1)}s`);
+    console.log(`  frames    ${result.framesRendered ?? "?"}${result.totalFrames ? ` / ${result.totalFrames}` : ""}`);
+    console.log(`  config    ${result.fps}fps · ${result.quality} · ${result.format}`);
+  });

--- a/packages/cli/src/pipeline/renderers/chrome.ts
+++ b/packages/cli/src/pipeline/renderers/chrome.ts
@@ -1,0 +1,52 @@
+/**
+ * @module pipeline/renderers/chrome
+ *
+ * Shared Chrome/Chromium discovery + preflight used by every Hyperframes-
+ * backed renderer (the FFmpeg-bridge backend in `hyperframes.ts` and the
+ * direct scene renderer in `commands/_shared/scene-render.ts`). Centralised
+ * so that adding a new candidate path or env var only touches one file.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const CHROME_NOT_FOUND_REASON =
+  "Chrome not found. Set HYPERFRAMES_CHROME_PATH, or install Chrome " +
+  "(macOS: brew install --cask google-chrome · Linux: apt install chromium). " +
+  "Run `vibe doctor` for details.";
+
+/**
+ * Walk the candidate list in priority order (env vars first, then puppeteer's
+ * cache, then well-known system locations). Returns the first existing path,
+ * or undefined when none are present.
+ */
+export function findChrome(): string | undefined {
+  const candidates = [
+    process.env.HYPERFRAMES_CHROME_PATH,
+    process.env.CHROME_PATH,
+    // puppeteer auto-downloaded headless shell
+    join(homedir(), ".cache", "puppeteer", "chrome-headless-shell", "mac_arm-147.0.7727.56",
+      "chrome-headless-shell-mac_arm", "chrome-headless-shell"),
+    // system Chrome / Chromium
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+    "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+  ];
+  for (const c of candidates) {
+    if (c && existsSync(c)) return c;
+  }
+  return undefined;
+}
+
+/**
+ * Returns `{ok: true}` when Chrome is available, otherwise a structured
+ * `{ok: false, reason}` with installation guidance. Used by both the
+ * `RenderBackend.preflight` interface and the standalone scene render path.
+ */
+export async function preflightChrome(): Promise<{ ok: true } | { ok: false; reason: string }> {
+  return findChrome() ? { ok: true } : { ok: false, reason: CHROME_NOT_FOUND_REASON };
+}

--- a/packages/cli/src/pipeline/renderers/hyperframes.ts
+++ b/packages/cli/src/pipeline/renderers/hyperframes.ts
@@ -1,44 +1,13 @@
-import { existsSync } from "node:fs";
-import { homedir } from "node:os";
-import * as path from "node:path";
 import type { RenderConfig } from "@hyperframes/producer";
 import type { RenderBackend, RenderOptions, RenderResult } from "./types.js";
-
-function findChrome(): string | undefined {
-  const candidates = [
-    process.env.HYPERFRAMES_CHROME_PATH,
-    process.env.CHROME_PATH,
-    // puppeteer auto-downloaded headless shell
-    path.join(homedir(), ".cache", "puppeteer", "chrome-headless-shell", "mac_arm-147.0.7727.56",
-      "chrome-headless-shell-mac_arm", "chrome-headless-shell"),
-    // system Chrome / Chromium
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    "/Applications/Chromium.app/Contents/MacOS/Chromium",
-    "/usr/bin/google-chrome",
-    "/usr/bin/chromium",
-    "/usr/bin/chromium-browser",
-    "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
-  ];
-  for (const c of candidates) {
-    if (c && existsSync(c)) return c;
-  }
-  return undefined;
-}
+import { preflightChrome } from "./chrome.js";
 
 export function createHyperframesBackend(): RenderBackend {
   return {
     name: "hyperframes",
 
     async preflight() {
-      const chrome = findChrome();
-      if (chrome) return { ok: true };
-      return {
-        ok: false,
-        reason:
-          "Chrome not found. Set HYPERFRAMES_CHROME_PATH, or install Chrome " +
-          "(macOS: brew install --cask google-chrome · Linux: apt install chromium). " +
-          "Run `vibe doctor` for details.",
-      };
+      return preflightChrome();
     },
 
     async render(options: RenderOptions): Promise<RenderResult> {


### PR DESCRIPTION
## Summary

Lands C4 of the Hyperframes scene-authoring MVP: `vibe scene render [<root>]` renders a scene project to MP4/WebM/MOV by handing the user's project dir + entry file straight to the Hyperframes producer (`createRenderJob` + `executeRenderJob`). Unlike the FFmpeg-bridge backend in `pipeline/renderers/hyperframes.ts` which has to convert a `TimelineState` into a temp project first, scene projects are already valid Hyperframes projects — so this path is genuinely thin.

- `_shared/scene-render.ts` exposes `executeSceneRender({ projectDir, root, output, fps, quality, format, workers, signal, onProgress })` returning a structured `SceneRenderResult`. No `process.exit`, safe for the C6 agent + MCP tools.
- Pure helpers `qualityToCrf`, `buildRenderConfig`, `defaultOutputPath` are unit-tested. Default output is `<projectDir>/renders/<projectName>-<isoStamp>.<format>` so it's covered by the `.gitignore` C1 emits.
- Chrome detection + preflight extracted from `pipeline/renderers/hyperframes.ts` into a shared `pipeline/renderers/chrome.ts` so both the FFmpeg-bridge backend and the new scene path share one source of truth.
- CLI flags validated up-front: `--fps 24|30|60`, `--quality draft|standard|high`, `--format mp4|webm|mov`, `--workers 1..16`. `--dry-run` previews resolved parameters; `--json` returns the full `SceneRenderResult`. Exits 1 on render failure.

No version bump — stays `0.52.1` until c8.

## Test plan

- [x] `pnpm -F @vibeframe/cli build` clean (tsc strict)
- [x] `pnpm -F @vibeframe/cli lint` — 0 errors (8 pre-existing warnings unrelated)
- [x] 13 new tests pass: 10 pure-helper + 3 validation/integration in `_shared/scene-render.test.ts`
- [x] Chrome-gated integration: rendered a 60-frame, 209KB MP4 from a 1-scene fixture locally in 4.4s. The test follows the existing `pipeline/renderers/__tests__/integration.test.ts` pattern — early-returns when Chrome is missing or `CI=1`.
- [x] Full CLI suite: 388 passing, 11 skipped, no regressions
- [x] Smoke (manual): `vibe scene init /tmp/x && vibe scene add intro --no-audio --no-image --duration 1.5 && vibe scene render --quality draft -o renders/out.mp4` produced a playable MP4 with correct frame count.

## MVP 1 sequence

- [x] c1 — `vibe scene init` + bilingual layout (#60)
- [x] c2 — `vibe scene add` (#61)
- [x] c3 — `vibe scene lint` (#62)
- [x] **c4 — `vibe scene render` (this PR)**
- [ ] c5 — `pipeline script-to-video --format scenes`
- [ ] c6 — agent + MCP tool sync
- [ ] c7 — `/vibe-scene` skill + example + README
- [ ] c8 — bump 0.53.0 + CHANGELOG