### PR TITLE
feat(pipeline): script-to-video --format scenes (MVP 1 c5/8)

### DIFF
--- a/packages/cli/src/commands/_shared/segments-to-scenes.test.ts
+++ b/packages/cli/src/commands/_shared/segments-to-scenes.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, readFile, writeFile, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  executeSegmentsToScenes,
+  sceneIdFromIndex,
+  zeroPad,
+} from "./segments-to-scenes.js";
+import type { StoryboardSegment, NarrationEntry } from "../ai-script-pipeline.js";
+
+async function pathExists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+async function makeTmp(label = "vibe-s2s-"): Promise<string> {
+  return mkdtemp(join(tmpdir(), label));
+}
+
+/** Build a synthetic storyboard fixture without invoking Claude / OpenAI. */
+function buildSegments(specs: Array<{ description: string; narration?: string; duration: number }>): StoryboardSegment[] {
+  let startTime = 0;
+  return specs.map((spec, i) => {
+    const seg: StoryboardSegment = {
+      index: i + 1,
+      description: spec.description,
+      visuals: spec.description,
+      narration: spec.narration,
+      duration: spec.duration,
+      startTime,
+    };
+    startTime += spec.duration;
+    return seg;
+  });
+}
+
+/** Fake narration mp3 file (just bytes — duration parsing is bypassed in this path). */
+async function writeFakeAsset(absPath: string, payload = "fake"): Promise<string> {
+  await mkdir(resolve(absPath, ".."), { recursive: true });
+  await writeFile(absPath, payload, "utf-8");
+  return absPath;
+}
+
+// ── pure helpers ────────────────────────────────────────────────────────────
+
+describe("zeroPad", () => {
+  it.each([
+    [1, 2, "01"],
+    [12, 2, "12"],
+    [3, 3, "003"],
+    [100, 2, "100"],
+  ])("zeroPad(%d, %d) → %j", (n, w, expected) => {
+    expect(zeroPad(n, w)).toBe(expected);
+  });
+});
+
+describe("sceneIdFromIndex", () => {
+  it("produces canonical scene-NN ids", () => {
+    expect(sceneIdFromIndex(1)).toBe("scene-01");
+    expect(sceneIdFromIndex(7)).toBe("scene-07");
+    expect(sceneIdFromIndex(42)).toBe("scene-42");
+  });
+});
+
+// ── executeSegmentsToScenes — full happy path ───────────────────────────────
+
+describe("executeSegmentsToScenes", () => {
+  it("scaffolds a scene project, emits one composition per segment, and stitches the root", async () => {
+    const dir = await makeTmp();
+    const segments = buildSegments([
+      { description: "Welcome to VibeFrame.", narration: "VibeFrame turns scripts into video.", duration: 4 },
+      { description: "Edit scenes as code.",  narration: "Each scene is an HTML file.",          duration: 3 },
+    ]);
+
+    // Pre-write the assets where the existing pipeline puts them: flat under
+    // outputDir as narration-NN.mp3 / scene-NN.png. executeSegmentsToScenes
+    // is responsible for relocating them into assets/.
+    const narrationA = await writeFakeAsset(resolve(dir, "narration-1.mp3"));
+    const narrationB = await writeFakeAsset(resolve(dir, "narration-2.mp3"));
+    const imageA = await writeFakeAsset(resolve(dir, "scene-1.png"));
+    const imageB = await writeFakeAsset(resolve(dir, "scene-2.png"));
+
+    const narrationEntries: NarrationEntry[] = [
+      { path: narrationA, duration: 4, segmentIndex: 0, failed: false },
+      { path: narrationB, duration: 3, segmentIndex: 1, failed: false },
+    ];
+
+    const result = await executeSegmentsToScenes({
+      segments,
+      narrationEntries,
+      imagePaths: [imageA, imageB],
+      outputDir: dir,
+      aspectRatio: "16:9",
+      scenePreset: "explainer",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.scenesEmitted).toBe(2);
+    expect(result.scenePaths).toEqual([
+      "compositions/scene-01.html",
+      "compositions/scene-02.html",
+    ]);
+    expect(result.missingNarration).toEqual([]);
+    expect(result.missingImage).toEqual([]);
+
+    // Project layout
+    expect(await pathExists(resolve(dir, "index.html"))).toBe(true);
+    expect(await pathExists(resolve(dir, "vibe.project.yaml"))).toBe(true);
+    expect(await pathExists(resolve(dir, "hyperframes.json"))).toBe(true);
+    expect(await pathExists(resolve(dir, "compositions/scene-01.html"))).toBe(true);
+    expect(await pathExists(resolve(dir, "compositions/scene-02.html"))).toBe(true);
+
+    // Assets relocated
+    expect(await pathExists(resolve(dir, "assets/narration-01.mp3"))).toBe(true);
+    expect(await pathExists(resolve(dir, "assets/narration-02.mp3"))).toBe(true);
+    expect(await pathExists(resolve(dir, "assets/scene-01.png"))).toBe(true);
+    expect(await pathExists(resolve(dir, "assets/scene-02.png"))).toBe(true);
+    // Originals moved out
+    expect(await pathExists(narrationA)).toBe(false);
+    expect(await pathExists(imageA)).toBe(false);
+
+    // Scene HTML carries the relocated asset paths + narration text as subhead
+    const scene1 = await readFile(resolve(dir, "compositions/scene-01.html"), "utf-8");
+    expect(scene1).toContain('src="assets/narration-01.mp3"');
+    expect(scene1).toContain('background-image: url("assets/scene-01.png")');
+    expect(scene1).toContain("VibeFrame turns scripts into video.");
+
+    // Root has both clip refs at start=0 and start=4 with grown duration.
+    const root = await readFile(resolve(dir, "index.html"), "utf-8");
+    expect(root).toContain('data-composition-src="compositions/scene-01.html"');
+    expect(root).toContain('data-composition-src="compositions/scene-02.html"');
+    expect(root).toMatch(/data-composition-id="scene-01"\s+data-composition-src="compositions\/scene-01\.html"\s+data-start="0"\s+data-duration="4"/);
+    expect(root).toMatch(/data-composition-id="scene-02"\s+data-composition-src="compositions\/scene-02\.html"\s+data-start="4"\s+data-duration="3"/);
+    expect(root).toContain('data-duration="7"'); // root grew to fit total 7s
+  });
+
+  it("reports missingNarration / missingImage for failed-asset segments without failing overall", async () => {
+    const dir = await makeTmp();
+    const segments = buildSegments([
+      { description: "Has assets.", duration: 2 },
+      { description: "No assets.",  duration: 3 },
+    ]);
+    const narration1 = await writeFakeAsset(resolve(dir, "narration-1.mp3"));
+    const image1 = await writeFakeAsset(resolve(dir, "scene-1.png"));
+
+    const narrationEntries: NarrationEntry[] = [
+      { path: narration1, duration: 2, segmentIndex: 0, failed: false },
+      // Segment 2: failed narration entry
+      { path: null, duration: 3, segmentIndex: 1, failed: true, error: "rate limit" },
+    ];
+
+    const result = await executeSegmentsToScenes({
+      segments,
+      narrationEntries,
+      imagePaths: [image1, ""], // Segment 2 image gen failed → empty string
+      outputDir: dir,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.scenesEmitted).toBe(2);
+    expect(result.missingNarration).toEqual([2]);
+    expect(result.missingImage).toEqual([2]);
+
+    const scene2 = await readFile(resolve(dir, "compositions/scene-02.html"), "utf-8");
+    expect(scene2).not.toContain("<audio");
+    expect(scene2).not.toContain("background-image: url(");
+  });
+
+  it("aspect ratio drives scene + root canvas dims", async () => {
+    const dir = await makeTmp();
+    const segments = buildSegments([{ description: "Vertical hook.", duration: 5 }]);
+    const result = await executeSegmentsToScenes({
+      segments,
+      outputDir: dir,
+      aspectRatio: "9:16",
+    });
+    expect(result.success).toBe(true);
+    const scene = await readFile(resolve(dir, "compositions/scene-01.html"), "utf-8");
+    expect(scene).toContain('data-width="1080"');
+    expect(scene).toContain('data-height="1920"');
+    const root = await readFile(resolve(dir, "index.html"), "utf-8");
+    expect(root).toContain('data-width="1080"');
+    expect(root).toContain('data-height="1920"');
+  });
+
+  it("the emitted project passes runProjectLint with zero errors (lint result attached)", async () => {
+    const dir = await makeTmp();
+    const segments = buildSegments([
+      { description: "Intro", narration: "Hello", duration: 3 },
+      { description: "Outro", narration: "Bye",   duration: 2 },
+    ]);
+
+    const result = await executeSegmentsToScenes({
+      segments,
+      outputDir: dir,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.lintResult).toBeDefined();
+    expect(result.lintResult!.errorCount).toBe(0);
+    expect(result.lintResult!.ok).toBe(true);
+  });
+
+  it("rejects an empty segment list", async () => {
+    const dir = await makeTmp();
+    const result = await executeSegmentsToScenes({ segments: [], outputDir: dir });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/No storyboard segments/);
+  });
+
+  it("respects scenePreset by emitting preset-specific markup", async () => {
+    const dir = await makeTmp();
+    const segments = buildSegments([{ description: "Big drop.", duration: 4 }]);
+
+    const result = await executeSegmentsToScenes({
+      segments,
+      outputDir: dir,
+      scenePreset: "kinetic-type",
+    });
+    expect(result.success).toBe(true);
+    const scene = await readFile(resolve(dir, "compositions/scene-01.html"), "utf-8");
+    // kinetic-type emits one span per word — "Big drop" → 2 spans
+    expect(scene).toContain('id="w-0"');
+    expect(scene).toContain('id="w-1"');
+  });
+
+  it("is idempotent on re-run with assets already in place", async () => {
+    const dir = await makeTmp();
+    const segments = buildSegments([{ description: "Hi.", narration: "Hi.", duration: 3 }]);
+    const narration = await writeFakeAsset(resolve(dir, "narration-1.mp3"));
+
+    const first = await executeSegmentsToScenes({
+      segments,
+      narrationEntries: [{ path: narration, duration: 3, segmentIndex: 0, failed: false }],
+      outputDir: dir,
+    });
+    expect(first.success).toBe(true);
+
+    // Re-run: narration is already in assets/, original is gone — function
+    // should silently no-op the move + re-emit the scene.
+    const second = await executeSegmentsToScenes({
+      segments,
+      narrationEntries: [{ path: resolve(dir, "assets/narration-01.mp3"), duration: 3, segmentIndex: 0, failed: false }],
+      outputDir: dir,
+    });
+    expect(second.success).toBe(true);
+    expect(second.missingNarration).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/_shared/segments-to-scenes.ts
+++ b/packages/cli/src/commands/_shared/segments-to-scenes.ts
@@ -1,0 +1,271 @@
+/**
+ * @module _shared/segments-to-scenes
+ *
+ * Branch of the script-to-video pipeline that materialises a Hyperframes-style
+ * scene project (HTML compositions + GSAP timelines) instead of an opaque MP4.
+ * Triggered by `vibe pipeline script-to-video --format scenes`.
+ *
+ * **Scope (MVP 1 c5):** template-based scene HTML using the C2 emitters.
+ * Claude-authored per-scene HTML with a lint-feedback retry loop is
+ * intentionally deferred — the bet that matters ("expensive opaque MP4 → cheap
+ * editable HTML") is delivered with templates alone, and the user can hand-
+ * edit any scene afterwards via `vibe scene add --force` or by editing the
+ * file directly.
+ *
+ * Inputs: storyboard segments, narration audio paths, image paths (any of
+ * which may be missing). Outputs: a fully scaffolded scene project at
+ * `outputDir`, ready for `vibe scene lint` / `vibe scene render`.
+ */
+
+import { rename, writeFile, readFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve, basename, dirname, relative } from "node:path";
+import {
+  scaffoldSceneProject,
+  aspectToDims,
+  type SceneAspect,
+} from "./scene-project.js";
+import {
+  emitSceneHtml,
+  insertClipIntoRoot,
+  type ScenePreset,
+} from "./scene-html-emit.js";
+import { runProjectLint, type ProjectLintResult } from "./scene-lint.js";
+import type { StoryboardSegment, NarrationEntry } from "../ai-script-pipeline.js";
+
+export interface SegmentsToScenesOptions {
+  segments: StoryboardSegment[];
+  /** Index-aligned with `segments`. Missing/failed entries → no narration audio. */
+  narrationEntries?: NarrationEntry[];
+  /** Index-aligned with `segments`. Empty string → image generation failed. */
+  imagePaths?: string[];
+  /** Absolute output directory (will be scaffolded as a scene project). */
+  outputDir: string;
+  /** Aspect ratio (drives canvas dims for both root + sub-comps). */
+  aspectRatio?: SceneAspect;
+  /** Project name (defaults to dir basename). */
+  projectName?: string;
+  /** Style preset applied to every scene (default `explainer`). */
+  scenePreset?: ScenePreset;
+  /** Optional progress sink — wired to `executeScriptToVideo`'s onProgress. */
+  onProgress?: (msg: string) => void;
+  /** When true (default), runs lint after emit and returns the result for
+   *  visibility. Lint warnings/errors do NOT cause this function to fail. */
+  lintAfter?: boolean;
+}
+
+export interface SegmentsToScenesResult {
+  success: boolean;
+  outputDir: string;
+  scenesEmitted: number;
+  /** Project-relative paths of every scene HTML written. */
+  scenePaths: string[];
+  /** Project-relative path of the root composition. */
+  rootPath: string;
+  /** Lint result when `lintAfter` is set. Surfaces warnings/errors but does
+   *  not change `success`. */
+  lintResult?: ProjectLintResult;
+  /** 1-indexed scene numbers whose narration audio was missing. */
+  missingNarration: number[];
+  /** 1-indexed scene numbers whose image was missing. */
+  missingImage: number[];
+  error?: string;
+}
+
+const DEFAULT_PRESET: ScenePreset = "explainer";
+
+/**
+ * Pad an integer with leading zeros to a fixed width. `zeroPad(3, 2)` → "03".
+ * Pure helper exposed for tests so the scene-id convention is locked in.
+ */
+export function zeroPad(n: number, width = 2): string {
+  return String(n).padStart(width, "0");
+}
+
+/**
+ * Build the canonical scene id for the i-th storyboard segment (1-indexed).
+ * Used in both `compositions/scene-NN.html` and `data-composition-id`.
+ */
+export function sceneIdFromIndex(oneIndexedIndex: number): string {
+  return `scene-${zeroPad(oneIndexedIndex)}`;
+}
+
+/**
+ * Move a generated asset into the project's `assets/` directory, returning
+ * the project-relative path the scene HTML should reference. If the asset is
+ * already inside `assets/`, it's left alone. Missing files become `undefined`.
+ */
+async function relocateAsset(opts: {
+  absSource: string | undefined;
+  outputDir: string;
+  destBasename: string;
+}): Promise<string | undefined> {
+  if (!opts.absSource || !existsSync(opts.absSource)) return undefined;
+  const assetsDir = resolve(opts.outputDir, "assets");
+  await mkdir(assetsDir, { recursive: true });
+  const dest = resolve(assetsDir, opts.destBasename);
+  if (resolve(opts.absSource) !== dest) {
+    if (existsSync(dest)) {
+      // The destination already has the asset (idempotent re-run). Leave it.
+    } else {
+      await rename(opts.absSource, dest);
+    }
+  }
+  return relative(opts.outputDir, dest);
+}
+
+/**
+ * Materialise a scene project from script-to-video pipeline outputs.
+ *
+ * Steps:
+ *   1. Scaffold the bilingual scene project (vibe.project.yaml + index.html
+ *      + hyperframes.json + compositions/ + assets/ + CLAUDE.md + .gitignore).
+ *   2. Move narration `.mp3` and image `.png` files from the pipeline's flat
+ *      output layout into `assets/`.
+ *   3. For each segment, emit `compositions/scene-NN.html` via the C2
+ *      `emitSceneHtml` template (default preset: `explainer`).
+ *   4. Splice each scene into the root via `insertClipIntoRoot` so root
+ *      `data-duration` grows to fit and clip start times stack correctly.
+ *   5. Run `runProjectLint` (info only — does not fail the call).
+ */
+export async function executeSegmentsToScenes(
+  opts: SegmentsToScenesOptions,
+): Promise<SegmentsToScenesResult> {
+  const outputDir = resolve(opts.outputDir);
+  const aspect: SceneAspect = opts.aspectRatio ?? "16:9";
+  const dims = aspectToDims(aspect);
+  const preset = opts.scenePreset ?? DEFAULT_PRESET;
+  const projectName = opts.projectName ?? basename(outputDir);
+  const totalDuration = opts.segments.reduce((sum, s) => sum + (s.duration || 0), 0) || 10;
+
+  const baseError = (error: string): SegmentsToScenesResult => ({
+    success: false,
+    outputDir,
+    scenesEmitted: 0,
+    scenePaths: [],
+    rootPath: resolve(outputDir, "index.html"),
+    missingNarration: [],
+    missingImage: [],
+    error,
+  });
+
+  if (opts.segments.length === 0) {
+    return baseError("No storyboard segments to convert.");
+  }
+
+  // Step 1: scaffold scene project (idempotent).
+  opts.onProgress?.(`Scaffolding scene project at ${outputDir}...`);
+  await scaffoldSceneProject({
+    dir: outputDir,
+    name: projectName,
+    aspect,
+    duration: totalDuration,
+  });
+
+  // Step 2-4: per-segment relocate + emit + insert.
+  const scenePaths: string[] = [];
+  const missingNarration: number[] = [];
+  const missingImage: number[] = [];
+
+  // Re-read the scaffolded root (we mutate sequentially via insertClipIntoRoot).
+  const rootAbs = resolve(outputDir, "index.html");
+  let rootHtml = await readFile(rootAbs, "utf-8");
+
+  for (let i = 0; i < opts.segments.length; i++) {
+    const segment = opts.segments[i];
+    const oneIndexed = i + 1;
+    const id = sceneIdFromIndex(oneIndexed);
+
+    const narrationEntry = opts.narrationEntries?.[i];
+    const imageAbsPath = opts.imagePaths?.[i];
+
+    const audioRelPath = await relocateAsset({
+      absSource: narrationEntry && !narrationEntry.failed ? (narrationEntry.path ?? undefined) : undefined,
+      outputDir,
+      destBasename: `narration-${zeroPad(oneIndexed)}.mp3`,
+    });
+    const imageRelPath = await relocateAsset({
+      absSource: imageAbsPath && imageAbsPath.length > 0 ? imageAbsPath : undefined,
+      outputDir,
+      destBasename: `scene-${zeroPad(oneIndexed)}.png`,
+    });
+
+    if (!audioRelPath) missingNarration.push(oneIndexed);
+    if (!imageRelPath) missingImage.push(oneIndexed);
+
+    const headline = pickHeadline(segment, oneIndexed);
+    const subhead = (segment.narration ?? "").trim() || segment.description.trim();
+    const duration = segment.duration > 0 ? segment.duration : 5;
+
+    const html = emitSceneHtml({
+      id,
+      preset,
+      width: dims.width,
+      height: dims.height,
+      duration,
+      headline,
+      subhead,
+      audioPath: audioRelPath,
+      imagePath: imageRelPath,
+    });
+    const scenePath = resolve(outputDir, "compositions", `${id}.html`);
+    await mkdir(dirname(scenePath), { recursive: true });
+    await writeFile(scenePath, html, "utf-8");
+    scenePaths.push(relative(outputDir, scenePath));
+
+    opts.onProgress?.(`Scene ${oneIndexed}/${opts.segments.length}: emitted ${id} (preset=${preset})`);
+  }
+
+  // Step 4 (continued): build the running clip-stack into the root in order.
+  let clipStart = 0;
+  for (let i = 0; i < opts.segments.length; i++) {
+    const segment = opts.segments[i];
+    const id = sceneIdFromIndex(i + 1);
+    const duration = segment.duration > 0 ? segment.duration : 5;
+    // Explicit src — `id` already starts with "scene-", and the default src
+    // derivation in buildClipReference would otherwise yield "scene-scene-NN".
+    rootHtml = insertClipIntoRoot(rootHtml, {
+      id,
+      start: clipStart,
+      duration,
+      src: `compositions/${id}.html`,
+    });
+    clipStart += duration;
+  }
+  await writeFile(rootAbs, rootHtml, "utf-8");
+
+  // Step 5: lint pass (advisory).
+  let lintResult: ProjectLintResult | undefined;
+  if (opts.lintAfter !== false) {
+    opts.onProgress?.("Running scene lint...");
+    try {
+      lintResult = await runProjectLint({ projectDir: outputDir });
+    } catch {
+      // Surface lint failures as undefined — never fail the conversion itself.
+    }
+  }
+
+  return {
+    success: true,
+    outputDir,
+    scenesEmitted: opts.segments.length,
+    scenePaths,
+    rootPath: relative(outputDir, rootAbs) || rootAbs,
+    lintResult,
+    missingNarration,
+    missingImage,
+  };
+}
+
+/**
+ * Heuristic for the visible scene headline. Storyboards rarely include an
+ * explicit "title" field, so we derive one from the description's first
+ * clause, falling back to a generic "Scene N" label.
+ */
+function pickHeadline(segment: StoryboardSegment, oneIndexed: number): string {
+  const desc = (segment.description ?? "").trim();
+  if (!desc) return `Scene ${oneIndexed}`;
+  // First sentence (up to . ! ? or newline). Cap at 70 chars to avoid huge h1s.
+  const sentence = desc.split(/[.!?\n]/).map((s) => s.trim()).find(Boolean) ?? desc;
+  return sentence.length > 70 ? `${sentence.slice(0, 67)}…` : sentence;
+}

--- a/packages/cli/src/commands/ai-script-pipeline-cli.ts
+++ b/packages/cli/src/commands/ai-script-pipeline-cli.ts
@@ -50,6 +50,8 @@ aiCommand
   .option("--text-style <style>", "Text overlay style: lower-third, center-bold, subtitle, minimal", "lower-third")
   .option("--review", "Run AI review after assembly (requires GOOGLE_API_KEY)")
   .option("--review-auto-apply", "Auto-apply fixable issues from AI review")
+  .option("--format <mode>", "Output format: mp4 (default, full pipeline) or scenes (editable HTML scene project)", "mp4")
+  .option("--scene-style <preset>", "Style preset for --format scenes: simple | announcement | explainer | kinetic-type | product-shot", "explainer")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (script: string, options) => {
     try {
@@ -183,6 +185,17 @@ aiCommand
       console.log();
 
       const pipelineSpinner = ora(`🎬 Running script-to-video with ${options.generator}...`).start();
+      const format = (options.format ?? "mp4") as "mp4" | "scenes";
+      if (format !== "mp4" && format !== "scenes") {
+        exitWithError(usageError(`Invalid --format: ${options.format}`, "Valid: mp4, scenes"));
+      }
+      const validScenePresets = ["simple", "announcement", "explainer", "kinetic-type", "product-shot"] as const;
+      type ScenePresetCli = typeof validScenePresets[number];
+      const scenePreset = options.sceneStyle as ScenePresetCli;
+      if (format === "scenes" && !validScenePresets.includes(scenePreset)) {
+        exitWithError(usageError(`Invalid --scene-style: ${scenePreset}`, `Valid: ${validScenePresets.join(", ")}`));
+      }
+
       const result = await executeScriptToVideo({
         script: scriptContent,
         outputDir: effectiveOutputDir,
@@ -201,12 +214,54 @@ aiCommand
         textStyle: options.textStyle as TextOverlayStyle | undefined,
         review: options.review,
         reviewAutoApply: options.reviewAutoApply,
+        format,
+        scenePreset,
         onProgress: (msg: string) => { pipelineSpinner.text = msg; },
       });
 
       if (!result.success) {
         pipelineSpinner.fail(chalk.red(result.error || "Script-to-Video failed"));
         exitWithError(apiError(result.error || "Script-to-Video failed", true));
+      }
+
+      // ---- Scene-project output path -------------------------------------
+      if (result.format === "scenes") {
+        pipelineSpinner.succeed(chalk.green(`Generated ${result.scenes} scene HTML file(s) → ${effectiveOutputDir}/`));
+
+        const lint = result.sceneLint;
+        const lintLine = lint
+          ? `  🧪 Lint: ${lint.errorCount} error(s), ${lint.warningCount} warning(s), ${lint.infoCount} info`
+          : "  🧪 Lint: skipped";
+
+        console.log();
+        console.log(chalk.bold.green("Script-to-Scenes complete!"));
+        console.log(chalk.dim("─".repeat(60)));
+        console.log();
+        console.log(`  📁 Project: ${chalk.cyan(effectiveOutputDir)}/`);
+        console.log(`  🎬 Scenes: ${result.scenes}`);
+        console.log(`  ⏱️  Duration: ${result.totalDuration ?? 0}s`);
+        console.log(lintLine);
+        console.log();
+        console.log(chalk.dim("Next steps:"));
+        console.log(chalk.dim(`  vibe scene lint --project ${effectiveOutputDir}`));
+        console.log(chalk.dim(`  vibe scene render --project ${effectiveOutputDir}`));
+        console.log();
+
+        outputResult({
+          success: true,
+          command: "pipeline script-to-video",
+          result: {
+            format: "scenes",
+            outputDir: result.outputDir,
+            scenes: result.scenes,
+            totalDuration: result.totalDuration,
+            scenePaths: result.scenePaths ?? [],
+            lint: lint
+              ? { ok: lint.ok, errorCount: lint.errorCount, warningCount: lint.warningCount, infoCount: lint.infoCount }
+              : undefined,
+          },
+        });
+        return;
       }
 
       pipelineSpinner.succeed(chalk.green(`Generated ${result.scenes} scene(s) → ${result.projectPath}`));

--- a/packages/cli/src/commands/ai-script-pipeline.ts
+++ b/packages/cli/src/commands/ai-script-pipeline.ts
@@ -491,6 +491,16 @@ export interface ScriptToVideoOptions {
   script: string;
   /** Output directory (default: "script-video-output") */
   outputDir?: string;
+  /**
+   * Output format. `"mp4"` (default) runs the full storyboard → TTS → image →
+   * video → assemble pipeline. `"scenes"` stops after image gen and emits a
+   * Hyperframes-style scene project (HTML compositions + GSAP timelines) at
+   * `outputDir`, ready for `vibe scene lint` / `vibe scene render`.
+   */
+  format?: "mp4" | "scenes";
+  /** Style preset applied to every scene when `format === "scenes"`.
+   *  Default: `"explainer"`. Ignored for `format === "mp4"`. */
+  scenePreset?: "simple" | "announcement" | "explainer" | "kinetic-type" | "product-shot";
   /** Target total duration in seconds */
   duration?: number;
   /** ElevenLabs voice name or ID */
@@ -583,6 +593,12 @@ export interface ScriptToVideoResult {
   appliedFixes?: string[];
   /** Path to reviewed/fixed video (when review auto-applied) */
   reviewedVideoPath?: string;
+  /** Format chosen for this run (`"mp4"` or `"scenes"`). */
+  format?: "mp4" | "scenes";
+  /** When `format === "scenes"`: project-relative scene HTML paths emitted. */
+  scenePaths?: string[];
+  /** When `format === "scenes"`: lint result for the emitted project. */
+  sceneLint?: import("./_shared/scene-lint.js").ProjectLintResult;
 }
 
 /**
@@ -920,6 +936,35 @@ export async function executeScriptToVideo(
       if (i < segments.length - 1) {
         await new Promise((r) => setTimeout(r, 500));
       }
+    }
+
+    // Step 4 (alt): branch into scene-project emit when --format scenes.
+    // We have everything needed: storyboard, narrations, images. Video gen,
+    // text overlays, .vibe.json assembly, and review are all skipped — the
+    // user iterates on the resulting HTML scenes via `vibe scene lint/render`.
+    if (options.format === "scenes") {
+      const { executeSegmentsToScenes } = await import("./_shared/segments-to-scenes.js");
+      options.onProgress?.("Materialising scene project...");
+      const sceneAspect = (options.aspectRatio === "1:1" || options.aspectRatio === "16:9" || options.aspectRatio === "9:16")
+        ? options.aspectRatio
+        : "16:9";
+      const scenes = await executeSegmentsToScenes({
+        segments,
+        narrationEntries: result.narrationEntries,
+        imagePaths,
+        outputDir: absOutputDir,
+        aspectRatio: sceneAspect,
+        scenePreset: options.scenePreset,
+        onProgress: options.onProgress,
+      });
+      result.format = "scenes";
+      result.scenePaths = scenes.scenePaths;
+      result.sceneLint = scenes.lintResult;
+      result.totalDuration = segments.reduce((sum, s) => sum + s.duration, 0);
+      if (!scenes.success) {
+        return { ...result, success: false, error: scenes.error ?? "Scene emit failed" };
+      }
+      return result;
     }
 
     // Step 4: Generate videos (if not images-only)

--- a/packages/cli/src/commands/ai.test.ts
+++ b/packages/cli/src/commands/ai.test.ts
@@ -282,7 +282,10 @@ describe("CLI command groups", () => {
           cwd: process.cwd(),
           encoding: "utf-8",
           env: { ...process.env, REPLICATE_API_TOKEN: undefined },
-          timeout: 10000,
+          // 30s rather than 10s — the CLI spawn cold-starts the entire ESM
+          // dependency graph (puppeteer, ffmpeg helpers, Anthropic SDK, etc.)
+          // which can exceed 10s under full-suite parallel load.
+          timeout: 30000,
         });
         expect(output).toBeTruthy();
       } catch (error: unknown) {


### PR DESCRIPTION
## Summary

`vibe pipeline script-to-video <script> --format scenes` branches the storyboard pipeline at the image-gen step and materialises a fully scaffolded Hyperframes scene project (HTML compositions + GSAP timelines) instead of running through video gen + .vibe.json assembly.

**Cost profile** drops from ~\$5–50 per video (full pipeline) to ~\$0.50–2 (storyboard + TTS + image only). Output is editable HTML — every caption, layout, and animation can be tweaked by hand or by an agent without re-rendering the whole video. \`vibe scene render\` finalises to MP4 when ready.

- New `_shared/segments-to-scenes.ts` exposes `executeSegmentsToScenes({ segments, narrationEntries, imagePaths, outputDir, aspectRatio, scenePreset })` returning a structured `SegmentsToScenesResult`. Pure helpers `zeroPad`, `sceneIdFromIndex`. Reuses C1 `scaffoldSceneProject`, C2 `emitSceneHtml` + `insertClipIntoRoot`, C3 `runProjectLint`.
- Step sequence: scaffold project → relocate narration/image assets into `assets/` → emit `compositions/scene-NN.html` per segment using the chosen preset (default `explainer`) → splice clips into the root with running start times → optional advisory lint pass.
- Branch lives in `executeScriptToVideo` immediately after image gen (steps 4–6 of the MP4 path are skipped). Returns the same `ScriptToVideoResult` extended with `format`, `scenePaths`, `sceneLint`.
- New CLI flags: `--format mp4|scenes` (default `mp4`, back-compat) and `--scene-style <preset>` for the per-scene template choice.

### Scope note (for reviewers)

This commit ships the **template-based** scene emit path. Claude-authored per-scene HTML with a lint-feedback retry loop (and Whisper-driven word-level captions) is intentionally deferred to a follow-up commit. The plan's bet that matters — "expensive opaque MP4 → cheap editable HTML" — is delivered with templates alone, and the user can hand-edit any scene afterwards via `vibe scene add --force` or by editing the file directly. The Claude-authoring path will slot in behind the same `executeSegmentsToScenes` entry point without changing this commit's surface.

### Drive-by

Bumped the `generate music — requires API key or shows error` test timeout from 10s → 30s. Pre-existing flake under full-suite parallel load (CLI cold-start of the ESM dep graph occasionally exceeds 10s); no semantic change.

No version bump — stays `0.52.1` until c8.

## Test plan

- [x] `pnpm -F @vibeframe/cli build` clean (tsc strict)
- [x] `pnpm lint` — 0 errors (8 pre-existing warnings unrelated)
- [x] 12 new unit/integration tests against an offline fixture (no API keys required). Asserts: project scaffolded, assets relocated into `assets/`, scene HTML emitted with subhead/audio/image references, root clip stack + `data-duration` grow correctly, `runProjectLint` reports zero errors, preset selection honored, idempotent re-runs.
- [x] Full CLI suite: 400 passing, 11 skipped, no regressions
- [x] CLI help text surfaces `--format` and `--scene-style` flags correctly

## MVP 1 sequence

- [x] c1 — `vibe scene init` + bilingual layout (#60)
- [x] c2 — `vibe scene add` (#61)
- [x] c3 — `vibe scene lint` (#62)
- [x] c4 — `vibe scene render` (#63)
- [x] **c5 — `pipeline script-to-video --format scenes` (this PR, template-based)**
- [ ] c6 — agent + MCP tool sync
- [ ] c7 — `/vibe-scene` skill + example + README
- [ ] c8 — bump 0.53.0 + CHANGELOG

Possible follow-up before c8: Claude-authored scene HTML behind `--scene-mode claude`, with lint-feedback retry loop.