### PR TITLE
feat(agent): scene_init/add/lint/render tools + MCP mirror (MVP 1 c6/8)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -99,6 +99,26 @@
       "import": "./src/commands/edit-cmd.ts",
       "types": "./src/commands/edit-cmd.ts"
     },
+    "./commands/scene": {
+      "import": "./src/commands/scene.ts",
+      "types": "./src/commands/scene.ts"
+    },
+    "./commands/_shared/scene-project": {
+      "import": "./src/commands/_shared/scene-project.ts",
+      "types": "./src/commands/_shared/scene-project.ts"
+    },
+    "./commands/_shared/scene-lint": {
+      "import": "./src/commands/_shared/scene-lint.ts",
+      "types": "./src/commands/_shared/scene-lint.ts"
+    },
+    "./commands/_shared/scene-render": {
+      "import": "./src/commands/_shared/scene-render.ts",
+      "types": "./src/commands/_shared/scene-render.ts"
+    },
+    "./commands/_shared/scene-html-emit": {
+      "import": "./src/commands/_shared/scene-html-emit.ts",
+      "types": "./src/commands/_shared/scene-html-emit.ts"
+    },
     "./pipeline": {
       "import": "./src/pipeline/index.ts",
       "types": "./src/pipeline/index.ts"

--- a/packages/cli/src/agent/tools/index.ts
+++ b/packages/cli/src/agent/tools/index.ts
@@ -127,6 +127,7 @@ export { registerMediaTools } from "./media.js";
 export { registerAITools } from "./ai.js";
 export { registerExportTools } from "./export.js";
 export { registerBatchTools } from "./batch.js";
+export { registerSceneTools } from "./scene.js";
 
 /**
  * Register all tools
@@ -139,6 +140,7 @@ export async function registerAllTools(registry: ToolRegistry): Promise<void> {
   const { registerAITools } = await import("./ai.js");
   const { registerExportTools } = await import("./export.js");
   const { registerBatchTools } = await import("./batch.js");
+  const { registerSceneTools } = await import("./scene.js");
 
   registerProjectTools(registry);
   registerTimelineTools(registry);
@@ -147,4 +149,5 @@ export async function registerAllTools(registry: ToolRegistry): Promise<void> {
   registerAITools(registry);
   registerExportTools(registry);
   registerBatchTools(registry);
+  registerSceneTools(registry);
 }

--- a/packages/cli/src/agent/tools/scene.test.ts
+++ b/packages/cli/src/agent/tools/scene.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { mkdtemp, readFile, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { ToolRegistry } from "./index.js";
+import { registerSceneTools, sceneToolDefinitions } from "./scene.js";
+import type { AgentContext, ToolDefinition } from "../types.js";
+
+async function pathExists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+async function makeTmp(label = "vibe-scene-agent-"): Promise<string> {
+  return mkdtemp(join(tmpdir(), label));
+}
+
+function ctx(workingDirectory: string): AgentContext {
+  return { projectPath: null, workingDirectory };
+}
+
+let registry: ToolRegistry;
+beforeEach(() => {
+  registry = new ToolRegistry();
+  registerSceneTools(registry);
+});
+
+describe("scene agent tools — registration + schema", () => {
+  it("registers exactly four scene_* tools", () => {
+    const names = registry.getDefinitions().map((t) => t.name).filter((n) => n.startsWith("scene_")).sort();
+    expect(names).toEqual(["scene_add", "scene_init", "scene_lint", "scene_render"]);
+  });
+
+  it("exports definitions matching the registered set (parity with sceneToolDefinitions)", () => {
+    const exported = sceneToolDefinitions.map((d) => d.name).sort();
+    const registered = registry.getDefinitions().map((t) => t.name).sort();
+    expect(exported).toEqual(registered);
+  });
+
+  it.each(sceneToolDefinitions.map((d) => [d.name, d] as const))(
+    "%s has well-formed JSON-schema-ish parameters",
+    (name: string, def: ToolDefinition) => {
+      expect(def.name).toBe(name);
+      expect(def.description.length).toBeGreaterThan(20);
+      expect(def.parameters.type).toBe("object");
+      expect(def.parameters.properties).toBeTypeOf("object");
+      expect(Array.isArray(def.parameters.required)).toBe(true);
+      // Every property has a string description.
+      for (const [key, prop] of Object.entries(def.parameters.properties)) {
+        expect(prop.description, `${name}.${key} missing description`).toBeTruthy();
+        expect(["string", "number", "boolean", "array", "object"]).toContain(prop.type);
+      }
+      // Every required arg is actually declared.
+      for (const req of def.parameters.required) {
+        expect(def.parameters.properties).toHaveProperty(req);
+      }
+    },
+  );
+
+  it("scene_init requires only `dir`; scene_add requires only `name`; lint+render are arg-free", () => {
+    const byName = Object.fromEntries(sceneToolDefinitions.map((d) => [d.name, d]));
+    expect(byName.scene_init.parameters.required).toEqual(["dir"]);
+    expect(byName.scene_add.parameters.required).toEqual(["name"]);
+    expect(byName.scene_lint.parameters.required).toEqual([]);
+    expect(byName.scene_render.parameters.required).toEqual([]);
+  });
+});
+
+describe("scene_init handler", () => {
+  it("scaffolds a project relative to the agent's working directory", async () => {
+    const cwd = await makeTmp();
+    const handler = registry.getHandler("scene_init")!;
+    const result = await handler({ dir: "promo", aspect: "9:16", duration: 8 }, ctx(cwd));
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Scene project scaffolded at promo");
+    expect(await pathExists(resolve(cwd, "promo/index.html"))).toBe(true);
+    expect(await pathExists(resolve(cwd, "promo/vibe.project.yaml"))).toBe(true);
+    expect(await pathExists(resolve(cwd, "promo/compositions"))).toBe(true);
+  });
+});
+
+describe("scene_add handler — offline path", () => {
+  it("adds a scene with skipAudio + skipImage and reports the new clip start/duration", async () => {
+    const cwd = await makeTmp();
+    await registry.getHandler("scene_init")!({ dir: ".", aspect: "16:9", duration: 6 }, ctx(cwd));
+
+    const result = await registry.getHandler("scene_add")!({
+      name: "Intro Scene",
+      preset: "announcement",
+      headline: "Hello",
+      duration: 4,
+      skipAudio: true,
+      skipImage: true,
+    }, ctx(cwd));
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Added scene "intro-scene"');
+    expect(result.output).toContain("preset=announcement");
+    expect(result.output).toContain("start:    0.00s");
+    expect(result.output).toContain("duration: 4.00s");
+
+    const sceneFile = await readFile(resolve(cwd, "compositions/scene-intro-scene.html"), "utf-8");
+    expect(sceneFile).toContain("Hello");
+    expect(sceneFile).not.toContain("<audio");
+  });
+
+  it("returns a structured failure when a scene file already exists (no --force)", async () => {
+    const cwd = await makeTmp();
+    await registry.getHandler("scene_init")!({ dir: "." }, ctx(cwd));
+    await registry.getHandler("scene_add")!({
+      name: "intro", duration: 3, skipAudio: true, skipImage: true,
+    }, ctx(cwd));
+
+    const second = await registry.getHandler("scene_add")!({
+      name: "intro", duration: 3, skipAudio: true, skipImage: true,
+    }, ctx(cwd));
+    expect(second.success).toBe(false);
+    expect(second.error).toMatch(/already exists/);
+  });
+});
+
+describe("scene_lint handler — offline path", () => {
+  it("reports ok for a freshly scaffolded + populated project", async () => {
+    const cwd = await makeTmp();
+    await registry.getHandler("scene_init")!({ dir: "." }, ctx(cwd));
+    await registry.getHandler("scene_add")!({
+      name: "hello", duration: 3, skipAudio: true, skipImage: true,
+    }, ctx(cwd));
+
+    const result = await registry.getHandler("scene_lint")!({}, ctx(cwd));
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Lint clean");
+  });
+
+  it("on an empty dir reports ok with zero findings (linter sees no files, the agent does not second-guess)", async () => {
+    const cwd = await makeTmp();
+    const result = await registry.getHandler("scene_lint")!({}, ctx(cwd));
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("0 error(s)");
+    expect(result.output).toContain("0 warning(s)");
+  });
+});
+
+describe("scene_render handler — Chrome-gated", () => {
+  it("returns a structured Chrome-not-found error when Chrome is missing OR the project is missing", async () => {
+    // We don't try to render — we just exercise the validation surface so the
+    // test stays Chrome-free. With a non-existent project the handler fails
+    // before reaching the Chrome preflight.
+    const cwd = await makeTmp();
+    const result = await registry.getHandler("scene_render")!({
+      projectDir: "no-such-dir",
+    }, ctx(cwd));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Project directory not found|Chrome not found|Root composition not found/);
+  });
+});

--- a/packages/cli/src/agent/tools/scene.ts
+++ b/packages/cli/src/agent/tools/scene.ts
@@ -1,0 +1,299 @@
+/**
+ * @module scene
+ * @description Agent tools for the per-scene HTML authoring surface
+ * (`vibe scene init/add/lint/render`). Each tool wraps the corresponding
+ * `executeXxx` from `commands/scene.ts` (or `_shared/scene-*.ts`) so the LLM
+ * agent can author and ship Hyperframes-style scene projects in natural
+ * language. Mirrored as MCP tools in `packages/mcp-server/src/tools/scene.ts`.
+ *
+ * ## Tools: scene_init, scene_add, scene_lint, scene_render
+ * ## Cost tier: Low (image+TTS for `scene_add` if narration/visuals supplied,
+ *                   otherwise free; `scene_render` is local Chrome/FFmpeg).
+ */
+
+import { resolve, relative } from "node:path";
+import type { ToolRegistry, ToolHandler } from "./index.js";
+import type { ToolDefinition, ToolResult } from "../types.js";
+import {
+  scaffoldSceneProject,
+  type SceneAspect,
+} from "../../commands/_shared/scene-project.js";
+import {
+  executeSceneAdd,
+  type SceneAddResult,
+} from "../../commands/scene.js";
+import {
+  runProjectLint,
+  type ProjectLintResult,
+} from "../../commands/_shared/scene-lint.js";
+import {
+  executeSceneRender,
+  type RenderFps,
+  type RenderQuality,
+  type RenderFormat,
+} from "../../commands/_shared/scene-render.js";
+import type { ScenePreset } from "../../commands/_shared/scene-html-emit.js";
+
+const SCENE_PRESETS = [
+  "simple",
+  "announcement",
+  "explainer",
+  "kinetic-type",
+  "product-shot",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+const sceneInitDef: ToolDefinition = {
+  name: "scene_init",
+  description:
+    "Scaffold a new bilingual VibeFrame + Hyperframes scene project. Creates index.html, hyperframes.json, vibe.project.yaml, compositions/, assets/, .gitignore, and a project-local CLAUDE.md. Idempotent: safe to run on a directory that already has hyperframes.json (the config is merged, not overwritten). No API keys required.",
+  parameters: {
+    type: "object",
+    properties: {
+      dir:      { type: "string",  description: "Project directory (created if missing). Relative paths resolve against the agent's working directory." },
+      name:     { type: "string",  description: "Project name. Defaults to the directory basename." },
+      aspect:   { type: "string",  description: "Aspect ratio for the canvas. Default 16:9.", enum: ["16:9", "9:16", "1:1", "4:5"] },
+      duration: { type: "number",  description: "Default root composition duration in seconds. Default 10." },
+    },
+    required: ["dir"],
+  },
+};
+
+const sceneAddDef: ToolDefinition = {
+  name: "scene_add",
+  description:
+    "Add a single scene to an existing scene project. Optionally generates narration audio (ElevenLabs) and/or a backdrop image (Gemini/OpenAI), then emits compositions/scene-<id>.html with a paused GSAP timeline and splices a clip reference into the root index.html. Use `skipAudio: true` and `skipImage: true` for text-only scenes that need no API calls.",
+  parameters: {
+    type: "object",
+    properties: {
+      name:          { type: "string",  description: "Scene name. Slugified into the composition id (e.g. 'My Intro' → 'my-intro')." },
+      preset:        { type: "string",  description: `Style preset for the scene HTML. Default 'simple'.`, enum: [...SCENE_PRESETS] },
+      narration:     { type: "string",  description: "Narration text. If the value is a path to an existing .txt/.md file, its contents are used. Drives TTS + scene duration." },
+      duration:      { type: "number",  description: "Explicit scene duration in seconds. Overrides narration audio duration." },
+      visuals:       { type: "string",  description: "Image prompt — generates assets/scene-<id>.png via the configured image provider." },
+      headline:      { type: "string",  description: "Visible headline text. Defaults to the humanised scene name." },
+      kicker:        { type: "string",  description: "Small label above the headline (used by 'explainer' and 'product-shot' presets)." },
+      projectDir:    { type: "string",  description: "Project directory. Defaults to the agent's working directory." },
+      insertInto:    { type: "string",  description: "Root composition file (relative to projectDir). Default 'index.html'." },
+      imageProvider: { type: "string",  description: "Image provider for --visuals. Default 'gemini'.", enum: ["gemini", "openai"] },
+      voice:         { type: "string",  description: "ElevenLabs voice id or name." },
+      skipAudio:     { type: "boolean", description: "Skip TTS even if narration is provided. Useful for offline / agent dry runs." },
+      skipImage:     { type: "boolean", description: "Skip image generation even if visuals is provided." },
+      force:         { type: "boolean", description: "Overwrite an existing compositions/scene-<id>.html." },
+    },
+    required: ["name"],
+  },
+};
+
+const sceneLintDef: ToolDefinition = {
+  name: "scene_lint",
+  description:
+    "Validate every scene file in a project against the public Hyperframes lint rules (in-process, no Chrome required). Returns errors, warnings, and info findings per file. Optional `fix: true` mechanically repairs `timed_element_missing_clip_class` only — other issues surface with fixHints for the agent to apply.",
+  parameters: {
+    type: "object",
+    properties: {
+      projectDir: { type: "string",  description: "Project directory. Defaults to the agent's working directory." },
+      root:       { type: "string",  description: "Root composition file relative to projectDir. Default 'index.html'." },
+      fix:        { type: "boolean", description: "Apply mechanical auto-fixes (currently: missing class=\"clip\")." },
+    },
+    required: [],
+  },
+};
+
+const sceneRenderDef: ToolDefinition = {
+  name: "scene_render",
+  description:
+    "Render a scene project to MP4/WebM/MOV via the Hyperframes producer. Requires Chrome installed locally. Output defaults to renders/<projectName>-<isoStamp>.<format>. Costly only in CPU/GPU (no API keys).",
+  parameters: {
+    type: "object",
+    properties: {
+      projectDir: { type: "string",  description: "Project directory. Defaults to the agent's working directory." },
+      root:       { type: "string",  description: "Root composition file relative to projectDir. Default 'index.html'." },
+      output:     { type: "string",  description: "Output file path (relative paths resolve against projectDir)." },
+      fps:        { type: "number",  description: "Frames per second. Must be 24, 30, or 60. Default 30." },
+      quality:    { type: "string",  description: "Quality preset. Default 'standard'.", enum: ["draft", "standard", "high"] },
+      format:     { type: "string",  description: "Container format. Default 'mp4'.", enum: ["mp4", "webm", "mov"] },
+      workers:    { type: "number",  description: "Capture worker count (1-16). Default 1." },
+    },
+    required: [],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+const sceneInitHandler: ToolHandler = async (args, context): Promise<ToolResult> => {
+  const dir = resolve(context.workingDirectory, args.dir as string);
+  try {
+    const result = await scaffoldSceneProject({
+      dir,
+      name: args.name as string | undefined,
+      aspect: args.aspect as SceneAspect | undefined,
+      duration: args.duration as number | undefined,
+    });
+    const lines: string[] = [
+      `✅ Scene project scaffolded at ${relative(context.workingDirectory, dir) || dir}`,
+      `   created: ${result.created.length} file(s)`,
+      `   merged:  ${result.merged.length} file(s)`,
+      `   skipped: ${result.skipped.length} file(s) (already existed)`,
+      ``,
+      `Next: scene_add { name: "intro", preset: "announcement", headline: "..." }`,
+    ];
+    return { toolCallId: "", success: true, output: lines.join("\n") };
+  } catch (error) {
+    return {
+      toolCallId: "",
+      success: false,
+      output: "",
+      error: `scene_init failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+};
+
+const sceneAddHandler: ToolHandler = async (args, context): Promise<ToolResult> => {
+  const projectDir = args.projectDir
+    ? resolve(context.workingDirectory, args.projectDir as string)
+    : context.workingDirectory;
+
+  const result: SceneAddResult = await executeSceneAdd({
+    name: args.name as string,
+    preset: (args.preset as ScenePreset | undefined) ?? "simple",
+    narration: args.narration as string | undefined,
+    duration: args.duration as number | undefined,
+    visuals: args.visuals as string | undefined,
+    headline: args.headline as string | undefined,
+    kicker: args.kicker as string | undefined,
+    projectDir,
+    insertInto: args.insertInto as string | undefined,
+    imageProvider: args.imageProvider as string | undefined,
+    voice: args.voice as string | undefined,
+    skipAudio: args.skipAudio as boolean | undefined,
+    skipImage: args.skipImage as boolean | undefined,
+    force: args.force as boolean | undefined,
+  });
+
+  if (!result.success) {
+    return {
+      toolCallId: "",
+      success: false,
+      output: "",
+      error: result.error ?? "scene_add failed",
+    };
+  }
+
+  const lines: string[] = [
+    `✅ Added scene "${result.id}" (preset=${result.preset})`,
+    `   start:    ${result.start.toFixed(2)}s`,
+    `   duration: ${result.duration.toFixed(2)}s`,
+    `   scene:    ${result.scenePath}`,
+    `   root:     ${result.rootPath}`,
+  ];
+  if (result.audioPath) lines.push(`   audio:    ${result.audioPath}`);
+  if (result.imagePath) lines.push(`   image:    ${result.imagePath}`);
+  return { toolCallId: "", success: true, output: lines.join("\n") };
+};
+
+function summariseLint(result: ProjectLintResult): string[] {
+  const lines: string[] = [
+    `${result.ok ? "✅" : "❌"} Lint ${result.ok ? "clean" : "failed"} — ` +
+      `${result.errorCount} error(s), ${result.warningCount} warning(s), ${result.infoCount} info`,
+  ];
+  for (const file of result.files) {
+    if (file.findings.length === 0) continue;
+    lines.push(``, `${file.file}`);
+    for (const f of file.findings) {
+      lines.push(`  [${f.severity}] ${f.code} — ${f.message}`);
+      if (f.fixHint) lines.push(`     → ${f.fixHint}`);
+    }
+  }
+  if (result.fixed.length > 0) {
+    lines.push(``, `Auto-fixed:`);
+    for (const fx of result.fixed) {
+      lines.push(`  ${fx.file}: ${fx.codes.join(", ")}`);
+    }
+  }
+  return lines;
+}
+
+const sceneLintHandler: ToolHandler = async (args, context): Promise<ToolResult> => {
+  const projectDir = args.projectDir
+    ? resolve(context.workingDirectory, args.projectDir as string)
+    : context.workingDirectory;
+  try {
+    const result = await runProjectLint({
+      projectDir,
+      rootRel: args.root as string | undefined,
+      fix: args.fix as boolean | undefined,
+    });
+    return {
+      toolCallId: "",
+      success: result.ok,
+      output: summariseLint(result).join("\n"),
+      error: result.ok ? undefined : `${result.errorCount} lint error(s)`,
+    };
+  } catch (error) {
+    return {
+      toolCallId: "",
+      success: false,
+      output: "",
+      error: `scene_lint failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+};
+
+const sceneRenderHandler: ToolHandler = async (args, context): Promise<ToolResult> => {
+  const projectDir = args.projectDir
+    ? resolve(context.workingDirectory, args.projectDir as string)
+    : context.workingDirectory;
+
+  const result = await executeSceneRender({
+    projectDir,
+    root: args.root as string | undefined,
+    output: args.output as string | undefined,
+    fps: args.fps as RenderFps | undefined,
+    quality: args.quality as RenderQuality | undefined,
+    format: args.format as RenderFormat | undefined,
+    workers: args.workers as number | undefined,
+  });
+
+  if (!result.success) {
+    return {
+      toolCallId: "",
+      success: false,
+      output: "",
+      error: result.error ?? "scene_render failed",
+    };
+  }
+
+  const lines: string[] = [
+    `✅ Render complete: ${result.outputPath}`,
+    `   duration: ${(((result.durationMs ?? 0) / 1000)).toFixed(1)}s`,
+    `   frames:   ${result.framesRendered ?? "?"}${result.totalFrames ? ` / ${result.totalFrames}` : ""}`,
+    `   config:   ${result.fps}fps · ${result.quality} · ${result.format}`,
+  ];
+  return { toolCallId: "", success: true, output: lines.join("\n") };
+};
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerSceneTools(registry: ToolRegistry): void {
+  registry.register(sceneInitDef, sceneInitHandler);
+  registry.register(sceneAddDef, sceneAddHandler);
+  registry.register(sceneLintDef, sceneLintHandler);
+  registry.register(sceneRenderDef, sceneRenderHandler);
+}
+
+// Exported for tests so the same defs can be inspected without instantiating
+// a registry.
+export const sceneToolDefinitions: ReadonlyArray<ToolDefinition> = [
+  sceneInitDef,
+  sceneAddDef,
+  sceneLintDef,
+  sceneRenderDef,
+];

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -16,8 +16,8 @@ describe("@vibeframe/mcp-server", () => {
       expect(tools.length).toBeGreaterThan(0);
     });
 
-    it("should have 54 tools total", () => {
-      expect(tools.length).toBe(54);
+    it("should have 58 tools total", () => {
+      expect(tools.length).toBe(58);
     });
 
     it("should have correct tool structure", () => {

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -9,6 +9,7 @@ import { detectionTools, handleDetectionToolCall } from "./detection.js";
 import { aiVideoTools, handleAiVideoToolCall } from "./ai-video.js";
 import { aiAudioTools, handleAiAudioToolCall } from "./ai-audio.js";
 import { aiEditAdvancedTools, handleAiEditAdvancedToolCall } from "./ai-edit-advanced.js";
+import { sceneTools, handleSceneToolCall } from "./scene.js";
 
 export const tools = [
   ...projectTools,
@@ -22,6 +23,7 @@ export const tools = [
   ...aiVideoTools,
   ...aiAudioTools,
   ...aiEditAdvancedTools,
+  ...sceneTools,
 ];
 
 type ToolHandler = (name: string, args: Record<string, unknown>) => Promise<string>;
@@ -38,6 +40,7 @@ for (const t of detectionTools) handlers[t.name] = handleDetectionToolCall;
 for (const t of aiVideoTools) handlers[t.name] = handleAiVideoToolCall;
 for (const t of aiAudioTools) handlers[t.name] = handleAiAudioToolCall;
 for (const t of aiEditAdvancedTools) handlers[t.name] = handleAiEditAdvancedToolCall;
+for (const t of sceneTools) handlers[t.name] = handleSceneToolCall;
 
 // Pre-compute required args per tool from each inputSchema for O(1) dispatch-time validation.
 // Fixes the class of bugs where handlers stringify `undefined` into filenames / URLs / prompts

--- a/packages/mcp-server/src/tools/scene.test.ts
+++ b/packages/mcp-server/src/tools/scene.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { sceneTools, handleSceneToolCall } from "./scene.js";
+import { tools, handleToolCall } from "./index.js";
+
+async function pathExists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+async function makeTmp(label = "vibe-mcp-scene-"): Promise<string> {
+  return mkdtemp(join(tmpdir(), label));
+}
+
+describe("MCP scene tools — registration", () => {
+  it("exports four tools with the canonical names", () => {
+    const names = sceneTools.map((t) => t.name).sort();
+    expect(names).toEqual(["scene_add", "scene_init", "scene_lint", "scene_render"]);
+  });
+
+  it("includes scene tools in the global MCP tools list", () => {
+    const globalNames = new Set(tools.map((t) => t.name));
+    expect(globalNames.has("scene_init")).toBe(true);
+    expect(globalNames.has("scene_add")).toBe(true);
+    expect(globalNames.has("scene_lint")).toBe(true);
+    expect(globalNames.has("scene_render")).toBe(true);
+  });
+
+  it.each(sceneTools.map((t) => [t.name, t] as const))(
+    "%s has well-formed inputSchema",
+    (name, tool) => {
+      expect(tool.name).toBe(name);
+      expect(tool.description.length).toBeGreaterThan(20);
+      expect(tool.inputSchema.type).toBe("object");
+      expect(tool.inputSchema.properties).toBeTypeOf("object");
+    },
+  );
+
+  it("scene_init declares `dir` as required; scene_add requires `name`; lint+render are arg-free", () => {
+    const byName = Object.fromEntries(sceneTools.map((t) => [t.name, t]));
+    expect((byName.scene_init.inputSchema as { required?: string[] }).required).toEqual(["dir"]);
+    expect((byName.scene_add.inputSchema as { required?: string[] }).required).toEqual(["name"]);
+    expect((byName.scene_lint.inputSchema as { required?: string[] }).required).toBeUndefined();
+    expect((byName.scene_render.inputSchema as { required?: string[] }).required).toBeUndefined();
+  });
+});
+
+describe("handleSceneToolCall — offline path", () => {
+  // We pass absolute paths for `dir` / `projectDir` so the handler doesn't
+  // depend on process.cwd() (vitest workers can't `process.chdir`).
+
+  it("scene_init scaffolds a project at the given absolute dir", async () => {
+    const dir = resolve(await makeTmp(), "promo");
+    const text = await handleSceneToolCall("scene_init", { dir, aspect: "9:16", duration: 6 });
+    const parsed = JSON.parse(text) as { success: boolean; created: string[] };
+    expect(parsed.success).toBe(true);
+    expect(parsed.created.length).toBeGreaterThan(0);
+    expect(await pathExists(resolve(dir, "index.html"))).toBe(true);
+  });
+
+  it("scene_add → scene_lint flow: skipAudio/skipImage scene + lint reports ok", async () => {
+    const projectDir = await makeTmp();
+    await handleSceneToolCall("scene_init", { dir: projectDir });
+
+    const addText = await handleSceneToolCall("scene_add", {
+      projectDir,
+      name: "intro",
+      preset: "announcement",
+      headline: "Hi",
+      duration: 4,
+      skipAudio: true,
+      skipImage: true,
+    });
+    const addParsed = JSON.parse(addText) as { success: boolean; id: string; preset: string };
+    expect(addParsed.success).toBe(true);
+    expect(addParsed.id).toBe("intro");
+    expect(addParsed.preset).toBe("announcement");
+
+    const lintText = await handleSceneToolCall("scene_lint", { projectDir });
+    const lintParsed = JSON.parse(lintText) as { ok: boolean; errorCount: number; files: unknown[] };
+    expect(lintParsed.ok).toBe(true);
+    expect(lintParsed.errorCount).toBe(0);
+    expect(lintParsed.files.length).toBeGreaterThan(0);
+  });
+
+  it("scene_render returns a structured failure when no project exists", async () => {
+    const text = await handleSceneToolCall("scene_render", {
+      projectDir: resolve(await makeTmp(), "missing"),
+    });
+    expect(text).toMatch(/scene_render failed|Project directory not found|Chrome not found|Root composition not found/);
+  });
+
+  it("dispatches scene_* tools through handleToolCall (the public MCP entry)", async () => {
+    const dir = resolve(await makeTmp(), "x");
+    const result = await handleToolCall("scene_init", { dir });
+    expect(result.content[0].type).toBe("text");
+    const parsed = JSON.parse(result.content[0].text) as { success: boolean };
+    expect(parsed.success).toBe(true);
+    expect(await pathExists(resolve(dir, "index.html"))).toBe(true);
+  });
+
+  it("handleToolCall enforces required args (scene_init without dir → error message)", async () => {
+    const result = await handleToolCall("scene_init", {});
+    expect(result.content[0].text).toMatch(/missing required argument.*dir/);
+  });
+});

--- a/packages/mcp-server/src/tools/scene.ts
+++ b/packages/mcp-server/src/tools/scene.ts
@@ -1,0 +1,209 @@
+/**
+ * MCP tools for the per-scene HTML authoring surface. Mirrors the agent
+ * tools in `packages/cli/src/agent/tools/scene.ts` so MCP hosts (Claude
+ * Desktop, Cursor, etc.) get the same surface as the in-process agent.
+ *
+ * Tools: scene_init, scene_add, scene_lint, scene_render
+ */
+
+import { resolve } from "node:path";
+import { scaffoldSceneProject } from "@vibeframe/cli/commands/_shared/scene-project";
+import { runProjectLint, type ProjectLintResult } from "@vibeframe/cli/commands/_shared/scene-lint";
+import { executeSceneRender } from "@vibeframe/cli/commands/_shared/scene-render";
+import { executeSceneAdd } from "@vibeframe/cli/commands/scene";
+
+const SCENE_PRESETS = ["simple", "announcement", "explainer", "kinetic-type", "product-shot"] as const;
+
+export const sceneTools = [
+  {
+    name: "scene_init",
+    description:
+      "Scaffold a new bilingual VibeFrame + Hyperframes scene project. Creates index.html, hyperframes.json, vibe.project.yaml, compositions/, assets/, .gitignore, and a project-local CLAUDE.md. Idempotent: re-running on an existing Hyperframes project merges hyperframes.json instead of overwriting. No API keys required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        dir:      { type: "string",  description: "Project directory (created if missing)." },
+        name:     { type: "string",  description: "Project name. Defaults to the directory basename." },
+        aspect:   { type: "string",  enum: ["16:9", "9:16", "1:1", "4:5"], description: "Aspect ratio. Default 16:9." },
+        duration: { type: "number",  description: "Default root composition duration in seconds. Default 10." },
+      },
+      required: ["dir"],
+    },
+  },
+  {
+    name: "scene_add",
+    description:
+      "Add a single scene to an existing scene project. Optionally generates narration audio (ElevenLabs) and/or a backdrop image (Gemini/OpenAI), then emits compositions/scene-<id>.html with a paused GSAP timeline and splices a clip reference into the root index.html. Use skipAudio:true and skipImage:true for text-only scenes that need no API calls.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name:          { type: "string",  description: "Scene name. Slugified into the composition id (e.g. 'My Intro' → 'my-intro')." },
+        preset:        { type: "string",  enum: [...SCENE_PRESETS], description: "Style preset for the scene HTML. Default 'simple'." },
+        narration:     { type: "string",  description: "Narration text. If the value is a path to an existing .txt/.md file, its contents are used. Drives TTS + scene duration." },
+        duration:      { type: "number",  description: "Explicit scene duration in seconds. Overrides narration audio duration." },
+        visuals:       { type: "string",  description: "Image prompt — generates assets/scene-<id>.png via the configured image provider." },
+        headline:      { type: "string",  description: "Visible headline text. Defaults to the humanised scene name." },
+        kicker:        { type: "string",  description: "Small label above the headline (used by 'explainer' and 'product-shot' presets)." },
+        projectDir:    { type: "string",  description: "Project directory. Defaults to the MCP server's cwd." },
+        insertInto:    { type: "string",  description: "Root composition file (relative to projectDir). Default 'index.html'." },
+        imageProvider: { type: "string",  enum: ["gemini", "openai"], description: "Image provider for visuals. Default 'gemini'." },
+        voice:         { type: "string",  description: "ElevenLabs voice id or name." },
+        skipAudio:     { type: "boolean", description: "Skip TTS even if narration is provided." },
+        skipImage:     { type: "boolean", description: "Skip image generation even if visuals is provided." },
+        force:         { type: "boolean", description: "Overwrite an existing compositions/scene-<id>.html." },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "scene_lint",
+    description:
+      "Validate every scene file in a project against the public Hyperframes lint rules (in-process, no Chrome required). Returns errors, warnings, and info findings per file. Optional fix:true mechanically repairs `timed_element_missing_clip_class` only — other issues surface with fixHints.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        projectDir: { type: "string",  description: "Project directory. Defaults to the MCP server's cwd." },
+        root:       { type: "string",  description: "Root composition file relative to projectDir. Default 'index.html'." },
+        fix:        { type: "boolean", description: "Apply mechanical auto-fixes (currently: missing class=\"clip\")." },
+      },
+    },
+  },
+  {
+    name: "scene_render",
+    description:
+      "Render a scene project to MP4/WebM/MOV via the Hyperframes producer. Requires Chrome installed locally. Output defaults to renders/<projectName>-<isoStamp>.<format>.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        projectDir: { type: "string",  description: "Project directory. Defaults to the MCP server's cwd." },
+        root:       { type: "string",  description: "Root composition file relative to projectDir. Default 'index.html'." },
+        output:     { type: "string",  description: "Output file path (relative paths resolve against projectDir)." },
+        fps:        { type: "number",  enum: [24, 30, 60], description: "Frames per second. Default 30." },
+        quality:    { type: "string",  enum: ["draft", "standard", "high"], description: "Quality preset. Default 'standard'." },
+        format:     { type: "string",  enum: ["mp4", "webm", "mov"], description: "Container format. Default 'mp4'." },
+        workers:    { type: "number",  description: "Capture worker count (1-16). Default 1." },
+      },
+    },
+  },
+];
+
+function summariseLint(result: ProjectLintResult): Record<string, unknown> {
+  return {
+    ok: result.ok,
+    errorCount: result.errorCount,
+    warningCount: result.warningCount,
+    infoCount: result.infoCount,
+    files: result.files.map((f) => ({
+      file: f.file,
+      isSubComposition: f.isSubComposition,
+      findings: f.findings.map((finding) => ({
+        code: finding.code,
+        severity: finding.severity,
+        message: finding.message,
+        fixHint: finding.fixHint,
+        elementId: finding.elementId,
+        selector: finding.selector,
+      })),
+    })),
+    fixed: result.fixed,
+  };
+}
+
+export async function handleSceneToolCall(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  switch (name) {
+    case "scene_init": {
+      const dir = resolve(process.cwd(), args.dir as string);
+      const result = await scaffoldSceneProject({
+        dir,
+        name: args.name as string | undefined,
+        aspect: args.aspect as "16:9" | "9:16" | "1:1" | "4:5" | undefined,
+        duration: args.duration as number | undefined,
+      });
+      return JSON.stringify({
+        success: true,
+        dir,
+        created: result.created,
+        merged: result.merged,
+        skipped: result.skipped,
+      });
+    }
+
+    case "scene_add": {
+      const projectDir = args.projectDir
+        ? resolve(process.cwd(), args.projectDir as string)
+        : process.cwd();
+      const result = await executeSceneAdd({
+        name: args.name as string,
+        preset: (args.preset as (typeof SCENE_PRESETS)[number] | undefined) ?? "simple",
+        narration: args.narration as string | undefined,
+        duration: args.duration as number | undefined,
+        visuals: args.visuals as string | undefined,
+        headline: args.headline as string | undefined,
+        kicker: args.kicker as string | undefined,
+        projectDir,
+        insertInto: args.insertInto as string | undefined,
+        imageProvider: args.imageProvider as string | undefined,
+        voice: args.voice as string | undefined,
+        skipAudio: args.skipAudio as boolean | undefined,
+        skipImage: args.skipImage as boolean | undefined,
+        force: args.force as boolean | undefined,
+      });
+      if (!result.success) return `scene_add failed: ${result.error}`;
+      return JSON.stringify({
+        success: true,
+        id: result.id,
+        preset: result.preset,
+        start: result.start,
+        duration: result.duration,
+        scenePath: result.scenePath,
+        rootPath: result.rootPath,
+        audioPath: result.audioPath,
+        imagePath: result.imagePath,
+      });
+    }
+
+    case "scene_lint": {
+      const projectDir = args.projectDir
+        ? resolve(process.cwd(), args.projectDir as string)
+        : process.cwd();
+      const result = await runProjectLint({
+        projectDir,
+        rootRel: args.root as string | undefined,
+        fix: args.fix as boolean | undefined,
+      });
+      return JSON.stringify(summariseLint(result));
+    }
+
+    case "scene_render": {
+      const projectDir = args.projectDir
+        ? resolve(process.cwd(), args.projectDir as string)
+        : process.cwd();
+      const result = await executeSceneRender({
+        projectDir,
+        root: args.root as string | undefined,
+        output: args.output as string | undefined,
+        fps: args.fps as 24 | 30 | 60 | undefined,
+        quality: args.quality as "draft" | "standard" | "high" | undefined,
+        format: args.format as "mp4" | "webm" | "mov" | undefined,
+        workers: args.workers as number | undefined,
+      });
+      if (!result.success) return `scene_render failed: ${result.error}`;
+      return JSON.stringify({
+        success: true,
+        outputPath: result.outputPath,
+        durationMs: result.durationMs,
+        framesRendered: result.framesRendered,
+        totalFrames: result.totalFrames,
+        fps: result.fps,
+        quality: result.quality,
+        format: result.format,
+      });
+    }
+
+    default:
+      throw new Error(`Unknown scene tool: ${name}`);
+  }
+}


### PR DESCRIPTION
## Summary

Wires the four `vibe scene *` subcommands into both the in-process agent registry and the MCP server, completing the CLI ↔ Agent ↔ MCP sync triangle that c5's `--format scenes` pipeline relies on.

Tools (snake_case per the convention in `.claude/rules/architecture.md`):

| Agent tool      | Wraps                          |
| --------------- | ------------------------------ |
| `scene_init`    | `scaffoldSceneProject`         |
| `scene_add`     | `executeSceneAdd`              |
| `scene_lint`    | `runProjectLint`               |
| `scene_render`  | `executeSceneRender`           |

### CLI side

- New `packages/cli/src/agent/tools/scene.ts`. Each handler resolves paths against `context.workingDirectory`, surfaces structured errors instead of throwing, and never calls `process.exit`.
- Registered through `registerSceneTools` (re-exported from `agent/tools/index.ts` and added to `registerAllTools`).
- Added scene path entries to `packages/cli/package.json#exports` so `@vibeframe/cli/commands/scene` and the `_shared/scene-*` helpers are reachable from the MCP package without dipping into source paths.

### MCP side

- New `packages/mcp-server/src/tools/scene.ts` mirroring the agent surface as JSON-schema tool defs + a `handleSceneToolCall` switch.
- Wired into the global tools list + handler dispatch table in `mcp-server/src/tools/index.ts`. Inherits the existing required-arg validation (regression-protected for #44 since c4).
- MCP server bundle still builds clean (esbuild → 21MB `dist/index.js`, no new external deps).

No version bump — stays `0.52.1` until c8.

## Test plan

- [x] `pnpm -F @vibeframe/cli build` clean (tsc strict)
- [x] `pnpm -F @vibeframe/mcp-server build` clean (esbuild bundle)
- [x] `pnpm lint` — 0 errors (8 pre-existing warnings unrelated)
- [x] **13 new agent tool tests** in `packages/cli/src/agent/tools/scene.test.ts` cover registration, schema integrity, and the offline lifecycle: `init → add (skipAudio + skipImage) → lint reports ok`.
- [x] **12 new MCP tests** in `packages/mcp-server/src/tools/scene.test.ts` mirror the same surface, plus dispatch through `handleToolCall` and the required-arg enforcement path.
- [x] Bumped the MCP-server `tools.length === 54` regression to 58 to reflect the four new entries.
- [x] Full CLI suite: 413 passing, 11 skipped, no regressions
- [x] Full MCP suite: 38 passing

## MVP 1 sequence

- [x] c1 — `vibe scene init` + bilingual layout (#60)
- [x] c2 — `vibe scene add` (#61)
- [x] c3 — `vibe scene lint` (#62)
- [x] c4 — `vibe scene render` (#63)
- [x] c5 — `pipeline script-to-video --format scenes` (#64)
- [x] **c6 — agent + MCP tool sync (this PR)**
- [ ] c7 — `/vibe-scene` skill + example + README
- [ ] c8 — bump 0.53.0 + CHANGELOG