### PR TITLE
docs(scene): /vibe-scene skill + scene-promo example + README (MVP 1 c7/8)

### DIFF
--- a/.claude/skills/vibe-scene/SKILL.md
+++ b/.claude/skills/vibe-scene/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: vibe-scene
+description: Author and edit per-scene HTML compositions (Hyperframes-backed). Use when the user wants editable, agent-friendly scenes instead of opaque MP4s — or wants to iterate on a single scene without re-rendering the whole project.
+---
+
+# vibe-scene — Per-scene HTML authoring
+
+A scene project is a directory that is **bilingual**: it works with both
+`vibe` and `npx hyperframes`. Each scene is one HTML file with scoped CSS and
+a paused GSAP timeline. Cheap to edit, cheap to lint, expensive only at render.
+
+Prefer this over `vibe pipeline script-to-video --format mp4` whenever the
+user expects to **iterate** on text, layout, or timing — text tweaks don't
+require regenerating video.
+
+## Authoring loop
+
+```bash
+vibe scene init my-promo -r 16:9 -d 30          # 1. scaffold project
+vibe scene add intro --style announcement \
+    --headline "Ship videos, not clicks"        # 2. author scene(s)
+vibe scene lint                                 # 3. validate
+vibe scene render                               # 4. render to MP4 (Chrome)
+```
+
+`vibe scene init` is **idempotent** — running it on an existing Hyperframes
+directory merges `hyperframes.json` instead of clobbering it. Safe to invoke
+on user-provided projects.
+
+## Subcommands
+
+```bash
+vibe scene init <dir> [-r 16:9|9:16|1:1|4:5] [-d <sec>]
+vibe scene add <name> --style <preset> [...]
+vibe scene lint [<root>] [--json] [--fix]
+vibe scene render [<root>] [--fps 30] [--quality standard] [--format mp4]
+```
+
+Run `vibe scene <sub> --help` for the full flag list, or
+`vibe schema scene.<sub>` for a machine-readable JSON shape.
+
+## Style presets (for `vibe scene add --style`)
+
+- **simple** — backdrop + bottom caption (default)
+- **announcement** — single huge headline, gradient text
+- **explainer** — kicker + title + subtitle stack
+- **kinetic-type** — words animate in word-by-word
+- **product-shot** — corner label + bottom headline + slow zoom
+
+All presets accept `--narration <text|file>`, `--visuals <prompt>`,
+`--headline`, `--kicker`. With `--narration`, scene duration auto-derives
+from the generated TTS audio.
+
+## Asset generation
+
+`vibe scene add` integrates the existing AI providers:
+
+- `--narration "..."` → ElevenLabs TTS → `assets/narration-<id>.mp3`
+- `--visuals "..."` → Gemini (default) or OpenAI image → `assets/scene-<id>.png`
+- `--no-audio` / `--no-image` skip generation (useful for hand-authored or
+  CI-friendly seeds).
+
+If keys are missing, the command exits with a usage error before any spend —
+no partial state.
+
+## Lint feedback loop (agent pattern)
+
+```bash
+vibe scene lint --json
+```
+
+Returns structured `{ ok, errorCount, warningCount, files: [{file, findings:[...]}], fixed: [...] }`.
+Each finding has `severity`, `code`, `message`, and an optional `fixHint`. The
+recommended agent loop:
+
+1. Run `vibe scene lint --json --fix` (mechanical fixes applied).
+2. If `errorCount > 0`, read the findings and edit the scene HTML.
+3. Re-lint. **Cap retries at 3** — if errors persist, fall back to a template
+   preset (`vibe scene add <id> --style simple --force`) and surface the
+   error to the user.
+
+`--fix` currently auto-resolves: missing `class="clip"`, missing
+`data-track-index`, GSAP timeline registration. Layout and content errors
+must be hand-fixed.
+
+## Scripts-to-scenes (one command)
+
+```bash
+vibe pipeline script-to-video "..." --format scenes -o my-video/ -a 16:9
+```
+
+This bundles `scene init` + segment-to-scene authoring + lint + render into a
+single pipeline. Output is an editable scene project, not a sealed MP4. Re-run
+`vibe scene render` after editing any scene to refresh the final video.
+
+Default `--format` is **mp4** for back-compat in v0.53; flips to **scenes** in
+v0.54.
+
+## Hyperframes interop
+
+If `/hyperframes` and `/gsap` skills are installed, prefer them for
+scene-internal animation work — they encode the upstream framework rules
+directly. VibeFrame's `vibe scene lint` is the same in-process linter HF uses,
+so findings transfer 1:1.
+
+If neither is installed, the **Key Rules** at the top of every scene project's
+`CLAUDE.md` (written by `vibe scene init`) cover the essentials:
+
+1. Every timed element needs `data-start`, `data-duration`, `data-track-index`.
+2. Timed elements **MUST** have `class="clip"`.
+3. Timelines must be paused and registered: `window.__timelines["<id>"] = gsap.timeline({ paused: true })`.
+4. `<video>` uses `muted`; route audio through a separate `<audio>` element.
+5. Sub-compositions reference scenes via `data-composition-src="compositions/<file>.html"`.
+6. No `Date.now()`, `Math.random()`, or network fetches — render must be deterministic.
+
+## When to use VibeFrame vs raw Hyperframes
+
+| Task | Tool |
+|------|------|
+| Generate narration + image, then author scene | `vibe scene add` |
+| Generate a full scenes project from a script | `vibe pipeline script-to-video --format scenes` |
+| Hand-tweak a single scene's animation | edit `compositions/<file>.html` directly |
+| Render the project | `vibe scene render` *or* `npx hyperframes render` (equivalent) |
+| Lint | `vibe scene lint` *or* `npx hyperframes lint` (equivalent) |
+
+The `vibe` CLI adds asset generation, AI orchestration, and pipeline
+integration on top of Hyperframes' rendering primitives. Pick `npx hyperframes`
+for pure framework work; pick `vibe` when AI assets or pipelines are involved.
+
+## Quality checklist before render
+
+- [ ] `vibe scene lint` exits 0 (or only warnings)
+- [ ] `vibe doctor` confirms a usable Chrome (required for render)
+- [ ] Root `data-duration` matches the sum of clip durations (auto-managed by
+      `vibe scene add` — only verify if you hand-edited)
+- [ ] Aspect ratio in `vibe.project.yaml` matches the destination platform
+
+## Common failures & fixes
+
+- **`Root composition not found`** — run `vibe scene init` first or pass `--project <dir>`.
+- **`Could not determine canvas dimensions`** — `index.html` lost its `data-width`/`data-height`. Re-init or copy them from `vibe.project.yaml`.
+- **`host_missing_composition_id` lint error** — root clip refs lost their `data-composition-id`. `--fix` doesn't repair this; re-add the scene with `--force`.
+- **Render hangs at 0% on macOS** — Chrome detection failed. Run `vibe doctor`; install Chrome / set `CHROME_PATH`.
+- **Scene HTML produced by Claude fails lint repeatedly** — drop to a template preset (`--style simple`) and treat the AI output as a starting point for hand-edits, not a finished asset.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ This registers:
 - **`/vibeframe`** — overview, command groups, and common workflows
 - **`/vibe-pipeline`** — YAML pipeline authoring helper (Video as Code)
 - **`/vibe-script-to-video`** — guided script-to-video walkthrough
+- **`/vibe-scene`** — per-scene HTML authoring (Hyperframes-backed, editable)
 
 Prefer manual install? Copy [`.claude/skills/`](https://github.com/vericontext/vibeframe/tree/main/.claude/skills) from this repo into your project.
 
@@ -230,6 +231,35 @@ Storyboards are saved as YAML for easy editing and version control.
 
 ---
 
+## Scene Authoring (HTML, not MP4)
+
+Since v0.53.0, `vibe scene` produces **editable per-scene HTML** instead of
+opaque MP4s. Each scene is a self-contained HTML file with scoped CSS and a
+paused GSAP timeline — text tweaks don't require regenerating video.
+
+```bash
+vibe scene init my-promo -r 16:9 -d 30
+vibe scene add intro --style announcement --headline "Ship videos, not clicks"
+vibe scene add core  --style explainer --kicker "VIDEO AS CODE" \
+                     --headline "Author scenes, not timelines"
+vibe scene lint                        # in-process Hyperframes linter
+vibe scene render -o promo.mp4         # requires Chrome
+```
+
+Scene projects are bilingual — they work with both `vibe` and
+[`npx hyperframes`](https://github.com/heygen-com/hyperframes). To produce a
+full scenes project from a written script in one shot:
+
+```bash
+vibe pipeline script-to-video "..." --format scenes -o my-promo/ -a 16:9
+```
+
+Run [`examples/scene-promo/`](examples/scene-promo/) for an end-to-end
+walkthrough. See `/vibe-scene` for the agent skill, including the lint
+feedback loop pattern (`--json --fix`, ≤3 retries, template fallback).
+
+---
+
 ## CLI Reference
 
 Every command supports `--help`. Run `vibe --help` for a full list.
@@ -241,6 +271,7 @@ Every command supports `--help`. Run `vibe --help` for a full list.
 | **`vibe analyze`** | `media`, `video`, `review`, `suggest` | `vibe analyze media video.mp4 "summarize"` |
 | **`vibe audio`** | `transcribe`, `voices`, `isolate`, `voice-clone`, `dub`, `duck` | `vibe audio transcribe audio.mp3` |
 | **`vibe pipeline`** | `script-to-video`, `highlights`, `auto-shorts`, `regenerate-scene`, `animated-caption` | `vibe pipeline script-to-video "..." -a 9:16` |
+| **`vibe scene`** | `init`, `add`, `lint`, `render` | `vibe scene add intro --style announcement --headline "..."` |
 | **`vibe project`** | `create`, `info`, `set` | `vibe project create "name"` |
 | **`vibe timeline`** | `add-source`, `add-clip`, `split`, `trim`, `move`, `delete`, `list` | `vibe timeline add-source project file` |
 | **`vibe batch`** | `import`, `concat`, `apply-effect` | `vibe batch import project dir/` |

--- a/examples/scene-promo/.gitignore
+++ b/examples/scene-promo/.gitignore
@@ -1,0 +1,11 @@
+# VibeFrame caches
+.vibeframe/cache/
+.vibeframe/checkpoints/
+
+# Render outputs
+renders/*.mp4
+tmp/
+
+# OS / editor
+.DS_Store
+*.log

--- a/examples/scene-promo/CLAUDE.md
+++ b/examples/scene-promo/CLAUDE.md
@@ -1,0 +1,62 @@
+# scene-promo — Scene Authoring Project
+
+This project is **bilingual**: it works with both VibeFrame (`vibe`) and
+HeyGen Hyperframes (`hyperframes`). You can run either CLI inside this
+directory.
+
+## Skills — USE THESE FIRST
+
+**Always invoke the relevant skill before authoring scenes.** Skills encode
+framework-specific patterns (GSAP timeline registration, data-attribute
+semantics, VibeFrame pipeline conventions) that are NOT in generic web docs.
+
+| Skill             | Command          | When to use                                                                           |
+| ----------------- | ---------------- | ------------------------------------------------------------------------------------- |
+| **vibe-scene**    | `/vibe-scene`    | Authoring / editing per-scene HTML in this project — preferred                        |
+| **hyperframes**   | `/hyperframes`   | Fallback: direct HF authoring (install via `npx skills add heygen-com/hyperframes`) |
+| **gsap**          | `/gsap`          | GSAP tweens, timelines, easing                                                        |
+
+If the skill is not available, follow the **Key Rules** below.
+
+## Project structure
+
+- `index.html` — root composition (timeline)
+- `compositions/scene-*.html` — per-scene HTML authored by you or the agent
+- `assets/` — shared media (narration audio, images, video)
+- `transcript.json` — Whisper word-level transcript (if narration exists)
+- `hyperframes.json` — HF registry config (speak to both toolchains)
+- `vibe.project.yaml` — VibeFrame config (providers, budget)
+- `renders/` — output MP4s
+
+## Commands
+
+```bash
+vibe scene add <name> --narration "..." --visuals "..."   # Author a new scene via AI
+vibe scene lint                                             # Validate scenes (in-process HF linter)
+vibe scene render                                           # Render to MP4
+
+# Hyperframes CLI (if installed — works in this project too)
+npx hyperframes preview
+npx hyperframes render
+```
+
+## Key Rules (for hand-authored scene HTML)
+
+1. Every timed element needs `data-start`, `data-duration`, and `data-track-index`.
+2. Elements with timing **MUST** have `class="clip"` — the framework uses this for visibility control.
+3. Timelines must be paused and registered on `window.__timelines`:
+   ```js
+   window.__timelines = window.__timelines || {};
+   window.__timelines["composition-id"] = gsap.timeline({ paused: true });
+   ```
+4. Videos use `muted` with a separate `<audio>` element for the audio track.
+5. Sub-compositions use `data-composition-src="compositions/file.html"`.
+6. Only deterministic logic — no `Date.now()`, `Math.random()`, or network fetches.
+
+## Linting — run after changes
+
+```bash
+vibe scene lint           # preferred — in-process, no network
+vibe scene lint --fix     # auto-fix mechanical issues
+vibe scene lint --json    # structured output for agent loops
+```

--- a/examples/scene-promo/README.md
+++ b/examples/scene-promo/README.md
@@ -1,0 +1,89 @@
+# scene-promo — `vibe scene` example
+
+A minimal bilingual scene project (works with both `vibe` and
+`npx hyperframes`) showing the **scene authoring** workflow shipped in
+v0.53.0. No API keys required — every scene uses the template presets only.
+
+## What this demonstrates
+
+Three template scenes stitched into an 18-second 16:9 timeline:
+
+| Scene | Preset         | Duration | Source                                     |
+|-------|----------------|----------|--------------------------------------------|
+| intro | `announcement` | 5s       | [`compositions/scene-intro.html`](compositions/scene-intro.html) |
+| core  | `explainer`    | 7s       | [`compositions/scene-core.html`](compositions/scene-core.html)   |
+| outro | `kinetic-type` | 6s       | [`compositions/scene-outro.html`](compositions/scene-outro.html) |
+
+Each scene is a self-contained HTML file with scoped CSS and a paused GSAP
+timeline. Edit them directly — text tweaks don't require regeneration. The
+root [`index.html`](index.html) just splices `<div class="clip">` references.
+
+## Recreate from scratch
+
+```bash
+vibe scene init scene-promo -r 16:9 -d 18
+
+vibe scene add intro \
+  --project scene-promo --style announcement \
+  --headline "Ship videos, not clicks" \
+  --duration 5 --no-audio --no-image
+
+vibe scene add core \
+  --project scene-promo --style explainer \
+  --kicker "VIDEO AS CODE" --headline "Author scenes, not timelines" \
+  --duration 7 --no-audio --no-image
+
+vibe scene add outro \
+  --project scene-promo --style kinetic-type \
+  --headline "Made with vibe scene" \
+  --duration 6 --no-audio --no-image
+```
+
+## Lint and render
+
+```bash
+vibe scene lint  --project scene-promo            # in-process Hyperframes lint
+vibe scene render --project scene-promo \
+                  --out renders/promo.mp4         # requires Chrome
+```
+
+Lint should report `ok: true` with 0 errors / 0 warnings (4 informational
+notices about CDN script hoisting are expected and harmless).
+
+## Add AI assets
+
+Drop `--no-audio` / `--no-image` to wire in real providers:
+
+```bash
+vibe scene add intro \
+  --project scene-promo --style announcement --force \
+  --headline "Ship videos, not clicks" \
+  --narration "Stop dragging clips. Start scripting them." \
+  --visuals "studio desk at dusk, soft cinematic lighting" \
+  --image-provider gemini
+```
+
+Costs: ~$0.02 ElevenLabs TTS + ~$0.04 Gemini image per scene. Set
+`ELEVENLABS_API_KEY` and `GOOGLE_API_KEY` in `.env` first (or run
+`vibe setup`).
+
+## One-shot: script-to-scenes
+
+`vibe pipeline script-to-video` can produce a scene project like this one
+from a written script in a single command:
+
+```bash
+vibe pipeline script-to-video "..." --format scenes -o my-promo/ -a 16:9
+```
+
+Output is editable HTML — re-run `vibe scene render` after any edit.
+
+## Hyperframes interop
+
+This directory is also a valid Hyperframes project. If you have the upstream
+CLI installed:
+
+```bash
+npx hyperframes preview        # live-reload preview
+npx hyperframes render         # equivalent to `vibe scene render`
+```

--- a/examples/scene-promo/compositions/scene-core.html
+++ b/examples/scene-promo/compositions/scene-core.html
@@ -1,0 +1,50 @@
+<template id="scene-core-template">
+  <div data-composition-id="core" data-start="0" data-duration="7" data-width="1920" data-height="1080">
+    <style>
+      [data-composition-id="core"] {
+        position: absolute; inset: 0; width: 100%; height: 100%;
+        font-family: -apple-system, "Helvetica Neue", Arial, sans-serif;
+        color: #fff; overflow: hidden; background: #000;
+      }
+      [data-composition-id="core"] .backdrop {
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(ellipse at center, #1a1a2e 0%, #000 70%);
+      }
+      [data-composition-id="core"] .stage {
+        position: absolute; inset: 0;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 24px; padding: 0 10%;
+      }
+      [data-composition-id="core"] .kicker {
+        font-size: 28px; letter-spacing: 6px; text-transform: uppercase;
+        color: #00c9ff; font-weight: 600;
+      }
+      [data-composition-id="core"] .title {
+        font-size: 110px; font-weight: 800; letter-spacing: -2px;
+        line-height: 1.05; margin: 0;
+      }
+      [data-composition-id="core"] .subtitle {
+        font-size: 38px; font-weight: 300; color: #c0c0d0; max-width: 80%;
+      }
+    </style>
+
+    <div class="backdrop"></div>
+    <div class="stage">
+      <div class="kicker" id="kicker">VIDEO AS CODE</div>
+      <h1 class="title" id="title">Author scenes, not timelines</h1>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+
+      tl.from('[data-composition-id="core"] #kicker', { opacity: 0, y: 16, duration: 0.4, ease: 'power2.out' }, 0.1);
+      tl.from('[data-composition-id="core"] #title', { opacity: 0, y: 60, duration: 0.7, ease: 'power3.out' }, 0.25);
+      
+
+      window.__timelines["core"] = tl;
+    </script>
+  </div>
+</template>

--- a/examples/scene-promo/compositions/scene-intro.html
+++ b/examples/scene-promo/compositions/scene-intro.html
@@ -1,0 +1,46 @@
+<template id="scene-intro-template">
+  <div data-composition-id="intro" data-start="0" data-duration="5" data-width="1920" data-height="1080">
+    <style>
+      [data-composition-id="intro"] {
+        position: absolute; inset: 0; width: 100%; height: 100%;
+        font-family: -apple-system, "Helvetica Neue", Arial, sans-serif;
+        color: #fff; overflow: hidden; background: #000;
+      }
+      [data-composition-id="intro"] .backdrop {
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(ellipse at center, #1a1a2e 0%, #000 70%);
+      }
+      [data-composition-id="intro"] .announce {
+        position: absolute; inset: 0;
+        display: flex; align-items: center; justify-content: center;
+        text-align: center;
+        padding: 0 8%;
+      }
+      [data-composition-id="intro"] .announce h1 {
+        margin: 0;
+        font-size: 160px;
+        font-weight: 900;
+        letter-spacing: -4px;
+        line-height: 1;
+        background: linear-gradient(90deg, #8e2de2, #00c9ff);
+        -webkit-background-clip: text; background-clip: text; color: transparent;
+        text-shadow: 0 8px 40px rgba(142,45,226,0.35);
+      }
+    </style>
+
+    <div class="backdrop"></div>
+    <div class="announce"><h1 id="headline">Ship videos, not clicks</h1></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+
+      tl.from('[data-composition-id="intro"] #headline', { opacity: 0, scale: 0.8, duration: 0.9, ease: 'back.out(1.6)' }, 0.15);
+      tl.to('[data-composition-id="intro"] #headline', { opacity: 0, duration: 0.4, ease: 'power2.in' }, 4.60);
+
+      window.__timelines["intro"] = tl;
+    </script>
+  </div>
+</template>

--- a/examples/scene-promo/compositions/scene-outro.html
+++ b/examples/scene-promo/compositions/scene-outro.html
@@ -1,0 +1,40 @@
+<template id="scene-outro-template">
+  <div data-composition-id="outro" data-start="0" data-duration="6" data-width="1920" data-height="1080">
+    <style>
+      [data-composition-id="outro"] {
+        position: absolute; inset: 0; width: 100%; height: 100%;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        color: #fff; overflow: hidden; background: #000;
+      }
+      [data-composition-id="outro"] .backdrop {
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(ellipse at center, #1a1a2e 0%, #000 70%);
+      }
+      [data-composition-id="outro"] .kinetic {
+        position: absolute; inset: 0;
+        display: flex; align-items: center; justify-content: center;
+        text-align: center; padding: 0 6%;
+        font-size: 180px; font-weight: 900; letter-spacing: -6px;
+        line-height: 1; text-shadow: 0 6px 30px rgba(0,0,0,0.6);
+      }
+      [data-composition-id="outro"] .kinetic .word { display: inline-block; margin: 0 12px; }
+    </style>
+
+    <div class="backdrop"></div>
+    <div class="kinetic"><span class="word" id="w-0">Made</span> <span class="word" id="w-1">with</span> <span class="word" id="w-2">vibe</span> <span class="word" id="w-3">scene</span></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+
+      tl.from('[data-composition-id="outro"] #w-0', { opacity: 0, y: 80, scale: 0.8, duration: 0.45, ease: 'back.out(1.8)' }, 0.05);
+      tl.from('[data-composition-id="outro"] #w-1', { opacity: 0, y: 80, scale: 0.8, duration: 0.45, ease: 'back.out(1.8)' }, 0.35);
+      tl.from('[data-composition-id="outro"] #w-2', { opacity: 0, y: 80, scale: 0.8, duration: 0.45, ease: 'back.out(1.8)' }, 0.65);
+      tl.from('[data-composition-id="outro"] #w-3', { opacity: 0, y: 80, scale: 0.8, duration: 0.45, ease: 'back.out(1.8)' }, 0.95);
+
+      window.__timelines["outro"] = tl;
+    </script>
+  </div>
+</template>

--- a/examples/scene-promo/hyperframes.json
+++ b/examples/scene-promo/hyperframes.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "compositions",
+    "components": "compositions/components",
+    "assets": "assets"
+  }
+}

--- a/examples/scene-promo/index.html
+++ b/examples/scene-promo/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        margin: 0;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="main"
+      data-start="0"
+      data-duration="18"
+      data-width="1920"
+      data-height="1080"
+    >
+      <!-- Scenes added via `vibe scene add` are inserted here. -->
+      <!-- Each scene reference: data-composition-id, data-composition-src, data-start, data-duration, data-track-index. -->
+      <!-- See compositions/*.html for sub-composition contents. -->
+
+      <div class="clip" data-composition-id="intro" data-composition-src="compositions/scene-intro.html" data-start="0" data-duration="5" data-track-index="1"></div>
+
+      <div class="clip" data-composition-id="core" data-composition-src="compositions/scene-core.html" data-start="5" data-duration="7" data-track-index="1"></div>
+
+      <div class="clip" data-composition-id="outro" data-composition-src="compositions/scene-outro.html" data-start="12" data-duration="6" data-track-index="1"></div>
+
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      window.__timelines["main"] = gsap.timeline({ paused: true });
+    </script>
+  </body>
+</html>

--- a/examples/scene-promo/meta.json
+++ b/examples/scene-promo/meta.json
@@ -1,0 +1,5 @@
+{
+  "id": "scene-promo",
+  "name": "scene-promo",
+  "createdAt": "2026-04-25T08:30:06.999Z"
+}

--- a/examples/scene-promo/vibe.project.yaml
+++ b/examples/scene-promo/vibe.project.yaml
@@ -1,0 +1,9 @@
+name: scene-promo
+aspect: 16:9
+defaultSceneDuration: 5
+providers:
+  image: null
+  tts: null
+  transcribe: null
+budget:
+  maxUsd: 0

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage: curl -fsSL https://raw.githubusercontent.com/vericontext/vibeframe/main/scripts/install-skills.sh | bash
 
 REPO_RAW="https://raw.githubusercontent.com/vericontext/vibeframe/main"
-SKILLS=(vibeframe vibe-pipeline vibe-script-to-video)
+SKILLS=(vibeframe vibe-pipeline vibe-script-to-video vibe-scene)
 TARGET_DIR="${CLAUDE_SKILLS_DIR:-.claude/skills}"
 
 if [ ! -d ".claude" ] && [ -z "${FORCE_INSTALL:-}" ]; then
@@ -26,4 +26,4 @@ done
 
 echo ""
 echo "Done. Restart Claude Code to pick up new skills."
-echo "Slash commands now available: /vibeframe, /vibe-pipeline, /vibe-script-to-video"
+echo "Slash commands now available: /vibeframe, /vibe-pipeline, /vibe-script-to-video, /vibe-scene"


### PR DESCRIPTION
## Summary

C7/8 of the scene authoring MVP — doc-only commit.

- **`.claude/skills/vibe-scene/SKILL.md`** — `/vibe-scene` skill: init→add→lint→render loop, 5 style presets, lint feedback pattern (`--json --fix`, ≤3 retries + template fallback), Hyperframes interop matrix. Follows `vibe-pipeline` / `vibe-script-to-video` conventions.
- **`examples/scene-promo/`** — bilingual end-to-end example (3 scenes, 18s, 16:9) that reproduces without API keys (`--no-audio --no-image`). README walks through recreation, AI asset upgrade path, and `npx hyperframes` interop.
- **`README.md`** — new "Scene Authoring (HTML, not MP4)" section after AI Pipelines, `vibe scene` row in the CLI Reference table, `/vibe-scene` in the skill list.
- **`scripts/install-skills.sh`** — include `vibe-scene`.

No source changes. Only commit left in the MVP 1 sequence is C8 (version bump 0.53.0 + CHANGELOG).

Stacked on #65 (c6) — rebase onto main once #65 merges.

## Test plan

- [x] `pnpm build` — FULL TURBO, 0 errors
- [x] `pnpm lint` — 0 errors (8 pre-existing warnings, unchanged)
- [x] `pnpm -F @vibeframe/cli test --run scene` — 127/127 pass (7 files)
- [x] `vibe scene lint --project examples/scene-promo` — `ok: true`, 0 errors / 0 warnings (4 informational CDN-script notices, expected)
- [ ] Manual review of skill content for accuracy against shipped CLI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)