### PR TITLE
chore: bump version to 0.53.0 (MVP 1 c8/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.53.0] - 2026-04-25
+
+### Added
+
+- scene_init/add/lint/render tools + MCP mirror (MVP 1 c6/8) (#65) *(agent)*
+- script-to-video --format scenes (MVP 1 c5/8) (#64) *(pipeline)*
+- vibe scene render via Hyperframes producer (MVP 1 c4/8) (#63) *(scene)*
+- vibe scene lint via runHyperframeLint (MVP 1 c3/8) (#62) *(scene)*
+- add template-based vibe scene add (MVP 1 c2/8) (#61) *(scene)*
+- scaffold vibe scene init + bilingual project layout (MVP 1 c1/8) (#60) *(scene)*
+- auto-tag main on version bump (closes #51) (#59) *(ci)*
+
+### Documentation
+
+- /vibe-scene skill + scene-promo example + README (MVP 1 c7/8) (#66) *(scene)*
+
 ## [0.52.1] - 2026-04-24
 
 ### Fixed
 
-- wire gpt-image-2 alias in "vibe generate image" *(generate)*
+- wire gpt-image-2 alias in "vibe generate image" (#57) *(generate)*
 
 ## [0.52.0] - 2026-04-24
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

C8/8 — final commit of the scene authoring MVP. Version bump + CHANGELOG.

- 7 package.json files: `0.52.1` → `0.53.0`
- `CHANGELOG.md` regenerated via `git-cliff --tag v0.53.0`

### What ships in 0.53.0

Scene-based authoring as a first-class VibeFrame primitive:

- `vibe scene init/add/lint/render` — author per-scene HTML projects (PRs #60, #61, #62, #63)
- `vibe pipeline script-to-video --format scenes` — flagship pipeline (PR #64)
- `scene_init/add/lint/render` agent + MCP tools (PR #65)
- `/vibe-scene` skill + `examples/scene-promo/` walkthrough + README (PR #66)

A scene project is bilingual — works with both `vibe` and `npx hyperframes`. Editable HTML replaces opaque MP4s where iteration matters (~10× cost reduction on `script-to-video`).

### Release flow

Auto-tag workflow (`.github/workflows/auto-tag.yml`) will create `v0.53.0` + dispatch `publish.yml` once this lands on main.

## Test plan

- [x] `pnpm build` — 6/6 tasks pass
- [x] `pnpm lint` — 10/10 tasks pass (0 errors)
- [x] `version-checker` agent — all 7 package.json + landing page badge sync to 0.53.0; no stray 0.52.x references
- [x] CHANGELOG.md captures all 8 PRs (#59, #60, #61, #62, #63, #64, #65, #66)

🤖 Generated with [Claude Code](https://claude.com/claude-code)