### PR TITLE
feat(whisper): word-level timestamps via granularity option (v0.54 c1/6)

### DIFF
--- a/packages/ai-providers/src/interface/types.ts
+++ b/packages/ai-providers/src/interface/types.ts
@@ -165,10 +165,46 @@ export interface TranscriptSegment {
 }
 
 /**
+ * A single word-level entry within a transcription result.
+ *
+ * Mirrors the Hyperframes `transcript.json` shape exactly so VibeFrame
+ * scene HTML can drive GSAP timelines with the same word timings.
+ */
+export interface TranscriptWord {
+  /** The word text (without surrounding whitespace) */
+  text: string;
+  /** Start time in seconds */
+  start: TimeSeconds;
+  /** End time in seconds */
+  end: TimeSeconds;
+}
+
+/**
+ * Granularity at which timestamps are returned by a transcription provider.
+ *
+ * - `"segment"` — sentence/utterance level (default, back-compat)
+ * - `"word"` — word level only
+ * - `"both"` — both segment and word level
+ */
+export type TranscriptGranularity = "segment" | "word" | "both";
+
+/**
+ * Optional parameters for {@link AIProvider.transcribe}.
+ *
+ * Providers ignore unsupported options.
+ */
+export interface TranscribeOptions {
+  /** BCP-47 language code hint (e.g. `"en"`, `"ko"`). */
+  language?: string;
+  /** Timestamp granularity. Defaults to `"segment"` for back-compat. */
+  granularity?: TranscriptGranularity;
+}
+
+/**
  * Result returned by {@link AIProvider.transcribe}.
  *
  * Contains the full transcript text, individual time-aligned segments,
- * and the detected language.
+ * optional word-level timings, and the detected language.
  */
 export interface TranscriptResult {
   /** Provider-assigned transcription job ID */
@@ -179,6 +215,8 @@ export interface TranscriptResult {
   fullText?: string;
   /** Individual segments */
   segments?: TranscriptSegment[];
+  /** Word-level timings (populated when granularity is "word" or "both") */
+  words?: TranscriptWord[];
   /** Detected language */
   detectedLanguage?: string;
   /** Error message if failed */
@@ -611,11 +649,17 @@ export interface AIProvider {
 
   /**
    * Transcribe audio to text (capability: `"speech-to-text"`).
+   *
+   * The third parameter accepts {@link TranscribeOptions} for granularity
+   * control. The legacy `language: string` form is still accepted as the
+   * second argument for back-compat.
+   *
    * @param audio - Audio data as a Blob.
    * @param language - Optional BCP-47 language code hint (e.g., `"en"`, `"ko"`).
-   * @returns Transcription result with full text and time-aligned segments.
+   * @param options - Additional transcription options (granularity, etc.).
+   * @returns Transcription result with full text, segments, and optionally word-level timings.
    */
-  transcribe?(audio: Blob, language?: string): Promise<TranscriptResult>;
+  transcribe?(audio: Blob, language?: string, options?: TranscribeOptions): Promise<TranscriptResult>;
 
   /**
    * Get AI-generated edit suggestions based on clips and a natural language instruction

--- a/packages/ai-providers/src/whisper/WhisperProvider.test.ts
+++ b/packages/ai-providers/src/whisper/WhisperProvider.test.ts
@@ -1,0 +1,171 @@
+/**
+ * WhisperProvider unit tests (mock-based, no API calls).
+ *
+ * Covers the granularity option added in v0.54: segment | word | both.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WhisperProvider } from "./WhisperProvider.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+vi.stubGlobal("crypto", { randomUUID: () => "test-uuid" });
+
+const audio = new Blob([new Uint8Array([1, 2, 3])]);
+
+const segmentResponse = {
+  text: "Hello world.",
+  language: "en",
+  segments: [
+    { id: 0, start: 0, end: 1.5, text: "Hello world." },
+  ],
+};
+
+const wordResponse = {
+  text: "Hello world.",
+  language: "en",
+  words: [
+    { word: "Hello", start: 0.0, end: 0.6 },
+    { word: "world.", start: 0.7, end: 1.5 },
+  ],
+};
+
+const bothResponse = {
+  ...segmentResponse,
+  words: wordResponse.words,
+};
+
+function okResponse(payload: unknown) {
+  return {
+    ok: true,
+    json: async () => payload,
+  };
+}
+
+function captureFormData(): FormData {
+  // Last call's `body` argument
+  const calls = mockFetch.mock.calls;
+  const last = calls[calls.length - 1];
+  return last[1].body as FormData;
+}
+
+describe("WhisperProvider", () => {
+  let provider: WhisperProvider;
+
+  beforeEach(async () => {
+    provider = new WhisperProvider();
+    await provider.initialize({ apiKey: "test-key" });
+    mockFetch.mockReset();
+  });
+
+  describe("initialization", () => {
+    it("declares speech-to-text capability", () => {
+      expect(provider.id).toBe("whisper");
+      expect(provider.capabilities).toContain("speech-to-text");
+    });
+
+    it("returns failed result without API key", async () => {
+      const fresh = new WhisperProvider();
+      const result = await fresh.transcribe(audio);
+      expect(result.status).toBe("failed");
+      expect(result.error).toContain("not configured");
+    });
+  });
+
+  describe("granularity: default (segment)", () => {
+    it("sends timestamp_granularities[]=segment when no options", async () => {
+      mockFetch.mockResolvedValueOnce(okResponse(segmentResponse));
+
+      const result = await provider.transcribe(audio);
+
+      const fd = captureFormData();
+      const granularities = fd.getAll("timestamp_granularities[]");
+      expect(granularities).toEqual(["segment"]);
+
+      expect(result.status).toBe("completed");
+      expect(result.segments).toHaveLength(1);
+      expect(result.segments?.[0].text).toBe("Hello world.");
+      expect(result.words).toBeUndefined();
+    });
+
+    it("attaches legacy language argument", async () => {
+      mockFetch.mockResolvedValueOnce(okResponse(segmentResponse));
+
+      await provider.transcribe(audio, "ko");
+
+      const fd = captureFormData();
+      expect(fd.get("language")).toBe("ko");
+    });
+  });
+
+  describe("granularity: word", () => {
+    it("sends timestamp_granularities[]=word and parses words", async () => {
+      mockFetch.mockResolvedValueOnce(okResponse(wordResponse));
+
+      const result = await provider.transcribe(audio, undefined, {
+        granularity: "word",
+      });
+
+      const fd = captureFormData();
+      const granularities = fd.getAll("timestamp_granularities[]");
+      expect(granularities).toEqual(["word"]);
+
+      expect(result.status).toBe("completed");
+      expect(result.words).toEqual([
+        { text: "Hello", start: 0.0, end: 0.6 },
+        { text: "world.", start: 0.7, end: 1.5 },
+      ]);
+      expect(result.segments).toBeUndefined();
+    });
+
+    it("accepts language via options", async () => {
+      mockFetch.mockResolvedValueOnce(okResponse(wordResponse));
+
+      await provider.transcribe(audio, undefined, {
+        language: "en",
+        granularity: "word",
+      });
+
+      const fd = captureFormData();
+      expect(fd.get("language")).toBe("en");
+    });
+  });
+
+  describe("granularity: both", () => {
+    it("sends both granularity values and parses both fields", async () => {
+      mockFetch.mockResolvedValueOnce(okResponse(bothResponse));
+
+      const result = await provider.transcribe(audio, undefined, {
+        granularity: "both",
+      });
+
+      const fd = captureFormData();
+      const granularities = fd.getAll("timestamp_granularities[]");
+      expect(granularities.sort()).toEqual(["segment", "word"]);
+
+      expect(result.segments).toHaveLength(1);
+      expect(result.words).toHaveLength(2);
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns failed result on non-ok response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        text: async () => "rate limit exceeded",
+      });
+
+      const result = await provider.transcribe(audio);
+      expect(result.status).toBe("failed");
+      expect(result.error).toContain("rate limit exceeded");
+    });
+
+    it("returns failed result on network error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("network down"));
+
+      const result = await provider.transcribe(audio);
+      expect(result.status).toBe("failed");
+      expect(result.error).toBe("network down");
+    });
+  });
+});

--- a/packages/ai-providers/src/whisper/WhisperProvider.ts
+++ b/packages/ai-providers/src/whisper/WhisperProvider.ts
@@ -2,11 +2,18 @@ import type {
   AIProvider,
   AICapability,
   ProviderConfig,
+  TranscribeOptions,
   TranscriptResult,
+  TranscriptWord,
 } from "../interface/types.js";
 
 /**
- * OpenAI Whisper provider for speech-to-text
+ * OpenAI Whisper provider for speech-to-text.
+ *
+ * Supports segment-level (default) and word-level timestamps via the
+ * `timestamp_granularities[]` query parameter on the `/audio/transcriptions`
+ * endpoint. Word-level output mirrors the Hyperframes `transcript.json`
+ * shape (`{text, start, end}`) so it can drive scene HTML GSAP timelines.
  */
 export class WhisperProvider implements AIProvider {
   id = "whisper";
@@ -30,7 +37,11 @@ export class WhisperProvider implements AIProvider {
     return !!this.apiKey;
   }
 
-  async transcribe(audio: Blob, language?: string): Promise<TranscriptResult> {
+  async transcribe(
+    audio: Blob,
+    language?: string,
+    options?: TranscribeOptions,
+  ): Promise<TranscriptResult> {
     if (!this.apiKey) {
       return {
         id: "",
@@ -39,15 +50,25 @@ export class WhisperProvider implements AIProvider {
       };
     }
 
+    const granularity = options?.granularity ?? "segment";
+
     try {
       const formData = new FormData();
       formData.append("file", audio, "audio.webm");
       formData.append("model", "whisper-1");
       formData.append("response_format", "verbose_json");
-      formData.append("timestamp_granularities[]", "segment");
 
-      if (language) {
-        formData.append("language", language);
+      // Whisper API accepts multiple `timestamp_granularities[]` values.
+      if (granularity === "segment" || granularity === "both") {
+        formData.append("timestamp_granularities[]", "segment");
+      }
+      if (granularity === "word" || granularity === "both") {
+        formData.append("timestamp_granularities[]", "word");
+      }
+
+      const lang = language ?? options?.language;
+      if (lang) {
+        formData.append("language", lang);
       }
 
       const response = await fetch(`${this.baseUrl}/audio/transcriptions`, {
@@ -71,26 +92,35 @@ export class WhisperProvider implements AIProvider {
         text: string;
         language?: string;
         segments?: Array<{ id: number; start: number; end: number; text: string }>;
+        words?: Array<{ word: string; start: number; end: number }>;
       };
 
-      return {
+      const result: TranscriptResult = {
         id: crypto.randomUUID(),
         status: "completed",
         fullText: data.text,
         detectedLanguage: data.language,
-        segments: data.segments?.map((seg: {
-          id: number;
-          start: number;
-          end: number;
-          text: string;
-        }, index: number) => ({
+      };
+
+      if (granularity === "segment" || granularity === "both") {
+        result.segments = data.segments?.map((seg, index) => ({
           id: `segment-${index}`,
           startTime: seg.start,
           endTime: seg.end,
           text: seg.text.trim(),
-          confidence: 1, // Whisper doesn't provide confidence per segment
-        })),
-      };
+          confidence: 1, // Whisper doesn't provide per-segment confidence
+        }));
+      }
+
+      if (granularity === "word" || granularity === "both") {
+        result.words = data.words?.map((w): TranscriptWord => ({
+          text: w.word,
+          start: w.start,
+          end: w.end,
+        }));
+      }
+
+      return result;
     } catch (error) {
       return {
         id: "",


### PR DESCRIPTION
## Summary

C1/6 of the v0.54 sequence: **Local TTS (Kokoro) + word-level A/V sync**. Plan: \`~/.claude/plans/logical-wibbling-sonnet.md\`.

This commit lands the **Whisper provider plumbing** for word-level timestamps. No CLI exposure — C4 will start calling it from the scene workflow.

- New types: \`TranscriptWord\`, \`TranscribeOptions\`, \`TranscriptGranularity\`. \`TranscriptResult.words?\` field added.
- \`WhisperProvider.transcribe()\` accepts optional third \`options\` arg. Defaults to \`"segment"\` — back-compat with all 9+ existing call sites.
- Word-level shape (\`{text, start, end}\`) mirrors Hyperframes \`transcript.json\` so we can drive GSAP timelines with identical word timings.
- 9 new unit tests cover all 3 granularities + legacy language arg + error paths.

## Test plan

- [x] \`pnpm -F @vibeframe/ai-providers test\` — 29/29 pass (12 grok + 9 whisper [new] + 8 index)
- [x] \`pnpm -F @vibeframe/cli test\` — 413/424 pass, 11 skipped (Chrome-gated, unaffected)
- [x] \`pnpm build\` — 6/6 FULL TURBO
- [x] \`pnpm lint\` — 10/10 (0 errors)
- [x] No call sites changed — \`grep -rn "transcribe(audio" packages/\` confirms all callers still pass legacy \`(audio, language)\` form

## Sequence context

| Commit | Status | What |
|---|---|---|
| **C1** | this PR | Whisper word-level + types |
| C2 | pending | KokoroProvider (\`kokoro-js\`, lazy ONNX init) |
| C3 | pending | TTS router (\`provider-resolver\` + \`tts-resolve\` factory) |
| C4 | pending | Scene workflow transcribe + \`--narration-file\` flag |
| C5 | pending | \`emitSceneHtml\` word-sync rendering |
| C6 | pending | examples + smoke + docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)