### PR TITLE
feat(scene): TTS router with Kokoro fallback + --tts flag (v0.54 c3/6)

### DIFF
--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -59,7 +59,7 @@ export interface VibeProjectConfig {
   /** Default providers per capability. `null` means "auto-resolve from env". */
   providers: {
     image: "openai" | "gemini" | "grok" | null;
-    tts: "elevenlabs" | null;
+    tts: "elevenlabs" | "kokoro" | null;
     transcribe: "whisper" | null;
   };
   /** Cost ceiling for `vibe pipeline` runs in this project. 0 disables. */

--- a/packages/cli/src/commands/_shared/tts-resolve.test.ts
+++ b/packages/cli/src/commands/_shared/tts-resolve.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the TTS router. The actual provider classes are mocked at
+ * the module level so we can drive resolution outcomes deterministically.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock factories are hoisted above imports — so any references must come
+// from vi.hoisted (which is also hoisted) rather than module-scope variables.
+const mocks = vi.hoisted(() => {
+  return {
+    elevenLabsTextToSpeech: vi.fn(),
+    elevenLabsInitialize: vi.fn(),
+    kokoroTextToSpeech: vi.fn(),
+    kokoroInitialize: vi.fn(),
+    hasApiKey: vi.fn(),
+    getApiKey: vi.fn(),
+  };
+});
+
+vi.mock("@vibeframe/ai-providers", () => ({
+  ElevenLabsProvider: class {
+    initialize = mocks.elevenLabsInitialize;
+    textToSpeech = mocks.elevenLabsTextToSpeech;
+  },
+  KokoroProvider: class {
+    initialize = mocks.kokoroInitialize;
+    textToSpeech = mocks.kokoroTextToSpeech;
+  },
+}));
+
+vi.mock("../../utils/api-key.js", () => ({
+  hasApiKey: (...args: unknown[]) => mocks.hasApiKey(...args),
+  getApiKey: (...args: unknown[]) => mocks.getApiKey(...args),
+}));
+
+const {
+  elevenLabsTextToSpeech,
+  elevenLabsInitialize,
+  kokoroTextToSpeech,
+  kokoroInitialize,
+  hasApiKey,
+  getApiKey,
+} = mocks;
+
+import {
+  parseTtsProviderName,
+  resolveTtsProvider,
+  TtsKeyMissingError,
+} from "./tts-resolve.js";
+
+describe("parseTtsProviderName", () => {
+  it("defaults to auto when undefined or empty", () => {
+    expect(parseTtsProviderName(undefined)).toBe("auto");
+    expect(parseTtsProviderName("")).toBe("auto");
+  });
+
+  it("accepts the three valid values", () => {
+    expect(parseTtsProviderName("auto")).toBe("auto");
+    expect(parseTtsProviderName("elevenlabs")).toBe("elevenlabs");
+    expect(parseTtsProviderName("kokoro")).toBe("kokoro");
+  });
+
+  it("throws for unknown providers", () => {
+    expect(() => parseTtsProviderName("openai")).toThrow(/Invalid --tts/);
+    expect(() => parseTtsProviderName("KOKORO")).toThrow(/Invalid --tts/);
+  });
+});
+
+describe("resolveTtsProvider", () => {
+  beforeEach(() => {
+    elevenLabsTextToSpeech.mockReset();
+    elevenLabsInitialize.mockReset();
+    kokoroTextToSpeech.mockReset();
+    kokoroInitialize.mockReset();
+    hasApiKey.mockReset();
+    getApiKey.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("auto", () => {
+    it("picks ElevenLabs when ELEVENLABS_API_KEY is set", async () => {
+      hasApiKey.mockReturnValue(true);
+      getApiKey.mockResolvedValue("sk-test");
+
+      const r = await resolveTtsProvider("auto");
+
+      expect(r.provider).toBe("elevenlabs");
+      expect(r.audioExtension).toBe("mp3");
+      expect(hasApiKey).toHaveBeenCalledWith("ELEVENLABS_API_KEY");
+      expect(elevenLabsInitialize).toHaveBeenCalledWith({ apiKey: "sk-test" });
+    });
+
+    it("falls back to Kokoro when ELEVENLABS_API_KEY is unset", async () => {
+      hasApiKey.mockReturnValue(false);
+
+      const r = await resolveTtsProvider("auto");
+
+      expect(r.provider).toBe("kokoro");
+      expect(r.audioExtension).toBe("wav");
+      expect(kokoroInitialize).toHaveBeenCalled();
+      expect(getApiKey).not.toHaveBeenCalled();
+    });
+
+    it("treats undefined preferred the same as auto", async () => {
+      hasApiKey.mockReturnValue(false);
+
+      const r = await resolveTtsProvider();
+
+      expect(r.provider).toBe("kokoro");
+    });
+  });
+
+  describe("explicit elevenlabs", () => {
+    it("uses ElevenLabs when key is present", async () => {
+      getApiKey.mockResolvedValue("sk-real");
+
+      const r = await resolveTtsProvider("elevenlabs");
+
+      expect(r.provider).toBe("elevenlabs");
+      expect(elevenLabsInitialize).toHaveBeenCalledWith({ apiKey: "sk-real" });
+    });
+
+    it("throws TtsKeyMissingError when key is absent", async () => {
+      getApiKey.mockResolvedValue(undefined);
+
+      await expect(resolveTtsProvider("elevenlabs")).rejects.toBeInstanceOf(
+        TtsKeyMissingError,
+      );
+      expect(kokoroInitialize).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("explicit kokoro", () => {
+    it("uses Kokoro without checking any key", async () => {
+      const r = await resolveTtsProvider("kokoro");
+
+      expect(r.provider).toBe("kokoro");
+      expect(r.audioExtension).toBe("wav");
+      expect(kokoroInitialize).toHaveBeenCalled();
+      expect(getApiKey).not.toHaveBeenCalled();
+      expect(hasApiKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("call dispatch", () => {
+    it("forwards voice + speed to ElevenLabs as voiceId/speed", async () => {
+      hasApiKey.mockReturnValue(true);
+      getApiKey.mockResolvedValue("sk-test");
+      elevenLabsTextToSpeech.mockResolvedValue({ success: true, audioBuffer: Buffer.from("x") });
+
+      const r = await resolveTtsProvider("elevenlabs");
+      await r.call("Hello.", { voice: "rachel", speed: 1.1 });
+
+      expect(elevenLabsTextToSpeech).toHaveBeenCalledWith("Hello.", {
+        voiceId: "rachel",
+        speed: 1.1,
+      });
+    });
+
+    it("forwards voice + speed + onProgress to Kokoro", async () => {
+      kokoroTextToSpeech.mockResolvedValue({ success: true, audioBuffer: Buffer.from("y") });
+
+      const r = await resolveTtsProvider("kokoro");
+      const onProgress = vi.fn();
+      await r.call("Hello.", { voice: "af_heart", speed: 1.0, onProgress });
+
+      expect(kokoroTextToSpeech).toHaveBeenCalledWith("Hello.", {
+        voice: "af_heart",
+        speed: 1.0,
+        onProgress,
+      });
+    });
+  });
+});
+
+describe("TtsKeyMissingError", () => {
+  it("provides actionable elevenlabs message", () => {
+    const err = new TtsKeyMissingError("elevenlabs");
+    expect(err.message).toMatch(/ELEVENLABS_API_KEY/);
+    expect(err.message).toMatch(/--tts kokoro/);
+    expect(err.provider).toBe("elevenlabs");
+  });
+
+  it("is identifiable via instanceof", () => {
+    const err = new TtsKeyMissingError("elevenlabs");
+    expect(err).toBeInstanceOf(TtsKeyMissingError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("TtsKeyMissingError");
+  });
+});

--- a/packages/cli/src/commands/_shared/tts-resolve.ts
+++ b/packages/cli/src/commands/_shared/tts-resolve.ts
@@ -1,0 +1,141 @@
+/**
+ * @module _shared/tts-resolve
+ *
+ * One-stop factory for picking a TTS provider at runtime. Used by every
+ * scene-authoring path that turns text into narration audio (currently
+ * `executeSceneAdd`; `script-to-video --format scenes` follows in C5+).
+ *
+ * Routes between:
+ *   - **ElevenLabs** — cloud, API-key gated, paid (~$0.02/scene). Default
+ *     when `ELEVENLABS_API_KEY` is set.
+ *   - **Kokoro** — local Apache 2.0 model, free, ~330MB first-call download.
+ *     The fallback for key-less users.
+ *
+ * The router exposes a uniform `TtsCallable` shape so call sites don't have
+ * to branch on provider id. Both providers already return the same
+ * `{ success, audioBuffer, error?, characterCount? }` result.
+ */
+
+import { ElevenLabsProvider, KokoroProvider } from "@vibeframe/ai-providers";
+import type { KokoroLoadEvent } from "@vibeframe/ai-providers";
+import { hasApiKey } from "../../utils/api-key.js";
+import { getApiKey } from "../../utils/api-key.js";
+
+/** TTS providers VibeFrame can route to. `"auto"` picks based on key availability. */
+export type TtsProviderName = "auto" | "elevenlabs" | "kokoro";
+
+/** Concrete provider id surfaced in result metadata. Never `"auto"`. */
+export type ResolvedTtsProvider = "elevenlabs" | "kokoro";
+
+/** Options accepted by every {@link TtsCallable}. Subset of provider-specific options. */
+export interface TtsCallOptions {
+  /**
+   * Provider-specific voice id. ElevenLabs takes voice names/ids
+   * (`"rachel"`, `"21m00Tcm..."`); Kokoro takes voice ids (`"af_heart"`,
+   * `"am_michael"`). The router does not map between the two.
+   */
+  voice?: string;
+  /** Speaking speed multiplier (Kokoro: 0.5–2; ElevenLabs: 0.7–1.2). */
+  speed?: number;
+  /** Cold-start progress callback (Kokoro only — fires on first ~330MB load). */
+  onProgress?: (event: KokoroLoadEvent) => void;
+}
+
+/** Result of a TTS call. Same shape both providers already return. */
+export interface TtsCallResult {
+  success: boolean;
+  audioBuffer?: Buffer;
+  error?: string;
+  characterCount?: number;
+}
+
+/** Synthesise speech from text. Provider-specific implementation lives behind this. */
+export type TtsCallable = (text: string, options?: TtsCallOptions) => Promise<TtsCallResult>;
+
+export interface TtsResolution {
+  /** Concrete provider chosen. */
+  provider: ResolvedTtsProvider;
+  /** Output container — drives the narration filename extension. */
+  audioExtension: "mp3" | "wav";
+  /** Synthesise text → audio buffer. */
+  call: TtsCallable;
+}
+
+/**
+ * Resolve a TTS provider preference into a callable + metadata.
+ *
+ * Resolution policy:
+ *   - `"elevenlabs"`: requires `ELEVENLABS_API_KEY`. Throws an `ApiKeyError`-style
+ *     error via {@link getApiKey} (consumed by `requireApiKey`/`exitWithError`).
+ *   - `"kokoro"`: always available (local). No key check.
+ *   - `"auto"` (or `undefined`): if `ELEVENLABS_API_KEY` is set, picks
+ *     ElevenLabs; otherwise falls back to Kokoro.
+ */
+export async function resolveTtsProvider(
+  preferred: TtsProviderName = "auto",
+): Promise<TtsResolution> {
+  const choice = preferred === "auto"
+    ? (hasApiKey("ELEVENLABS_API_KEY") ? "elevenlabs" : "kokoro")
+    : preferred;
+
+  if (choice === "elevenlabs") {
+    return buildElevenLabs();
+  }
+  return buildKokoro();
+}
+
+async function buildElevenLabs(): Promise<TtsResolution> {
+  const key = await getApiKey("ELEVENLABS_API_KEY", "ElevenLabs");
+  if (!key) {
+    throw new TtsKeyMissingError("elevenlabs");
+  }
+  const provider = new ElevenLabsProvider();
+  await provider.initialize({ apiKey: key });
+  const call: TtsCallable = async (text, opts) =>
+    provider.textToSpeech(text, {
+      voiceId: opts?.voice,
+      speed: opts?.speed,
+    });
+  return { provider: "elevenlabs", audioExtension: "mp3", call };
+}
+
+async function buildKokoro(): Promise<TtsResolution> {
+  const provider = new KokoroProvider();
+  // No-op initialize — Kokoro doesn't take a config but we keep parity with
+  // the AIProvider lifecycle for future audit checks.
+  await provider.initialize({});
+  const call: TtsCallable = async (text, opts) =>
+    provider.textToSpeech(text, {
+      voice: opts?.voice,
+      speed: opts?.speed,
+      onProgress: opts?.onProgress,
+    });
+  return { provider: "kokoro", audioExtension: "wav", call };
+}
+
+/**
+ * Thrown when the caller asked for a specific provider whose key/runtime is
+ * unavailable. Carries the provider id so the caller can format a clean
+ * `usageError`/`exitWithError`.
+ */
+export class TtsKeyMissingError extends Error {
+  constructor(public readonly provider: ResolvedTtsProvider) {
+    super(
+      provider === "elevenlabs"
+        ? "ElevenLabs API key required (ELEVENLABS_API_KEY). Run 'vibe setup', set ELEVENLABS_API_KEY in .env, or pass --tts kokoro for local synthesis."
+        : `Provider ${provider} is unavailable.`,
+    );
+    this.name = "TtsKeyMissingError";
+  }
+}
+
+/** Validate a free-form `--tts <value>` against {@link TtsProviderName}. */
+export function parseTtsProviderName(value: string | undefined): TtsProviderName {
+  if (!value) return "auto";
+  if (value === "auto" || value === "elevenlabs" || value === "kokoro") {
+    return value;
+  }
+  throw new Error(
+    `Invalid --tts: ${value}. Valid: auto, elevenlabs, kokoro.`,
+  );
+}

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -22,10 +22,15 @@ import chalk from "chalk";
 import ora from "ora";
 import { parse as yamlParse } from "yaml";
 import {
-  ElevenLabsProvider,
   GeminiProvider,
   OpenAIImageProvider,
 } from "@vibeframe/ai-providers";
+import {
+  resolveTtsProvider,
+  TtsKeyMissingError,
+  parseTtsProviderName,
+  type TtsProviderName,
+} from "./_shared/tts-resolve.js";
 import {
   scaffoldSceneProject,
   aspectToDims,
@@ -184,7 +189,8 @@ sceneCommand
   .option("--insert-into <path>", "Root composition file to update", "index.html")
   .option("--project <dir>", "Project directory", ".")
   .option("--image-provider <name>", "Image provider: gemini, openai", "gemini")
-  .option("--voice <id>", "ElevenLabs voice id or name")
+  .option("--tts <provider>", "TTS provider: auto, elevenlabs, kokoro (default auto — picks ElevenLabs when key set, else Kokoro local)", "auto")
+  .option("--voice <id>", "Voice id (ElevenLabs name/id, or Kokoro id like af_heart, am_michael)")
   .option("--no-audio", "Skip TTS even when --narration is provided (useful for tests/agent dry runs)")
   .option("--no-image", "Skip image generation even when --visuals is provided")
   .option("--force", "Overwrite an existing compositions/scene-<id>.html")
@@ -192,6 +198,12 @@ sceneCommand
   .action(async (name: string, options) => {
     if (options.style) options.style = validatePreset(options.style);
     if (options.duration !== undefined) options.duration = validateDuration(options.duration);
+    let tts: TtsProviderName;
+    try {
+      tts = parseTtsProviderName(options.tts);
+    } catch (error) {
+      exitWithError(usageError(error instanceof Error ? error.message : String(error)));
+    }
 
     if (options.dryRun) {
       const id = slugifySceneName(name);
@@ -210,6 +222,7 @@ sceneCommand
           project: options.project,
           insertInto: options.insertInto,
           imageProvider: options.imageProvider,
+          tts,
           audio: options.audio,   // commander sets `audio: false` when --no-audio is passed
           image: options.image,
         },
@@ -231,6 +244,7 @@ sceneCommand
         projectDir: options.project,
         insertInto: options.insertInto,
         imageProvider: options.imageProvider,
+        tts,
         voice: options.voice,
         skipAudio: options.audio === false,
         skipImage: options.image === false,
@@ -301,7 +315,9 @@ export interface SceneAddOptions {
   insertInto?: string;
   /** "gemini" | "openai". */
   imageProvider?: string;
-  /** ElevenLabs voice id/name. */
+  /** TTS provider preference. Defaults to `"auto"` (ElevenLabs if key set, else Kokoro). */
+  tts?: TtsProviderName;
+  /** Voice id (ElevenLabs name/id, or Kokoro id like `af_heart`). */
   voice?: string;
   /** When true, skip TTS even if narration is provided. */
   skipAudio?: boolean;
@@ -411,18 +427,32 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
   let narrationDuration: number | undefined;
 
   if (narrationText && !opts.skipAudio) {
-    const elevenlabsKey = await getApiKey("ELEVENLABS_API_KEY", "ElevenLabs");
-    if (!elevenlabsKey) {
-      return errResult("ElevenLabs API key required for --narration. Set ELEVENLABS_API_KEY, run 'vibe setup', or pass --no-audio.");
+    let resolution;
+    try {
+      resolution = await resolveTtsProvider(opts.tts ?? "auto");
+    } catch (error) {
+      if (error instanceof TtsKeyMissingError) {
+        return errResult(error.message);
+      }
+      throw error;
     }
-    opts.onProgress?.("Generating narration with ElevenLabs...");
-    const elevenlabs = new ElevenLabsProvider();
-    await elevenlabs.initialize({ apiKey: elevenlabsKey });
-    const tts = await elevenlabs.textToSpeech(narrationText, { voiceId: opts.voice });
+    opts.onProgress?.(
+      resolution.provider === "kokoro"
+        ? "Generating narration with Kokoro (local — first run downloads ~330MB)..."
+        : "Generating narration with ElevenLabs...",
+    );
+    const tts = await resolution.call(narrationText, {
+      voice: opts.voice,
+      onProgress: (event) => {
+        if (event.status === "progress" && typeof event.progress === "number") {
+          opts.onProgress?.(`Kokoro model: ${event.file ?? ""} ${Math.round(event.progress)}%`);
+        }
+      },
+    });
     if (!tts.success || !tts.audioBuffer) {
-      return errResult(`ElevenLabs TTS failed: ${tts.error ?? "unknown error"}`);
+      return errResult(`${resolution.provider} TTS failed: ${tts.error ?? "unknown error"}`);
     }
-    audioRelPath = `assets/narration-${id}.mp3`;
+    audioRelPath = `assets/narration-${id}.${resolution.audioExtension}`;
     audioAbsPath = resolve(projectDir, audioRelPath);
     await mkdir(dirname(audioAbsPath), { recursive: true });
     await writeFile(audioAbsPath, tts.audioBuffer);

--- a/packages/cli/src/utils/provider-resolver.ts
+++ b/packages/cli/src/utils/provider-resolver.ts
@@ -8,7 +8,12 @@ import { hasApiKey } from "./api-key.js";
 
 interface ProviderCandidate {
   name: string;
-  envVar: string;
+  /**
+   * Environment variable that must be set for this provider to be available.
+   * `null` means the provider is always available (e.g. local on-device models
+   * with no API key).
+   */
+  envVar: string | null;
   label: string;
 }
 
@@ -25,8 +30,12 @@ const VIDEO_PROVIDERS: ProviderCandidate[] = [
   { name: "runway", envVar: "RUNWAY_API_SECRET", label: "Runway" },
 ];
 
+// `kokoro` runs locally with no API key — it's the always-available fallback
+// behind ElevenLabs. Listing it last keeps existing key-holding users on
+// ElevenLabs by default while letting key-less users land on Kokoro.
 const SPEECH_PROVIDERS: ProviderCandidate[] = [
   { name: "elevenlabs", envVar: "ELEVENLABS_API_KEY", label: "ElevenLabs" },
+  { name: "kokoro", envVar: null, label: "Kokoro (local)" },
 ];
 
 const PROVIDER_MAP: Record<string, ProviderCandidate[]> = {
@@ -69,14 +78,14 @@ export function resolveProvider(
   // Check config default first
   if (configDefaults?.[category]) {
     const preferred = candidates.find(c => c.name === configDefaults![category]);
-    if (preferred && hasApiKey(preferred.envVar)) {
+    if (preferred && (preferred.envVar === null || hasApiKey(preferred.envVar))) {
       return { name: preferred.name, label: preferred.label };
     }
   }
 
   // Fall back to first available
   for (const candidate of candidates) {
-    if (hasApiKey(candidate.envVar)) {
+    if (candidate.envVar === null || hasApiKey(candidate.envVar)) {
       return { name: candidate.name, label: candidate.label };
     }
   }


### PR DESCRIPTION
## Summary

C3/6 of the v0.54 sequence. Wires \`vibe scene add\` to the new TTS router so key-less users land on the local Kokoro provider automatically.

**Behaviour change** (visible to users):
- ELEVENLABS_API_KEY set → ElevenLabs (mp3 narration). **No change.**
- ELEVENLABS_API_KEY unset → **Kokoro local** (wav narration), instead of usage error. First call downloads ~330MB to \`~/.cache/huggingface/hub\`.
- \`vibe scene add --tts <auto|elevenlabs|kokoro>\` flag forces the choice.

**Design points:**
- \`commands/_shared/tts-resolve.ts\` factory returns a uniform \`TtsCallable\` plus the resolved provider id and audio extension. Custom \`TtsKeyMissingError\` carries enough context for actionable error formatting.
- \`provider-resolver.ts\`: \`ProviderCandidate.envVar\` widened to \`string | null\`. Kokoro registered as the always-available fallback in \`SPEECH_PROVIDERS\`.
- \`scene-project.ts\`: \`providers.tts\` union extended with \`"kokoro"\` so \`vibe.project.yaml\` can pin a provider per project.

**Out of scope:** \`ai-script-pipeline.ts\` (script-to-video bulk TTS) still uses ElevenLabs directly. Its auto-speed-adjust loop wants per-call fine-tuning that's worth its own commit. **C5** will revisit.

## Test plan

- [x] \`pnpm -F @vibeframe/cli test --run tts-resolve\` — **13/13** new tests
- [x] \`pnpm -F @vibeframe/cli test --run scene\` — **127/127** still pass
- [x] \`pnpm build\` — 6/6 (cached)
- [x] \`pnpm lint\` — 10/10 (0 errors)
- [ ] Real Kokoro download exercised by C6 smoke test

## Sequence

| Commit | Status | What |
|---|---|---|
| C1 | merged (#68) | Whisper word-level + types |
| C2 | merged (#69) | KokoroProvider |
| **C3** | this PR | TTS router + \`--tts\` flag |
| C4 | pending | Scene workflow transcribe + \`--narration-file\` |
| C5 | pending | \`emitSceneHtml\` word-sync + script-to-video TTS routing |
| C6 | pending | examples + smoke + docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)