### PR TITLE
feat(scene): word-by-word GSAP timing in emitSceneHtml (v0.54 c5/6)

### DIFF
--- a/packages/cli/src/commands/_shared/scene-html-emit.test.ts
+++ b/packages/cli/src/commands/_shared/scene-html-emit.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   buildClipReference,
+  buildTranscriptTweens,
   emitSceneHtml,
   insertClipIntoRoot,
   nextSceneStart,
   readRootDims,
+  renderTranscriptSpans,
   slugifySceneName,
   SCENE_PRESETS,
+  type SceneTranscriptWord,
   type ScenePreset,
 } from "./scene-html-emit.js";
 import { buildEmptyRootHtml } from "./scene-project.js";
@@ -246,5 +249,221 @@ describe("emitSceneHtml — preset specifics", () => {
       duration: 4,
     });
     expect(html).toContain("Product Shot");
+  });
+});
+
+// ── word-sync helpers ───────────────────────────────────────────────────────
+
+describe("renderTranscriptSpans", () => {
+  it("emits one span per word with sequential data-i indices", () => {
+    const out = renderTranscriptSpans([
+      { text: "Hello", start: 0, end: 0.5 },
+      { text: "world.", start: 0.6, end: 1.0 },
+    ]);
+    expect(out).toBe(
+      `<span class="word" data-i="0">Hello</span> <span class="word" data-i="1">world.</span>`,
+    );
+  });
+
+  it("escapes HTML metacharacters inside words", () => {
+    const out = renderTranscriptSpans([{ text: '"<x>&', start: 0, end: 0.5 }]);
+    expect(out).toContain("&quot;&lt;x&gt;&amp;");
+  });
+
+  it("returns empty string for an empty transcript", () => {
+    expect(renderTranscriptSpans([])).toBe("");
+  });
+});
+
+describe("buildTranscriptTweens", () => {
+  const words: SceneTranscriptWord[] = [
+    { text: "Hello", start: 0, end: 0.5 },
+    { text: "world.", start: 0.6, end: 1.0 },
+  ];
+
+  it("emits one absolute-timed fromTo per word", () => {
+    const tweens = buildTranscriptTweens(words, "[data-composition-id=\"x\"] .caption .word");
+    expect(tweens).toContain(`tl.fromTo('[data-composition-id="x"] .caption .word[data-i="0"]'`);
+    expect(tweens).toContain(`tl.fromTo('[data-composition-id="x"] .caption .word[data-i="1"]'`);
+    // Absolute start times preserved
+    expect(tweens).toContain(", 0)");    // first word at 0
+    expect(tweens).toContain(", 0.6)");  // second word at 0.6
+  });
+
+  it("clamps negative start times to 0", () => {
+    const tweens = buildTranscriptTweens(
+      [{ text: "First", start: -0.05, end: 0.3 }],
+      "x",
+    );
+    expect(tweens).toContain(", 0)");
+  });
+});
+
+// ── per-preset word-sync rendering ──────────────────────────────────────────
+
+const transcriptFixture: SceneTranscriptWord[] = [
+  { text: "Ship", start: 0.05, end: 0.5 },
+  { text: "videos,", start: 0.55, end: 1.1 },
+  { text: "not", start: 1.2, end: 1.4 },
+  { text: "clicks.", start: 1.45, end: 2.0 },
+];
+
+describe("emitSceneHtml — word-sync rendering", () => {
+  describe("simple preset", () => {
+    it("renders captions as static text when transcript is absent", () => {
+      const html = emitSceneHtml({
+        id: "x",
+        preset: "simple",
+        width: 1920,
+        height: 1080,
+        duration: 3,
+        subhead: "Ship videos.",
+      });
+      expect(html).toContain('<div class="caption" id="caption">Ship videos.</div>');
+      expect(html).not.toContain('class="word"');
+      expect(html).not.toContain("tl.fromTo");
+    });
+
+    it("splits caption into word spans with absolute GSAP timing when transcript is present", () => {
+      const html = emitSceneHtml({
+        id: "x",
+        preset: "simple",
+        width: 1920,
+        height: 1080,
+        duration: 3,
+        subhead: "Ship videos, not clicks.",
+        transcript: transcriptFixture,
+      });
+      // Each word becomes its own span
+      expect(html).toContain('<span class="word" data-i="0">Ship</span>');
+      expect(html).toContain('<span class="word" data-i="3">clicks.</span>');
+      // GSAP timeline uses absolute start times
+      expect(html).toContain("tl.fromTo");
+      expect(html).toContain(", 0.05)"); // first word
+      expect(html).toContain(", 1.45)"); // last word
+      // Final fade-out preserved
+      expect(html).toContain(", 2.60)"); // dur (3) - 0.4 = 2.6
+    });
+  });
+
+  describe("explainer preset", () => {
+    it("renders subtitle as static text when transcript is absent", () => {
+      const html = emitSceneHtml({
+        id: "x",
+        preset: "explainer",
+        width: 1920,
+        height: 1080,
+        duration: 4,
+        headline: "Title",
+        subhead: "Subtitle text",
+      });
+      expect(html).toContain('<div class="subtitle" id="subtitle">Subtitle text</div>');
+      expect(html).not.toContain('class="word"');
+    });
+
+    it("splits subtitle into word spans when transcript is present (kicker/title stay static)", () => {
+      const html = emitSceneHtml({
+        id: "x",
+        preset: "explainer",
+        width: 1920,
+        height: 1080,
+        duration: 4,
+        kicker: "VIDEO AS CODE",
+        headline: "Author scenes, not timelines",
+        subhead: "Ship videos, not clicks.",
+        transcript: transcriptFixture,
+      });
+      // Subtitle becomes word spans
+      expect(html).toContain('<span class="word" data-i="0">Ship</span>');
+      // Kicker + title remain static
+      expect(html).toContain('<div class="kicker" id="kicker">VIDEO AS CODE</div>');
+      expect(html).toContain('<h1 class="title" id="title">Author scenes, not timelines</h1>');
+      // GSAP word-sync against #subtitle .word
+      expect(html).toContain(`#subtitle .word[data-i="0"]`);
+    });
+
+    it("falls back to static subtitle when transcript present but subhead empty", () => {
+      const html = emitSceneHtml({
+        id: "x",
+        preset: "explainer",
+        width: 1920,
+        height: 1080,
+        duration: 4,
+        headline: "Title",
+        transcript: transcriptFixture,
+      });
+      // No subtitle div, no word spans (CSS rules can still mention .subtitle)
+      expect(html).not.toContain('id="subtitle"');
+      expect(html).not.toContain('class="word"');
+    });
+  });
+
+  describe("kinetic-type preset", () => {
+    it("uses even stagger when transcript is absent", () => {
+      const html = emitSceneHtml({
+        id: "x",
+        preset: "kinetic-type",
+        width: 1920,
+        height: 1080,
+        duration: 3,
+        headline: "Ship videos",
+      });
+      expect(html).toContain('id="w-0"');
+      expect(html).toContain('id="w-1"');
+      // Stagger generates even start values, e.g. 0.05, 0.05+s, ...
+      expect(html).toMatch(/, 0\.\d{2}\)/);
+    });
+
+    it("uses absolute transcript timing when present (overrides headline source)", () => {
+      const html = emitSceneHtml({
+        id: "x",
+        preset: "kinetic-type",
+        width: 1920,
+        height: 1080,
+        duration: 3,
+        headline: "ignored when transcript supplied",
+        transcript: transcriptFixture,
+      });
+      // Transcript words become the visible text
+      expect(html).toContain(">Ship<");
+      expect(html).toContain(">clicks.<");
+      expect(html).not.toContain(">ignored<");
+      // Absolute timings present in tweens
+      expect(html).toContain(", 0.05)");
+      expect(html).toContain(", 1.45)");
+    });
+  });
+
+  describe("announcement preset (transcript ignored — static headline)", () => {
+    it("does not split headline even when transcript is present", () => {
+      const html = emitSceneHtml({
+        id: "x",
+        preset: "announcement",
+        width: 1920,
+        height: 1080,
+        duration: 3,
+        headline: "Big Headline",
+        transcript: transcriptFixture,
+      });
+      expect(html).toContain('<h1 id="headline">Big Headline</h1>');
+      expect(html).not.toContain('class="word"');
+    });
+  });
+
+  describe("product-shot preset (transcript ignored)", () => {
+    it("does not split headline even when transcript is present", () => {
+      const html = emitSceneHtml({
+        id: "x",
+        preset: "product-shot",
+        width: 1920,
+        height: 1080,
+        duration: 3,
+        headline: "Big Product",
+        transcript: transcriptFixture,
+      });
+      expect(html).toContain('id="headline"');
+      expect(html).toContain("Big Product");
+      expect(html).not.toContain('class="word"');
+    });
   });
 });

--- a/packages/cli/src/commands/_shared/scene-html-emit.ts
+++ b/packages/cli/src/commands/_shared/scene-html-emit.ts
@@ -30,6 +30,17 @@ export const SCENE_PRESETS: readonly ScenePreset[] = [
   "product-shot",
 ] as const;
 
+/**
+ * One word from a Whisper word-level transcript. Mirrors
+ * {@link import("@vibeframe/ai-providers").TranscriptWord} but is duplicated
+ * here so this module stays pure (no provider package import).
+ */
+export interface SceneTranscriptWord {
+  text: string;
+  start: number;
+  end: number;
+}
+
 export interface EmitSceneInput {
   /** Kebab-case scene id; appears in `data-composition-id` and template id. */
   id: string;
@@ -50,6 +61,14 @@ export interface EmitSceneInput {
   imagePath?: string;
   /** Project-relative narration audio path (e.g. "assets/narration-intro.mp3"). */
   audioPath?: string;
+  /**
+   * Word-level timings (Whisper output) for narration sync. When supplied, the
+   * `simple`, `explainer`, and `kinetic-type` presets render each word as its
+   * own `<span class="word">` and animate them at their absolute audio start
+   * times via GSAP. `announcement` and `product-shot` ignore this field —
+   * their headlines are intentionally static.
+   */
+  transcript?: SceneTranscriptWord[];
 }
 
 const GSAP_CDN = "https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js";
@@ -91,6 +110,44 @@ export function slugifySceneName(name: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   return slug || "scene";
+}
+
+// ---------------------------------------------------------------------------
+// Word-sync helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a transcript as `<span class="word" data-i="N">…</span>` markup,
+ * separated by literal whitespace so kerning and wrapping behave naturally.
+ * Returns the empty string when there's nothing to render.
+ */
+export function renderTranscriptSpans(transcript: SceneTranscriptWord[]): string {
+  return transcript
+    .map((w, i) => `<span class="word" data-i="${i}">${esc(w.text)}</span>`)
+    .join(" ");
+}
+
+/**
+ * Build absolute-timing GSAP tweens that fade each transcript word in at its
+ * narration `start` time. The `targetSelector` parametrises the scope so the
+ * same routine can drive `simple` (`.caption .word`), `explainer`
+ * (`#subtitle .word`), or `kinetic-type` (`.kinetic .word`).
+ *
+ * Each tween is `tl.fromTo(sel, {opacity:0,y:10}, {opacity:1,y:0,duration:0.18}, start)`
+ * — short enough to feel responsive at any speech rate, long enough to avoid
+ * popping at 30fps. Words clamp to non-negative starts.
+ */
+export function buildTranscriptTweens(
+  transcript: SceneTranscriptWord[],
+  targetSelector: string,
+): string {
+  return transcript
+    .map((w, i) => {
+      const start = Math.max(0, Number(w.start.toFixed(3)));
+      const sel = `${targetSelector}[data-i="${i}"]`;
+      return `tl.fromTo('${sel}', { opacity: 0, y: 10 }, { opacity: 1, y: 0, duration: 0.18, ease: 'power2.out' }, ${start});`;
+    })
+    .join("\n      ");
 }
 
 // ---------------------------------------------------------------------------
@@ -140,7 +197,20 @@ function buildPreset(input: Required<Pick<EmitSceneInput, "id" | "preset" | "dur
 
   switch (input.preset) {
     case "simple": {
-      const caption = subhead || headline;
+      const transcript = input.transcript;
+      const useWordSync = !!(transcript && transcript.length > 0);
+      const captionText = subhead || headline;
+      const captionInner = useWordSync
+        ? renderTranscriptSpans(transcript)
+        : esc(captionText);
+      const wordCss = useWordSync
+        ? `\n      ${scope} .caption .word { display: inline-block; opacity: 0; }`
+        : "";
+      const timeline = useWordSync
+        ? `${buildTranscriptTweens(transcript, `${scope} .caption .word`)}
+      tl.to('${scope} .caption', { opacity: 0, duration: 0.4, ease: 'power2.in' }, ${(dur - 0.4).toFixed(2)});`
+        : `tl.from('${scope} .caption', { opacity: 0, y: 28, duration: 0.6, ease: 'power2.out' }, 0.1);
+      tl.to('${scope} .caption', { opacity: 0, duration: 0.4, ease: 'power2.in' }, ${(dur - 0.4).toFixed(2)});`;
       return {
         css: `${scope} {
         position: absolute; inset: 0; width: 100%; height: 100%;
@@ -156,11 +226,10 @@ function buildPreset(input: Required<Pick<EmitSceneInput, "id" | "preset" | "dur
         font-weight: 700;
         line-height: 1.2;
         text-shadow: 0 4px 20px rgba(0,0,0,0.65);
-      }`,
+      }${wordCss}`,
         body: `${backdropMarkup}
-    <div class="caption" id="caption">${esc(caption)}</div>`,
-        timeline: `tl.from('${scope} .caption', { opacity: 0, y: 28, duration: 0.6, ease: 'power2.out' }, 0.1);
-      tl.to('${scope} .caption', { opacity: 0, duration: 0.4, ease: 'power2.in' }, ${(dur - 0.4).toFixed(2)});`,
+    <div class="caption" id="caption">${captionInner}</div>`,
+        timeline,
       };
     }
     case "announcement": {
@@ -196,6 +265,17 @@ function buildPreset(input: Required<Pick<EmitSceneInput, "id" | "preset" | "dur
     case "explainer": {
       const k = kicker || humanise(id).toUpperCase();
       const sub = subhead || "";
+      const transcript = input.transcript;
+      const useWordSync = !!(transcript && transcript.length > 0 && sub);
+      const subtitleInner = useWordSync ? renderTranscriptSpans(transcript) : esc(sub);
+      const wordCss = useWordSync
+        ? `\n      ${scope} #subtitle .word { display: inline-block; opacity: 0; }`
+        : "";
+      const subtitleTween = useWordSync
+        ? buildTranscriptTweens(transcript, `${scope} #subtitle .word`)
+        : sub
+          ? `tl.from('${scope} #subtitle', { opacity: 0, y: 30, duration: 0.55, ease: 'power3.out' }, 0.55);`
+          : "";
       return {
         css: `${scope} {
         position: absolute; inset: 0; width: 100%; height: 100%;
@@ -218,30 +298,44 @@ function buildPreset(input: Required<Pick<EmitSceneInput, "id" | "preset" | "dur
       }
       ${scope} .subtitle {
         font-size: 38px; font-weight: 300; color: #c0c0d0; max-width: 80%;
-      }`,
+      }${wordCss}`,
         body: `${backdropMarkup}
     <div class="stage">
       <div class="kicker" id="kicker">${esc(k)}</div>
       <h1 class="title" id="title">${esc(headline)}</h1>${sub ? `
-      <div class="subtitle" id="subtitle">${esc(sub)}</div>` : ""}
+      <div class="subtitle" id="subtitle">${subtitleInner}</div>` : ""}
     </div>`,
         timeline: `tl.from('${scope} #kicker', { opacity: 0, y: 16, duration: 0.4, ease: 'power2.out' }, 0.1);
       tl.from('${scope} #title', { opacity: 0, y: 60, duration: 0.7, ease: 'power3.out' }, 0.25);
-      ${sub ? `tl.from('${scope} #subtitle', { opacity: 0, y: 30, duration: 0.55, ease: 'power3.out' }, 0.55);` : ""}`,
+      ${subtitleTween}`,
       };
     }
     case "kinetic-type": {
-      const words = headline.split(/\s+/).filter(Boolean);
+      const transcript = input.transcript;
+      const useWordSync = !!(transcript && transcript.length > 0);
+      // When transcript is supplied, drive word entries from it (narration is
+      // the ground truth — what's spoken is what's shown). Otherwise fall back
+      // to splitting the headline.
+      const words = useWordSync
+        ? transcript.map((w) => w.text)
+        : headline.split(/\s+/).filter(Boolean);
       const wordSpans = words
-        .map((w, i) => `<span class="word" id="w-${i}">${esc(w)}</span>`)
+        .map((w, i) => `<span class="word" data-i="${i}" id="w-${i}">${esc(w)}</span>`)
         .join(" ");
       const stagger = Math.max(0.08, Math.min(0.3, (dur - 0.6) / Math.max(words.length, 1)));
-      const tweens = words
-        .map((_, i) => {
-          const start = (0.05 + i * stagger).toFixed(2);
-          return `tl.from('${scope} #w-${i}', { opacity: 0, y: 80, scale: 0.8, duration: 0.45, ease: 'back.out(1.8)' }, ${start});`;
-        })
-        .join("\n      ");
+      const tweens = useWordSync
+        ? transcript
+            .map((w, i) => {
+              const start = Math.max(0, Number(w.start.toFixed(3)));
+              return `tl.from('${scope} #w-${i}', { opacity: 0, y: 80, scale: 0.8, duration: 0.35, ease: 'back.out(1.8)' }, ${start});`;
+            })
+            .join("\n      ")
+        : words
+            .map((_, i) => {
+              const start = (0.05 + i * stagger).toFixed(2);
+              return `tl.from('${scope} #w-${i}', { opacity: 0, y: 80, scale: 0.8, duration: 0.45, ease: 'back.out(1.8)' }, ${start});`;
+            })
+            .join("\n      ");
       return {
         css: `${scope} {
         position: absolute; inset: 0; width: 100%; height: 100%;

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -520,6 +520,7 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
   // we just lose word-level animation timing.
   let transcriptRelPath: string | undefined;
   let transcriptWordCount: number | undefined;
+  let transcriptWords: { text: string; start: number; end: number }[] | undefined;
 
   if (audioAbsPath && !opts.skipTranscribe) {
     const whisperKey = await getApiKey("OPENAI_API_KEY", "OpenAI");
@@ -543,6 +544,7 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
           const transcriptAbs = resolve(projectDir, transcriptRelPath);
           await writeFile(transcriptAbs, JSON.stringify(transcript.words, null, 2), "utf-8");
           transcriptWordCount = transcript.words.length;
+          transcriptWords = transcript.words.map((w) => ({ text: w.text, start: w.start, end: w.end }));
         } else if (transcript.status === "failed") {
           opts.onProgress?.(`Transcribe failed: ${transcript.error ?? "unknown error"}`);
         }
@@ -630,6 +632,7 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
     kicker: opts.kicker,
     imagePath: imageRelPath,
     audioPath: audioRelPath,
+    transcript: transcriptWords,
   });
   await mkdir(dirname(scenePath), { recursive: true });
   await writeFile(scenePath, sceneHtml, "utf-8");


### PR DESCRIPTION
## Summary

C5/6 — closes the loop on the v0.53.0 sync gap. The HTML now puts each narration word on the GSAP timeline at its actual audio start time, so the rendered MP4 has captions that appear exactly when the word is spoken.

**End-to-end flow now wired:**

\`\`\`
TTS (Kokoro/ElevenLabs)
  → Whisper word-level (C1)
  → assets/transcript-{id}.json (C4)
  → emitSceneHtml transcript field (this PR)
  → per-word GSAP fromTo at absolute audio offsets
  → Hyperframes producer captures synced MP4
\`\`\`

**Per-preset behaviour:**

| Preset | Without transcript | With transcript |
|---|---|---|
| **simple** | static caption | each word fades in at its audio start |
| **explainer** | static subtitle | subtitle words sync; kicker + title stay static |
| **kinetic-type** | even stagger from headline | absolute transcript timing; transcript text wins over headline |
| **announcement** | unchanged | **ignored** (static headline) |
| **product-shot** | unchanged | **ignored** (static headline) |

**Helpers extracted** as pure module-level functions for testability:
- \`renderTranscriptSpans(words)\` — span markup
- \`buildTranscriptTweens(words, selector)\` — GSAP fromTo strings
- \`SceneTranscriptWord\` type — duplicated locally so the module stays pure (no provider package import)

## Test plan

- [x] **14 new tests** in \`scene-html-emit.test.ts\` (helpers ×5, per-preset ×9)
- [x] **All 47 pre-existing emit tests still pass** — coverage is purely additive, no regression
- [x] Full CLI suite **146/146** (was 127 → +14 emit + +5 scene from C4)
- [x] \`pnpm build\` 6/6, \`pnpm lint\` 0 errors
- [ ] End-to-end visual sync confirmed by C6 smoke render

## Sequence

| Commit | Status | What |
|---|---|---|
| C1 | merged (#68) | Whisper word-level + types |
| C2 | merged (#69) | KokoroProvider |
| C3 | merged (#70) | TTS router + \`--tts\` flag |
| C4 | merged (#71) | Scene transcribe + \`--narration-file\` |
| **C5** | this PR | \`emitSceneHtml\` word-sync rendering |
| C6 | pending | examples + smoke + docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)