### PR TITLE
docs(scene): TTS + word-sync examples, skill, smoke (v0.54 c6/6)

### DIFF
--- a/.claude/skills/vibe-scene/SKILL.md
+++ b/.claude/skills/vibe-scene/SKILL.md
@@ -55,13 +55,42 @@ from the generated TTS audio.
 
 `vibe scene add` integrates the existing AI providers:
 
-- `--narration "..."` → ElevenLabs TTS → `assets/narration-<id>.mp3`
+- `--narration "..."` → TTS provider (see below) → `assets/narration-<id>.{mp3|wav}`
+- `--narration-file <path>` → copies a pre-existing wav/mp3 (TTS skipped)
+- After audio exists → Whisper word-level transcribe → `assets/transcript-<id>.json`
 - `--visuals "..."` → Gemini (default) or OpenAI image → `assets/scene-<id>.png`
-- `--no-audio` / `--no-image` skip generation (useful for hand-authored or
-  CI-friendly seeds).
+- `--no-audio` / `--no-image` / `--no-transcribe` skip individual stages
+  (useful for hand-authored or CI-friendly seeds).
 
-If keys are missing, the command exits with a usage error before any spend —
-no partial state.
+### TTS provider (`--tts <auto|elevenlabs|kokoro>`)
+
+| Provider | Cost | Quality | Cold start | Output |
+|---|---|---|---|---|
+| **ElevenLabs** | ~$0.02/scene | high | none | mp3 |
+| **Kokoro** (local, Apache 2.0) | $0 | medium-high | first call downloads ~330MB | wav |
+
+`--tts auto` (default): picks ElevenLabs when `ELEVENLABS_API_KEY` is set,
+otherwise falls back to Kokoro. Local-only users get a working pipeline
+with no API key. The first Kokoro call shows a `~330MB download` spinner
+and caches to `~/.cache/huggingface/hub`; subsequent calls add ~1–2s.
+
+Voice: `--voice af_heart` (Kokoro, default), `--voice rachel` (ElevenLabs).
+
+### Word-level caption sync
+
+Whenever `assets/transcript-<id>.json` exists, three presets render each
+narration word as its own `<span class="word">` and animate them at the
+audio's absolute word start time:
+
+- `simple` — caption splits into word spans with fade-in at each start.
+- `explainer` — subtitle splits; kicker + title stay static.
+- `kinetic-type` — uses transcript timing instead of even stagger.
+  **Visible text comes from the transcript**, not `--headline` (narration
+  is the ground truth).
+
+`announcement` and `product-shot` ignore the transcript — their headlines
+are intentionally static. Use `--no-transcribe` to skip Whisper if you
+don't want word-sync (or have no `OPENAI_API_KEY`).
 
 ## Lint feedback loop (agent pattern)
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,27 @@ full scenes project from a written script in one shot:
 vibe pipeline script-to-video "..." --format scenes -o my-promo/ -a 16:9
 ```
 
+### Free local TTS + word-level caption sync (v0.54)
+
+`vibe scene add --narration "..."` now works with **no API key**. Without
+`ELEVENLABS_API_KEY`, VibeFrame falls back to **Kokoro-82M** (Apache 2.0)
+running locally — first call downloads ~330MB to
+`~/.cache/huggingface/hub`, then renders are free.
+
+```bash
+# Free local TTS (Kokoro)
+vibe scene add hook --narration "Ship videos, not clicks." --tts kokoro
+
+# Or use any external wav (npx hyperframes tts, macOS say, voice memo)
+vibe scene add hook --narration-file ./my-voice.wav
+```
+
+Whenever audio is present and `OPENAI_API_KEY` is set, narration is
+auto-transcribed (Whisper word-level) into `assets/transcript-<id>.json`
+and threaded into the scene HTML. Captions then **fade in word-by-word at
+the exact audio timestamp** — no more "scene says X but caption shows Y"
+drift. Supported on `simple`, `explainer`, and `kinetic-type` presets.
+
 Run [`examples/scene-promo/`](examples/scene-promo/) for an end-to-end
 walkthrough. See `/vibe-scene` for the agent skill, including the lint
 feedback loop pattern (`--json --fix`, ≤3 retries, template fallback).

--- a/examples/scene-promo/.gitignore
+++ b/examples/scene-promo/.gitignore
@@ -6,6 +6,14 @@
 renders/*.mp4
 tmp/
 
+# Generated narration audio + transcripts — re-generated on demand by
+# `vibe scene add --narration "..."`. Keeping them out of git keeps the
+# repo lean (~250KB+ per scene) and lets contributors regenerate with
+# whatever provider (Kokoro local / ElevenLabs) they prefer.
+assets/narration-*.wav
+assets/narration-*.mp3
+assets/transcript-*.json
+
 # OS / editor
 .DS_Store
 *.log

--- a/examples/scene-promo/README.md
+++ b/examples/scene-promo/README.md
@@ -67,6 +67,46 @@ Costs: ~$0.02 ElevenLabs TTS + ~$0.04 Gemini image per scene. Set
 `ELEVENLABS_API_KEY` and `GOOGLE_API_KEY` in `.env` first (or run
 `vibe setup`).
 
+## Free local TTS + word-level caption sync (v0.54)
+
+Skip the ElevenLabs cost entirely with `--tts kokoro` — first call
+downloads the ~330MB Kokoro-82M model to `~/.cache/huggingface/hub`,
+subsequent calls run in seconds:
+
+```bash
+vibe scene add narrated \
+  --project scene-promo --style explainer \
+  --kicker "WHY VIBE SCENE" \
+  --headline "Edit text, not pixels" \
+  --narration "Each word lights up the moment it's spoken." \
+  --tts kokoro --no-image
+```
+
+This emits three things into `assets/`:
+- `narration-narrated.wav` — Kokoro audio output
+- `transcript-narrated.json` — Whisper word-level timings (needs `OPENAI_API_KEY`)
+- `compositions/scene-narrated.html` — subtitle is split into one
+  `<span class="word">` per transcript entry, each fading in at its
+  absolute audio start time.
+
+Press `vibe scene render` and the captured MP4 has captions that appear
+exactly when each word is spoken. The `simple`, `explainer`, and
+`kinetic-type` presets all support word-sync; `announcement` and
+`product-shot` ignore the transcript (their headlines are static by design).
+
+Already have a wav from another tool (`npx hyperframes tts`, macOS `say`,
+hand-recorded)? Pass it directly — VibeFrame still transcribes it for sync:
+
+```bash
+vibe scene add custom \
+  --narration-file ./my-voice.wav \
+  --headline "Custom voiceover" \
+  --no-image
+```
+
+The generated `assets/narration-*.{wav,mp3}` and `assets/transcript-*.json`
+files are `.gitignore`d — re-run the command above to regenerate.
+
 ## One-shot: script-to-scenes
 
 `vibe pipeline script-to-video` can produce a scene project like this one

--- a/tests/smoke/kokoro.sh
+++ b/tests/smoke/kokoro.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# v0.54 smoke test — exercises the full local-TTS + word-sync pipeline
+# end-to-end against a real Kokoro model and a real Whisper API. Lives
+# outside CI because:
+#
+#   1. The first run downloads ~330MB to ~/.cache/huggingface/hub.
+#   2. Whisper transcribe needs OPENAI_API_KEY (~$0.001/scene).
+#
+# Run manually after a v0.54.x release:
+#
+#   bash tests/smoke/kokoro.sh
+#
+# The script:
+#   1. Builds the CLI.
+#   2. Scaffolds a throwaway scene project under /tmp.
+#   3. Adds a scene with --tts kokoro --no-image and asserts the
+#      narration .wav and (if OPENAI_API_KEY set) transcript .json land.
+#   4. Runs `vibe scene lint --json` and asserts ok=true.
+#   5. Optionally renders to MP4 if Chrome is available.
+#
+# Exits non-zero on the first failed assertion.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+VIBE="node $ROOT_DIR/packages/cli/dist/index.js"
+TMPDIR="${TMPDIR:-/tmp}"
+SMOKE_DIR="$(mktemp -d "$TMPDIR/vibe-smoke-kokoro-XXXXXX")"
+trap 'rm -rf "$SMOKE_DIR"' EXIT
+
+green() { printf "\033[32m%s\033[0m\n" "$*"; }
+red()   { printf "\033[31m%s\033[0m\n" "$*" >&2; }
+step()  { printf "\033[36m▶ %s\033[0m\n" "$*"; }
+
+step "Building CLI"
+( cd "$ROOT_DIR" && pnpm -F @vibeframe/cli build >/dev/null )
+
+step "Scaffolding scene project at $SMOKE_DIR"
+$VIBE scene init "$SMOKE_DIR/promo" -r 16:9 -d 6 --json >/dev/null
+
+step "Adding narrated scene via Kokoro (first call may download ~330MB)"
+SCENE_RESULT="$($VIBE scene add hook \
+  --project "$SMOKE_DIR/promo" \
+  --style simple \
+  --narration "Ship videos, not clicks." \
+  --tts kokoro \
+  --duration 4 \
+  --no-image \
+  --json)"
+
+NARRATION_PATH="$(echo "$SCENE_RESULT" | python3 -c "import sys,json;print(json.load(sys.stdin).get('audioPath',''))")"
+TRANSCRIPT_PATH="$(echo "$SCENE_RESULT" | python3 -c "import sys,json;print(json.load(sys.stdin).get('transcriptPath',''))")"
+
+if [ -z "$NARRATION_PATH" ] || [ ! -f "$NARRATION_PATH" ]; then
+  red "Expected narration .wav file but found: $NARRATION_PATH"
+  exit 1
+fi
+green "✓ Narration audio at $NARRATION_PATH ($(stat -f%z "$NARRATION_PATH" 2>/dev/null || stat -c%s "$NARRATION_PATH") bytes)"
+
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+    red "OPENAI_API_KEY set but transcript not produced: $TRANSCRIPT_PATH"
+    exit 1
+  fi
+  WORDS="$(python3 -c "import json;print(len(json.load(open('$TRANSCRIPT_PATH'))))")"
+  green "✓ Whisper transcript at $TRANSCRIPT_PATH ($WORDS word entries)"
+
+  SCENE_HTML="$SMOKE_DIR/promo/compositions/scene-hook.html"
+  if ! grep -q 'class="word"' "$SCENE_HTML"; then
+    red "Scene HTML did not include word-sync spans — emitSceneHtml lost the transcript"
+    exit 1
+  fi
+  green "✓ Scene HTML contains <span class=\"word\"> entries"
+else
+  green "○ OPENAI_API_KEY not set — skipping transcript + word-sync assertions"
+fi
+
+step "Running scene lint (in-process Hyperframes)"
+LINT="$($VIBE scene lint --project "$SMOKE_DIR/promo" --json)"
+LINT_OK="$(echo "$LINT" | python3 -c "import sys,json;print(json.load(sys.stdin)['ok'])")"
+if [ "$LINT_OK" != "True" ]; then
+  red "Lint reported ok=false:"
+  echo "$LINT"
+  exit 1
+fi
+green "✓ Lint clean"
+
+if [ "${SMOKE_RENDER:-0}" = "1" ]; then
+  step "Rendering to MP4 (requires Chrome)"
+  $VIBE scene render --project "$SMOKE_DIR/promo" \
+    --out "$SMOKE_DIR/promo/renders/smoke.mp4" \
+    --quality draft --fps 24 --json >/dev/null
+  if [ -s "$SMOKE_DIR/promo/renders/smoke.mp4" ]; then
+    green "✓ Render produced MP4 ($(stat -f%z "$SMOKE_DIR/promo/renders/smoke.mp4" 2>/dev/null || stat -c%s "$SMOKE_DIR/promo/renders/smoke.mp4") bytes)"
+  else
+    red "Render did not produce a non-empty MP4"
+    exit 1
+  fi
+fi
+
+green "All smoke assertions passed."


### PR DESCRIPTION
## Summary

C6/6 — final commit of the v0.54 sequence. Pure documentation + smoke
test additions around the new local-TTS + word-sync pipeline.

**Changes:**

- \`examples/scene-promo/\`:
  - \`.gitignore\` excludes generated \`narration-*.{wav,mp3}\` + \`transcript-*.json\` (regenerable, ~250KB+/scene avoided).
  - README gains a "Free local TTS + word-level caption sync" section walking through \`--tts kokoro\`, \`--narration-file\`, and what files land in \`assets/\`.
- \`.claude/skills/vibe-scene/SKILL.md\`: TTS provider comparison matrix (ElevenLabs vs Kokoro: cost / quality / cold start / output) + word-sync coverage map (which presets opt in/out).
- Root \`README.md\`: appends a v0.54 subsection under Scene Authoring covering the no-API-key path and word-sync.
- New: \`tests/smoke/kokoro.sh\` (+x) — manual end-to-end harness. Scaffolds a throwaway project, runs Kokoro, optionally transcribes (if \`OPENAI_API_KEY\`), asserts scene HTML contains word spans, runs lint, optionally renders. Outside CI because cold start downloads ~330MB.

**No source-code changes.** Build + lint + 146/146 scene tests stay green from C5. After this merges, v0.54 is feature-complete; a separate \`chore: bump to 0.54.0 + CHANGELOG\` will follow when you cut the release.

## Test plan

- [x] \`pnpm build\` 6/6 (FULL TURBO — cached, no source touched)
- [x] \`pnpm lint\` 10/10 (cached)
- [x] \`vibe scene lint --project examples/scene-promo --json\` → \`ok: true\` (4 informational notices unchanged)
- [x] \`bash -n tests/smoke/kokoro.sh\` — shell syntax OK
- [ ] Manual end-to-end: \`bash tests/smoke/kokoro.sh\` (blocked on local Kokoro download / OPENAI_API_KEY — runs after merge)

## Sequence (v0.54 complete after this merges)

| Commit | Status | What |
|---|---|---|
| C1 | merged (#68) | Whisper word-level + types |
| C2 | merged (#69) | KokoroProvider |
| C3 | merged (#70) | TTS router + \`--tts\` flag |
| C4 | merged (#71) | Scene transcribe + \`--narration-file\` |
| C5 | merged (#72) | \`emitSceneHtml\` word-sync |
| **C6** | this PR | examples + skill + README + smoke |

🤖 Generated with [Claude Code](https://claude.com/claude-code)