### PR TITLE
chore: bump version to 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.54.0] - 2026-04-25
+
+### Added
+
+- word-by-word GSAP timing in emitSceneHtml (v0.54 c5/6) (#72) *(scene)*
+- auto Whisper transcribe + --narration-file (v0.54 c4/6) (#71) *(scene)*
+- TTS router with Kokoro fallback + --tts flag (v0.54 c3/6) (#70) *(scene)*
+- local Kokoro-82M TTS provider (v0.54 c2/6) (#69) *(kokoro)*
+- word-level timestamps via granularity option (v0.54 c1/6) (#68) *(whisper)*
+
+### Documentation
+
+- TTS + word-sync examples, skill, smoke (v0.54 c6/6) (#73) *(scene)*
+
 ## [0.53.0] - 2026-04-25
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Cuts the v0.54.0 release wrapping the 6-commit local-TTS + word-sync sequence (#68 → #73).

- 7 package.json files: \`0.53.0\` → \`0.54.0\`
- \`CHANGELOG.md\` regenerated via \`git-cliff --tag v0.54.0\`

### What ships in 0.54.0

- **Free local TTS via Kokoro-82M** (Apache 2.0). \`vibe scene add --narration "..."\` now works with **no API key** — first call downloads ~330MB, subsequent calls free in seconds. ElevenLabs users see no change (auto router prefers it when key is set).
- **Word-level caption sync** via Whisper word-level transcribe. Each narration word fades in at its audio start time (\`simple\`, \`explainer\`, \`kinetic-type\` presets). Closes the v0.53.0 gap where captions and audio drifted.
- **External wav input** via \`--narration-file\` — drop in \`hyperframes tts\` / macOS \`say\` / hand-recorded audio and VibeFrame still transcribes for sync.
- New flags: \`--tts auto|elevenlabs|kokoro\`, \`--narration-file\`, \`--no-transcribe\`, \`--transcribe-language\`.

### Release flow

Auto-tag workflow will create \`v0.54.0\` + dispatch \`publish.yml\` once this lands on main.

## Test plan

- [x] \`pnpm build\` 6/6
- [x] \`pnpm lint\` 10/10 (0 errors)
- [x] \`version-checker\` agent — all 7 package.json + landing page badge sync to 0.54.0; no stray 0.53.x
- [x] CHANGELOG captures all 6 PRs (#68, #69, #70, #71, #72, #73)
- [ ] Post-merge: auto-tag → npm publish → smoke test \`bash tests/smoke/kokoro.sh\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)