### PR TITLE
feat(scene): post-render ffmpeg audio mux (v0.55 c2/3)

### DIFF
--- a/packages/cli/src/commands/_shared/scene-audio-mux.test.ts
+++ b/packages/cli/src/commands/_shared/scene-audio-mux.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for scene-audio-mux. Pure construction only — `muxAudioIntoVideo`
+ * is exercised by the C3 smoke test, not here, so CI doesn't depend on
+ * ffmpeg installation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildAudioMuxFilter } from "./scene-audio-mux.js";
+import type { SceneAudioElement } from "./scene-audio-scan.js";
+
+function makeAudio(overrides: Partial<SceneAudioElement> = {}): SceneAudioElement {
+  return {
+    srcRel: "assets/narration-1.wav",
+    srcAbs: "/proj/assets/narration-1.wav",
+    absoluteStart: 0,
+    durationHint: "auto",
+    clipDurationCap: 5,
+    volume: 1,
+    trackIndex: 2,
+    compositionSrc: "compositions/scene-1.html",
+    ...overrides,
+  };
+}
+
+describe("buildAudioMuxFilter", () => {
+  it("returns null for an empty list", () => {
+    expect(buildAudioMuxFilter([])).toBeNull();
+  });
+
+  it("single input: trim + delay + volume → labelled stream, no amix", () => {
+    const filter = buildAudioMuxFilter([makeAudio()]);
+    expect(filter).not.toBeNull();
+    expect(filter!.inputCount).toBe(1);
+    expect(filter!.outLabel).toBe("[a0]");
+    // Per-stage construction
+    expect(filter!.filterComplex).toBe(
+      "[1:a]atrim=duration=5.000,asetpts=PTS-STARTPTS,adelay=0:all=1,volume=1[a0]",
+    );
+    // No amix
+    expect(filter!.filterComplex).not.toContain("amix");
+  });
+
+  it("converts absoluteStart to milliseconds for adelay", () => {
+    const filter = buildAudioMuxFilter([
+      makeAudio({ absoluteStart: 1.234, clipDurationCap: 3 }),
+    ]);
+    expect(filter!.filterComplex).toContain("adelay=1234:all=1");
+  });
+
+  it("preserves volume in the filter", () => {
+    const filter = buildAudioMuxFilter([
+      makeAudio({ volume: 0.6 }),
+    ]);
+    expect(filter!.filterComplex).toContain("volume=0.6");
+  });
+
+  it("multi-input: builds per-stream stages plus an amix", () => {
+    const filter = buildAudioMuxFilter([
+      makeAudio({ absoluteStart: 0, clipDurationCap: 3 }),
+      makeAudio({
+        absoluteStart: 3,
+        clipDurationCap: 4,
+        volume: 0.8,
+        srcRel: "assets/narration-2.wav",
+        srcAbs: "/proj/assets/narration-2.wav",
+      }),
+    ]);
+    expect(filter!.inputCount).toBe(2);
+    expect(filter!.outLabel).toBe("[mixed]");
+    expect(filter!.filterComplex).toContain(
+      "[1:a]atrim=duration=3.000,asetpts=PTS-STARTPTS,adelay=0:all=1,volume=1[a0]",
+    );
+    expect(filter!.filterComplex).toContain(
+      "[2:a]atrim=duration=4.000,asetpts=PTS-STARTPTS,adelay=3000:all=1,volume=0.8[a1]",
+    );
+    expect(filter!.filterComplex).toContain(
+      "[a0][a1]amix=inputs=2:dropout_transition=0:normalize=0[mixed]",
+    );
+  });
+
+  it("clamps negative clipDurationCap to 0", () => {
+    const filter = buildAudioMuxFilter([
+      makeAudio({ clipDurationCap: -1 }),
+    ]);
+    expect(filter!.filterComplex).toContain("atrim=duration=0.000");
+  });
+
+  it("clamps negative absoluteStart to 0 in adelay", () => {
+    const filter = buildAudioMuxFilter([
+      makeAudio({ absoluteStart: -0.05 }),
+    ]);
+    expect(filter!.filterComplex).toContain("adelay=0:all=1");
+  });
+
+  it("falls back to volume=1 when value is non-finite", () => {
+    const filter = buildAudioMuxFilter([
+      makeAudio({ volume: NaN }),
+    ]);
+    expect(filter!.filterComplex).toContain("volume=1");
+  });
+
+  it("emits a deterministic label sequence (a0, a1, a2, ...)", () => {
+    const filter = buildAudioMuxFilter([
+      makeAudio(),
+      makeAudio({ absoluteStart: 1 }),
+      makeAudio({ absoluteStart: 2 }),
+    ]);
+    expect(filter!.filterComplex).toContain("[a0]");
+    expect(filter!.filterComplex).toContain("[a1]");
+    expect(filter!.filterComplex).toContain("[a2]");
+    expect(filter!.outLabel).toBe("[mixed]");
+  });
+});

--- a/packages/cli/src/commands/_shared/scene-audio-mux.ts
+++ b/packages/cli/src/commands/_shared/scene-audio-mux.ts
@@ -1,0 +1,216 @@
+/**
+ * @module _shared/scene-audio-mux
+ *
+ * Lay every `<audio>` element discovered by `scene-audio-scan.ts` onto a
+ * single audio track and mux it into the producer's silent video output.
+ *
+ * Why this exists: `@hyperframes/producer` renders frames + assembles the
+ * MP4 but does not embed audio from sub-composition `<audio>` elements
+ * (verified against the upstream Hyperframes reference example). We do the
+ * mux ourselves with one ffmpeg pass, copying the producer's video stream
+ * untouched so we don't pay a re-encode tax.
+ *
+ * The filter graph for N audio inputs is:
+ *
+ *   [1:a]adelay=Sms:all=1,volume=V[a1];
+ *   [2:a]adelay=Sms:all=1,volume=V[a2];
+ *   ...
+ *   [a1][a2]...amix=inputs=N:dropout_transition=0:normalize=0[mixed]
+ *
+ * Single-input case skips the amix (cheaper and avoids amix's auto-gain).
+ *
+ * Pure construction lives in `buildAudioMuxFilter`. The async `muxAudioIntoVideo`
+ * shells out to ffmpeg via the project's existing `execSafe` wrapper.
+ */
+
+import { rename, unlink } from "node:fs/promises";
+import { resolve, dirname, extname, basename } from "node:path";
+import { execSafe, commandExists } from "../../utils/exec-safe.js";
+import type { SceneAudioElement } from "./scene-audio-scan.js";
+
+export interface AudioMuxFilter {
+  /** ffmpeg `-filter_complex` string. */
+  filterComplex: string;
+  /** Output stream label inside the graph (e.g. `[mixed]` or `[a0]`). */
+  outLabel: string;
+  /** Number of audio inputs the caller must `-i` before this filter. */
+  inputCount: number;
+}
+
+/**
+ * Build a filter_complex for the given audio elements. Pure — no I/O.
+ *
+ * Each element becomes one ffmpeg input (input index 1, 2, ... — input 0 is
+ * the silent video). `adelay` shifts the audio to its absolute timeline
+ * start, `volume` applies per-element gain, and `amix` blends them. When
+ * there's only one element we skip `amix` entirely.
+ */
+export function buildAudioMuxFilter(audios: SceneAudioElement[]): AudioMuxFilter | null {
+  if (audios.length === 0) return null;
+
+  const labels: string[] = [];
+  const stages: string[] = [];
+
+  audios.forEach((a, i) => {
+    const inputIdx = i + 1; // input 0 is the video
+    const delayMs = Math.max(0, Math.round(a.absoluteStart * 1000));
+    const volume = Number.isFinite(a.volume) ? a.volume : 1;
+    // Hard-cap audio length at the parent clip's duration so a long wav
+    // doesn't bleed past its scene. Use atrim+asetpts for a clean cut.
+    const trimSec = Math.max(0, a.clipDurationCap);
+    const label = `a${i}`;
+    const stage = [
+      `[${inputIdx}:a]`,
+      `atrim=duration=${trimSec.toFixed(3)},`,
+      `asetpts=PTS-STARTPTS,`,
+      `adelay=${delayMs}:all=1,`,
+      `volume=${volume}`,
+      `[${label}]`,
+    ].join("");
+    stages.push(stage);
+    labels.push(`[${label}]`);
+  });
+
+  if (audios.length === 1) {
+    return {
+      filterComplex: stages.join(";"),
+      outLabel: labels[0],
+      inputCount: 1,
+    };
+  }
+
+  const mix = `${labels.join("")}amix=inputs=${audios.length}:dropout_transition=0:normalize=0[mixed]`;
+  return {
+    filterComplex: `${stages.join(";")};${mix}`,
+    outLabel: "[mixed]",
+    inputCount: audios.length,
+  };
+}
+
+export interface AudioMuxOptions {
+  /** Producer's silent video output (will be replaced with the mux'd file). */
+  videoPath: string;
+  /** Audio elements with absolute timing, from `scanSceneAudio`. */
+  audios: SceneAudioElement[];
+  /** Final output container — drives the audio codec choice. */
+  format: "mp4" | "webm" | "mov";
+  /** Cap output to this many seconds via ffmpeg `-t`. Falls back to `videoDuration`. */
+  totalDuration?: number;
+  /** Producer's video duration (probed by ffprobe). Used as default cap. */
+  videoDuration?: number;
+  /** Callback for ffmpeg stderr lines (progress / errors). */
+  onProgress?: (line: string) => void;
+}
+
+export interface AudioMuxResult {
+  /** True when ffmpeg succeeded. */
+  success: boolean;
+  /** Absolute path of the produced file (overwrites the input on success). */
+  outputPath: string;
+  /** ffmpeg stderr tail when success === false. */
+  error?: string;
+  /** Number of audio inputs muxed. */
+  audioCount: number;
+}
+
+/**
+ * Audio codec for each container. Stays in sync with what the upstream
+ * producer chose for video so the file stays playable.
+ */
+function audioCodecForFormat(format: AudioMuxOptions["format"]): string {
+  if (format === "webm") return "libopus";
+  if (format === "mov") return "pcm_s16le"; // ProRes-friendly
+  return "aac";
+}
+
+/**
+ * Run ffmpeg to overlay every `<audio>` element onto the producer's silent
+ * video. Replaces the input file on success. Idempotent — re-running on the
+ * same project repeats the work but produces an equivalent result.
+ *
+ * No-op (`success: true, audioCount: 0`) when `audios` is empty.
+ */
+export async function muxAudioIntoVideo(opts: AudioMuxOptions): Promise<AudioMuxResult> {
+  if (opts.audios.length === 0) {
+    return { success: true, outputPath: opts.videoPath, audioCount: 0 };
+  }
+
+  if (!commandExists("ffmpeg")) {
+    return {
+      success: false,
+      outputPath: opts.videoPath,
+      audioCount: opts.audios.length,
+      error: "ffmpeg not found in PATH — install via `brew install ffmpeg` (mac) or your package manager",
+    };
+  }
+
+  const filter = buildAudioMuxFilter(opts.audios);
+  if (!filter) {
+    return { success: true, outputPath: opts.videoPath, audioCount: 0 };
+  }
+
+  // Write to a sibling temp file then atomic-rename over the original. Avoids
+  // corrupting the producer's MP4 if ffmpeg crashes mid-write.
+  const ext = extname(opts.videoPath) || `.${opts.format}`;
+  const tmpPath = resolve(
+    dirname(opts.videoPath),
+    `.${basename(opts.videoPath, ext)}.muxing${ext}`,
+  );
+
+  const args: string[] = ["-y", "-loglevel", "error", "-i", opts.videoPath];
+  for (const a of opts.audios) {
+    args.push("-i", a.srcAbs);
+  }
+  args.push(
+    "-filter_complex",
+    filter.filterComplex,
+    "-map",
+    "0:v",
+    "-map",
+    filter.outLabel,
+    "-c:v",
+    "copy",
+    "-c:a",
+    audioCodecForFormat(opts.format),
+    // Cap on the video duration so audio that overruns the producer's render
+    // (e.g. a long Kokoro wav on a short scene) doesn't extend the output.
+    // Video drives the timeline because the producer already counted frames.
+    "-t",
+    (opts.totalDuration && opts.totalDuration > 0
+      ? opts.totalDuration.toFixed(3)
+      : opts.videoDuration?.toFixed(3) ?? ""),
+  );
+  // Drop trailing empty -t value if neither override nor probe-supplied
+  // duration was provided. ffmpeg without -t falls back to its default
+  // (longest input) which is fine when -c:v copy keeps the video stream.
+  if (args[args.length - 1] === "") {
+    args.pop();
+    args.pop(); // also drop the "-t" flag
+  }
+  args.push("-movflags", "+faststart", tmpPath);
+
+  try {
+    const { stderr } = await execSafe("ffmpeg", args);
+    if (stderr && opts.onProgress) {
+      stderr.split(/\r?\n/).forEach((line) => opts.onProgress?.(line));
+    }
+  } catch (err) {
+    // execSafe throws on non-zero exit. Surface ffmpeg's stderr if present.
+    const msg = err instanceof Error ? err.message : String(err);
+    // Best-effort cleanup of the half-written temp.
+    try { await unlink(tmpPath); } catch { /* ignore */ }
+    return {
+      success: false,
+      outputPath: opts.videoPath,
+      audioCount: opts.audios.length,
+      error: `ffmpeg mux failed: ${msg}`,
+    };
+  }
+
+  await rename(tmpPath, opts.videoPath);
+  return {
+    success: true,
+    outputPath: opts.videoPath,
+    audioCount: opts.audios.length,
+  };
+}

--- a/packages/cli/src/commands/_shared/scene-render.ts
+++ b/packages/cli/src/commands/_shared/scene-render.ts
@@ -13,7 +13,7 @@
  * returns a structured result instead of throwing or exiting.
  */
 
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir, readFile, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { resolve, relative, dirname, basename } from "node:path";
 import { parse as yamlParse } from "yaml";
@@ -24,6 +24,8 @@ import {
 } from "@hyperframes/producer";
 import { preflightChrome } from "../../pipeline/renderers/chrome.js";
 import { rootExists } from "./scene-lint.js";
+import { scanSceneAudio } from "./scene-audio-scan.js";
+import { muxAudioIntoVideo } from "./scene-audio-mux.js";
 
 export type RenderFps = 24 | 30 | 60;
 export type RenderQuality = "draft" | "standard" | "high";
@@ -56,6 +58,12 @@ export interface SceneRenderResult {
   fps?: RenderFps;
   quality?: RenderQuality;
   format?: RenderFormat;
+  /** Number of `<audio>` elements muxed into the final file. 0 = silent project. */
+  audioCount?: number;
+  /** True when ffmpeg was invoked to overlay audio on the producer's video. */
+  audioMuxApplied?: boolean;
+  /** Non-fatal warning from the audio mux pass — caller may surface to the user. */
+  audioMuxWarning?: string;
   error?: string;
 }
 
@@ -184,6 +192,40 @@ export async function executeSceneRender(opts: SceneRenderOptions = {}): Promise
     };
   }
 
+  // -- Audio mux pass (post-producer) ------------------------------------
+  // The producer emits silent video — sub-composition <audio> elements are
+  // not picked up. We scan the project ourselves and lay them onto the
+  // video in one ffmpeg pass with -c:v copy (no re-encode).
+  let audioCount = 0;
+  let audioMuxApplied = false;
+  let audioMuxWarning: string | undefined;
+  try {
+    opts.onProgress?.(0.95, "Mixing audio");
+    const rootHtml = await readFile(resolve(projectDir, root), "utf-8");
+    const audios = await scanSceneAudio({ projectDir, rootHtml });
+    audioCount = audios.length;
+    if (audios.length > 0) {
+      const videoDuration =
+        job.totalFrames && config.fps ? job.totalFrames / config.fps : undefined;
+      const mux = await muxAudioIntoVideo({
+        videoPath: outputPath,
+        audios,
+        format: config.format ?? "mp4",
+        videoDuration,
+        onProgress: (line) => {
+          if (line) opts.onProgress?.(0.97, line);
+        },
+      });
+      if (mux.success) {
+        audioMuxApplied = true;
+      } else {
+        audioMuxWarning = mux.error;
+      }
+    }
+  } catch (err) {
+    audioMuxWarning = err instanceof Error ? err.message : String(err);
+  }
+
   return {
     success: true,
     outputPath: relative(process.cwd(), outputPath) || outputPath,
@@ -193,6 +235,9 @@ export async function executeSceneRender(opts: SceneRenderOptions = {}): Promise
     fps: config.fps,
     quality: config.quality,
     format: config.format,
+    audioCount,
+    audioMuxApplied,
+    audioMuxWarning,
   };
 }
 


### PR DESCRIPTION
## Summary

C2/3 of the v0.55 audio-mux hotfix. **Closes the gap exposed in v0.54 pre-HN smoke**: rendered MP4s now contain the narration track, not just silent video.

**Behaviour change** (visible to users): \`vibe scene render\` on a project with \`<audio>\` elements now produces an MP4 with audio. Previously the producer dropped the audio silently.

**Verified end-to-end** on a fresh project with Kokoro narration:

\`\`\`
before: codec_type=video duration=6.0     (no audio stream)
after:  codec_type=video duration=6.0
        codec_type=audio duration=2.0     ← narration playing
\`\`\`

**Module:** \`scene-audio-mux.ts\`
- \`buildAudioMuxFilter(audios)\` — pure ffmpeg \`-filter_complex\` builder. Each audio gets \`atrim\` (clip-duration cap) + \`asetpts\` (rebase PTS) + \`adelay\` (absolute timeline) + \`volume\`. Multi-input graphs end with \`amix=normalize=0\`. Single input skips amix.
- \`muxAudioIntoVideo(...)\` — runs ffmpeg via \`execSafe\`. Writes to sibling temp file then atomic-renames. \`-c:v copy\` (no re-encode). Audio codec follows container (aac/opus/pcm). \`-t videoDuration\` caps audio that overruns frame count.

**executeSceneRender wiring:**
- After producer succeeds, reads root HTML, calls \`scanSceneAudio()\`, runs \`muxAudioIntoVideo()\`.
- New result fields: \`audioCount\`, \`audioMuxApplied\`, \`audioMuxWarning\`.
- Mux failures are **non-fatal** — silent video preserved, warning surfaced.
- Skipped (no-op) when \`ffmpeg\` not on PATH or no audio elements.

**Stacked on:** #75 (C1 scene-audio-scan).

## Test plan

- [x] **9 new unit tests** for \`buildAudioMuxFilter\` (single/multi input, delay ms, NaN volume fallback, negative clamps, deterministic labels)
- [x] **Manual end-to-end**: Kokoro narration → render → ffprobe shows audio stream with correct duration
- [x] All scene tests still pass: **169/169**
- [x] \`pnpm build\` 6/6, \`pnpm lint\` 0 errors
- [ ] C3 will land an automated audio-stream assertion in \`tests/smoke/kokoro.sh\`

## Sequence

| Commit | Status | What |
|---|---|---|
| C1 | #75 (open) | scene-audio-scan helper |
| **C2** | this PR | scene-audio-mux + scene-render wiring |
| C3 | pending | smoke audio assertion + docs + bump 0.55.0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)