### PR TITLE
chore: release v0.55.0 — audio in rendered MP4 (v0.55 c3/3)

### DIFF
--- a/.claude/skills/vibe-scene/SKILL.md
+++ b/.claude/skills/vibe-scene/SKILL.md
@@ -92,6 +92,18 @@ audio's absolute word start time:
 are intentionally static. Use `--no-transcribe` to skip Whisper if you
 don't want word-sync (or have no `OPENAI_API_KEY`).
 
+### Audio in the rendered MP4 (v0.55)
+
+`vibe scene render` runs an ffmpeg post-pass that overlays every
+`<audio>` element onto the producer's video at its absolute timeline
+position. The producer's video stream is copied untouched (`-c:v copy`
+— no re-encode) so the only added cost is one cheap audio mux.
+
+The render JSON now reports `audioCount` (how many `<audio>` elements
+were found) and `audioMuxApplied` (whether the ffmpeg pass succeeded).
+If `ffmpeg` is missing from PATH the producer's silent video is left
+in place and `audioMuxWarning` carries the reason.
+
 ## Lint feedback loop (agent pattern)
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.55.0] - 2026-04-25
+
+### Added
+
+- post-render ffmpeg audio mux (v0.55 c2/3) (#76) *(scene)*
+- scene-audio-scan helper for post-render mux (v0.55 c1/3) (#75) *(scene)*
+
 ## [0.54.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ and threaded into the scene HTML. Captions then **fade in word-by-word at
 the exact audio timestamp** — no more "scene says X but caption shows Y"
 drift. Supported on `simple`, `explainer`, and `kinetic-type` presets.
 
+In v0.55, `vibe scene render` adds a post-producer **ffmpeg audio mux
+pass** so the rendered MP4 actually carries the narration track instead
+of being silent. `-c:v copy` keeps it cheap (no video re-encode); the
+render JSON reports `audioCount` + `audioMuxApplied` for agent
+introspection.
+
 Run [`examples/scene-promo/`](examples/scene-promo/) for an end-to-end
 walkthrough. See `/vibe-scene` for the agent skill, including the lint
 feedback loop pattern (`--json --fix`, ≤3 retries, template fallback).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/examples/scene-promo/README.md
+++ b/examples/scene-promo/README.md
@@ -90,9 +90,12 @@ This emits three things into `assets/`:
   absolute audio start time.
 
 Press `vibe scene render` and the captured MP4 has captions that appear
-exactly when each word is spoken. The `simple`, `explainer`, and
-`kinetic-type` presets all support word-sync; `announcement` and
-`product-shot` ignore the transcript (their headlines are static by design).
+exactly when each word is spoken **and** the narration plays as the audio
+track (v0.55+ — `vibe scene render` runs a post-producer ffmpeg mux pass
+that overlays every `<audio>` element onto the video at its absolute
+timeline position). The `simple`, `explainer`, and `kinetic-type` presets
+all support word-sync; `announcement` and `product-shot` ignore the
+transcript (their headlines are static by design).
 
 Already have a wav from another tool (`npx hyperframes tts`, macOS `say`,
 hand-recorded)? Pass it directly — VibeFrame still transcribes it for sync:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -851,4 +851,13 @@ sceneCommand
     console.log(`  duration  ${(((result.durationMs ?? 0) / 1000)).toFixed(1)}s`);
     console.log(`  frames    ${result.framesRendered ?? "?"}${result.totalFrames ? ` / ${result.totalFrames}` : ""}`);
     console.log(`  config    ${result.fps}fps · ${result.quality} · ${result.format}`);
+    if (result.audioCount && result.audioCount > 0) {
+      const muxStatus = result.audioMuxApplied
+        ? chalk.green(`✓ ${result.audioCount} track${result.audioCount === 1 ? "" : "s"} muxed`)
+        : chalk.yellow(`⚠ ${result.audioCount} track${result.audioCount === 1 ? "" : "s"} skipped`);
+      console.log(`  audio     ${muxStatus}`);
+      if (result.audioMuxWarning) {
+        console.log(chalk.dim(`            ${result.audioMuxWarning}`));
+      }
+    }
   });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",

--- a/tests/smoke/kokoro.sh
+++ b/tests/smoke/kokoro.sh
@@ -29,6 +29,16 @@ TMPDIR="${TMPDIR:-/tmp}"
 SMOKE_DIR="$(mktemp -d "$TMPDIR/vibe-smoke-kokoro-XXXXXX")"
 trap 'rm -rf "$SMOKE_DIR"' EXIT
 
+# Load .env from repo root so OPENAI_API_KEY / ELEVENLABS_API_KEY visible
+# to the shell. The CLI itself loads .env via dotenv, but our shell
+# conditionals (`if [ -n "$OPENAI_API_KEY" ]`) need it pre-exported.
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
 green() { printf "\033[32m%s\033[0m\n" "$*"; }
 red()   { printf "\033[31m%s\033[0m\n" "$*" >&2; }
 step()  { printf "\033[36m▶ %s\033[0m\n" "$*"; }
@@ -87,14 +97,34 @@ fi
 green "✓ Lint clean"
 
 if [ "${SMOKE_RENDER:-0}" = "1" ]; then
-  step "Rendering to MP4 (requires Chrome)"
-  $VIBE scene render --project "$SMOKE_DIR/promo" \
+  step "Rendering to MP4 (requires Chrome + ffmpeg)"
+  # Producer (`@hyperframes/producer`) writes [WARN]/[INFO] lines to stdout
+  # alongside our --json output. Strip everything before the first `{` so
+  # python json.loads sees only the result envelope.
+  RENDER_RESULT="$($VIBE scene render --project "$SMOKE_DIR/promo" \
     --out "$SMOKE_DIR/promo/renders/smoke.mp4" \
-    --quality draft --fps 24 --json >/dev/null
-  if [ -s "$SMOKE_DIR/promo/renders/smoke.mp4" ]; then
-    green "✓ Render produced MP4 ($(stat -f%z "$SMOKE_DIR/promo/renders/smoke.mp4" 2>/dev/null || stat -c%s "$SMOKE_DIR/promo/renders/smoke.mp4") bytes)"
-  else
+    --quality draft --fps 24 --json | awk '/^\{/{found=1} found')"
+  MP4="$SMOKE_DIR/promo/renders/smoke.mp4"
+  if [ ! -s "$MP4" ]; then
     red "Render did not produce a non-empty MP4"
+    exit 1
+  fi
+  AUDIO_MUX="$(echo "$RENDER_RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('audioMuxApplied',False))")"
+  green "✓ Render produced MP4 ($(stat -f%z "$MP4" 2>/dev/null || stat -c%s "$MP4") bytes)"
+
+  # v0.55+: verify the post-producer ffmpeg mux pass actually embedded audio.
+  # Catches regressions where the producer skips audio capture and our mux
+  # also falls through (e.g. ffmpeg missing, filter graph bug).
+  if [ "$AUDIO_MUX" = "True" ]; then
+    AUDIO_STREAM_COUNT="$(ffprobe -v error -select_streams a -show_entries stream=index -of csv=p=0 "$MP4" | wc -l | tr -d ' ')"
+    if [ "$AUDIO_STREAM_COUNT" -lt "1" ]; then
+      red "audioMuxApplied=true but rendered MP4 has no audio stream — mux pass regressed"
+      exit 1
+    fi
+    AUDIO_DURATION="$(ffprobe -v error -select_streams a:0 -show_entries stream=duration -of csv=p=0 "$MP4")"
+    green "✓ MP4 has $AUDIO_STREAM_COUNT audio stream(s), narration ${AUDIO_DURATION}s"
+  else
+    red "audioMuxApplied was not true. JSON: $RENDER_RESULT"
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

C3/3 of the v0.55 audio-mux hotfix — releases the fix.

**v0.55 ships** the missing piece from the v0.54 sync story: \`vibe scene render\` now produces MP4s **with narration audio**. v0.53/0.54 emitted silent video because \`@hyperframes/producer\` doesn't pick up sub-composition \`<audio>\` elements (verified against the upstream reference example). The post-render ffmpeg mux landed in #75 + #76 closes the gap with \`-c:v copy\` (no re-encode).

**Changes in this PR:**
- \`smoke/kokoro.sh\`: \`source .env\` so OPENAI/ELEVENLABS keys reach shell conditionals (caught during v0.54 smoke). \`SMOKE_RENDER=1\` now asserts \`audioMuxApplied: true\` and verifies the output has ≥1 audio stream via ffprobe.
- \`vibe scene render\` text output adds an audio summary line (\`audio  ✓ N tracks muxed\` / \`⚠ skipped\` + warning).
- Docs: SKILL.md gains a v0.55 audio section; scene-promo README + root README mention the new behaviour.
- CHANGELOG regenerated, 7 \`package.json\` bumped to \`0.55.0\`.

**Auto-tag workflow** creates \`v0.55.0\` + dispatches \`publish.yml\` on main merge.

## What 0.55.0 fixes (user-visible)

\`\`\`
v0.54 render: codec_type=video duration=6.0     (silent)
v0.55 render: codec_type=video duration=6.0
              codec_type=audio duration=2.0     ← narration plays
\`\`\`

## Test plan

- [x] \`pnpm build\` 6/6, \`pnpm lint\` 0 errors
- [x] All scene tests **169/169** still pass
- [x] Manual smoke (\`SMOKE_RENDER=1 bash tests/smoke/kokoro.sh\`):
  - ✓ Kokoro narration generated (192KB wav)
  - ✓ Whisper transcript (4 word entries)
  - ✓ Scene HTML word-sync spans
  - ✓ Lint clean
  - ✓ MP4 has 1 audio stream, narration 2.0s
- [x] \`version-checker\` agent will run on the release branch (deferred to merge time)
- [ ] Post-merge: auto-tag \`v0.55.0\` → publish.yml → npm publish → \`@vibeframe/cli@0.55.0\` live

## Sequence (v0.55 complete after this merges)

| Commit | Status | What |
|---|---|---|
| C1 | merged (#75) | scene-audio-scan helper |
| C2 | merged (#76) | scene-audio-mux + render wiring |
| **C3** | this PR | smoke audio assertion + docs + bump 0.55.0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)