### PR TITLE
fix(cli): auto TTS fallback to Kokoro + actionable FFmpeg message (v0.55.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.55.1] - 2026-04-25
+## [0.55.2] - 2026-04-25
+
+### Documentation
+
+- asciinema quickstart embed in README (#79) *(demo)*
 
 ### Fixed
 
-- bundle CLI with esbuild so npm install actually works (v0.55.1) *(cli)*
+- bundle CLI with esbuild so npm install actually works (v0.55.1) (#78) *(cli)*
 
 ## [0.55.0] - 2026-04-25
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/ai-audio.ts
+++ b/packages/cli/src/commands/ai-audio.ts
@@ -923,7 +923,7 @@ aiCommand
 
       // Check FFmpeg availability
       if (!commandExists("ffmpeg")) {
-        exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+        exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
       }
 
       const spinner = ora("Processing audio ducking...").start();

--- a/packages/cli/src/commands/ai-broll.ts
+++ b/packages/cli/src/commands/ai-broll.ts
@@ -156,7 +156,7 @@ export function registerBrollCommand(ai: Command): void {
 
         // Check FFmpeg availability
         if (!commandExists("ffmpeg")) {
-          exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+          exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
         }
 
         console.log();

--- a/packages/cli/src/commands/ai-edit-cli.ts
+++ b/packages/cli/src/commands/ai-edit-cli.ts
@@ -71,7 +71,7 @@ No API key needed (FFmpeg only). Use --use-gemini for smart detection (requires 
 
       // Check FFmpeg
       if (!commandExists("ffmpeg")) {
-        exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+        exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
       }
 
       const ext = extname(videoPath);
@@ -200,7 +200,7 @@ Requires: OPENAI_API_KEY (Whisper transcription) + FFmpeg`)
 
       // Check FFmpeg
       if (!commandExists("ffmpeg")) {
-        exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+        exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
       }
 
       if (options.dryRun) {
@@ -298,7 +298,7 @@ aiCommand
       }
 
       if (!commandExists("ffmpeg")) {
-        exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+        exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
       }
 
       if (options.dryRun) {
@@ -382,7 +382,7 @@ aiCommand
       }
 
       if (!commandExists("ffmpeg")) {
-        exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+        exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
       }
 
       if (options.dryRun) {
@@ -573,7 +573,7 @@ aiCommand
 
       // Check FFmpeg
       if (!commandExists("ffmpeg")) {
-        exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+        exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
       }
 
       if (options.dryRun) {

--- a/packages/cli/src/commands/ai-edit.ts
+++ b/packages/cli/src/commands/ai-edit.ts
@@ -260,7 +260,7 @@ export async function executeSilenceCut(options: SilenceCutOptions): Promise<Sil
   }
 
   if (!commandExists("ffmpeg")) {
-    return { success: false, error: "FFmpeg not found. Please install FFmpeg." };
+    return { success: false, error: "FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details." };
   }
 
   const method = useGemini ? "gemini" : "ffmpeg";
@@ -519,7 +519,7 @@ export async function executeJumpCut(options: JumpCutOptions): Promise<JumpCutRe
   }
 
   if (!commandExists("ffmpeg")) {
-    return { success: false, error: "FFmpeg not found. Please install FFmpeg." };
+    return { success: false, error: "FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details." };
   }
 
   const openaiKey = apiKey || process.env.OPENAI_API_KEY;
@@ -723,7 +723,7 @@ export async function executeCaption(options: CaptionOptions): Promise<CaptionRe
   }
 
   if (!commandExists("ffmpeg")) {
-    return { success: false, error: "FFmpeg not found. Please install FFmpeg." };
+    return { success: false, error: "FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details." };
   }
 
   const openaiKey = apiKey || process.env.OPENAI_API_KEY;
@@ -913,7 +913,7 @@ export async function executeNoiseReduce(options: NoiseReduceOptions): Promise<N
   }
 
   if (!commandExists("ffmpeg")) {
-    return { success: false, error: "FFmpeg not found. Please install FFmpeg." };
+    return { success: false, error: "FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details." };
   }
 
   try {
@@ -1014,7 +1014,7 @@ export async function executeFade(options: FadeOptions): Promise<FadeResult> {
   }
 
   if (!commandExists("ffmpeg")) {
-    return { success: false, error: "FFmpeg not found. Please install FFmpeg." };
+    return { success: false, error: "FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details." };
   }
 
   try {
@@ -1379,7 +1379,7 @@ export async function applyTextOverlays(options: TextOverlayOptions): Promise<Te
 
   // Check FFmpeg
   if (!commandExists("ffmpeg")) {
-    return { success: false, error: "FFmpeg not found. Please install FFmpeg." };
+    return { success: false, error: "FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details." };
   }
 
   // Check drawtext filter availability

--- a/packages/cli/src/commands/ai-highlights.ts
+++ b/packages/cli/src/commands/ai-highlights.ts
@@ -854,7 +854,7 @@ Analyze both what is SHOWN (visual cues, actions, expressions) and what is SAID 
             try {
               if (!commandExists("ffmpeg")) {
                 audioSpinner.fail("FFmpeg not found");
-                exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+                exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
               }
 
               const { stdout: probeOut } = await execSafe("ffprobe", [
@@ -1075,7 +1075,7 @@ Analyze both what is SHOWN (visual cues, actions, expressions) and what is SAID 
         }
 
         if (!commandExists("ffmpeg")) {
-          exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+          exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
         }
 
         const targetDuration = parseInt(options.duration);

--- a/packages/cli/src/commands/ai-image.ts
+++ b/packages/cli/src/commands/ai-image.ts
@@ -320,7 +320,7 @@ aiCommand
         }
 
         if (!commandExists("ffmpeg")) {
-          exitWithError(generalError("FFmpeg not found. Please install FFmpeg."));
+          exitWithError(generalError("FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details."));
         }
 
         const apiKey = await getApiKey("GOOGLE_API_KEY", "Google", options.apiKey);
@@ -985,7 +985,7 @@ export async function executeThumbnailBestFrame(options: ThumbnailBestFrameOptio
   }
 
   if (!commandExists("ffmpeg")) {
-    return { success: false, error: "FFmpeg not found. Please install FFmpeg." };
+    return { success: false, error: "FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run `vibe doctor` for details." };
   }
 
   const googleKey = apiKey || process.env.GOOGLE_API_KEY;

--- a/packages/cli/src/utils/api-key.test.ts
+++ b/packages/cli/src/utils/api-key.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { loadEnv, getApiKey } from "./api-key.js";
+import { loadEnv, getApiKey, hasApiKey } from "./api-key.js";
 
 describe("api-key utilities", () => {
   const originalEnv = process.env;
@@ -36,6 +36,29 @@ describe("api-key utilities", () => {
       delete process.env.TEST_KEY;
       const result = await getApiKey("TEST_KEY", "Test");
       expect(result).toBeNull();
+    });
+  });
+
+  describe("hasApiKey", () => {
+    // Regression: prior implementation called the async
+    // `getApiKeyFromConfig(envVar)` without `await`, so `!!Promise` always
+    // returned `true`. That made `vibe scene add --tts auto` always pick
+    // ElevenLabs even when no key was present — defeating the v0.54
+    // local-Kokoro fallback.
+
+    it("returns true when env var is set", () => {
+      process.env.TEST_PROBE_KEY = "actual-secret";
+      expect(hasApiKey("TEST_PROBE_KEY")).toBe(true);
+    });
+
+    it("returns false when env var is unset", () => {
+      delete process.env.TEST_PROBE_KEY;
+      expect(hasApiKey("TEST_PROBE_KEY")).toBe(false);
+    });
+
+    it("returns false for empty-string env var", () => {
+      process.env.TEST_PROBE_KEY = "";
+      expect(hasApiKey("TEST_PROBE_KEY")).toBe(false);
     });
   });
 });

--- a/packages/cli/src/utils/api-key.ts
+++ b/packages/cli/src/utils/api-key.ts
@@ -209,12 +209,20 @@ export class ApiKeyError extends Error {
 
 /**
  * Check if an API key is available without prompting or side effects.
+ *
+ * Sync env-only check — for the config-file fallback (set via `vibe setup`),
+ * use the async {@link getApiKey} instead. Two bugs in the previous
+ * implementation made this lie: (1) `getApiKeyFromConfig` is async and
+ * was called without `await`, so `!!Promise` always returned `true`,
+ * and (2) the function expects a provider key (`"elevenlabs"`) but was
+ * being passed the env-var name (`"ELEVENLABS_API_KEY"`). The result
+ * was that `vibe scene add --tts auto` always took the ElevenLabs path
+ * and crashed with "API key required" even though we were supposed to
+ * fall back to local Kokoro. Caught during pre-HN error-message audit.
  */
 export function hasApiKey(envVar: string): boolean {
   loadEnv();
-  if (process.env[envVar]) return true;
-  const key = getApiKeyFromConfig(envVar);
-  return !!key;
+  return !!process.env[envVar];
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Pre-HN step 4 (error-message audit) caught two regressions in already-shipped code.

### 1. \`vibe scene add --tts auto\` never actually fell back to Kokoro

Under \`auto\` (the default) without \`ELEVENLABS_API_KEY\`, the CLI **always** tried ElevenLabs and failed with "API key required" — defeating the entire v0.54 router design.

**Root cause**: \`hasApiKey()\` called the async \`getApiKeyFromConfig\` without \`await\`, then did \`!!Promise(...)\` which is always \`true\`. The function also received the env-var name (\`"ELEVENLABS_API_KEY"\`) when \`getApiKeyFromConfig\` expects the provider key (\`"elevenlabs"\`). The two bugs cancelled into "always claim a key exists."

**Fix**: \`hasApiKey\` is now a sync env-only check. The async \`getApiKey\` already handles the config-file path for callers that need to actually use the key. Adds three regression tests for env set / unset / empty.

**Verified end-to-end**:

\`\`\`
$ env -u ELEVENLABS_API_KEY vibe scene add x \\
    --narration "test fallback" --no-image --json
"audioPath": ".../assets/narration-x.wav"   # Kokoro picked, not ElevenLabs
\`\`\`

### 2. Standardise the bare "FFmpeg not found. Please install FFmpeg." message

Six command modules emitted that string with no install hint. Replaced everywhere with:

\`\`\`
FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run \`vibe doctor\` for details.
\`\`\`

So first-time users hitting the failure get an actionable command on the spot.

## Test plan

- [x] **3 new \`hasApiKey\` regression tests** (env set, unset, empty-string)
- [x] All 169 scene tests still pass
- [x] \`pnpm build\` 6/6, \`pnpm lint\` 0 errors
- [x] Manual env -u test confirms Kokoro fallback works
- [ ] Post-merge: rerun \`bash assets/demos/asciinema-demo.sh\` validates production path

## Other audit findings (not in this PR)

- \`vibe doctor\` JSON output is comprehensive (node + ffmpeg + filters + config + optionalTools + per-provider configured flags + commands using each).
- \`vibe scene render\` Chrome-missing message already excellent: "Set HYPERFRAMES_CHROME_PATH, or install Chrome (macOS: brew install --cask google-chrome · Linux: apt install chromium). Run \`vibe doctor\` for details."
- \`--tts elevenlabs\` (explicit) without key still gives a great message — references both \`vibe setup\` and \`--tts kokoro\`.

7 \`package.json\` bumped 0.55.1 → 0.55.2. CHANGELOG regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)