### PR TITLE
feat(image): default text-to-image to OpenAI gpt-image-2 (v0.56.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.55.2] - 2026-04-25
+## [0.56.0] - 2026-04-25
 
 ### Documentation
 
+- polish v0.55 self-promo — unified visuals, BGM, no black tail (#84) *(web)*
+- refresh /demo page with v0.55 self-promo + 3-surface section (#83) *(web)*
+- clearer quickstart + agent-mode + Claude Code walkthrough (#82) *(demos)*
+- vibe scene render vs npx hyperframes render (#81) *(comparison)*
 - asciinema quickstart embed in README (#79) *(demo)*
 
 ### Fixed
 
+- drop tail fade-out from announcement + simple presets (#85) *(scene)*
+- auto TTS fallback to Kokoro + actionable FFmpeg message (v0.55.2) (#80) *(cli)*
 - bundle CLI with esbuild so npm install actually works (v0.55.1) (#78) *(cli)*
 
 ## [0.55.0] - 2026-04-25

--- a/MODELS.md
+++ b/MODELS.md
@@ -115,9 +115,9 @@ Used for Remotion component code generation (`vibe generate motion`).
 
 | Provider | Model | Env Key | CLI Option | Notes |
 |----------|-------|---------|------------|-------|
-| OpenAI | `gpt-image-1.5` | `OPENAI_API_KEY` | `-p openai` | **Default (OpenAI)**. Quality tiers: low ($0.009), medium ($0.035), high ($0.133) |
-| OpenAI | `gpt-image-2` | `OPENAI_API_KEY` | `-p openai -m 2` | Flagship, 2026-04-21 GA. Higher fidelity. ~$0.04–$0.35/image |
-| Gemini | `gemini-2.5-flash-image` | `GOOGLE_API_KEY` | `-p gemini` | Default. Nano Banana Flash - **GA**, fast |
+| OpenAI | `gpt-image-2` | `OPENAI_API_KEY` | `-p openai` (default) | **Default since v0.56.** Artificial Analysis ELO 1332, #1 on text-to-image leaderboard. ~$0.04–$0.35/image |
+| OpenAI | `gpt-image-1.5` | `OPENAI_API_KEY` | `-p openai -m 1.5` | Previous default, still strong on editing (#1 editing leaderboard). Quality tiers: low ($0.009), medium ($0.035), high ($0.133) |
+| Gemini | `gemini-2.5-flash-image` | `GOOGLE_API_KEY` | `-p gemini` | Nano Banana Flash - **GA**, fast. Auto-selected when only `GOOGLE_API_KEY` is set |
 | Gemini | `gemini-3.1-flash-image-preview` | `GOOGLE_API_KEY` | `-p gemini -m 3.1-flash` | Nano Banana 2 - Image Search grounding, 512px |
 | Gemini | `gemini-3-pro-image-preview` | `GOOGLE_API_KEY` | `-p gemini -m pro` | Nano Banana Pro - higher quality, up to 4K |
 | xAI Grok | `grok-imagine-image` | `XAI_API_KEY` | `-p grok` | $0.02/image, standard quality |

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Best used for onboarding and quick experiments. For production workflows, use CL
 | Category | Providers | Default |
 |----------|-----------|---------|
 | **Agent LLM** | OpenAI, Claude, Gemini, xAI, OpenRouter, Ollama | GPT-5-mini |
-| **Image** | Gemini, OpenAI, xAI Grok | Gemini Nano Banana |
+| **Image** | OpenAI, Gemini, xAI Grok | OpenAI gpt-image-2 (since v0.56 — Artificial Analysis ELO #1) · Gemini fallback when no `OPENAI_API_KEY` |
 | **Video** | xAI Grok, Kling, Runway, Veo | Grok Imagine |
 | **Audio** | ElevenLabs, Whisper | - |
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.55.2",
+  "version": "0.56.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.55.2",
+  "version": "0.56.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.55.2",
+  "version": "0.56.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/src/openai-image/OpenAIImageProvider.ts
+++ b/packages/ai-providers/src/openai-image/OpenAIImageProvider.ts
@@ -6,9 +6,12 @@ import type {
 
 /**
  * GPT Image model types
- * - gpt-image-1.5: Default model (best cost/quality ratio)
- * - gpt-image-2: Flagship model released 2026-04-21 (higher fidelity, pricier)
- * - dall-e-3: Legacy model
+ * - gpt-image-2: Default since v0.56 — Artificial Analysis ELO 1332,
+ *   #1 on the text-to-image leaderboard at the time of switch (released
+ *   2026-04-21, ~70 ELO above any non-OpenAI model).
+ * - gpt-image-1.5: Previous default, still strong for editing (#1 on
+ *   the editing leaderboard) and cheaper (~$0.04 vs ~$0.08 high).
+ * - dall-e-3: Legacy model.
  */
 export type GPTImageModel = "gpt-image-1.5" | "gpt-image-2" | "dall-e-3";
 
@@ -68,7 +71,11 @@ export interface ImageEditOptions {
 }
 
 /** Default model — GPT Image 1.5 for best cost/quality. gpt-image-2 is opt-in (pricier). */
-const DEFAULT_MODEL: GPTImageModel = "gpt-image-1.5";
+// Default model bumped to gpt-image-2 in v0.56 (Artificial Analysis ELO
+// 1332 → #1 on text-to-image leaderboard). Pass `model: "gpt-image-1.5"`
+// explicitly to keep the old default — still cheaper and #1 on the
+// editing leaderboard.
+const DEFAULT_MODEL: GPTImageModel = "gpt-image-2";
 
 /**
  * OpenAI Image provider (GPT Image 1.5 / GPT Image 2 / DALL-E)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.55.2",
+  "version": "0.56.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/utils/provider-resolver.ts
+++ b/packages/cli/src/utils/provider-resolver.ts
@@ -17,9 +17,16 @@ interface ProviderCandidate {
   label: string;
 }
 
+// As of v0.56, OpenAI is the preferred image provider — gpt-image-2
+// holds Artificial Analysis ELO 1332 on the text-to-image leaderboard
+// (#1; ~70 ELO above any non-OpenAI model). Users without an OpenAI
+// key automatically fall through to Gemini, so Gemini-only setups are
+// unaffected. Set `defaults.imageProvider: gemini` in
+// `~/.vibeframe/config.yaml` to keep the previous behaviour even when
+// both keys are present.
 const IMAGE_PROVIDERS: ProviderCandidate[] = [
-  { name: "gemini", envVar: "GOOGLE_API_KEY", label: "Gemini" },
   { name: "openai", envVar: "OPENAI_API_KEY", label: "OpenAI" },
+  { name: "gemini", envVar: "GOOGLE_API_KEY", label: "Gemini" },
   { name: "grok", envVar: "XAI_API_KEY", label: "Grok" },
 ];
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.55.2",
+  "version": "0.56.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.55.2",
+  "version": "0.56.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.55.2",
+  "version": "0.56.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Two coordinated changes that flip the out-of-the-box image surface to OpenAI's flagship model:

### Step 1 · OpenAIImageProvider default model: 1.5 → 2

\`DEFAULT_MODEL\` in \`packages/ai-providers/src/openai-image/OpenAIImageProvider.ts\` becomes \`gpt-image-2\`. Pass \`model: "gpt-image-1.5"\` (or \`-m 1.5\` on the CLI) to keep the previous default.

### Step 2 · IMAGE_PROVIDERS order: \`openai → gemini → grok\`

A user with only \`GOOGLE_API_KEY\` is unchanged (Gemini fallback). Only-OpenAI is unchanged. The behaviour difference is for the **both-keys** case, where we now pick OpenAI. Override via \`defaults.imageProvider: gemini\` in \`~/.vibeframe/config.yaml\`.

## Why now — data, not vibes

[Artificial Analysis text-to-image leaderboard](https://artificialanalysis.ai/image/leaderboard/text-to-image) (blind user vote, ELO):

| Rank | Model | ELO |
|---|---|---|
| **1** | **GPT Image 2 (high)** | **1332** |
| 2 | GPT Image 1.5 (high) | 1270 |
| 3 | Nano Banana 2 (Gemini 3.1 Flash) | 1262 |
| 4 | Nano Banana Pro | 1216 |

70 ELO between #1 and #3 is meaningful (~60 % win rate). On the [editing leaderboard](https://artificialanalysis.ai/image/leaderboard/editing) gpt-image-1.5 narrowly beats gpt-image-2 (1260 vs 1244), but text-to-image is the dominant code path — \`vibe scene add --visuals\`, \`vibe pipeline script-to-video\`, /demo self-promo, etc.

## Cost impact

Image cost roughly doubles for users who had both keys set:

| | Per image |
|---|---|
| Old default (Gemini Nano Banana) | ~\$0.04 |
| New default (gpt-image-2 high) | ~\$0.08–0.10 |

Pipeline cost: \`vibe pipeline script-to-video --format scenes\` with 5 scenes goes ~\$0.20 → ~\$0.40–0.50.

## Override paths

| Want | How |
|---|---|
| Keep Gemini | \`defaults.imageProvider: gemini\` in \`~/.vibeframe/config.yaml\`, or \`-p gemini\` per call |
| Stick with gpt-image-1.5 | \`-m 1.5\` per call, or \`OpenAIImageProvider.generateImage(prompt, { model: "gpt-image-1.5" })\` |
| Per-pipeline override | \`vibe pipeline script-to-video ... --image-provider gemini\` |

## Files touched

- \`packages/ai-providers/src/openai-image/OpenAIImageProvider.ts\` — default model + leaderboard reference in JSDoc
- \`packages/cli/src/utils/provider-resolver.ts\` — \`IMAGE_PROVIDERS\` order + comment explaining override
- \`MODELS.md\` — gpt-image-2 promoted, gpt-image-1.5 row notes editing-leaderboard #1
- \`README.md\` — AI provider table line for Image
- 7 \`package.json\` bumped 0.55.2 → 0.56.0
- \`CHANGELOG.md\` regenerated via \`git-cliff --tag v0.56.0\`

## Test plan

- [x] \`pnpm -F @vibeframe/cli test\` — **471/471** (+11 skipped Chrome-gated)
- [x] \`pnpm -F @vibeframe/ai-providers test\` — 40/40
- [x] \`pnpm build\` 6/6
- [x] \`pnpm lint\` 0 errors
- [ ] Post-merge: auto-tag → npm publish → \`@vibeframe/cli@0.56.0\` live

🤖 Generated with [Claude Code](https://claude.com/claude-code)