### PR TITLE
feat(fal): add fal.ai provider hosting Seedance 2.0 (v0.57.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,5 @@ OPENROUTER_API_KEY=
 # ImgBB API Key (for image hosting - used by Kling image-to-video)
 # Get yours at: https://api.imgbb.com/
 IMGBB_API_KEY=
+
+FAL_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.56.0] - 2026-04-25
+## [0.57.0] - 2026-04-25
+
+### Added
+
+- default text-to-image to OpenAI gpt-image-2 (v0.56.0) *(image)*
 
 ### Documentation
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -144,13 +144,15 @@ Grok Imagine supports 14 aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:
 
 ---
 
-## Text-to-Video (4)
+## Text-to-Video (5)
 
 > Models marked **Audio: Yes** generate synchronized sound (dialogue, SFX, ambient). Silent models need separate `vibe generate speech` / `vibe generate sound-effect`.
 
 | Provider | Model | Duration | Audio | Env Key | CLI Option | Notes |
 |----------|-------|----------|-------|---------|------------|-------|
-| xAI Grok | `grok-imagine-video` | 1-15 sec | Yes | `XAI_API_KEY` | `-p grok` | **Default**. Best lip-sync/native audio. $0.07/s (720p) |
+| fal.ai | `seedance-2.0` (ByteDance) | 4-15 sec | Yes | `FAL_KEY` | `-p fal` | **Auto-default when `FAL_KEY` set** (since v0.57). Artificial Analysis ELO 1270 #2 text, 1347 #2 image. ByteDance has no public API — fal.ai is the gateway. |
+| fal.ai | `seedance-2.0-fast` | 4-15 sec | Yes | `FAL_KEY` | `-p fal -m fast` | Lower-latency / lower-cost variant of Seedance 2.0 |
+| xAI Grok | `grok-imagine-video` | 1-15 sec | Yes | `XAI_API_KEY` | `-p grok` | Fallback default when `FAL_KEY` is unset. Best lip-sync/native audio. $0.07/s (720p) |
 | Kling | `kling-v2-5-turbo` | 5-10 sec | No | `KLING_API_KEY` | `-p kling` | Fast (~36s generation) |
 | Kling | `kling-v2-6` | 5-10 sec | No | `KLING_API_KEY` | `-p kling -m v2.6` | High quality |
 | Kling | `kling-v3` | 5-10 sec | No | `KLING_API_KEY` | `-p kling -m v3` | Higher quality, multi-shot, lip-sync |
@@ -178,6 +180,7 @@ All text-to-video providers also support image-to-video. Key differences per pro
 
 | Provider | Model | I2V Support | Image Input | Notes |
 |----------|-------|-------------|-------------|-------|
+| fal.ai | `seedance-2.0` | Yes | **URL only** | Auto-uploads via ImgBB (`IMGBB_API_KEY`). Supports `--last-frame` for end-frame transition. |
 | xAI Grok | `grok-imagine-video` | Yes | URL or data URI | Same pricing as T2V |
 | Kling | all v2.5+ models | Yes | **URL only** | Auto-uploads via ImgBB (`IMGBB_API_KEY`) |
 | Veo | all models | Yes | base64 (first frame) | Supports `--last-frame` for frame interpolation |

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",
@@ -56,6 +56,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@fal-ai/client": "^1.10.0",
     "@vibeframe/core": "workspace:*",
     "kokoro-js": "^1.2.1"
   },

--- a/packages/ai-providers/src/fal/FalProvider.test.ts
+++ b/packages/ai-providers/src/fal/FalProvider.test.ts
@@ -1,0 +1,208 @@
+/**
+ * FalProvider unit tests.
+ *
+ * The real fal client is mocked via `vi.mock("@fal-ai/client")` so the
+ * tests run instantly with no network. Each case asserts the endpoint
+ * id we picked, the input payload we sent, or the failure path we
+ * surface — the behaviour the rest of the codebase relies on.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  subscribe: vi.fn(),
+  createFalClient: vi.fn(),
+}));
+
+vi.mock("@fal-ai/client", () => ({
+  createFalClient: (...args: unknown[]) => {
+    mocks.createFalClient(...args);
+    return { subscribe: mocks.subscribe };
+  },
+}));
+
+import { FalProvider } from "./FalProvider.js";
+
+describe("FalProvider", () => {
+  let provider: FalProvider;
+
+  beforeEach(() => {
+    mocks.subscribe.mockReset();
+    mocks.createFalClient.mockReset();
+    provider = new FalProvider();
+  });
+
+  describe("initialization", () => {
+    it("declares text-to-video and image-to-video capabilities", () => {
+      expect(provider.id).toBe("fal");
+      expect(provider.capabilities).toContain("text-to-video");
+      expect(provider.capabilities).toContain("image-to-video");
+    });
+
+    it("is unconfigured before initialize", () => {
+      expect(provider.isConfigured()).toBe(false);
+    });
+
+    it("creates the fal client when an API key is supplied", async () => {
+      await provider.initialize({ apiKey: "fal_pst_test" });
+      expect(mocks.createFalClient).toHaveBeenCalledWith({ credentials: "fal_pst_test" });
+      expect(provider.isConfigured()).toBe(true);
+    });
+
+    it("stays unconfigured when no API key is provided", async () => {
+      await provider.initialize({});
+      expect(provider.isConfigured()).toBe(false);
+    });
+  });
+
+  describe("generateVideo — text-to-video", () => {
+    beforeEach(async () => {
+      await provider.initialize({ apiKey: "fal_pst_test" });
+    });
+
+    it("hits the standard text-to-video endpoint by default", async () => {
+      mocks.subscribe.mockResolvedValueOnce({
+        requestId: "req-abc",
+        data: { video: { url: "https://fal.media/output.mp4" } },
+      });
+
+      const result = await provider.generateVideo("a cat surfing", {
+        prompt: "a cat surfing",
+        aspectRatio: "16:9",
+        duration: 6,
+      });
+
+      expect(mocks.subscribe).toHaveBeenCalledWith(
+        "bytedance/seedance-2.0/text-to-video",
+        expect.objectContaining({
+          input: expect.objectContaining({
+            prompt: "a cat surfing",
+            aspect_ratio: "16:9",
+            resolution: "720p",
+            duration: 6,
+          }),
+        }),
+      );
+      expect(result).toMatchObject({
+        id: "req-abc",
+        status: "completed",
+        videoUrl: "https://fal.media/output.mp4",
+      });
+    });
+
+    it("routes to the fast variant when model = seedance-2.0-fast", async () => {
+      mocks.subscribe.mockResolvedValueOnce({
+        requestId: "req-fast",
+        data: { video: { url: "https://fal.media/fast.mp4" } },
+      });
+
+      await provider.generateVideo("any prompt", {
+        prompt: "any prompt",
+        model: "seedance-2.0-fast",
+      });
+
+      expect(mocks.subscribe.mock.calls[0][0]).toBe(
+        "bytedance/seedance-2.0/fast/text-to-video",
+      );
+    });
+
+    it("clamps unreasonable durations into the 4–15 s API range", async () => {
+      mocks.subscribe.mockResolvedValueOnce({
+        requestId: "req-clamp",
+        data: { video: { url: "https://x" } },
+      });
+
+      await provider.generateVideo("p", { prompt: "p", duration: 99 });
+      expect(mocks.subscribe.mock.calls[0][1].input.duration).toBe(15);
+
+      mocks.subscribe.mockResolvedValueOnce({
+        requestId: "req-clamp2",
+        data: { video: { url: "https://x" } },
+      });
+      await provider.generateVideo("p", { prompt: "p", duration: 1 });
+      expect(mocks.subscribe.mock.calls[1][1].input.duration).toBe(4);
+    });
+
+    it("falls back to aspect=auto on unknown ratios", async () => {
+      mocks.subscribe.mockResolvedValueOnce({
+        requestId: "req-aspect",
+        data: { video: { url: "https://x" } },
+      });
+
+      await provider.generateVideo("p", {
+        prompt: "p",
+        aspectRatio: "5:3" as unknown as "16:9",
+      });
+
+      expect(mocks.subscribe.mock.calls[0][1].input.aspect_ratio).toBe("auto");
+    });
+
+    it("returns a structured failure when subscribe rejects", async () => {
+      mocks.subscribe.mockRejectedValueOnce(new Error("rate limited"));
+      const result = await provider.generateVideo("p", { prompt: "p" });
+      expect(result.status).toBe("failed");
+      expect(result.error).toContain("rate limited");
+    });
+
+    it("returns a structured failure when no video URL is returned", async () => {
+      mocks.subscribe.mockResolvedValueOnce({
+        requestId: "req-empty",
+        data: {},
+      });
+      const result = await provider.generateVideo("p", { prompt: "p" });
+      expect(result.status).toBe("failed");
+      expect(result.error).toMatch(/video URL/);
+    });
+  });
+
+  describe("generateVideo — image-to-video", () => {
+    beforeEach(async () => {
+      await provider.initialize({ apiKey: "fal_pst_test" });
+    });
+
+    it("routes to image-to-video when an HTTPS reference image is supplied", async () => {
+      mocks.subscribe.mockResolvedValueOnce({
+        requestId: "req-i2v",
+        data: { video: { url: "https://fal.media/i2v.mp4" } },
+      });
+
+      await provider.generateVideo("zoom in slowly", {
+        prompt: "zoom in slowly",
+        referenceImage: "https://example.com/seed.png",
+      });
+
+      expect(mocks.subscribe.mock.calls[0][0]).toBe(
+        "bytedance/seedance-2.0/image-to-video",
+      );
+      expect(mocks.subscribe.mock.calls[0][1].input.image_url).toBe(
+        "https://example.com/seed.png",
+      );
+    });
+
+    it("ignores non-HTTPS reference images and falls back to text-to-video", async () => {
+      mocks.subscribe.mockResolvedValueOnce({
+        requestId: "req-fallback",
+        data: { video: { url: "https://x" } },
+      });
+
+      await provider.generateVideo("p", {
+        prompt: "p",
+        referenceImage: "data:image/png;base64,iVBORw0...",
+      });
+
+      expect(mocks.subscribe.mock.calls[0][0]).toBe(
+        "bytedance/seedance-2.0/text-to-video",
+      );
+      expect(mocks.subscribe.mock.calls[0][1].input.image_url).toBeUndefined();
+    });
+  });
+
+  describe("error handling without init", () => {
+    it("returns a clean error when generateVideo is called before initialize", async () => {
+      const fresh = new FalProvider();
+      const result = await fresh.generateVideo("p", { prompt: "p" });
+      expect(result.status).toBe("failed");
+      expect(result.error).toMatch(/FAL_KEY/);
+    });
+  });
+});

--- a/packages/ai-providers/src/fal/FalProvider.ts
+++ b/packages/ai-providers/src/fal/FalProvider.ts
@@ -1,0 +1,205 @@
+import { createFalClient, type FalClient } from "@fal-ai/client";
+import type {
+  AIProvider,
+  AICapability,
+  ProviderConfig,
+  GenerateOptions,
+  VideoResult,
+} from "../interface/types.js";
+
+/**
+ * fal.ai endpoints for ByteDance Seedance 2.0.
+ *
+ * "No API" on the Artificial Analysis leaderboard means there is no
+ * direct ByteDance API — fal.ai is the gateway. Both quality and
+ * `fast` variants are exposed; the fast tier trades fidelity for
+ * latency and cost.
+ *
+ *   text-to-video         — Artificial Analysis ELO 1270 (#2)
+ *   image-to-video        — Artificial Analysis ELO 1347 (#2)
+ *
+ * Reference: https://artificialanalysis.ai/video/leaderboard/text-to-video
+ */
+export type SeedanceVariant = "seedance-2.0" | "seedance-2.0-fast";
+
+// Endpoint ids match fal.ai's documented JS-client form exactly. They
+// don't carry a `fal-ai/` prefix despite the URL slug suggesting one —
+// see https://fal.ai/models/bytedance/seedance-2.0/text-to-video.
+const ENDPOINT_TEXT_TO_VIDEO: Record<SeedanceVariant, string> = {
+  "seedance-2.0":      "bytedance/seedance-2.0/text-to-video",
+  "seedance-2.0-fast": "bytedance/seedance-2.0/fast/text-to-video",
+};
+
+const ENDPOINT_IMAGE_TO_VIDEO: Record<SeedanceVariant, string> = {
+  "seedance-2.0":      "bytedance/seedance-2.0/image-to-video",
+  "seedance-2.0-fast": "bytedance/seedance-2.0/fast/image-to-video",
+};
+
+const DEFAULT_VARIANT: SeedanceVariant = "seedance-2.0";
+
+/** Resolutions Seedance 2.0 accepts. The API rejects everything else. */
+const VALID_RESOLUTIONS = ["480p", "720p", "1080p"] as const;
+type SeedanceResolution = (typeof VALID_RESOLUTIONS)[number];
+
+/** Aspect ratios Seedance 2.0 accepts. */
+const VALID_ASPECTS = ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16", "auto"] as const;
+type SeedanceAspect = (typeof VALID_ASPECTS)[number];
+
+/** Shape of the video object Seedance returns. */
+interface SeedanceOutput {
+  video?: { url?: string; content_type?: string; file_size?: number };
+  seed?: number;
+}
+
+/**
+ * Provider hosting ByteDance Seedance 2.0 via fal.ai.
+ *
+ * Implements both `text-to-video` and `image-to-video` against the same
+ * underlying client. Uses `client.subscribe()` so the call blocks until
+ * the queue produces a final URL — avoids exposing the queue lifecycle
+ * to the rest of the codebase, which expects synchronous-feeling
+ * `generateVideo` semantics like the other providers.
+ *
+ * `generate_audio` defaults to `true` on the upstream API: Seedance
+ * synthesises native sound effects + speech alongside the video, so a
+ * narrated scene-render does NOT need our v0.55 ffmpeg audio mux to
+ * carry an audio track. Useful when the caller is happy to let the
+ * model compose the soundtrack.
+ */
+export class FalProvider implements AIProvider {
+  id = "fal";
+  name = "fal.ai (Seedance 2.0)";
+  description = "fal.ai hosting ByteDance Seedance 2.0 — Artificial Analysis #2 on both text-to-video and image-to-video leaderboards";
+  capabilities: AICapability[] = ["text-to-video", "image-to-video"];
+  iconUrl = "/icons/fal.svg";
+  isAvailable = true;
+
+  private client?: FalClient;
+  private apiKey?: string;
+
+  async initialize(config: ProviderConfig): Promise<void> {
+    this.apiKey = config.apiKey;
+    if (!this.apiKey) return;
+    this.client = createFalClient({ credentials: this.apiKey });
+  }
+
+  isConfigured(): boolean {
+    return !!this.apiKey && !!this.client;
+  }
+
+  /**
+   * Generate a video from a text prompt — or from a reference image when
+   * `options.referenceImage` is set (treated as an image-to-video
+   * request, routed to a different endpoint).
+   *
+   * fal.subscribe blocks until the final result is available. It also
+   * surfaces queue / log events through `onQueueUpdate`, which we drop
+   * silently for now — the CLI's existing spinner is the user-facing
+   * progress UI.
+   */
+  async generateVideo(
+    prompt: string,
+    options?: GenerateOptions,
+  ): Promise<VideoResult> {
+    if (!this.client) {
+      return {
+        id: "",
+        status: "failed",
+        error: "fal.ai API key not configured. Set FAL_KEY in .env.",
+      };
+    }
+
+    const variant = (options?.model as SeedanceVariant | undefined) ?? DEFAULT_VARIANT;
+    if (!Object.hasOwn(ENDPOINT_TEXT_TO_VIDEO, variant)) {
+      return {
+        id: "",
+        status: "failed",
+        error: `Unknown Seedance variant: ${variant}. Valid: ${Object.keys(ENDPOINT_TEXT_TO_VIDEO).join(", ")}.`,
+      };
+    }
+
+    const referenceImage = pickReferenceImageUrl(options?.referenceImage);
+    const isImageToVideo = !!referenceImage;
+    const endpointId = isImageToVideo
+      ? ENDPOINT_IMAGE_TO_VIDEO[variant]
+      : ENDPOINT_TEXT_TO_VIDEO[variant];
+
+    const aspect = normaliseAspect(options?.aspectRatio);
+    const resolution = normaliseResolution(options?.resolution);
+    const duration = normaliseDuration(options?.duration);
+
+    const input: Record<string, unknown> = {
+      prompt,
+      aspect_ratio: aspect,
+      resolution,
+      duration,
+    };
+    if (referenceImage) input.image_url = referenceImage;
+    if (options?.negativePrompt) input.negative_prompt = options.negativePrompt;
+    if (typeof options?.seed === "number") input.seed = options.seed;
+    if (options?.lastFrame) input.end_image_url = options.lastFrame;
+
+    try {
+      const out = await this.client.subscribe(endpointId, { input, logs: false });
+      const data = (out?.data ?? {}) as SeedanceOutput;
+      const url = data.video?.url;
+      if (!url) {
+        return {
+          id: typeof out?.requestId === "string" ? out.requestId : "",
+          status: "failed",
+          error: "fal.subscribe returned without a video URL",
+        };
+      }
+      return {
+        id: typeof out?.requestId === "string" ? out.requestId : "",
+        status: "completed",
+        videoUrl: url,
+        progress: 100,
+      };
+    } catch (err) {
+      return {
+        id: "",
+        status: "failed",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+}
+
+/**
+ * Accept the same `referenceImage` shapes other providers do. fal.ai
+ * needs an HTTPS URL — base64 / Blob isn't supported here yet (callers
+ * that have only a local file should upload it via fal.storage first,
+ * which we leave as a follow-up).
+ */
+function pickReferenceImageUrl(input: unknown): string | undefined {
+  if (typeof input !== "string") return undefined;
+  if (input.startsWith("http://") || input.startsWith("https://")) return input;
+  return undefined;
+}
+
+function normaliseAspect(value?: string): SeedanceAspect {
+  if (!value) return "auto";
+  return (VALID_ASPECTS as readonly string[]).includes(value)
+    ? (value as SeedanceAspect)
+    : "auto";
+}
+
+function normaliseResolution(value?: string): SeedanceResolution {
+  if (!value) return "720p";
+  if ((VALID_RESOLUTIONS as readonly string[]).includes(value)) {
+    return value as SeedanceResolution;
+  }
+  // Map common aliases the CLI surfaces elsewhere.
+  if (value === "4k") return "1080p";
+  return "720p";
+}
+
+function normaliseDuration(value?: number): number | "auto" {
+  if (typeof value !== "number") return "auto";
+  if (!Number.isFinite(value)) return "auto";
+  // Seedance accepts 4–15s; clamp anything outside.
+  return Math.max(4, Math.min(15, Math.round(value)));
+}
+
+export const falProvider = new FalProvider();

--- a/packages/ai-providers/src/fal/index.ts
+++ b/packages/ai-providers/src/fal/index.ts
@@ -1,0 +1,1 @@
+export * from "./FalProvider.js";

--- a/packages/ai-providers/src/index.ts
+++ b/packages/ai-providers/src/index.ts
@@ -31,6 +31,8 @@ export { KlingProvider, klingProvider } from "./kling/index.js";
 export type { KlingVideoExtendOptions } from "./kling/index.js";
 export { GrokProvider, grokProvider } from "./grok/index.js";
 export type { GrokModel, GrokVideoOptions, GrokImageOptions, GrokEditOptions } from "./grok/index.js";
+export { FalProvider, falProvider } from "./fal/index.js";
+export type { SeedanceVariant } from "./fal/index.js";
 export { ReplicateProvider, replicateProvider } from "./replicate/index.js";
 export type { ReplicateUpscaleOptions, ReplicateUpscaleResult, ReplicateInpaintOptions, MusicGenerationOptions, MusicGenerationResult, AudioRestorationOptions, AudioRestorationResult } from "./replicate/index.js";
 // Re-export commonly used types

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -38,6 +38,7 @@ import {
   ReplicateProvider,
   ClaudeProvider,
   GrokProvider,
+  FalProvider,
 } from "@vibeframe/ai-providers";
 import { requireApiKey, hasApiKey } from "../utils/api-key.js";
 import { hasTTY, prompt as promptText } from "../utils/tty.js";
@@ -523,7 +524,7 @@ generateCommand
   .alias("vid")
   .description("Generate video using AI (Kling, Runway, Veo, or Grok)")
   .argument("[prompt]", "Text prompt describing the video (interactive if omitted)")
-  .option("-p, --provider <provider>", "Provider: grok (default), kling, runway, veo", "grok")
+  .option("-p, --provider <provider>", "Provider: grok (default), kling, runway, veo, fal (Seedance 2.0)", "grok")
   .option("-k, --api-key <key>", "API key (or set XAI_API_KEY / RUNWAY_API_SECRET / KLING_API_KEY / GOOGLE_API_KEY env)")
   .option("-o, --output <path>", "Output file path (downloads video)")
   .option("-i, --image <path>", "Reference image for image-to-video")
@@ -574,6 +575,7 @@ Examples:
       // Auto-fallback: if default provider's key is missing, find one that works
       const videoEnvMap: Record<string, string> = {
         grok: "XAI_API_KEY", veo: "GOOGLE_API_KEY", kling: "KLING_API_KEY", runway: "RUNWAY_API_SECRET",
+        fal: "FAL_KEY",
       };
       if (videoEnvMap[provider] && !hasApiKey(videoEnvMap[provider]) && !options.apiKey) {
         const resolved = resolveProvider("video");
@@ -894,6 +896,46 @@ Examples:
           },
           300000
         );
+      } else if (provider === "fal") {
+        // fal.ai → ByteDance Seedance 2.0 (Artificial Analysis #2 on
+        // both video leaderboards). The fal client's `subscribe` blocks
+        // until the queue produces a final URL, so we don't need a
+        // separate wait/poll loop like the other providers.
+        const fal = new FalProvider();
+        await fal.initialize({ apiKey });
+
+        // Seedance 2.0 image-to-video needs an HTTPS URL. base64 / data
+        // URIs aren't accepted, so reuse the same ImgBB upload trick
+        // Kling uses when an image was passed via `-i`.
+        let falImage = referenceImage;
+        if (falImage && falImage.startsWith("data:")) {
+          spinner.text = "Uploading image to ImgBB for fal...";
+          const imgbbKey = (await getApiKeyFromConfig("imgbb")) || process.env.IMGBB_API_KEY;
+          if (!imgbbKey) {
+            spinner.fail("ImgBB API key required for fal image-to-video");
+            exitWithError(authError("IMGBB_API_KEY", "ImgBB"));
+          }
+          const base64Data = falImage.split(",")[1];
+          const imageBuffer = Buffer.from(base64Data, "base64");
+          const uploadResult = await uploadToImgbb(imageBuffer, imgbbKey);
+          if (!uploadResult.success || !uploadResult.url) {
+            spinner.fail("ImgBB upload failed");
+            exitWithError(apiError(`ImgBB upload failed: ${uploadResult.error}`, true));
+          }
+          falImage = uploadResult.url;
+        }
+
+        spinner.text = "Generating video with Seedance 2.0 (this may take 1-3 minutes)...";
+        const falModel = options.model === "fast" ? "seedance-2.0-fast" : "seedance-2.0";
+        result = await fal.generateVideo(prompt, {
+          prompt,
+          referenceImage: falImage,
+          duration: options.duration ? parseInt(options.duration) : undefined,
+          aspectRatio: options.ratio as "16:9" | "9:16" | "1:1" | "4:5",
+          negativePrompt: options.negative,
+          model: falModel,
+        });
+        finalResult = result;
       }
 
       if (!finalResult || finalResult.status !== "completed") {

--- a/packages/cli/src/utils/provider-resolver.ts
+++ b/packages/cli/src/utils/provider-resolver.ts
@@ -30,7 +30,22 @@ const IMAGE_PROVIDERS: ProviderCandidate[] = [
   { name: "grok", envVar: "XAI_API_KEY", label: "Grok" },
 ];
 
+// As of v0.57, fal.ai (Seedance 2.0) leads when its key is set —
+// Artificial Analysis ELO 1270 #2 on text-to-video, 1347 #2 on
+// image-to-video (the only model ahead of it on either chart is
+// Alibaba's HappyHorse-1.0 which has no public API).
+//
+//   text-to-video  Seedance 2.0  1270 (#2)  vs Grok 1230 (#6) → +40 ELO
+//   image-to-video Seedance 2.0  1347 (#2)  vs Grok 1327 (#3) → +20 ELO
+//
+// References:
+//   https://artificialanalysis.ai/video/leaderboard/text-to-video
+//   https://artificialanalysis.ai/video/leaderboard/image-to-video
+//
+// Users without a FAL_KEY fall through to Grok / Veo / Kling / Runway
+// in that order, so existing setups are unchanged.
 const VIDEO_PROVIDERS: ProviderCandidate[] = [
+  { name: "fal", envVar: "FAL_KEY", label: "fal.ai (Seedance 2.0)" },
   { name: "grok", envVar: "XAI_API_KEY", label: "Grok" },
   { name: "veo", envVar: "GOOGLE_API_KEY", label: "Veo" },
   { name: "kling", envVar: "KLING_API_KEY", label: "Kling" },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
 
   packages/ai-providers:
     dependencies:
+      '@fal-ai/client':
+        specifier: ^1.10.0
+        version: 1.10.0
       '@vibeframe/core':
         specifier: workspace:*
         version: link:../core
@@ -967,6 +970,10 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@fal-ai/client@1.10.0':
+    resolution: {integrity: sha512-sQWnBc6cdIzK8nFybrVKal0rLeJS2vqrrNxx4Hcc0SorndkfkMXL3TIAiIfiF/AlZuVoRpazpNg6n8K81WHzOQ==}
+    engines: {node: '>=18.0.0'}
+
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
@@ -1244,6 +1251,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@msgpack/msgpack@3.1.3':
+    resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
+    engines: {node: '>= 18'}
 
   '@next/env@14.2.25':
     resolution: {integrity: sha512-JnzQ2cExDeG7FxJwqAksZ3aqVJrHjFwZQAEJ9gQZSoEhIow7SNoKZzju/AwQ+PLIR4NY8V0rhcVozx/2izDO0w==}
@@ -2551,6 +2562,10 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
+  eventsource-parser@1.1.2:
+    resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
+    engines: {node: '>=14.18'}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -3550,6 +3565,9 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  robot3@0.4.1:
+    resolution: {integrity: sha512-hzjy826lrxzx8eRgv80idkf8ua1JAepRc9Efdtj03N3KNJuznQCPlyCJ7gnUmDFwZCLQjxy567mQVKmdv2BsXQ==}
+
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -4483,6 +4501,12 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@fal-ai/client@1.10.0':
+    dependencies:
+      '@msgpack/msgpack': 3.1.3
+      eventsource-parser: 1.1.2
+      robot3: 0.4.1
+
   '@floating-ui/core@1.7.4':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -4762,6 +4786,8 @@ snapshots:
     transitivePeerDependencies:
       - hono
       - supports-color
+
+  '@msgpack/msgpack@3.1.3': {}
 
   '@next/env@14.2.25': {}
 
@@ -6106,6 +6132,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
+  eventsource-parser@1.1.2: {}
+
   eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
@@ -7155,6 +7183,8 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
+
+  robot3@0.4.1: {}
 
   rollup@4.57.1:
     dependencies:


### PR DESCRIPTION
## Summary

Adds the missing top-tier video model. Artificial Analysis ranks ByteDance Seedance 2.0 at **#2 on both** video leaderboards:

| | Seedance 2.0 ELO | Previous default (Grok) |
|---|---|---|
| [text-to-video](https://artificialanalysis.ai/video/leaderboard/text-to-video) | **1270 (#2)** | 1230 (#6) |
| [image-to-video](https://artificialanalysis.ai/video/leaderboard/image-to-video) | **1347 (#2)** | 1327 (#3) |

The only model ahead of Seedance on either chart is Alibaba HappyHorse-1.0, which has no public API. ByteDance also has no direct API — **fal.ai is the gateway**.

## What ships

- New \`FalProvider\` wrapping \`@fal-ai/client@1.10.0\`. Uses \`client.subscribe()\` so generateVideo feels synchronous like the other providers (Kling, Grok, Veo, Runway).
- Two variants exposed:
  - \`-p fal\` → \`bytedance/seedance-2.0/text-to-video\` or \`/image-to-video\` based on \`-i\` flag
  - \`-p fal -m fast\` → \`/fast/...\` variant (lower latency, cheaper)
- \`VIDEO_PROVIDERS\` now leads with fal when \`FAL_KEY\` is set. Without the key the old fall-through (Grok → Veo → Kling → Runway) is unchanged.
- Image-to-video reuses Kling's auto-ImgBB-upload trick — Seedance only accepts HTTPS URLs.
- Reference-to-video variant deferred to v0.58 (needs multi-image option plumbing).

## End-to-end verification

Real call against fal.ai (Seedance 2.0 fast, 16:9, 4 s, prompt = "purple-to-teal orb pulsing in dark void"):

\`\`\`
request id 019dc5fb-5e08-7ef2-8875-726d426b0e31
videoUrl   https://v3b.fal.media/files/b/0a97b48b/lWDdgIinkWZhw7Mf0UHiC_video.mp4
elapsed    82 s
\`\`\`

## Test plan

- [x] **13 new unit tests** for \`FalProvider\` (endpoint routing, fast variant, duration clamp, aspect fallback, error paths, HTTPS-only image guard)
- [x] All \`@vibeframe/ai-providers\` tests pass (53/53 incl. existing 40)
- [x] All \`@vibeframe/cli\` tests pass (471/471 + 11 skipped)
- [x] \`pnpm build\` 6/6, \`pnpm lint\` 0 errors
- [x] **Real fal API end-to-end** — 82 s, MP4 returned (id above)

## Files

- \`packages/ai-providers/src/fal/FalProvider.ts\` — provider (~190 LOC)
- \`packages/ai-providers/src/fal/FalProvider.test.ts\` — 13 tests
- \`packages/ai-providers/src/fal/index.ts\` — barrel
- \`packages/ai-providers/src/index.ts\` — re-export
- \`packages/ai-providers/package.json\` — \`@fal-ai/client@^1.10.0\`
- \`packages/cli/src/utils/provider-resolver.ts\` — \`VIDEO_PROVIDERS\` lead
- \`packages/cli/src/commands/generate.ts\` — \`-p fal\` branch + ImgBB auto-upload
- \`MODELS.md\` — Seedance row + I2V table notes
- 7 \`package.json\` bumped 0.56.0 → 0.57.0
- \`CHANGELOG.md\` regenerated

Replaces #87 (auto-closed when its stacked base \`feat/gpt-image-2-default\` was deleted on #86 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)