### PR TITLE
fix(cli): allow -p fal in vibe generate video (v0.57.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.57.1] - 2026-04-25
+
+### Fixed
+
+- allow -p fal in vibe generate video (v0.57.1) *(cli)*
+
 ## [0.57.0] - 2026-04-25
 
 ### Added
 
-- default text-to-image to OpenAI gpt-image-2 (v0.56.0) *(image)*
+- add fal.ai provider hosting Seedance 2.0 (v0.57.0) (#88) *(fal)*
+
+## [0.56.0] - 2026-04-25
+
+### Added
+
+- default text-to-image to OpenAI gpt-image-2 (v0.56.0) (#86) *(image)*
 
 ### Documentation
 
@@ -17,12 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refresh /demo page with v0.55 self-promo + 3-surface section (#83) *(web)*
 - clearer quickstart + agent-mode + Claude Code walkthrough (#82) *(demos)*
 - vibe scene render vs npx hyperframes render (#81) *(comparison)*
-- asciinema quickstart embed in README (#79) *(demo)*
 
 ### Fixed
 
 - drop tail fade-out from announcement + simple presets (#85) *(scene)*
+
+## [0.55.2] - 2026-04-25
+
+### Documentation
+
+- asciinema quickstart embed in README (#79) *(demo)*
+
+### Fixed
+
 - auto TTS fallback to Kokoro + actionable FFmpeg message (v0.55.2) (#80) *(cli)*
+
+## [0.55.1] - 2026-04-25
+
+### Fixed
+
 - bundle CLI with esbuild so npm install actually works (v0.55.1) (#78) *(cli)*
 
 ## [0.55.0] - 2026-04-25

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -567,7 +567,7 @@ Examples:
       }
 
       let provider = options.provider.toLowerCase();
-      const validProviders = ["runway", "kling", "veo", "grok"];
+      const validProviders = ["runway", "kling", "veo", "grok", "fal"];
       if (!validProviders.includes(provider)) {
         exitWithError(usageError(`Invalid provider: ${provider}`, `Available providers: ${validProviders.join(", ")}`));
       }
@@ -641,12 +641,14 @@ Examples:
         kling: "KLING_API_KEY",
         veo: "GOOGLE_API_KEY",
         grok: "XAI_API_KEY",
+        fal: "FAL_KEY",
       };
       const providerNameMap: Record<string, string> = {
         runway: "Runway",
         kling: "Kling",
         veo: "Veo",
         grok: "Grok",
+        fal: "fal.ai (Seedance 2.0)",
       };
       const envKey = envKeyMap[provider];
       const providerName = providerNameMap[provider];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

v0.57.0 ships the FalProvider end-to-end *but* leaves \`fal\` out of the \`validProviders\` gate in \`vibe generate video\`. Result: passing \`-p fal\` explicitly bounces with

\`\`\`
"Available providers: runway, kling, veo, grok"
\`\`\`

even when \`FAL_KEY\` is set and the FalProvider branch right below it is fully wired.

Auto-fallback (no \`-p\` flag, \`FAL_KEY\` set, grok key absent) **was** working, which is why CI passed — only the explicit-flag path failed. Caught by a fresh-install end-to-end smoke against \`@vibeframe/cli@0.57.0\` from npm.

## Patch

- adds \`"fal"\` to \`validProviders\`
- adds \`fal\` entries to \`envKeyMap\` and \`providerNameMap\` so the existing \`requireApiKey\` / spinner UX show the friendly label

## End-to-end verification (post-fix)

Real call against fal.ai (\`-p fal -m fast -d 4 -r 16:9\`, prompt = "purple-to-teal orb pulsing in dark void"):

\`\`\`
request id 019dc623-07b8-7431-ae08-729b8bc73c2f
videoUrl   https://v3b.fal.media/files/b/0a97b590/lMsrnATUZJHxM-9f3YwpC_video.mp4
elapsed    92 s
\`\`\`

## Test plan

- [x] \`pnpm -F @vibeframe/cli build\` ✓
- [x] \`pnpm -F @vibeframe/cli lint\` 0 errors
- [x] \`pnpm -F @vibeframe/cli test --run\` — 471/471 + 11 skipped
- [x] **Real fal API end-to-end** — 92 s, MP4 returned (id above)
- [x] \`@vibeframe/cli@0.57.0\` fresh-install repro before fix → "Invalid provider: fal"
- [x] Local bundle after fix → success

## Known follow-up

Same gap exists in v0.56's image flow: Commander default \`-p\` is \`gemini\`, so users with **both** \`OPENAI_API_KEY\` + \`GOOGLE_API_KEY\` still default to gemini despite gpt-image-2 leading IMAGE_PROVIDERS. Same logic in video — users with both \`FAL_KEY\` + \`XAI_API_KEY\` still default to grok. This patch does NOT change those defaults — flagging for a follow-up since it's a behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)