### PR TITLE
fix(cli): provider priority resolves correctly when multiple keys are set (v0.57.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.57.2] - 2026-04-25
+
+### Fixed
+
+- provider priority resolves correctly when multiple keys are set (v0.57.2) *(cli)*
+
 ## [0.57.1] - 2026-04-25
 
 ### Fixed
 
-- allow -p fal in vibe generate video (v0.57.1) *(cli)*
+- allow -p fal in vibe generate video (v0.57.1) (#89) *(cli)*
 
 ## [0.57.0] - 2026-04-25
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -114,7 +114,7 @@ generateCommand
   .alias("img")
   .description("Generate image using AI (Gemini, DALL-E, or Runway)")
   .argument("[prompt]", "Image description prompt (interactive if omitted)")
-  .option("-p, --provider <provider>", "Provider: gemini, openai, grok, runway (dalle is deprecated)", "gemini")
+  .option("-p, --provider <provider>", "Provider: openai (default when OPENAI_API_KEY set), gemini, grok, runway (dalle is deprecated)")
   .option("-k, --api-key <key>", "API key (or set env: OPENAI_API_KEY, GOOGLE_API_KEY)")
   .option("-o, --output <path>", "Output file path (downloads image)")
   .option("-s, --size <size>", "Image size (openai: 1024x1024, 1536x1024, 1024x1536)", "1024x1024")
@@ -149,22 +149,32 @@ Examples:
         validateOutputPath(options.output);
       }
 
-      // Auto-resolve provider if user didn't explicitly set one
-      let provider = options.provider.toLowerCase();
+      // Resolve provider:
+      //  - explicit -p flag wins (validated, then key-presence checked)
+      //  - no flag → IMAGE_PROVIDERS priority list (openai > gemini > grok)
+      //  - if no keys at all → keep gemini as last-resort default so the
+      //    later requireApiKey() prints a friendly Gemini-specific message
       const validProviders = ["openai", "dalle", "gemini", "grok", "runway"];
-      if (!validProviders.includes(provider)) {
-        exitWithError(usageError(`Invalid provider: ${provider}`, `Available providers: openai, gemini, grok, runway`));
-      }
-      // Auto-fallback: if default provider's key is missing, find one that works
       const providerEnvMap: Record<string, string> = {
         gemini: "GOOGLE_API_KEY", openai: "OPENAI_API_KEY", grok: "XAI_API_KEY",
       };
-      if (providerEnvMap[provider] && !hasApiKey(providerEnvMap[provider]) && !options.apiKey) {
-        const resolved = resolveProvider("image");
-        if (resolved) {
-          log(chalk.dim(`  ${provider} key not found. Using ${resolved.label} instead.`));
-          provider = resolved.name;
+      let provider: string;
+      if (options.provider) {
+        provider = options.provider.toLowerCase();
+        if (!validProviders.includes(provider)) {
+          exitWithError(usageError(`Invalid provider: ${provider}`, `Available providers: openai, gemini, grok, runway`));
         }
+        // Explicit choice's key missing → fall back via resolver
+        if (providerEnvMap[provider] && !hasApiKey(providerEnvMap[provider]) && !options.apiKey) {
+          const resolved = resolveProvider("image");
+          if (resolved) {
+            log(chalk.dim(`  ${provider} key not found. Using ${resolved.label} instead.`));
+            provider = resolved.name;
+          }
+        }
+      } else {
+        const resolved = resolveProvider("image");
+        provider = resolved?.name ?? "gemini";
       }
 
       // Show deprecation warning for "dalle"
@@ -524,7 +534,7 @@ generateCommand
   .alias("vid")
   .description("Generate video using AI (Kling, Runway, Veo, or Grok)")
   .argument("[prompt]", "Text prompt describing the video (interactive if omitted)")
-  .option("-p, --provider <provider>", "Provider: grok (default), kling, runway, veo, fal (Seedance 2.0)", "grok")
+  .option("-p, --provider <provider>", "Provider: fal (Seedance 2.0, default when FAL_KEY set), grok, kling, runway, veo")
   .option("-k, --api-key <key>", "API key (or set XAI_API_KEY / RUNWAY_API_SECRET / KLING_API_KEY / GOOGLE_API_KEY env)")
   .option("-o, --output <path>", "Output file path (downloads video)")
   .option("-i, --image <path>", "Reference image for image-to-video")
@@ -566,23 +576,32 @@ Examples:
         validateOutputPath(options.output);
       }
 
-      let provider = options.provider.toLowerCase();
+      // Resolve provider:
+      //  - explicit -p flag wins (validated, then key-presence checked)
+      //  - no flag → VIDEO_PROVIDERS priority list (fal > grok > veo > kling > runway)
+      //  - if no keys at all → keep grok as last-resort default so the
+      //    later requireApiKey() prints a friendly Grok-specific message
       const validProviders = ["runway", "kling", "veo", "grok", "fal"];
-      if (!validProviders.includes(provider)) {
-        exitWithError(usageError(`Invalid provider: ${provider}`, `Available providers: ${validProviders.join(", ")}`));
-      }
-
-      // Auto-fallback: if default provider's key is missing, find one that works
       const videoEnvMap: Record<string, string> = {
         grok: "XAI_API_KEY", veo: "GOOGLE_API_KEY", kling: "KLING_API_KEY", runway: "RUNWAY_API_SECRET",
         fal: "FAL_KEY",
       };
-      if (videoEnvMap[provider] && !hasApiKey(videoEnvMap[provider]) && !options.apiKey) {
-        const resolved = resolveProvider("video");
-        if (resolved) {
-          log(chalk.dim(`  ${provider} key not found. Using ${resolved.label} instead.`));
-          provider = resolved.name;
+      let provider: string;
+      if (options.provider) {
+        provider = options.provider.toLowerCase();
+        if (!validProviders.includes(provider)) {
+          exitWithError(usageError(`Invalid provider: ${provider}`, `Available providers: ${validProviders.join(", ")}`));
         }
+        if (videoEnvMap[provider] && !hasApiKey(videoEnvMap[provider]) && !options.apiKey) {
+          const resolved = resolveProvider("video");
+          if (resolved) {
+            log(chalk.dim(`  ${provider} key not found. Using ${resolved.label} instead.`));
+            provider = resolved.name;
+          }
+        }
+      } else {
+        const resolved = resolveProvider("video");
+        provider = resolved?.name ?? "grok";
       }
 
       // Read image early so we can auto-detect aspect ratio before dry-run

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Problem

v0.56 promoted gpt-image-2 to #1 in \`IMAGE_PROVIDERS\` and v0.57 promoted fal/Seedance to #1 in \`VIDEO_PROVIDERS\` — but Commander's hardcoded \`-p\` defaults (\`"gemini"\` for image, \`"grok"\` for video) still **won the priority race for users with multiple keys configured**.

The resolver (\`resolveProvider()\`) was only consulted when the default provider's key was *missing*. So a user with both \`OPENAI_API_KEY\` + \`GOOGLE_API_KEY\` kept landing on gemini, and one with \`FAL_KEY\` + \`XAI_API_KEY\` kept landing on grok — the **opposite** of what the v0.56 / v0.57 release notes documented.

Caught while finishing the v0.57.1 fresh-install verification.

## Fix

Restructured \`vibe generate image\` and \`vibe generate video\` to:

1. **Drop the hardcoded \`-p\` default** in the Commander option declaration
2. **No \`-p\` flag** → consult \`resolveProvider()\` first (the documented priority list)
3. **Explicit \`-p\`** → validate, then fall through to the existing key-fallback path
4. **No keys at all** → fall back to the legacy default (\`"gemini"\` / \`"grok"\`) so the existing \`requireApiKey()\` prints a useful per-provider error rather than a generic one

## Behavior matrix (verified via \`--dry-run\`)

| Scenario | Before | After |
|---|---|---|
| video, no \`-p\`, FAL + XAI both set | grok ❌ | **fal** ✅ |
| image, no \`-p\`, OPENAI + GOOGLE both set | gemini ❌ | **openai** ✅ |
| video \`-p grok\` (explicit) | grok | grok (unchanged) |
| image \`-p gemini\` (explicit) | gemini | gemini (unchanged) |
| video \`-p kling\`, no KLING_API_KEY | resolver fallback | resolver fallback (unchanged) |
| no keys at all | grok / gemini error | grok / gemini error (unchanged) |

## Test plan

- [x] \`pnpm -F @vibeframe/cli build\` ✓
- [x] \`pnpm -F @vibeframe/cli lint\` 0 errors
- [x] \`pnpm -F @vibeframe/cli test --run\` — 471/471 + 11 skipped
- [x] All 6 scenarios above verified with real env (FAL_KEY, XAI_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY all set)

## Why patch (0.57.2), not minor

The v0.56 / v0.57 release notes already advertised gpt-image-2 / Seedance as the new defaults. Current behavior is a regression from documented intent — fixing it aligns code with what users were already told to expect, so SemVer-patch is appropriate.

## Files

- \`packages/cli/src/commands/generate.ts\` — restructured image + video provider resolution (~45 LOC)
- 7 \`package.json\` bumped 0.57.1 → 0.57.2
- \`CHANGELOG.md\` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)