### PR TITLE
fix(cli): refresh onboarding for fal + Kokoro defaults (v0.57.3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,45 +1,47 @@
 # VibeEdit Environment Variables
 # Copy this file to .env and fill in your API keys
 
-# OpenAI API Key (for Whisper transcription)
+# OpenAI API Key (Whisper transcription, gpt-image-2 — default text-to-image since v0.56)
 # Get yours at: https://platform.openai.com/api-keys
 OPENAI_API_KEY=
 
-# Google API Key (for Gemini auto-edit suggestions)
+# Google API Key (Gemini auto-edit suggestions, image gen, Veo video)
 # Get yours at: https://aistudio.google.com/apikey
 GOOGLE_API_KEY=
 
-# Anthropic API Key (for Claude motion graphics & storyboarding)
+# Anthropic API Key (Claude motion graphics & storyboarding)
 # Get yours at: https://console.anthropic.com/
 ANTHROPIC_API_KEY=
 
-# ElevenLabs API Key (for text-to-speech)
+# ElevenLabs API Key (text-to-speech — Kokoro local fallback runs when this is unset, since v0.54)
 # Get yours at: https://elevenlabs.io/api
 ELEVENLABS_API_KEY=
 
-# Runway API Secret (for video generation)
+# fal.ai API Key (Seedance 2.0 video — default text/image-to-video since v0.57, Artificial Analysis ELO #2)
+# Get yours at: https://fal.ai/dashboard/keys
+FAL_KEY=
+
+# xAI API Key (Grok video generation — fallback when no FAL_KEY)
+# Get yours at: https://console.x.ai/
+XAI_API_KEY=
+
+# Runway API Secret (Runway Gen-4.5 video generation)
 # Get yours at: https://app.runwayml.com/settings/api-keys
 RUNWAY_API_SECRET=
 
-# Kling API Key (for video generation)
+# Kling API Key (Kling video generation)
 # Format: ACCESS_KEY:SECRET_KEY
 # Get yours at: https://platform.klingai.com/
 KLING_API_KEY=
 
-# xAI API Key (for Grok Imagine video generation)
-# Get yours at: https://console.x.ai/
-XAI_API_KEY=
-
-# Replicate API Token (for music generation, video upscale, audio restoration)
+# Replicate API Token (music generation, video upscale, audio restoration)
 # Get yours at: https://replicate.com/account/api-tokens
 REPLICATE_API_TOKEN=
 
-# OpenRouter API Key (for accessing 300+ AI models via unified API)
+# OpenRouter API Key (300+ AI models via unified API, used by `vibe agent`)
 # Get yours at: https://openrouter.ai/keys
 OPENROUTER_API_KEY=
 
-# ImgBB API Key (for image hosting - used by Kling image-to-video)
+# ImgBB API Key (image hosting — used by Kling and fal.ai for image-to-video uploads)
 # Get yours at: https://api.imgbb.com/
 IMGBB_API_KEY=
-
-FAL_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.57.3] - 2026-04-25
+
+### Fixed
+
+- refresh onboarding for fal + Kokoro defaults (v0.57.3) *(cli)*
+
 ## [0.57.2] - 2026-04-25
 
 ### Fixed
 
-- provider priority resolves correctly when multiple keys are set (v0.57.2) *(cli)*
+- provider priority resolves correctly when multiple keys are set (v0.57.2) (#90) *(cli)*
 
 ## [0.57.1] - 2026-04-25
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -42,8 +42,13 @@ const COMMAND_KEY_MAP: Record<string, string[]> = {
   XAI_API_KEY: [
     "agent -p xai",
     "generate image -p grok",
-    "generate video",
+    "generate video -p grok",
     "edit image -p grok",
+  ],
+  FAL_KEY: [
+    "generate video -p fal (Seedance 2.0 — default since v0.57)",
+    "generate video -p fal -m fast (lower-latency variant)",
+    "generate video -p fal -i <image> (image-to-video)",
   ],
   ELEVENLABS_API_KEY: [
     "generate speech",
@@ -56,7 +61,7 @@ const COMMAND_KEY_MAP: Record<string, string[]> = {
   KLING_API_KEY: ["generate video -p kling"],
   RUNWAY_API_SECRET: ["generate video -p runway"],
   REPLICATE_API_TOKEN: ["generate music -p replicate"],
-  IMGBB_API_KEY: ["generate video -p kling (image-to-video)"],
+  IMGBB_API_KEY: ["generate video -p kling/fal (image-to-video upload host)"],
 };
 
 /** Commands that need no API key (FFmpeg only) */

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -90,25 +90,25 @@ const AI_FEATURES: AIFeature[] = [
   {
     label: "Images",
     desc: "generate + edit",
-    defaultProvider: "Gemini Nano Banana",
-    alsoAvailable: "OpenAI GPT Image, Grok Imagine",
-    keys: [{ configKey: "google", envVar: "GOOGLE_API_KEY", name: "Google", url: "https://aistudio.google.com/apikey", what: "Gemini image generation + editing + video analysis" }],
+    defaultProvider: "OpenAI gpt-image-2 (Artificial Analysis #1, since v0.56)",
+    alsoAvailable: "Gemini Nano Banana, Grok Imagine",
+    keys: [{ configKey: "openai", envVar: "OPENAI_API_KEY", name: "OpenAI", url: "https://platform.openai.com/api-keys", what: "gpt-image-2 image generation + editing (also Whisper, Agent)" }],
     tryCommand: 'vibe generate image "a sunset over mountains" -o test.png',
   },
   {
     label: "Videos",
     desc: "generate + extend",
-    defaultProvider: "Grok Imagine (native audio)",
-    alsoAvailable: "Kling, Runway Gen-4.5, Google Veo",
-    keys: [{ configKey: "xai", envVar: "XAI_API_KEY", name: "xAI", url: "https://console.x.ai", what: "Grok video generation with native audio" }],
+    defaultProvider: "fal.ai Seedance 2.0 (Artificial Analysis #2 t2v + i2v, since v0.57)",
+    alsoAvailable: "Grok Imagine, Kling, Runway Gen-4.5, Google Veo",
+    keys: [{ configKey: "fal", envVar: "FAL_KEY", name: "fal.ai", url: "https://fal.ai/dashboard/keys", what: "ByteDance Seedance 2.0 text-to-video and image-to-video" }],
     tryCommand: 'vibe generate video "ocean waves" -o waves.mp4',
   },
   {
     label: "Audio",
     desc: "TTS, SFX, music, voice clone",
-    defaultProvider: "ElevenLabs",
+    defaultProvider: "ElevenLabs (paid, premium quality) — falls back to local Kokoro when no key (free, since v0.54)",
     alsoAvailable: "Replicate MusicGen (music only)",
-    keys: [{ configKey: "elevenlabs", envVar: "ELEVENLABS_API_KEY", name: "ElevenLabs", url: "https://elevenlabs.io/app/settings/api-keys", what: "Text-to-speech, sound effects, music, voice cloning" }],
+    keys: [{ configKey: "elevenlabs", envVar: "ELEVENLABS_API_KEY", name: "ElevenLabs", url: "https://elevenlabs.io/app/settings/api-keys", what: "Text-to-speech, sound effects, music, voice cloning (skip to use local Kokoro)" }],
     tryCommand: 'vibe generate speech "Hello world" -o hello.mp3',
   },
   {
@@ -178,9 +178,9 @@ async function runSetupWizard(fullSetup = false): Promise<void> {
     config.llm.provider = "claude";
     const pipelineKeys: AIFeatureKey[] = [
       { configKey: "anthropic", envVar: "ANTHROPIC_API_KEY", name: "Anthropic", url: "https://console.anthropic.com/settings/keys", what: "Claude — storyboard generation + reasoning" },
-      { configKey: "google", envVar: "GOOGLE_API_KEY", name: "Google", url: "https://aistudio.google.com/apikey", what: "Gemini — image generation + video analysis" },
-      { configKey: "elevenlabs", envVar: "ELEVENLABS_API_KEY", name: "ElevenLabs", url: "https://elevenlabs.io/app/settings/api-keys", what: "Text-to-speech narration + music" },
-      { configKey: "xai", envVar: "XAI_API_KEY", name: "xAI", url: "https://console.x.ai", what: "Grok — video generation with native audio" },
+      { configKey: "openai", envVar: "OPENAI_API_KEY", name: "OpenAI", url: "https://platform.openai.com/api-keys", what: "gpt-image-2 image generation (default since v0.56) + Whisper word-level transcribe" },
+      { configKey: "fal", envVar: "FAL_KEY", name: "fal.ai", url: "https://fal.ai/dashboard/keys", what: "Seedance 2.0 — video generation, default since v0.57" },
+      { configKey: "elevenlabs", envVar: "ELEVENLABS_API_KEY", name: "ElevenLabs", url: "https://elevenlabs.io/app/settings/api-keys", what: "Text-to-speech narration + music (skip to use local Kokoro)" },
     ];
 
     console.log(chalk.dim("Step 2 of 2"));
@@ -352,11 +352,12 @@ async function runCustomSetup(config: Awaited<ReturnType<typeof loadConfig>> & o
   console.log();
 
   const allProviders = [
+    { key: "openai", name: "OpenAI", env: "OPENAI_API_KEY", desc: "gpt-image-2 image gen ($, default since v0.56), Whisper transcribe, Agent" },
     { key: "anthropic", name: "Anthropic", env: "ANTHROPIC_API_KEY", desc: "Claude — storyboard, color grade, reframe, Agent ($)" },
-    { key: "openai", name: "OpenAI", env: "OPENAI_API_KEY", desc: "Whisper (captions, jump-cut $), GPT Image ($), Agent" },
+    { key: "fal", name: "fal.ai", env: "FAL_KEY", desc: "Seedance 2.0 video gen ($$, default since v0.57)" },
     { key: "google", name: "Google", env: "GOOGLE_API_KEY", desc: "Gemini — image gen (free tier), video analysis ($), Veo ($$)" },
     { key: "xai", name: "xAI", env: "XAI_API_KEY", desc: "Grok — video gen with audio ($$), image ($), Agent" },
-    { key: "elevenlabs", name: "ElevenLabs", env: "ELEVENLABS_API_KEY", desc: "TTS ($), SFX, music, voice clone, dubbing" },
+    { key: "elevenlabs", name: "ElevenLabs", env: "ELEVENLABS_API_KEY", desc: "TTS ($), SFX, music, voice clone, dubbing — skip to use local Kokoro" },
     { key: "runway", name: "Runway", env: "RUNWAY_API_SECRET", desc: "Gen-4.5 video generation ($$)" },
     { key: "kling", name: "Kling", env: "KLING_API_KEY", desc: "v2.5/v3 video — std ($$) and pro ($$$) modes" },
     { key: "openrouter", name: "OpenRouter", env: "OPENROUTER_API_KEY", desc: "300+ models via one key — Agent only (pay per model)" },
@@ -507,6 +508,7 @@ async function showConfig(): Promise<void> {
     { key: "openai", name: "OpenAI", env: "OPENAI_API_KEY" },
     { key: "google", name: "Google", env: "GOOGLE_API_KEY" },
     { key: "xai", name: "xAI", env: "XAI_API_KEY" },
+    { key: "fal", name: "fal.ai", env: "FAL_KEY" },
     { key: "elevenlabs", name: "ElevenLabs", env: "ELEVENLABS_API_KEY" },
     { key: "runway", name: "Runway", env: "RUNWAY_API_SECRET" },
     { key: "kling", name: "Kling", env: "KLING_API_KEY" },

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -23,6 +23,7 @@ export interface VibeConfig {
     elevenlabs?: string;
     runway?: string;
     kling?: string;
+    fal?: string;
     imgbb?: string;
     replicate?: string;
     xai?: string;
@@ -36,7 +37,7 @@ export interface VibeConfig {
     /** Default provider for image generation */
     imageProvider?: "gemini" | "openai" | "grok";
     /** Default provider for video generation */
-    videoProvider?: "grok" | "kling" | "runway" | "veo";
+    videoProvider?: "fal" | "grok" | "kling" | "runway" | "veo";
     /** Default provider for storyboard analysis */
     storyboardProvider?: "claude" | "openai" | "gemini";
     /** Default voice for TTS */
@@ -68,6 +69,7 @@ export const PROVIDER_ENV_VARS: Record<string, string> = {
   elevenlabs: "ELEVENLABS_API_KEY",
   runway: "RUNWAY_API_SECRET",
   kling: "KLING_API_KEY",
+  fal: "FAL_KEY",
   imgbb: "IMGBB_API_KEY",
   replicate: "REPLICATE_API_TOKEN",
   xai: "XAI_API_KEY",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Problem

The onboarding surfaces (\`vibe setup\`, \`vibe doctor\`, \`.env.example\`, config schema) were never updated when fal.ai/Seedance 2.0 became the **video default in v0.57** or when Kokoro local TTS became the **keyless TTS fallback in v0.54**.

Concrete user-visible regressions:

- \`vibe setup\` wizard kept calling Gemini Nano Banana the image default (v0.56 promoted gpt-image-2) and Grok the video default (v0.57 promoted Seedance 2.0)
- \`vibe setup --show\` and \`runCustomSetup()\` had **no row for FAL_KEY** — users couldn't see/save it through the wizard
- \`~/.vibeframe/config.yaml\` schema had **no \`providers.fal\` field** and the \`defaults.videoProvider\` enum rejected \`"fal"\`
- \`vibe doctor\` had **no FAL_KEY entry** in \`COMMAND_KEY_MAP\` — didn't list any fal-related commands
- \`.env.example\` had a bare \`FAL_KEY=\` line with no comment, while every other key had a "what / where" header

## What changes

| File | Change |
|---|---|
| \`.env.example\` | Full FAL_KEY block (v0.57 + AA #2 context); reordered logically; ImgBB note now mentions fal |
| \`packages/cli/src/config/schema.ts\` | \`providers.fal?: string\`, \`videoProvider\` includes \`"fal"\`, \`PROVIDER_ENV_VARS.fal = FAL_KEY\` |
| \`packages/cli/src/commands/setup.ts\` (AI_FEATURES) | Image → OpenAI gpt-image-2 default · Video → fal Seedance 2.0 default · Audio → Kokoro local fallback note |
| \`packages/cli/src/commands/setup.ts\` (full-pipeline preset) | Key bundle includes FAL_KEY, drops implicit Grok-as-video assumption |
| \`packages/cli/src/commands/setup.ts\` (custom setup + showConfig) | \`allProviders\` + \`providerKeys\` lists include fal |
| \`packages/cli/src/commands/doctor.ts\` | \`COMMAND_KEY_MAP.FAL_KEY\` with t2v / \`-m fast\` / i2v entries; IMGBB hint mentions fal i2v |

## End-to-end verification

\`\`\`
$ vibe doctor --json | jq '.result.providers.fal'
{
  "envVar": "FAL_KEY",
  "configured": true,
  "commands": [
    "generate video -p fal (Seedance 2.0 — default since v0.57)",
    "generate video -p fal -m fast (lower-latency variant)",
    "generate video -p fal -i <image> (image-to-video)"
  ]
}

$ vibe setup --show | grep fal
  ✓ fal.ai       463c********e1f9 (.env)
\`\`\`

## Test plan

- [x] \`pnpm -F @vibeframe/cli build\` ✓
- [x] \`pnpm -F @vibeframe/cli lint\` 0 errors
- [x] \`pnpm -F @vibeframe/cli test --run\` — 471/471 + 11 skipped
- [x] \`vibe doctor --json\` shows fal entry
- [x] \`vibe setup --show\` shows fal.ai row

## Coordination

Stacks alongside #91 (docs refresh) without overlap — different file sets:
- #91 → \`README.md\`, \`apps/web/app/page.tsx\`
- This PR → \`.env.example\`, \`packages/cli/src/{commands,config}\`

Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)