### PR TITLE
fix(counts): MCP tool count is 58, not 59 (test fixtures over-count)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VibeFrame
 
-**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 59 MCP tools bundled.
+**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 58 MCP tools bundled.
 
 [![GitHub stars](https://img.shields.io/github/stars/vericontext/vibeframe)](https://github.com/vericontext/vibeframe/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -207,7 +207,7 @@ Prefer manual install? Copy [`.claude/skills/`](https://github.com/vericontext/v
 
 ## MCP Integration (Claude Desktop / Cursor)
 
-The CLI is the primary interface; MCP is the gateway for Claude Desktop & Cursor users (59 MCP tools exposed). No clone needed — add to your config and restart:
+The CLI is the primary interface; MCP is the gateway for Claude Desktop & Cursor users (58 MCP tools exposed). No clone needed — add to your config and restart:
 
 ```json
 {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,7 +11,7 @@ const inter = Inter({ subsets: ["latin"] });
 // directory listing + MCP tool name regex), so they stay in sync with the
 // source. Falls back to the post-v0.57 numbers if env var lookup fails.
 const AI_PROVIDERS = process.env.NEXT_PUBLIC_AI_PROVIDERS ?? "13";
-const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "59";
+const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "58";
 const SHARE_DESCRIPTION = `YAML pipelines, ${AI_PROVIDERS} AI providers, ${MCP_TOOLS} MCP tools bundled. Ship videos, not clicks.`;
 
 export const metadata: Metadata = {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -7,7 +7,13 @@ const pkg = require("./package.json");
 function countPattern(dir, pattern) {
   let total = 0;
   try {
-    const files = fs.readdirSync(dir).filter((f) => f.endsWith(".ts"));
+    // Exclude *.test.ts — fixture strings in tests (e.g. `name: "intro"`
+    // inside a handleSceneToolCall arg) get caught by the production regex
+    // and over-count by 1+. The MCP server actually registers 58 tools at
+    // runtime, not 59.
+    const files = fs.readdirSync(dir).filter(
+      (f) => f.endsWith(".ts") && !f.endsWith(".test.ts"),
+    );
     for (const file of files) {
       const content = fs.readFileSync(path.join(dir, file), "utf8");
       const matches = content.match(new RegExp(pattern, "g"));

--- a/scripts/sync-counts.sh
+++ b/scripts/sync-counts.sh
@@ -40,8 +40,12 @@ fi
 # `interface` (the type-only folder that defines the AIProvider contract).
 AI_PROVIDERS=$(find packages/ai-providers/src -mindepth 1 -maxdepth 1 -type d ! -name interface | wc -l | tr -d ' ')
 
-# MCP tool definitions
-MCP_TOOLS=$(grep -rh 'name: "' packages/mcp-server/src/tools/ 2>/dev/null | wc -l | tr -d ' ')
+# MCP tool definitions. Exclude *.test.ts — test fixture strings
+# (e.g. `name: "intro"` inside a handleSceneToolCall) match the regex but
+# aren't registered tools. Source-true count is 58 at runtime; an over-count
+# regex would let next.config.js advertise 59.
+MCP_TOOLS=$(grep -rh --include='*.ts' --exclude='*.test.ts' 'name: "' \
+  packages/mcp-server/src/tools/ 2>/dev/null | wc -l | tr -d ' ')
 
 # Agent tool definitions
 AGENT_TOOLS=$(grep -r 'ToolDefinition = {' packages/cli/src/agent/tools/ 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
## Pre-promotion smoke caught real drift

Before kicking off promotion I ran a fresh-install end-to-end against \`@vibeframe/cli@0.57.3\` from npm:

\`\`\`
$ npx -y @vibeframe/mcp-server  →  tools/list  →  58 entries
$ README.md / landing / OG meta →  "59 MCP tools"
\`\`\`

So we've been telling Twitter/LinkedIn/Show HN we ship 59 MCP tools when the server actually exposes 58.

## Root cause

Both \`apps/web/next.config.js\` and \`scripts/sync-counts.sh\` counted regex matches of \`name: "..."\` across every \`.ts\` file under \`packages/mcp-server/src/tools/\`, including \`.test.ts\`. The scene test has:

\`\`\`ts
await handleSceneToolCall("scene_add", { name: "intro", preset: "announcement" })
\`\`\`

That fixture line was getting counted as a 59th MCP tool that doesn't actually exist.

## Fix

- \`apps/web/next.config.js\`: skip \`*.test.ts\` when counting tool definitions
- \`scripts/sync-counts.sh\`: same exclusion + comment explaining the trap
- \`README.md\` tagline + MCP integration paragraph: 59 → 58 (2 occurrences)
- \`apps/web/app/layout.tsx\` hardcoded fallback constant: \`"59"\` → \`"58"\`

## Test plan

- [x] \`bash scripts/sync-counts.sh --check\` reports clean
- [x] \`pnpm -F web build\` succeeds; built HTML now consistently shows "13 AI providers, 58 MCP tools" across hero, description meta, OG, Twitter
- [x] \`npx -y @vibeframe/mcp-server\` JSON-RPC \`tools/list\` returns 58 entries (matches what we now advertise)

Once this lands, promotion can go out without "but actually we have 58, sorry" footnotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)