### PR TITLE
feat(scene): DESIGN.md hard-gate + 8 visual styles (v0.58.0)

### DIFF
--- a/.claude/skills/vibe-scene/SKILL.md
+++ b/.claude/skills/vibe-scene/SKILL.md
@@ -13,7 +13,43 @@ Prefer this over `vibe pipeline script-to-video --format mp4` whenever the
 user expects to **iterate** on text, layout, or timing — text tweaks don't
 require regenerating video.
 
-## Authoring loop
+## Two authoring paths
+
+VibeFrame supports two paths into the same project layout. Pick by the kind
+of output the user expects.
+
+| Path | When to use | Output quality |
+|---|---|---|
+| **High-craft** — `DESIGN.md` + `/hyperframes` skill in Claude Code | User wants cinematic finish, named visual identity, motion principles, transitions that actually punctuate the narrative | Matches what the Hyperframes ecosystem ships |
+| **Quick draft / fallback** — `vibe scene add --style <preset>` | No agent in the loop, or fast iteration on layout/timing/text — same project format, just template-rendered HTML | Generic but functional; great for proof-of-concept and CI dogfood |
+
+**Default to the high-craft path when an agent is available.** The
+`scene-html-emit` 5-preset path exists so non-agent flows still work — it
+is intentionally not the cinematic finish layer.
+
+## High-craft path (DESIGN.md → agent → HTML)
+
+1. `vibe scene init my-promo --visual-style "Swiss Pulse"` — seeds
+   `DESIGN.md` (palette, typography, motion, transitions) plus the
+   `vibe.project.yaml`/`hyperframes.json`/`index.html` scaffold.
+2. Install / load the Hyperframes skill set so `/hyperframes` is in scope:
+   ```bash
+   npx skills add heygen-com/hyperframes
+   ```
+3. Hand the user's `DESIGN.md` + `STORYBOARD.md` (and any narration text)
+   to Claude Code with `/hyperframes` loaded; ask it to author each scene
+   HTML directly under `compositions/scene-<id>.html`. The skill enforces
+   the visual identity contract — scenes that contradict DESIGN.md are
+   rejected on lint.
+4. `vibe scene lint --fix` for mechanical issues, `vibe scene render` to
+   MP4. Asset generation (`vibe scene add --visuals "..." --no-html`) can
+   still run alongside.
+
+`DESIGN.md` is the hard-gate: never author scene HTML before it exists.
+Browse named styles via `vibe scene styles`; re-seed an existing project
+with `vibe scene init . --visual-style "<name>"` (idempotent).
+
+## Quick-draft path (5-preset `scene add`)
 
 ```bash
 vibe scene init my-promo -r 16:9 -d 30          # 1. scaffold project
@@ -30,7 +66,8 @@ on user-provided projects.
 ## Subcommands
 
 ```bash
-vibe scene init <dir> [-r 16:9|9:16|1:1|4:5] [-d <sec>]
+vibe scene init <dir> [-r 16:9|9:16|1:1|4:5] [-d <sec>] [--visual-style "<name>"]
+vibe scene styles [<name>]                    # list / show vendored visual identities
 vibe scene add <name> --style <preset> [...]
 vibe scene lint [<root>] [--json] [--fix]
 vibe scene render [<root>] [--fps 30] [--quality standard] [--format mp4]

--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -6,6 +6,7 @@ import { parse as yamlParse } from "yaml";
 
 import {
   aspectToDims,
+  buildDesignMd,
   buildEmptyRootHtml,
   buildHyperframesConfig,
   buildHyperframesMeta,
@@ -16,6 +17,7 @@ import {
   scaffoldSceneProject,
   type HyperframesConfig,
 } from "./scene-project.js";
+import { getVisualStyle } from "./visual-styles.js";
 
 async function makeTmp(label = "vibe-scene-test-"): Promise<string> {
   return mkdtemp(join(tmpdir(), label));
@@ -114,6 +116,60 @@ describe("buildProjectClaudeMd", () => {
     expect(md).toContain("vibe scene add");
     expect(md).toContain("npx hyperframes");
   });
+
+  it("introduces the DESIGN.md hard-gate and hyperframes skill install", () => {
+    const md = buildProjectClaudeMd("my-promo");
+    expect(md).toContain("DESIGN.md");
+    expect(md).toContain("hard-gate");
+    expect(md).toContain("npx skills add heygen-com/hyperframes");
+  });
+});
+
+describe("buildDesignMd", () => {
+  it("emits placeholder sections when no style is provided", () => {
+    const md = buildDesignMd({ name: "my-promo" });
+    expect(md).toContain("# my-promo — Design");
+    expect(md).toContain("Hard-gate.");
+    // Section headings are stable.
+    expect(md).toContain("## Style");
+    expect(md).toContain("## Palette");
+    expect(md).toContain("## Typography");
+    expect(md).toContain("## Composition");
+    expect(md).toContain("## Motion");
+    expect(md).toContain("## Transition");
+    expect(md).toContain("## What NOT to do");
+    // Placeholder hint to seed from a named style.
+    expect(md).toContain("--visual-style");
+  });
+
+  it("seeds from a named style: pulls palette, typography, motion, transition, avoid", () => {
+    const swiss = getVisualStyle("Swiss Pulse");
+    expect(swiss).toBeDefined();
+    const md = buildDesignMd({ name: "my-promo", style: swiss });
+
+    expect(md).toContain("Swiss Pulse");
+    expect(md).toContain("Josef Müller-Brockmann");
+    // Palette hex appears verbatim.
+    expect(md).toContain("#0066FF");
+    // Typography rule.
+    expect(md).toContain("Helvetica or Inter Bold");
+    // Motion / GSAP signature.
+    expect(md).toContain("expo.out");
+    // Transition.
+    expect(md).toContain("Cinematic Zoom");
+    // Anti-patterns.
+    expect(md).toContain("Decorative transitions");
+    // Footer attribution.
+    expect(md).toContain('--visual-style "Swiss Pulse"');
+  });
+
+  it("accepts the slug form when looked up via getVisualStyle", () => {
+    const slug = getVisualStyle("data-drift");
+    expect(slug).toBeDefined();
+    const md = buildDesignMd({ name: "ai-promo", style: slug });
+    expect(md).toContain("Data Drift");
+    expect(md).toContain("#7c3aed");
+  });
 });
 
 describe("buildSceneGitignore", () => {
@@ -152,6 +208,7 @@ describe("scaffoldSceneProject", () => {
       "index.html",
       "vibe.project.yaml",
       "CLAUDE.md",
+      "DESIGN.md",
       ".gitignore",
     ];
     for (const f of expected) {
@@ -163,6 +220,40 @@ describe("scaffoldSceneProject", () => {
     expect(result.created.length).toBe(expected.length);
     expect(result.merged).toEqual([]);
     expect(result.skipped).toEqual([]);
+  });
+
+  it("seeds DESIGN.md from --visual-style when provided", async () => {
+    const dir = await makeTmp();
+    const style = getVisualStyle("Swiss Pulse");
+    expect(style).toBeDefined();
+    await scaffoldSceneProject({ dir, name: "fixture", visualStyle: style });
+    const design = await readFile(resolve(dir, "DESIGN.md"), "utf-8");
+    expect(design).toContain("Swiss Pulse");
+    expect(design).toContain("#0066FF");
+    expect(design).toContain("Helvetica or Inter Bold");
+  });
+
+  it("DESIGN.md falls back to placeholders when no style provided", async () => {
+    const dir = await makeTmp();
+    await scaffoldSceneProject({ dir, name: "fixture" });
+    const design = await readFile(resolve(dir, "DESIGN.md"), "utf-8");
+    expect(design).toContain("# fixture — Design");
+    expect(design).toContain("--visual-style");
+    // Should NOT pre-fill from any specific style:
+    expect(design).not.toContain("Swiss Pulse");
+    expect(design).not.toContain("Velvet Standard");
+  });
+
+  it("preserves a user-edited DESIGN.md across re-init", async () => {
+    const dir = await makeTmp();
+    await scaffoldSceneProject({ dir, name: "fixture" });
+    const designPath = resolve(dir, "DESIGN.md");
+    await writeFile(designPath, "# Custom design\n\nMy notes.\n", "utf-8");
+
+    const second = await scaffoldSceneProject({ dir, name: "fixture" });
+    const after = await readFile(designPath, "utf-8");
+    expect(after).toBe("# Custom design\n\nMy notes.\n");
+    expect(second.skipped.some((p) => p.endsWith("DESIGN.md"))).toBe(true);
   });
 
   it("vibe.project.yaml parses as valid YAML and carries the chosen aspect", async () => {

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -15,6 +15,8 @@ import { mkdir, readFile, writeFile, access } from "node:fs/promises";
 import { resolve, basename } from "node:path";
 import { stringify as yamlStringify } from "yaml";
 
+import type { VisualStyle } from "./visual-styles.js";
+
 /** Supported aspect ratios for scene projects (maps to CSS canvas dims). */
 export type SceneAspect = "16:9" | "9:16" | "1:1" | "4:5";
 
@@ -161,6 +163,100 @@ export function buildEmptyRootHtml(opts: { aspect: SceneAspect; duration: number
 `;
 }
 
+/**
+ * Project-local `DESIGN.md` template — the visual-identity hard-gate.
+ *
+ * Hyperframes' `hyperframes` skill teaches: "no scene HTML before DESIGN.md is
+ * authored." This template seeds that contract so the project never opens
+ * with a blank slate. When `style` is provided, the rules are pre-filled
+ * from the vendored named-style data (`visual-styles.ts`); otherwise the
+ * user (or agent) fills the placeholders.
+ *
+ * The agent-driven craft path expects this file as input — see
+ * `.claude/skills/vibe-scene/SKILL.md`.
+ */
+export function buildDesignMd(opts: {
+  name: string;
+  style?: VisualStyle;
+}): string {
+  const { name, style } = opts;
+
+  const intro = style
+    ? `Visual identity for **${name}**, scaffolded from the **${style.name}** style (after ${style.designer}). Customise freely — this file is the single source of truth for every scene's palette, typography, and motion.`
+    : `Visual identity for **${name}**. Fill the sections below before authoring any scene HTML or generating any backdrop. Pick a named style with \`vibe scene styles\` if you want a credible starting point.`;
+
+  const moodLine = style
+    ? `**Mood:** ${style.mood} · **Best for:** ${style.bestFor}`
+    : `**Mood:** _(one line — what should the viewer FEEL?)_`;
+
+  const palette = style
+    ? `${style.palette.map((c) => `- \`${c}\``).join("\n")}\n\n${style.paletteNotes}`
+    : `- _hex_ — primary\n- _hex_ — accent\n\n_2–3 colours max. Declare explicit hex values; never name colours abstractly._`;
+
+  const typography = style
+    ? style.typography
+    : `_One family, two weights. State the role of each (headline / label / body)._`;
+
+  const composition = style
+    ? style.composition
+    : `_Grid? Centered? Layered? How does negative space behave?_`;
+
+  const motion = style
+    ? `${style.motion}\n\n**GSAP signature:** ${style.gsapSignature}`
+    : `_How fast? Snappy or fluid? Overshoot or precision?_\n\n**GSAP signature:** _e.g. \`expo.out\`, \`sine.inOut\`, \`back.out(1.8)\`_`;
+
+  const transition = style
+    ? style.transition
+    : `_Which Hyperframes shader matches the energy? (Cinematic Zoom, Cross-Warp Morph, Glitch, Domain Warp, …)_`;
+
+  const avoid = style
+    ? style.avoid.map((a) => `- ${a}`).join("\n")
+    : `- _anti-pattern 1_\n- _anti-pattern 2_\n- _anti-pattern 3_`;
+
+  return `# ${name} — Design
+
+> **Hard-gate.** This file defines the visual identity of every scene.
+> Author it before generating any HTML, backdrop image, or motion.
+> The Hyperframes \`hyperframes\` skill enforces this: scenes that
+> contradict DESIGN.md are rejected.
+
+${intro}
+
+## Style
+
+${moodLine}
+
+## Palette
+
+${palette}
+
+## Typography
+
+${typography}
+
+## Composition
+
+${composition}
+
+## Motion
+
+${motion}
+
+## Transition
+
+${transition}
+
+## What NOT to do
+
+${avoid}
+
+---
+
+_Browse other named styles: \`vibe scene styles\`_
+${style ? `_This file was seeded by \`vibe scene init --visual-style "${style.name}"\`._` : `_Seed this file from a named style: \`vibe scene init <dir> --visual-style "<name>"\`._`}
+`;
+}
+
 /** Project-local CLAUDE.md that orients an AI agent to both toolchains. */
 export function buildProjectClaudeMd(name: string): string {
   return `# ${name} — Scene Authoring Project
@@ -168,6 +264,16 @@ export function buildProjectClaudeMd(name: string): string {
 This project is **bilingual**: it works with both VibeFrame (\`vibe\`) and
 HeyGen Hyperframes (\`hyperframes\`). You can run either CLI inside this
 directory.
+
+## Visual identity hard-gate
+
+**Author \`DESIGN.md\` before any scene HTML.** It defines palette,
+typography, motion, and transition rules. Both the agent-driven path and
+the fallback emit reference it; scenes that contradict DESIGN.md are
+rejected by the Hyperframes \`hyperframes\` skill.
+
+Browse named styles: \`vibe scene styles\`. Re-seed from one with
+\`vibe scene init . --visual-style "Swiss Pulse"\` (idempotent).
 
 ## Skills — USE THESE FIRST
 
@@ -177,14 +283,23 @@ semantics, VibeFrame pipeline conventions) that are NOT in generic web docs.
 
 | Skill             | Command          | When to use                                                                           |
 | ----------------- | ---------------- | ------------------------------------------------------------------------------------- |
-| **vibe-scene**    | \`/vibe-scene\`    | Authoring / editing per-scene HTML in this project — preferred                        |
-| **hyperframes**   | \`/hyperframes\`   | Fallback: direct HF authoring (install via \`npx skills add heygen-com/hyperframes\`) |
+| **hyperframes**   | \`/hyperframes\`   | Cinematic-quality composition — DESIGN.md hard-gate, named styles, motion principles  |
+| **vibe-scene**    | \`/vibe-scene\`    | VibeFrame's authoring loop, AI assets, lint feedback, pipeline integration            |
 | **gsap**          | \`/gsap\`          | GSAP tweens, timelines, easing                                                        |
 
-If the skill is not available, follow the **Key Rules** below.
+Install the Hyperframes skills once per machine:
+
+\`\`\`bash
+npx skills add heygen-com/hyperframes
+\`\`\`
+
+Restart your agent session (or reload the skill list) after installing.
+If skills aren't available, follow the **Key Rules** below — they cover
+the framework-level minimum, not the cinematic craft layer.
 
 ## Project structure
 
+- \`DESIGN.md\` — visual identity contract (palette, type, motion, transitions)
 - \`index.html\` — root composition (timeline)
 - \`compositions/scene-*.html\` — per-scene HTML authored by you or the agent
 - \`assets/\` — shared media (narration audio, images, video)
@@ -254,6 +369,12 @@ export interface ScaffoldOptions {
   aspect?: SceneAspect;
   duration?: number;
   now?: Date;
+  /**
+   * Optional named visual style (e.g. "Swiss Pulse"). When provided,
+   * `DESIGN.md` is seeded with the style's palette / typography / motion
+   * rules instead of placeholders. Resolved via `getVisualStyle()`.
+   */
+  visualStyle?: VisualStyle;
 }
 
 export interface ScaffoldResult {
@@ -343,6 +464,20 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
   } else {
     await writeFile(claudePath, buildProjectClaudeMd(name), "utf-8");
     created.push(claudePath);
+  }
+
+  // DESIGN.md — visual-identity hard-gate (Hyperframes skill convention).
+  // Preserve existing so users can hand-edit between init runs.
+  const designPath = resolve(dir, "DESIGN.md");
+  if (await pathExists(designPath)) {
+    skipped.push(designPath);
+  } else {
+    await writeFile(
+      designPath,
+      buildDesignMd({ name, style: opts.visualStyle }),
+      "utf-8",
+    );
+    created.push(designPath);
   }
 
   // .gitignore — preserve existing.

--- a/packages/cli/src/commands/_shared/visual-styles.test.ts
+++ b/packages/cli/src/commands/_shared/visual-styles.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getVisualStyle,
+  listVisualStyles,
+  visualStyleNames,
+} from "./visual-styles.js";
+
+describe("listVisualStyles", () => {
+  it("ships the eight named styles in stable order", () => {
+    const names = listVisualStyles().map((s) => s.name);
+    expect(names).toEqual([
+      "Swiss Pulse",
+      "Velvet Standard",
+      "Deconstructed",
+      "Maximalist Type",
+      "Data Drift",
+      "Soft Signal",
+      "Folk Frequency",
+      "Shadow Cut",
+    ]);
+  });
+
+  it("every style has a non-empty palette + typography + motion + transition + 3 anti-patterns", () => {
+    for (const s of listVisualStyles()) {
+      expect(s.palette.length).toBeGreaterThanOrEqual(2);
+      expect(s.typography.length).toBeGreaterThan(0);
+      expect(s.motion.length).toBeGreaterThan(0);
+      expect(s.transition.length).toBeGreaterThan(0);
+      expect(s.gsapSignature.length).toBeGreaterThan(0);
+      expect(s.avoid.length).toBe(3);
+      // Slugs are kebab-case lowercase, name-derived.
+      expect(s.slug).toMatch(/^[a-z]+(-[a-z]+)*$/);
+    }
+  });
+});
+
+describe("getVisualStyle", () => {
+  it("matches by exact display name", () => {
+    expect(getVisualStyle("Swiss Pulse")?.slug).toBe("swiss-pulse");
+  });
+
+  it("is case-insensitive on display name", () => {
+    expect(getVisualStyle("velvet standard")?.name).toBe("Velvet Standard");
+    expect(getVisualStyle("MAXIMALIST TYPE")?.name).toBe("Maximalist Type");
+  });
+
+  it("matches by slug", () => {
+    expect(getVisualStyle("data-drift")?.name).toBe("Data Drift");
+    expect(getVisualStyle("shadow-cut")?.name).toBe("Shadow Cut");
+  });
+
+  it("returns undefined for unknown names", () => {
+    expect(getVisualStyle("Nonexistent")).toBeUndefined();
+    expect(getVisualStyle("")).toBeUndefined();
+  });
+
+  it("trims whitespace before matching", () => {
+    expect(getVisualStyle("  Soft Signal  ")?.slug).toBe("soft-signal");
+  });
+});
+
+describe("visualStyleNames", () => {
+  it("renders comma-joined quoted display names suitable for help text", () => {
+    const out = visualStyleNames();
+    expect(out).toContain('"Swiss Pulse"');
+    expect(out).toContain('"Shadow Cut"');
+    expect(out.split(",").length).toBe(8);
+  });
+});

--- a/packages/cli/src/commands/_shared/visual-styles.ts
+++ b/packages/cli/src/commands/_shared/visual-styles.ts
@@ -1,0 +1,255 @@
+/**
+ * @module _shared/visual-styles
+ *
+ * Eight named visual identities used to seed `DESIGN.md` when scaffolding a
+ * scene project. The structured data below distils the rules that
+ * Hyperframes' `hyperframes` skill encodes in
+ * `skills/hyperframes/visual-styles.md` (Apache 2.0). VibeFrame vendors the
+ * data — not the prose — so a project scaffolded without an active agent
+ * still gets a credible DESIGN.md as a starting point.
+ *
+ * The agent-driven path (`/hyperframes` skill loaded in Claude Code) remains
+ * the canonical way to author final compositions; this module just ensures
+ * the visual contract exists in the project before any HTML is written.
+ *
+ * Source-of-truth attribution: HeyGen Hyperframes — https://hyperframes.heygen.com
+ * License: Apache 2.0 (see NOTICE)
+ */
+
+/** One named visual identity. Designed to round-trip into DESIGN.md. */
+export interface VisualStyle {
+  /** Display name, e.g. "Swiss Pulse". */
+  name: string;
+  /** URL/CLI-friendly slug, e.g. "swiss-pulse". */
+  slug: string;
+  /** Designer or movement the style references. */
+  designer: string;
+  /** One-line mood, e.g. "Clinical, precise". */
+  mood: string;
+  /** Content categories the style works best for. */
+  bestFor: string;
+  /** 2–3 hex colours that anchor the palette. */
+  palette: string[];
+  /** Free-form palette description (warm/cold, primary/accent). */
+  paletteNotes: string;
+  /** Typography rules — family, weights, role per weight. */
+  typography: string;
+  /** Composition rules — grid, spacing, framing. */
+  composition: string;
+  /** Motion rules — speed, easing, character. */
+  motion: string;
+  /** Hyperframes shader name(s) that match the energy. */
+  transition: string;
+  /** GSAP signature — easing functions and feel. */
+  gsapSignature: string;
+  /** 3 anti-patterns to avoid for this style. */
+  avoid: string[];
+}
+
+const STYLES: VisualStyle[] = [
+  {
+    name: "Swiss Pulse",
+    slug: "swiss-pulse",
+    designer: "Josef Müller-Brockmann",
+    mood: "Clinical, precise",
+    bestFor: "SaaS dashboards, developer tools, APIs, metrics",
+    palette: ["#1a1a1a", "#ffffff", "#0066FF"],
+    paletteNotes:
+      "Black, white, ONE accent — electric blue (#0066FF) or amber (#FFB300). Never both accents at once.",
+    typography:
+      "Helvetica or Inter Bold for headlines, Regular for labels. Numbers dominate at 80–120px.",
+    composition:
+      "Grid-locked. Every element snaps to an invisible 12-column grid. Hard cuts only — no decorative transitions.",
+    motion:
+      "Animated counters count up from 0. Entries are fast and snap into place. Nothing floats.",
+    transition: "Cinematic Zoom or SDF Iris (precise, geometric)",
+    gsapSignature: "expo.out, power4.out — fast arrivals, hard stops",
+    avoid: [
+      "Decorative transitions (fades, dissolves) — use hard cuts",
+      "Two accent colours competing in one frame",
+      "Off-grid placement or floating elements",
+    ],
+  },
+  {
+    name: "Velvet Standard",
+    slug: "velvet-standard",
+    designer: "Massimo Vignelli",
+    mood: "Premium, timeless",
+    bestFor: "Luxury products, enterprise software, keynotes, investor decks",
+    palette: ["#000000", "#ffffff", "#1a237e"],
+    paletteNotes:
+      "Black, white, ONE rich accent — deep navy (#1a237e) or gold (#c9a84c).",
+    typography:
+      "Thin sans-serif, ALL CAPS, wide letter-spacing (0.15em+). Sequential reveals only.",
+    composition:
+      "Generous negative space. Symmetrical, centered, architectural precision. Nothing busy.",
+    motion:
+      "Slow, deliberate. Sequential reveals with long holds. No frantic motion.",
+    transition: "Cross-Warp Morph (elegant, organic flow between scenes)",
+    gsapSignature: "sine.inOut, power1 — nothing snaps, everything glides",
+    avoid: [
+      "Tight letter-spacing — kills the premium register",
+      "Bouncy or elastic easings — too playful",
+      "Multiple elements arriving at once — break sequence",
+    ],
+  },
+  {
+    name: "Deconstructed",
+    slug: "deconstructed",
+    designer: "Neville Brody",
+    mood: "Industrial, raw",
+    bestFor: "Tech news, developer launches, security products, punk-energy reveals",
+    palette: ["#1a1a1a", "#D4501E", "#f0f0f0"],
+    paletteNotes:
+      "Dark grey (#1a1a1a), rust orange (#D4501E), raw white (#f0f0f0).",
+    typography:
+      "Type at angles, overlapping edges, escaping frames. Bold industrial weight.",
+    composition:
+      "Gritty textures — scan-line effects, glitch artifacts baked into the design.",
+    motion:
+      "Text SLAMS and SHATTERS. Letters scramble then snap to final position.",
+    transition: "Glitch shader or Whip Pan (breaks the rules, feels aggressive)",
+    gsapSignature: "back.out(2.5), steps(8), elastic.out(1.2, 0.4) — intentional irregularity",
+    avoid: [
+      "Polished, centered compositions — must feel raw",
+      "Smooth fades — use glitch / scramble entries",
+      "Soft easings — every motion lands hard",
+    ],
+  },
+  {
+    name: "Maximalist Type",
+    slug: "maximalist-type",
+    designer: "Paula Scher",
+    mood: "Loud, kinetic",
+    bestFor: "Big product launches, milestone announcements, high-energy hype videos",
+    palette: ["#E63946", "#FFD60A", "#000000", "#ffffff"],
+    paletteNotes:
+      "Bold saturated: red (#E63946), yellow (#FFD60A), black, white — maximum contrast.",
+    typography:
+      "Text IS the visual. Overlapping type layers at different scales and angles, filling 50–80% of frame.",
+    composition:
+      "Text layered OVER footage — never empty backgrounds. 2–3 second rapid-fire scenes.",
+    motion:
+      "Everything is kinetic — slamming, sliding, scaling. No static moments.",
+    transition: "Ridged Burn (explosive, dramatic, impossible to ignore)",
+    gsapSignature: "expo.out, back.out(1.8) — fast arrivals, hard stops",
+    avoid: [
+      "Static moments — every frame must move",
+      "Empty backgrounds — text and footage must layer",
+      "Single typeface at a single size — must be layered",
+    ],
+  },
+  {
+    name: "Data Drift",
+    slug: "data-drift",
+    designer: "Refik Anadol",
+    mood: "Futuristic, immersive",
+    bestFor: "AI products, ML platforms, data companies, speculative tech",
+    palette: ["#0a0a0a", "#7c3aed", "#06b6d4"],
+    paletteNotes:
+      "Iridescent — deep black (#0a0a0a), electric purple (#7c3aed), cyan (#06b6d4).",
+    typography:
+      "Thin futuristic sans-serif — floating, weightless, minimal text.",
+    composition:
+      "Fluid morphing compositions. Extreme scale shifts (micro → macro). Particles coalesce into numbers.",
+    motion:
+      "Light traces data paths through the frame. Smooth, continuous, organic — nothing hard.",
+    transition: "Gravitational Lens or Domain Warp (otherworldly distortion)",
+    gsapSignature: "sine.inOut, power2.out — smooth, continuous, organic",
+    avoid: [
+      "Hard cuts — break the immersion",
+      "Heavy/bold typography — too grounded",
+      "Static compositions — must feel like flow",
+    ],
+  },
+  {
+    name: "Soft Signal",
+    slug: "soft-signal",
+    designer: "Stefan Sagmeister",
+    mood: "Intimate, warm",
+    bestFor: "Wellness brands, personal stories, lifestyle products, human-centered apps",
+    palette: ["#F5A623", "#FFF8EC", "#C4A3A3", "#8FAF8C"],
+    paletteNotes:
+      "Warm amber (#F5A623), cream (#FFF8EC), dusty rose (#C4A3A3), sage green (#8FAF8C).",
+    typography:
+      "Handwritten-style or humanist serif fonts. Personal, lowercase, delicate.",
+    composition:
+      "Close-up framing feel — single element fills the frame. Nothing feels corporate.",
+    motion:
+      "Slow drifts and floats, never snaps. Soft organic motion throughout.",
+    transition: "Thermal Distortion (warm, flowing, like heat shimmer)",
+    gsapSignature: "sine.inOut, power1.inOut — everything breathes",
+    avoid: [
+      "Sharp geometric layouts — break the warmth",
+      "Hard easings or snaps — too clinical",
+      "Cool tones (blue/green-blue) without warm balance",
+    ],
+  },
+  {
+    name: "Folk Frequency",
+    slug: "folk-frequency",
+    designer: "Eduardo Terrazas",
+    mood: "Cultural, vivid",
+    bestFor: "Consumer apps, food platforms, community products, festive launches",
+    palette: ["#FF1493", "#0047AB", "#FFE000", "#009B77"],
+    paletteNotes:
+      "Vivid folk: hot pink (#FF1493), cobalt blue (#0047AB), sun yellow (#FFE000), emerald (#009B77).",
+    typography:
+      "Bold warm rounded type. Every frame feels handcrafted.",
+    composition:
+      "Pattern and repetition — folk art rhythm and density. Layered compositions with rich visual texture.",
+    motion:
+      "Colorful motion — elements bounce, pop, and spin into place with joy.",
+    transition: "Swirl Vortex or Ripple Waves (hypnotic, celebratory)",
+    gsapSignature: "back.out(1.6), elastic.out(1, 0.5) — overshoots feel intentional",
+    avoid: [
+      "Muted or monochrome palettes — kill the celebration",
+      "Pure flat / minimal compositions — must feel layered",
+      "Linear easings — motion should feel joyful",
+    ],
+  },
+  {
+    name: "Shadow Cut",
+    slug: "shadow-cut",
+    designer: "Hans Hillmann",
+    mood: "Dark, cinematic",
+    bestFor: "Security products, dramatic reveals, investigative content, intense launches",
+    palette: ["#0a0a0a", "#3a3a3a", "#ffffff", "#C1121F"],
+    paletteNotes:
+      "Near-monochrome — deep blacks (#0a0a0a), cold greys (#3a3a3a), stark white + ONE accent (blood red #C1121F or toxic green #39FF14).",
+    typography:
+      "Sharp angular text like film noir title cards. Heavy contrast, no softness.",
+    composition:
+      "Heavy shadow — elements emerge from darkness. The reveal IS the narrative.",
+    motion:
+      "Slow creeping push-ins, dramatic scale reveals. Silence before the hit matters.",
+    transition: "Domain Warp (dissolves reality before revealing the next scene)",
+    gsapSignature: "power4.in for exits, power3.out for dramatic reveals — pause before the hit",
+    avoid: [
+      "Bright or saturated palettes — kill the cinematic mood",
+      "Bouncy easings — break the tension",
+      "Quick cuts — let the reveal breathe",
+    ],
+  },
+];
+
+/** All vendored styles in display order. */
+export function listVisualStyles(): readonly VisualStyle[] {
+  return STYLES;
+}
+
+/**
+ * Find a style by name (case-insensitive) or slug. Returns undefined if no
+ * match. Caller is responsible for surfacing a usage error.
+ */
+export function getVisualStyle(query: string): VisualStyle | undefined {
+  const q = query.trim().toLowerCase();
+  return STYLES.find(
+    (s) => s.name.toLowerCase() === q || s.slug === q,
+  );
+}
+
+/** Comma-joined list of valid `--visual-style` argument values, for help/error text. */
+export function visualStyleNames(): string {
+  return STYLES.map((s) => `"${s.name}"`).join(", ");
+}

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -39,6 +39,12 @@ import {
   type VibeProjectConfig,
 } from "./_shared/scene-project.js";
 import {
+  getVisualStyle,
+  listVisualStyles,
+  visualStyleNames,
+  type VisualStyle,
+} from "./_shared/visual-styles.js";
+import {
   emitSceneHtml,
   insertClipIntoRoot,
   nextSceneStart,
@@ -93,6 +99,20 @@ function validatePreset(value: string): ScenePreset {
   return value as ScenePreset;
 }
 
+function validateVisualStyle(value: string): VisualStyle {
+  const found = getVisualStyle(value);
+  if (!found) {
+    exitWithError(
+      usageError(
+        `Unknown visual style: ${value}`,
+        `Valid: ${visualStyleNames()}. Browse details with \`vibe scene styles\`.`,
+      ),
+    );
+  }
+  // exitWithError aborts; this branch is unreachable but typescript needs it.
+  return found as VisualStyle;
+}
+
 export const sceneCommand = new Command("scene")
   .description("Author and render per-scene HTML compositions (Hyperframes backend)")
   .addHelpText("after", `
@@ -120,24 +140,34 @@ sceneCommand
   .option("-n, --name <name>", "Project name (defaults to directory basename)")
   .option("-r, --ratio <ratio>", "Aspect ratio: 16:9, 9:16, 1:1, 4:5", "16:9")
   .option("-d, --duration <sec>", "Default root composition duration (seconds)", "10")
+  .option("--visual-style <name>", `Seed DESIGN.md from a named style (browse via \`vibe scene styles\`). E.g. "Swiss Pulse"`)
   .option("--dry-run", "Preview parameters without writing files")
   .action(async (dir: string, options) => {
     const aspect = validateAspect(options.ratio);
     const duration = validateDuration(options.duration);
     const name = (options.name as string | undefined) ?? basename(dir.replace(/\/+$/, ""));
+    const visualStyle = options.visualStyle
+      ? validateVisualStyle(options.visualStyle as string)
+      : undefined;
 
     if (options.dryRun) {
       outputResult({
         dryRun: true,
         command: "scene init",
-        params: { dir, name, aspect, duration },
+        params: {
+          dir,
+          name,
+          aspect,
+          duration,
+          visualStyle: visualStyle?.name ?? null,
+        },
       });
       return;
     }
 
     const spinner = isJsonMode() ? null : ora(`Scaffolding scene project at ${dir}...`).start();
     try {
-      const result = await scaffoldSceneProject({ dir, name, aspect, duration });
+      const result = await scaffoldSceneProject({ dir, name, aspect, duration, visualStyle });
 
       if (isJsonMode()) {
         outputResult({
@@ -147,6 +177,7 @@ sceneCommand
           name,
           aspect,
           duration,
+          visualStyle: visualStyle?.name ?? null,
           created: result.created,
           merged: result.merged,
           skipped: result.skipped,
@@ -164,7 +195,13 @@ sceneCommand
       console.log();
       console.log(chalk.bold.cyan("Next steps"));
       console.log(chalk.dim("─".repeat(60)));
-      console.log(`  ${chalk.cyan("vibe scene add")} <name>    ${chalk.dim("# author a scene via AI")}`);
+      if (visualStyle) {
+        console.log(`  ${chalk.dim("DESIGN.md seeded with")} ${chalk.bold(visualStyle.name)} ${chalk.dim("— review and customise.")}`);
+      } else {
+        console.log(`  ${chalk.cyan("vibe scene styles")}        ${chalk.dim("# pick a named style for DESIGN.md")}`);
+      }
+      console.log(`  ${chalk.cyan("npx skills add heygen-com/hyperframes")}  ${chalk.dim("# load the cinematic-craft skill set")}`);
+      console.log(`  ${chalk.cyan("vibe scene add")} <name>    ${chalk.dim("# fallback path: 5-preset emit")}`);
       console.log(`  ${chalk.cyan("vibe scene lint")}          ${chalk.dim("# validate HTML")}`);
       console.log(`  ${chalk.cyan("vibe scene render")}        ${chalk.dim("# render to MP4")}`);
     } catch (error) {
@@ -172,6 +209,81 @@ sceneCommand
       const msg = error instanceof Error ? error.message : String(error);
       exitWithError(generalError(`Failed to scaffold: ${msg}`));
     }
+  });
+
+// ---------------------------------------------------------------------------
+// `vibe scene styles` — list / show vendored visual identities
+// ---------------------------------------------------------------------------
+
+sceneCommand
+  .command("styles")
+  .description("List vendored visual styles (or show one) for DESIGN.md seeding")
+  .argument("[name]", "Style name to inspect (omit to list all)")
+  .action((name?: string) => {
+    if (!name) {
+      const all = listVisualStyles();
+      if (isJsonMode()) {
+        outputResult({
+          success: true,
+          command: "scene styles",
+          count: all.length,
+          styles: all.map((s) => ({
+            name: s.name,
+            slug: s.slug,
+            designer: s.designer,
+            mood: s.mood,
+            bestFor: s.bestFor,
+          })),
+        });
+        return;
+      }
+      console.log();
+      console.log(chalk.bold.cyan("Visual styles"));
+      console.log(chalk.dim("─".repeat(60)));
+      for (const s of all) {
+        console.log(
+          `  ${chalk.bold(s.name.padEnd(18))} ${chalk.dim(s.mood.padEnd(24))} ${chalk.dim(s.bestFor)}`,
+        );
+      }
+      console.log();
+      console.log(chalk.dim("Show details: "), chalk.cyan('vibe scene styles "<name>"'));
+      console.log(chalk.dim("Seed DESIGN.md:"), chalk.cyan('vibe scene init <dir> --visual-style "<name>"'));
+      return;
+    }
+
+    const style = getVisualStyle(name);
+    if (!style) {
+      exitWithError(
+        usageError(
+          `Unknown visual style: ${name}`,
+          `Valid: ${visualStyleNames()}.`,
+        ),
+      );
+      return;
+    }
+
+    if (isJsonMode()) {
+      outputResult({ success: true, command: "scene styles", style });
+      return;
+    }
+
+    console.log();
+    console.log(chalk.bold.cyan(style.name), chalk.dim(`— ${style.designer}`));
+    console.log(chalk.dim("─".repeat(60)));
+    console.log(`${chalk.bold("Mood:")}        ${style.mood}`);
+    console.log(`${chalk.bold("Best for:")}    ${style.bestFor}`);
+    console.log(`${chalk.bold("Palette:")}     ${style.palette.join(", ")}`);
+    console.log(chalk.dim("              ") + style.paletteNotes);
+    console.log(`${chalk.bold("Typography:")}  ${style.typography}`);
+    console.log(`${chalk.bold("Composition:")} ${style.composition}`);
+    console.log(`${chalk.bold("Motion:")}      ${style.motion}`);
+    console.log(`${chalk.bold("GSAP:")}        ${style.gsapSignature}`);
+    console.log(`${chalk.bold("Transition:")}  ${style.transition}`);
+    console.log();
+    console.log(chalk.bold("Avoid:"));
+    for (const a of style.avoid) console.log(`  ${chalk.red("•")} ${a}`);
+    console.log();
+    console.log(chalk.dim("Seed DESIGN.md:"), chalk.cyan(`vibe scene init <dir> --visual-style "${style.name}"`));
   });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First step on the v0.58 roadmap (`docs/ROADMAP-v0.58.md`) — bring the Hyperframes skill ecosystem into VibeFrame projects **without forking it**.

PRs #98–#104 tried to encode composition craft into 5 hardcoded emit presets and lost. Hyperframes already publishes 2,972 lines of explicit craft knowledge as agent skills (named visual styles, motion principles, the DESIGN.md hard-gate). This PR ships the **contract layer** that lets the agent-driven path do the cinematic work; the existing `scene-html-emit` 5-preset path stays as quick-draft fallback.

## What lands

- **8 vendored visual styles** (`visual-styles.ts`) — Swiss Pulse, Velvet Standard, Deconstructed, Maximalist Type, Data Drift, Soft Signal, Folk Frequency, Shadow Cut. Each carries palette / typography / composition / motion / GSAP signature / transition shader / 3 anti-patterns. Apache-2.0 attribution to upstream HF skills.
- **`buildDesignMd()`** — visual-identity hard-gate template. Placeholders by default; pre-filled when a named style is provided.
- **`vibe scene init --visual-style "Swiss Pulse"`** — case-insensitive name or slug. Surfaces the full list on typo. Writes `DESIGN.md` alongside the existing scaffold (preserves user edits on re-init).
- **`vibe scene styles [name]`** — new subcommand. List all 8 (mood + best-for table) or show one in full. JSON output for agent loops.
- **CLAUDE.md project template** gains a "Visual identity hard-gate" section + `npx skills add heygen-com/hyperframes` install hint.
- **`.claude/skills/vibe-scene/SKILL.md`** introduces the two paths (high-craft DESIGN.md → `/hyperframes` vs. quick-draft 5-preset emit) and frames `scene-html-emit` as fallback, not primary.

## Sample output

```
$ vibe scene init my-promo --visual-style "Swiss Pulse"
Scene project ready: my-promo

Files
  + my-promo/hyperframes.json
  + my-promo/meta.json
  + my-promo/index.html
  + my-promo/vibe.project.yaml
  + my-promo/CLAUDE.md
  + my-promo/DESIGN.md
  + my-promo/.gitignore

Next steps
  DESIGN.md seeded with Swiss Pulse — review and customise.
  npx skills add heygen-com/hyperframes  # load the cinematic-craft skill set
  vibe scene add <name>    # fallback path: 5-preset emit
  vibe scene lint          # validate HTML
  vibe scene render        # render to MP4
```

## Out of scope (per ROADMAP)

- ❌ `scene-html-emit.ts` internals (Pass 2 lands later)
- ❌ YAML pipeline `compose-scenes-with-skills` action (v0.59.0)
- ❌ Demo MP4 regeneration (v0.60.0)

## Test plan

- [x] 499 existing CLI tests pass
- [x] 12 new tests (8 visual-styles assertions + 4 DESIGN.md/scaffold assertions)
- [x] `pnpm build` green across the monorepo
- [x] `pnpm -F @vibeframe/cli lint` 0 errors
- [x] Smoke: `vibe scene init --visual-style "Swiss Pulse"` writes correct DESIGN.md
- [x] Smoke: `vibe scene styles` lists all 8; `vibe scene styles "Swiss Pulse"` shows full detail
- [ ] CI: typecheck + build-and-test (20, 22)
- [ ] Vercel preview unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)