### PR TITLE
fix(scene): treat --duration as minimum so narration never gets clipped

### DIFF
--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -728,9 +728,31 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
   }
 
   // -- Decide scene duration -----------------------------------------------
+  // Scene duration must be ≥ narration audio length, otherwise the parent
+  // clip's data-duration cuts the audio short. The previous heuristic
+  // (`opts.duration ?? narrationDuration ?? fallback`) honored an explicit
+  // `--duration` even when shorter than the generated TTS, producing
+  // "scene feels rushed / narration cut off". `--duration` is now a
+  // *minimum*; when narration audio is longer, extend to fit narration +
+  // the SCENE_OVERLAP_SECONDS crossfade tail + a small TTS-tail buffer.
   const cfg = await loadVibeProjectConfig(projectDir);
   const fallback = cfg?.defaultSceneDuration ?? 5;
-  const duration = opts.duration ?? narrationDuration ?? fallback;
+  const NARRATION_TAIL_BUFFER = 0.5;
+  const userDur = opts.duration;
+  const audioMinDur = narrationDuration !== undefined
+    ? narrationDuration + SCENE_OVERLAP_SECONDS + NARRATION_TAIL_BUFFER
+    : undefined;
+  let duration: number;
+  if (userDur !== undefined && audioMinDur !== undefined) {
+    duration = Math.max(userDur, audioMinDur);
+  } else if (audioMinDur !== undefined) {
+    duration = audioMinDur;
+  } else if (userDur !== undefined) {
+    duration = userDur;
+  } else {
+    duration = fallback;
+  }
+  duration = Number(duration.toFixed(2));
 
   // -- Emit scene HTML -----------------------------------------------------
   opts.onProgress?.("Emitting scene HTML...");


### PR DESCRIPTION
## Summary

`vibe scene add --duration 3 --narration "..."` had a precedence bug: when the generated TTS audio came out longer than the user-supplied duration (e.g. 3.77 s narration on a `--duration 3` scene), the parent clip's \`data-duration="3"\` cut the audio mid-word. Visibly: scene felt rushed, narration trailed off, lip-sync drifted.

\`--duration\` is now a **minimum**, not an upper bound:

\`\`\`
duration = max(userDur, narrationDur + SCENE_OVERLAP_SECONDS + 0.5)
\`\`\`

- 0.5 s buffers TTS tail silence
- \`SCENE_OVERLAP_SECONDS\` reserves the crossfade tail so spoken content survives the join
- When no user duration is supplied, the audio-derived minimum is used directly
- When no narration is generated, the explicit \`--duration\` (or \`vibe.project.yaml#defaultSceneDuration\`) wins

## Lineage

Cherry-picked from the closed #104 — that PR also rebuilt the synthesised hero MP4, which the v0.58 pivot deprecated. The duration fix is independent and useful, so it ships standalone.

## Test plan

- [x] \`pnpm -F @vibeframe/cli build\` green
- [x] \`pnpm -F @vibeframe/cli lint\` 0 errors
- [x] 112 scene-adjacent tests pass
- [ ] CI: typecheck + build-and-test (20, 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)