### PR TITLE
chore(counts): standardise README comparison table on 58 MCP tools + harden sync hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | Layer | Hyperframes | VibeFrame |
 |---|---|---|
 | **AI generation** | — | OpenAI gpt-image-2 (image default since v0.56), fal.ai Seedance 2.0 (video default since v0.57), Veo, Kling, Runway, Grok, ElevenLabs, Replicate |
-| **Agent integrations** | — | MCP server (59 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
+| **Agent integrations** | — | MCP server (58 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
 | **Traditional editing** | — | `vibe edit` silence-cut · jump-cut · caption · grade · reframe · speed-ramp · fade · noise-reduce (84+ commands total) |
 | **AI analysis** | — | `vibe analyze` media/video/review/suggest (multimodal LLMs) |
 | **AI pipelines** | composition format only | `vibe pipeline script-to-video` · `highlights` · `auto-shorts` · `animated-caption` |
@@ -87,7 +87,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | **Local Kokoro TTS** | ✅ Python `kokoro-onnx` | ✅ Node `kokoro-js` — same Kokoro-82M model, auto-fallback when no `ELEVENLABS_API_KEY` |
 | **Local Whisper transcribe** | ✅ whisper-cpp (offline) | OpenAI Whisper API (cloud, word-level) |
 | **Claude Code skills** | ✅ `hyperframes skills add` | ✅ ships `/vibeframe`, `/vibe-pipeline`, `/vibe-script-to-video`, `/vibe-scene` |
-| **MCP server** | ❌ | ✅ 59 tools |
+| **MCP server** | ❌ | ✅ 58 tools |
 | **Render** | ✅ native (BeginFrame, parity, HDR, Studio NLE) | uses Hyperframes backend or FFmpeg |
 | **License** | Apache 2.0 | MIT |
 

--- a/scripts/sync-counts.sh
+++ b/scripts/sync-counts.sh
@@ -111,6 +111,20 @@ R_MCP_BUNDLED=$(first_num '\*\*[0-9]+ MCP tools\*\*' README.md)
 [ -n "$R_MCP_BUNDLED" ] && [ "$R_MCP_BUNDLED" != "$MCP_TOOLS" ] && \
   err "README.md MCP cell shows '${R_MCP_BUNDLED} MCP tools' but actual = ${MCP_TOOLS}"
 
+# Comparison table — "MCP server (N tools, ..." and "✅ N tools" cells.
+# These were missed before #108 cleanup landed; check each occurrence.
+while IFS= read -r line; do
+  N=$(echo "$line" | grep -oE 'MCP server \([0-9]+ tools' | grep -oE '[0-9]+' | head -1)
+  [ -n "$N" ] && [ "$N" != "$MCP_TOOLS" ] && \
+    err "README.md comparison row says 'MCP server (${N} tools' but actual = ${MCP_TOOLS}"
+done < <(grep -E 'MCP server \([0-9]+ tools' README.md)
+
+while IFS= read -r line; do
+  N=$(echo "$line" | grep -oE '✅ [0-9]+ tools' | grep -oE '[0-9]+' | head -1)
+  [ -n "$N" ] && [ "$N" != "$MCP_TOOLS" ] && \
+    err "README.md MCP-server row says '✅ ${N} tools' but actual = ${MCP_TOOLS}"
+done < <(grep -E '✅ [0-9]+ tools' README.md)
+
 # ── A2. apps/web/app/page.tsx hero copy ─────────────────────────────────
 # Hero copy may interpolate ${process.env.NEXT_PUBLIC_AI_PROVIDERS} (preferred)
 # or hardcode. If hardcoded, must match.


### PR DESCRIPTION
## Summary

Task A on the v0.58 diagnostic plan — clean up the 58/59 MCP-tool drift in the README before publishing v0.58.0 to npm. Two changes:

1. **README.md comparison table** — rows for "Agent integrations" and "MCP server" now read "58 tools" (matches `mcp-server/src/tools/` actual count). The tagline was already 58 from #97; only the deeper comparison cells had stale 59s.
2. **`scripts/sync-counts.sh`** — adds two new patterns:
   - `MCP server (N tools, ...` → must equal \`\$MCP_TOOLS\`
   - `✅ N tools` → must equal \`\$MCP_TOOLS\`
   Both enumerate every match (not just first) so future comparison rows are covered.

## Verified

- \`bash scripts/sync-counts.sh --check\` → "All SSOT counts and provider enumeration in sync."
- Temporarily injecting "99 tools" trips the new hook with the expected error.
- Pre-existing checks (tagline, agent count, MCP cell) still pass.

## Test plan

- [x] Sync hook clean
- [x] Sync hook catches injected drift (tested with temporary "99 tools")
- [ ] CI: typecheck + build-and-test (20, 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)