### PR TITLE
docs(demo): restore asciinema embeds + add v0.58 callout (R1 stopgap)

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -4,6 +4,11 @@ Three surfaces, same tools. Pick the entry point that matches how you already
 work — every section below is **copy-pasteable** and produces a real artifact
 on disk.
 
+> The asciinema recordings in the [README](README.md#demo) show v0.57 commands and
+> pre-date the v0.58 visual-identity features (`vibe scene init --visual-style "<name>"`,
+> `vibe scene styles`, the `DESIGN.md` hard-gate). The walkthroughs below include both —
+> start with whichever surface fits you.
+
 | Surface | Best for | API keys needed |
 |---|---|---|
 | [1. CLI direct (`vibe`)](#1-cli-direct--vibe-quickstart) | Scripted workflows, CI, terminal-first authors | None for the offline path; `OPENAI_API_KEY` for word-sync captions |
@@ -27,7 +32,10 @@ TTS); a Whisper key adds word-synced captions if you set one.
 vibe doctor                                   # checks Node, FFmpeg, Chrome
 
 # 1. Scaffold a scene project (16:9, default 30s root)
-vibe scene init my-promo
+#    --visual-style seeds DESIGN.md from a named identity. Browse the 8
+#    available styles with `vibe scene styles`. Omit the flag to write a
+#    placeholder DESIGN.md you fill in yourself.
+vibe scene init my-promo --visual-style "Swiss Pulse"
 cd my-promo
 
 # 2. Add a narrated hook scene

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@
 
 ## Demo
 
-VibeFrame meets you wherever you write — same 58 MCP tools, three surfaces. The
-recordings below are being re-cut for v0.58; in the meantime,
-**[`DEMO.md`](DEMO.md)** has a copy-pasteable follow-along for each surface that
-produces a real artifact in under five minutes.
+VibeFrame meets you wherever you write — same 58 MCP tools, three surfaces. Each
+clip below is a real terminal recording. For a copy-pasteable walkthrough you
+can follow live, see **[`DEMO.md`](DEMO.md)**.
 
 ### 1. Quickstart — `vibe` CLI directly (≈90 s)
 
@@ -24,8 +23,9 @@ Install, scaffold a scene project, narrate with free local Kokoro TTS, render to
 MP4 with synced captions.
 
 <p align="center">
-  <i>📹 Recording coming soon (v0.58 re-cut). Follow along in
-  <a href="DEMO.md#1-cli-direct--vibe-quickstart">DEMO.md › 1. CLI direct</a>.</i>
+  <a href="https://github.com/vericontext/vibeframe/blob/main/assets/demos/vibeframe-quickstart.svg">
+    <img src="https://raw.githubusercontent.com/vericontext/vibeframe/main/assets/demos/vibeframe-quickstart.svg" alt="VibeFrame CLI quickstart asciinema" />
+  </a>
 </p>
 
 ### 2. Standalone agent mode — `vibe agent` (≈50 s)
@@ -34,8 +34,9 @@ Bring your own LLM (Claude / OpenAI / Gemini / Grok / OpenRouter / Ollama).
 Natural language in, multi-tool execution out — no MCP host required.
 
 <p align="center">
-  <i>📹 Recording coming soon (v0.58 re-cut). Follow along in
-  <a href="DEMO.md#2-standalone-agent-repl--vibe-agent">DEMO.md › 2. Standalone agent REPL</a>.</i>
+  <a href="https://github.com/vericontext/vibeframe/blob/main/assets/demos/vibeframe-agent.svg">
+    <img src="https://raw.githubusercontent.com/vericontext/vibeframe/main/assets/demos/vibeframe-agent.svg" alt="VibeFrame agent mode asciinema (BYO LLM)" />
+  </a>
 </p>
 
 ### 3. Inside Claude Code / Cursor (MCP) — `@vibeframe/mcp-server`
@@ -44,11 +45,14 @@ Same tools as `vibe agent`, surfaced through MCP for any compatible host. One
 JSON config block, no CLI install needed (`npx` pulls the bundle on demand).
 
 <p align="center">
-  <i>📹 Recording coming soon (v0.58 re-cut). Follow along in
-  <a href="DEMO.md#3-inside-claude-code--cursor-mcp">DEMO.md › 3. Inside Claude Code / Cursor</a>.</i>
+  <a href="https://github.com/vericontext/vibeframe/blob/main/assets/demos/vibeframe-claude-code.svg">
+    <img src="https://raw.githubusercontent.com/vericontext/vibeframe/main/assets/demos/vibeframe-claude-code.svg" alt="VibeFrame inside Claude Code (MCP) asciinema" />
+  </a>
 </p>
 
-[`assets/demos/claude-code-walkthrough.md`](assets/demos/claude-code-walkthrough.md) has the original 5-prompt walkthrough plus the recording recipe.
+> **New in v0.58 (not yet in the recordings above):** `vibe scene init --visual-style "Swiss Pulse"` seeds a `DESIGN.md` hard-gate; `vibe scene styles` browses 8 named visual identities (Swiss Pulse, Velvet Standard, Deconstructed, Maximalist Type, Data Drift, Soft Signal, Folk Frequency, Shadow Cut). The cinematic-craft path runs through Hyperframes' `/hyperframes` skill in Claude Code — `npx skills add heygen-com/hyperframes`. See [`docs/ROADMAP-v0.58.md`](docs/ROADMAP-v0.58.md) for the v0.59 / v0.60 plan.
+
+[`assets/demos/claude-code-walkthrough.md`](assets/demos/claude-code-walkthrough.md) has the full 5-prompt walkthrough plus the recording recipe.
 
 **Older long-form videos**: [CLI walkthrough](https://youtu.be/EJUUpPp2d_8) · [Claude Code integration](https://youtu.be/sdf930sZ7co)
 


### PR DESCRIPTION
## Summary

Task C on the v0.58 diagnostic plan — bridge the demo credibility gap (R1) until v0.60 ships the cinematic-finish demo via v0.59 \`compose-scenes-with-skills\`.

PR #108 demoted the three asciinema SVGs to "Coming soon (v0.58 re-cut)" out of caution. **That demote was too aggressive.** The recordings show v0.57 CLI commands that all still work in v0.58 — v0.58 only *added* a new path (DESIGN.md hard-gate + named visual styles) without breaking anything in the cuts. Three "Coming soon" placeholders were a worse first impression than three accurate-but-pre-v0.58 recordings.

## What ships

- **Re-embeds** \`assets/demos/vibeframe-{quickstart,agent,claude-code}.svg\` in the README. Files were never deleted in #108 (still in repo at \`assets/demos/\`); only the embed was removed.
- **"New in v0.58" callout** under the three demos pointing at \`--visual-style\`, \`vibe scene styles\`, the \`DESIGN.md\` hard-gate, and \`npx skills add heygen-com/hyperframes\`. Honest expectations: recordings predate these features, here's what's new.
- **DEMO.md preamble note** that the recordings predate v0.58 (so readers landing there from README's links aren't surprised by new flags in §1).
- **DEMO.md §1 scaffold** now uses \`vibe scene init my-promo --visual-style "Swiss Pulse"\` — exercises the v0.58 surface in the copy-pasteable walkthrough.

## What's NOT in this PR

- Re-recording the asciinema cuts. That waits for v0.60 when the new demo (cinematic, via v0.59 compose-scenes-with-skills) is ready to be the canonical hero.

## R1 status before / after

| | Before (post-#108) | After (this PR) |
|---|---|---|
| /demo hero | 3× "📹 Coming soon (v0.58 re-cut)" | 3× real terminal recordings + v0.58 callout |
| README first impression | Coming soon × 3 | Three accurate cuts + clear "what's new" |
| Honesty about v0.58 features | Implied recordings would be re-cut | Explicit: recordings predate v0.58, here are the new features |

## Test plan

- [x] \`scripts/sync-counts.sh --check\` clean
- [x] No leftover "Coming soon" strings in README/DEMO
- [ ] Vercel preview shows three asciinema SVGs at /demo
- [ ] CI: typecheck + build-and-test (20, 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)