### PR TITLE
fix(image): cast commander strings to ImageOptions unions in shared helper

### DIFF
--- a/packages/cli/src/commands/_shared/openai-image.ts
+++ b/packages/cli/src/commands/_shared/openai-image.ts
@@ -16,7 +16,7 @@
  */
 
 import { OpenAIImageProvider } from "@vibeframe/ai-providers";
-import type { ImageResult } from "@vibeframe/ai-providers";
+import type { ImageOptions, ImageResult } from "@vibeframe/ai-providers";
 
 /** Subset of CLI options consumed by the helper. */
 export interface OpenAIImageHelperOptions {
@@ -66,11 +66,18 @@ export async function executeOpenAIImageGenerate(
 
   const { openaiModel, modelLabel } = resolveOpenAIImageModel(options.model);
 
+  // commander hands back unconstrained strings for `--size` / `--quality`
+  // / `--style`. The provider's `ImageOptions` narrows these to specific
+  // unions ("1024x1024" | "1536x1024" | …, etc.). The original duplicated
+  // handlers were `any`-typed via commander's loose `OptionValues`, which
+  // is why this never tripped before the dedup; the helper makes the
+  // shape explicit, so we cast at the single call boundary instead of
+  // ANY-laundering through the call sites.
   const result = await provider.generateImage(prompt, {
     model: openaiModel,
-    size: options.size,
-    quality: options.quality,
-    style: options.style,
+    size: options.size as ImageOptions["size"],
+    quality: options.quality as ImageOptions["quality"],
+    style: options.style as ImageOptions["style"],
     n: options.count !== undefined ? parseInt(options.count, 10) : undefined,
   });
 


### PR DESCRIPTION
## Summary

#112 (G) shipped a typecheck regression that admin-override let through. CI's strict \`pnpm -r exec tsc --noEmit\` reported:

\`\`\`
src/commands/_shared/openai-image.ts(71,5): error TS2322:
  Type 'string | undefined' is not assignable to type
  '"auto" | "1024x1024" | "1536x1024" | "1024x1536" | undefined'.
\`\`\`

(same for \`quality\` and \`style\`).

**Why local missed it:** \`pnpm build\` is esbuild bundling, \`pnpm test\` is vitest — neither runs strict tsc across all packages. The typecheck CI job is the gate.

**Why the original handlers didn't trip this:** they passed commander's loose \`OptionValues\` (effectively \`any\`) directly into the provider call. \`any\` satisfies any narrow union. The dedup helper made the shape explicit (\`string | undefined\`), which doesn't.

**Fix:** cast at the single helper boundary using the provider's exported \`ImageOptions["size"]\` / \`["quality"]\` / \`["style"]\` types. One file changed, +11 / -4 lines. Documented cast points so future readers know why.

#113 (E) typecheck also failed in CI for the same reason — it was branched off main *after* #112 merged, so it inherited the broken typecheck. Both get retroactively fixed by this PR.

## Verified

- \`pnpm -r exec tsc --noEmit\` exits 0
- Behaviour parity preserved (commander still hands strings, provider still narrows them at the API call boundary)

## Test plan

- [x] Local typecheck clean
- [ ] CI: typecheck + build-and-test (20, 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)