### PR TITLE
chore(gitignore): drop vestigial entries for tracked dev docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,9 @@ packages/cli/*.mp3
 # Docs media (regenerable)
 docs/*.mp4
 
-# Internal docs
+# Private dev docs — patterns kept so locally-created files stay out
+# of accidental `git add .`. Files like scripts/FUNC_TEST.md /
+# QUICK_TEST.md / CLAUDE_CODE_TEST.md *are* committed dev playbooks
+# (golden-path smoke tests) — they're public on purpose.
 ROADMAP-CLOUD.md
 scripts/DEV_GUIDE.md
-scripts/FUNC_TEST.md
-scripts/QUICK_TEST.md


### PR DESCRIPTION
## Summary

L2 of the post-v0.58 dead-code cleanup. \`scripts/FUNC_TEST.md\` and \`scripts/QUICK_TEST.md\` are **tracked dev playbooks** (golden-path smoke tests for new contributors) — they're meant to be in the repo. The gitignore entries were no-ops (gitignore only filters untracked paths) and the "Internal docs" header implied they were private, contradicting actual state.

## Diff

\`\`\`diff
-# Internal docs
+# Private dev docs — patterns kept so locally-created files stay out
+# of accidental \`git add .\`. Files like scripts/FUNC_TEST.md /
+# QUICK_TEST.md / CLAUDE_CODE_TEST.md *are* committed dev playbooks
+# (golden-path smoke tests) — they're public on purpose.
 ROADMAP-CLOUD.md
 scripts/DEV_GUIDE.md
-scripts/FUNC_TEST.md
-scripts/QUICK_TEST.md
\`\`\`

\`ROADMAP-CLOUD.md\` and \`scripts/DEV_GUIDE.md\` stay — they don't currently exist on disk but the patterns protect against future locally-created private files.

## Test plan

- [x] No code change; gitignore-only edit
- [ ] CI: typecheck + build-and-test (20, 22) — should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)