### PR TITLE
refactor(pipeline): remove deprecated 'narrations' field — use narrationEntries throughout

### DIFF
--- a/packages/cli/src/agent/tools/integration.test.ts
+++ b/packages/cli/src/agent/tools/integration.test.ts
@@ -25,7 +25,7 @@ vi.mock("../../commands/ai-script-pipeline.js", () => ({
     scenes: 3,
     storyboardPath: "/test/output/storyboard.json",
     projectPath: "/test/output/project.vibe.json",
-    narrations: ["/test/output/narration-1.mp3"],
+    narrationEntries: [{ path: "/test/output/narration-1.mp3", duration: 3, segmentIndex: 0, failed: false }],
     images: ["/test/output/scene-1.png"],
     videos: ["/test/output/scene-1.mp4"],
     totalDuration: 30,

--- a/packages/cli/src/commands/ai-script-pipeline.ts
+++ b/packages/cli/src/commands/ai-script-pipeline.ts
@@ -571,8 +571,6 @@ export interface ScriptToVideoResult {
   storyboardPath?: string;
   /** Path to the generated .vibe.json project file */
   projectPath?: string;
-  /** @deprecated Use narrationEntries for proper segment tracking */
-  narrations?: string[];
   /** Narration entries with segment index tracking */
   narrationEntries?: NarrationEntry[];
   /** Paths to generated scene images */
@@ -730,7 +728,6 @@ export async function executeScriptToVideo(
       outputDir: absOutputDir,
       scenes: segments.length,
       storyboardPath,
-      narrations: [],
       narrationEntries: [],
       images: [],
       videos: [],
@@ -808,8 +805,6 @@ export async function executeScriptToVideo(
 
           segment.duration = actualDuration;
 
-          // Add to both arrays for backwards compatibility
-          result.narrations!.push(audioPath);
           result.narrationEntries!.push({
             path: audioPath,
             duration: actualDuration,


### PR DESCRIPTION
## Summary

L3 of the post-v0.58 dead-code cleanup. \`ScriptToVideoResult.narrations?: string[]\` was marked \`@deprecated\` ("Use narrationEntries"), but the same file kept populating it side-by-side with \`narrationEntries\` "for backwards compatibility." Nobody actually consumed \`result.narrations\` — every downstream reader uses \`narrationEntries\`.

## What's gone

- \`narrations?: string[]\` field on \`ScriptToVideoResult\` (with the \`@deprecated\` comment)
- \`narrations: []\` initialiser
- \`result.narrations!.push(audioPath)\` dual-write loop body + its "backwards compatibility" comment
- Integration test mock updated to use the proper \`NarrationEntry\` shape

## Why it's safe

\`grep -rn "result\\.narrations\\|narrations:" packages\` confirms zero remaining references. The two production consumers (scene materialiser line 953, timeline narration-clip loop line 1315) already read from \`narrationEntries\`.

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\` exit 0
- [x] 48 tests pass (segments-to-scenes 12 + integration 36)
- [x] \`pnpm lint\` 0 errors
- [ ] CI: typecheck + build-and-test (20, 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)