### PR TITLE
docs(examples): add catalog README, link from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ vibe run promo.yaml               # execute pipeline
 vibe run promo.yaml --resume      # retry from last checkpoint
 ```
 
-See [examples/](examples/) for ready-to-use pipeline templates.
+See [`examples/README.md`](examples/README.md) for the catalog — three runnable YAML pipelines (offline / AI promo / budget-capped) plus a bilingual `scene-promo/` project.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# VibeFrame examples
+
+Each YAML below is a runnable pipeline. Pass `--dry-run` first to see the
+projected cost; remove the flag to actually execute.
+
+| File | What it does | API keys | Est. cost |
+|---|---|---|---|
+| [`demo-pipeline.yaml`](demo-pipeline.yaml) | Detect scene changes, cut silence, add fade in/out — entirely offline | _(none — FFmpeg only)_ | $0 |
+| [`promo-video.yaml`](promo-video.yaml) | Image + narration + music + image-to-video + audio mix + colour grade — six steps, full AI promo | `GOOGLE_API_KEY`, `XAI_API_KEY`, `ELEVENLABS_API_KEY` | ≈ $5 |
+| [`promo-with-budget.yaml`](promo-with-budget.yaml) | Same shape as `promo-video.yaml` but with a `budget.costUsd: 5.00` ceiling — executor aborts before any step that would exceed it. Demonstrates [Opus 4.7 Task Budgets](../docs/ROADMAP-v0.58.md). | same as above | ≤ $5 (enforced) |
+| [`scene-promo/`](scene-promo/) | Bilingual scene-authoring project (works with both `vibe scene` and `npx hyperframes`). The canonical scene example referenced by [`docs/comparison.md`](../docs/comparison.md) and [`tests/comparison/render-bench.sh`](../tests/comparison/render-bench.sh). | optional `OPENAI_API_KEY` (Whisper word-sync), `ELEVENLABS_API_KEY` (else local Kokoro) | ≤ $0.20 |
+
+## Running
+
+```bash
+vibe run examples/demo-pipeline.yaml             # offline, ~30 s
+vibe run examples/promo-video.yaml --dry-run     # preview cost, no API calls
+vibe run examples/promo-video.yaml               # execute (will spend ≈ $5)
+
+# scene-promo lives in its own dir — see its README
+vibe scene render --project examples/scene-promo
+```
+
+For a step-by-step authoring walkthrough, see [`DEMO.md`](../DEMO.md). For
+the full command reference, [`docs/cookbook.md`](../docs/cookbook.md). For
+the YAML pipeline DSL itself, [`/vibe-pipeline`](../.claude/skills/vibe-pipeline/SKILL.md)
+(Claude Code skill).


### PR DESCRIPTION
## Summary

L4 of the post-v0.58 dead-code cleanup. Three YAML pipelines under \`examples/\` had **zero references** outside the dir — README only had a generic \`See [examples/](examples/)\` link. Each YAML actually parses + dry-runs cleanly; they were just hidden.

## Verified the YAMLs work

\`\`\`
demo-pipeline.yaml         → 3 steps, $0          (FFmpeg only)
promo-video.yaml           → 6 steps, ≈$5         (full AI promo)
promo-with-budget.yaml     → 4 steps, $5.42 projected vs $5.00 ceiling — abort surfaces correctly
\`\`\`

## What ships

- New \`examples/README.md\` — one-screen catalog: file × purpose × API keys × estimated cost × \`vibe run\` line
- Includes \`scene-promo/\` (the bilingual scene-authoring project already referenced from \`docs/comparison.md\` + \`tests/comparison/render-bench.sh\`) so all 4 example shapes are visible from one place
- README's existing \`examples/\` line tightened to point at the new index

## Test plan

- [x] All 3 YAMLs dry-run cleanly
- [x] \`tsc --noEmit\` clean (no code change)
- [ ] CI: typecheck + build-and-test (20, 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)