### PR TITLE
feat(scene): lint retry loop wraps composeBeatHtml (v0.59 C4)

### DIFF
--- a/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
@@ -7,13 +7,17 @@ import {
   buildSystemPrompt,
   buildUserPrompt,
   composeBeatHtml,
+  composeBeatWithRetry,
   computeCacheKey,
   defaultCacheDir,
   extractHtml,
+  formatLintFeedback,
+  lintBeatHtml,
   ComposeBeatError,
 } from "./compose-scenes-skills.js";
 
 import type { Beat } from "./storyboard-parse.js";
+import type { LintFinding } from "./scene-lint.js";
 
 // Shared fixtures
 const beat: Beat = {
@@ -248,5 +252,159 @@ describe("composeBeatHtml", () => {
 
     const args = create.mock.calls[0][0];
     expect(args.max_tokens).toBe(8_000);
+  });
+});
+
+// ── Lint feedback helpers (C4) ──────────────────────────────────────────
+
+describe("formatLintFeedback", () => {
+  it("returns empty string when no errors", () => {
+    expect(formatLintFeedback([])).toBe("");
+    const warningsOnly: LintFinding[] = [
+      { severity: "warning", code: "x", message: "y" },
+    ];
+    expect(formatLintFeedback(warningsOnly)).toBe("");
+  });
+
+  it("formats each error as ERROR [code] message", () => {
+    const findings: LintFinding[] = [
+      { severity: "error", code: "missing_clip_class", message: 'div lacks class="clip"' },
+      { severity: "error", code: "no_timeline", message: "no GSAP timeline registered" },
+    ];
+    const out = formatLintFeedback(findings);
+    expect(out).toContain('ERROR [missing_clip_class] div lacks class="clip"');
+    expect(out).toContain("ERROR [no_timeline] no GSAP timeline registered");
+  });
+
+  it("includes fixHint on a separate line when present", () => {
+    const findings: LintFinding[] = [
+      {
+        severity: "error",
+        code: "missing_clip_class",
+        message: 'div lacks class="clip"',
+        fixHint: 'add class="clip" to the timed div',
+      },
+    ];
+    const out = formatLintFeedback(findings);
+    expect(out).toContain("Fix hint: add class=\"clip\"");
+  });
+
+  it("filters out non-error findings (warnings/info)", () => {
+    const findings: LintFinding[] = [
+      { severity: "error", code: "real-error", message: "fix me" },
+      { severity: "warning", code: "soft-warn", message: "minor" },
+      { severity: "info", code: "fyi", message: "irrelevant" },
+    ];
+    const out = formatLintFeedback(findings);
+    expect(out).toContain("real-error");
+    expect(out).not.toContain("soft-warn");
+    expect(out).not.toContain("fyi");
+  });
+});
+
+describe("lintBeatHtml", () => {
+  it("returns errors for HTML missing required structure", () => {
+    // Missing data-composition-id, data-width, data-height entirely
+    const html = `<template id="bad"><div>hi</div></template>`;
+    const r = lintBeatHtml(html, "test");
+    expect(r.errorCount).toBeGreaterThan(0);
+  });
+
+  it("structure has expected counts shape", () => {
+    const html = `<template id="bad"><div>nothing</div></template>`;
+    const r = lintBeatHtml(html, "test");
+    expect(r).toHaveProperty("errorCount");
+    expect(r).toHaveProperty("warningCount");
+    expect(r).toHaveProperty("findings");
+    expect(Array.isArray(r.findings)).toBe(true);
+  });
+});
+
+// ── composeBeatWithRetry (C4) ───────────────────────────────────────────
+
+const validHtml = `<template id="scene-1-template">
+  <div data-composition-id="scene-1" data-width="1920" data-height="1080" data-start="0" data-duration="3">
+    <div class="clip" data-start="0" data-duration="3" data-track-index="0">
+      <p>Hello</p>
+    </div>
+    <script>
+      window.__timelines = window.__timelines || {};
+      window.__timelines["scene-1"] = { paused: true };
+    </script>
+  </div>
+</template>`;
+
+const invalidHtml = `<template id="bad"><div>nothing</div></template>`;
+
+function fenced(html: string): string {
+  return "```html\n" + html + "\n```";
+}
+
+describe("composeBeatWithRetry", () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), "compose-retry-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("returns lintAttempts=1 when first shot lints clean", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: fenced(validHtml) }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    const r = await composeBeatWithRetry(
+      { ...baseCtx, cacheDir },
+      { client: { messages: { create } } as never },
+    );
+
+    expect(r.lintAttempts).toBe(1);
+    expect(r.lint.errorCount).toBe(0);
+    expect(create).toHaveBeenCalledOnce();
+  });
+
+  it("retries with feedback when first shot fails lint, returns lintAttempts=2 on success", async () => {
+    const create = vi.fn()
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: fenced(invalidHtml) }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: fenced(validHtml) }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+
+    const r = await composeBeatWithRetry(
+      { ...baseCtx, cacheDir },
+      { client: { messages: { create } } as never },
+    );
+
+    expect(r.lintAttempts).toBe(2);
+    expect(r.lint.errorCount).toBe(0);
+    expect(create).toHaveBeenCalledTimes(2);
+
+    // Retry call's user prompt must include the lint findings as feedback
+    const retryArgs = create.mock.calls[1][0];
+    const retryUserMsg = retryArgs.messages[0].content;
+    expect(retryUserMsg).toContain("Previous attempt failed lint");
+  });
+
+  it("throws lint-failed-after-retry when both attempts fail", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: fenced(invalidHtml) }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    await expect(
+      composeBeatWithRetry({ ...baseCtx, cacheDir }, { client: { messages: { create } } as never }),
+    ).rejects.toMatchObject({
+      name: "ComposeBeatError",
+      code: "lint-failed-after-retry",
+    });
+    expect(create).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.ts
@@ -32,6 +32,12 @@ import { readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import {
+  runHyperframeLint,
+  type PreparedHyperframeLintInput,
+} from "@hyperframes/producer";
+
+import { filterSubCompFalsePositives, type LintFinding } from "./scene-lint.js";
 import type { Beat } from "./storyboard-parse.js";
 
 /** Effort level → model + token caps. */
@@ -301,4 +307,98 @@ export async function composeBeatHtml(
     latencyMs,
     model: settings.model,
   };
+}
+
+// ── Lint retry loop (C4) ────────────────────────────────────────────────
+
+export interface BeatLintResult {
+  errorCount: number;
+  warningCount: number;
+  findings: LintFinding[];
+}
+
+/**
+ * Lint a single beat's HTML in-memory using `@hyperframes/producer`'s
+ * `runHyperframeLint` directly — no temp project shell, no subprocess.
+ *
+ * Sub-composition false-positives are filtered (matches what the
+ * `vibe scene lint` command does). The result is the same set of
+ * findings the user would see if they ran `vibe scene lint` after
+ * the beat HTML landed in a project.
+ */
+export function lintBeatHtml(html: string, beatId: string): BeatLintResult {
+  const prepared: PreparedHyperframeLintInput = {
+    html,
+    entryFile: `compositions/scene-${beatId}.html`,
+    source: "projectDir",
+  };
+  const raw = runHyperframeLint(prepared);
+  const findings = filterSubCompFalsePositives(raw.findings as LintFinding[], true);
+  return {
+    errorCount: findings.filter((f) => f.severity === "error").length,
+    warningCount: findings.filter((f) => f.severity === "warning").length,
+    findings,
+  };
+}
+
+/**
+ * Format lint findings into a feedback block for the retry prompt.
+ * Errors only — warnings don't block, so we don't burn the LLM's
+ * attention budget on them.
+ */
+export function formatLintFeedback(findings: LintFinding[]): string {
+  const errors = findings.filter((f) => f.severity === "error");
+  if (errors.length === 0) return "";
+  return errors
+    .map((f) => {
+      const fix = f.fixHint ? `\n  Fix hint: ${f.fixHint}` : "";
+      return `ERROR [${f.code}] ${f.message}${fix}`;
+    })
+    .join("\n");
+}
+
+export interface ComposeBeatWithRetryResult extends ComposeBeatResult {
+  /** 1 if first-shot HTML linted clean; 2 if retry succeeded. */
+  lintAttempts: 1 | 2;
+  /** Lint result from the *final* (winning) attempt. */
+  lint: BeatLintResult;
+}
+
+/**
+ * `composeBeatHtml` + lint feedback retry loop, capped at 1 retry.
+ *
+ * Pre-flight (PR #111) showed 5/5 first-pass success at $0.058/scene; deeper
+ * retry loops just burn budget. If the second attempt also fails lint,
+ * throws `ComposeBeatError("lint-failed-after-retry", ...)` with the final
+ * findings — caller (C5 pipeline action) decides whether to fall back to
+ * the 5-preset emit path or surface the failure to the user.
+ *
+ * Cache contract preserved: retries use a different `retryFeedback`, which
+ * is folded into the cache key, so retries don't accidentally serve the
+ * cached first-shot HTML.
+ */
+export async function composeBeatWithRetry(
+  ctx: ComposeBeatContext,
+  overrides?: { client?: Anthropic; now?: () => number },
+): Promise<ComposeBeatWithRetryResult> {
+  // Attempt 1 — no retry feedback (cache-friendly first shot).
+  const first = await composeBeatHtml(ctx, overrides);
+  const lint1 = lintBeatHtml(first.html, ctx.beat.id);
+  if (lint1.errorCount === 0) {
+    return { ...first, lintAttempts: 1, lint: lint1 };
+  }
+
+  // Attempt 2 — feed lint findings back into the prompt.
+  const feedback = formatLintFeedback(lint1.findings);
+  const second = await composeBeatHtml({ ...ctx, retryFeedback: feedback }, overrides);
+  const lint2 = lintBeatHtml(second.html, ctx.beat.id);
+  if (lint2.errorCount === 0) {
+    return { ...second, lintAttempts: 2, lint: lint2 };
+  }
+
+  // Both failed → fatal.
+  throw new ComposeBeatError(
+    "lint-failed-after-retry",
+    `Beat "${ctx.beat.id}" failed lint after retry. Final findings:\n${formatLintFeedback(lint2.findings)}`,
+  );
 }


### PR DESCRIPTION
## Summary

**v0.59 C4.** Wraps \`composeBeatHtml\` (C3) with a single-retry lint feedback loop so the agent gets one chance to fix its own mistakes before falling out to the caller.

## New exports

\`\`\`ts
lintBeatHtml(html, beatId) → BeatLintResult
formatLintFeedback(findings) → string
composeBeatWithRetry(ctx) → ComposeBeatWithRetryResult
\`\`\`

## Flow

\`\`\`
Attempt 1 (no retry feedback)
  → lint clean → return { lintAttempts: 1 }
  → lint errors → format feedback, attempt 2
                → lint clean → return { lintAttempts: 2 }
                → lint errors → throw ComposeBeatError("lint-failed-after-retry")
\`\`\`

Caller (C5 pipeline action) decides whether to fall back to the 5-preset emit path or surface failure.

## Why 1 retry max

Pre-flight (PR #111) showed 5/5 first-pass success at \$0.058/scene. Deeper retry loops just burn budget on edge cases the prompt couldn't fix.

## Cache contract preserved

\`retryFeedback\` is part of the cache key (folded by C3's \`computeCacheKey\`) so retries don't accidentally serve the cached first-shot HTML. Two attempts → up to two cache entries with different keys.

## Lint mechanism

In-memory via \`@hyperframes/producer\`'s \`runHyperframeLint\` directly — no temp project shell, no subprocess. Sub-composition false positives filtered (matches what the \`vibe scene lint\` command does).

## Verification

- 29/29 unit tests pass (was 20 from C3, +9 here: 4 formatLintFeedback, 2 lintBeatHtml, 3 composeBeatWithRetry)
- Mocked Anthropic SDK; no live API calls
- \`tsc --noEmit\` exits 0
- \`lint\` 0 errors