### PR TITLE
feat(scene): per-beat fanout + onProgress callback (v0.59 C6)

### DIFF
--- a/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
@@ -512,6 +512,89 @@ describe("executeComposeScenesWithSkills", () => {
     expect(r.error).toContain("no `## Beat …` headings");
   });
 
+  it("emits onProgress events per beat: start → fresh|cached|failed", async () => {
+    seedProject(
+      projectRoot,
+      "# d",
+      "## Beat 1 — A\n\nbody\n\n## Beat 2 — B\n\nbody\n",
+    );
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: fenceHtml(validSceneHtml) }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+    const events: string[] = [];
+
+    await executeComposeScenesWithSkills(
+      {
+        cacheDir,
+        onProgress: (e) => events.push(`${e.type}:${e.beatId}:${e.beatIndex}`),
+      },
+      projectRoot,
+      { client: { messages: { create } } as never },
+    );
+
+    // Both beats fired through start → fresh (no cache hits on first run).
+    expect(events).toContain("beat-start:1:0");
+    expect(events).toContain("beat-start:2:1");
+    expect(events).toContain("beat-fresh:1:0");
+    expect(events).toContain("beat-fresh:2:1");
+    expect(events.filter((e) => e.startsWith("beat-failed"))).toHaveLength(0);
+  });
+
+  it("emits beat-cached on second run when content already cached", async () => {
+    seedProject(projectRoot, "# d", "## Beat 1 — A\n\nbody\n");
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: fenceHtml(validSceneHtml) }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    // First run — fresh.
+    const events1: string[] = [];
+    await executeComposeScenesWithSkills(
+      { cacheDir, onProgress: (e) => events1.push(e.type) },
+      projectRoot,
+      { client: { messages: { create } } as never },
+    );
+    expect(events1).toContain("beat-fresh");
+
+    // Second run — same project + same cacheDir → cache hit.
+    const events2: string[] = [];
+    await executeComposeScenesWithSkills(
+      { cacheDir, onProgress: (e) => events2.push(e.type) },
+      projectRoot,
+      { client: { messages: { create } } as never },
+    );
+    expect(events2).toContain("beat-cached");
+    expect(events2).not.toContain("beat-fresh");
+  });
+
+  it("aggregates multiple beat failures into one error message (doesn't fail-fast)", async () => {
+    seedProject(
+      projectRoot,
+      "# d",
+      "## Beat 1 — Bad\n\nbody\n\n## Beat 2 — AlsoBad\n\nbody\n",
+    );
+    // Every call returns invalid HTML → both beats fail twice → both throw.
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: fenceHtml("<template id=\"x\"><div>nope</div></template>") }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    const r = await executeComposeScenesWithSkills(
+      { cacheDir },
+      projectRoot,
+      { client: { messages: { create } } as never },
+    );
+
+    expect(r.success).toBe(false);
+    // Both beat ids appear in the aggregated error (deriveBeatId → "1", "2")
+    expect(r.error).toContain("- 1: ");
+    expect(r.error).toContain("- 2: ");
+    expect(r.error).toMatch(/failed at 2 beats/);
+    // 4 calls total: 2 beats × 2 attempts (initial + retry)
+    expect(create).toHaveBeenCalledTimes(4);
+  });
+
   it("aborts on first beat failure and reports partial progress", async () => {
     seedProject(
       projectRoot,

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.ts
@@ -423,6 +423,13 @@ export async function composeBeatWithRetry(
  *
  * Returns the project root as `output` and per-beat metadata in `data`.
  */
+/** Per-beat lifecycle event emitted to the optional `onProgress` callback. */
+export type ComposeProgressEvent =
+  | { type: "beat-start"; beatId: string; beatIndex: number; totalBeats: number }
+  | { type: "beat-cached"; beatId: string; beatIndex: number; totalBeats: number; lintAttempts: 1 | 2 }
+  | { type: "beat-fresh"; beatId: string; beatIndex: number; totalBeats: number; lintAttempts: 1 | 2; costUsd?: number; latencyMs?: number }
+  | { type: "beat-failed"; beatId: string; beatIndex: number; totalBeats: number; error: string };
+
 export interface ComposeScenesParams {
   /** Path to DESIGN.md, relative to project root. */
   design?: string;
@@ -434,6 +441,8 @@ export interface ComposeScenesParams {
   effort?: ComposeEffort;
   /** Override the cache directory (tests). */
   cacheDir?: string;
+  /** Optional per-beat progress callback (CLI spinner / pipeline reporter). */
+  onProgress?: (event: ComposeProgressEvent) => void;
 }
 
 export interface ComposeScenesActionResult {
@@ -459,8 +468,13 @@ export interface ComposeScenesActionResult {
 }
 
 /**
- * Execute the action. Sequential per-beat fanout in C5; parallelisation
- * lands in C6. Tests inject `overrides` to mock the SDK + clock.
+ * Execute the action. Per-beat fanout via `Promise.allSettled` — all beats
+ * compose in parallel, all errors surface together (rather than fail-fast,
+ * which would still pay for in-flight API calls without surfacing their
+ * findings). Tests inject `overrides` to mock the SDK + clock.
+ *
+ * Wall-clock for an N-beat compose ≈ slowest single beat (~8s @ Sonnet 4.6
+ * per pre-flight PR #111), regardless of N. Cost still scales with N.
  */
 export async function executeComposeScenesWithSkills(
   params: ComposeScenesParams,
@@ -498,18 +512,31 @@ export async function executeComposeScenesWithSkills(
   const compositionsDir = join(projectRoot, "compositions");
   await mkdir(compositionsDir, { recursive: true });
 
-  const written: ComposeScenesActionResult["data"] extends infer D
-    ? D extends { written: infer W } ? W : never
-    : never = [];
-  let totalCostUsd = 0;
-  let totalTokensIn = 0;
-  let totalTokensOut = 0;
-  let cacheHits = 0;
+  const onProgress = params.onProgress ?? (() => {});
+  const totalBeats = beats.length;
 
-  for (const beat of beats) {
-    let result;
+  // Fan out per-beat composes. Each task returns either { ok: true, ... }
+  // (with the result + write path) or { ok: false, error } so we can
+  // aggregate failures in order.
+  type FanoutOutcome =
+    | {
+        ok: true;
+        beatId: string;
+        beatIndex: number;
+        path: string;
+        result: ComposeBeatWithRetryResult;
+      }
+    | {
+        ok: false;
+        beatId: string;
+        beatIndex: number;
+        error: string;
+      };
+
+  const tasks: Array<Promise<FanoutOutcome>> = beats.map(async (beat, beatIndex): Promise<FanoutOutcome> => {
+    onProgress({ type: "beat-start", beatId: beat.id, beatIndex, totalBeats });
     try {
-      result = await composeBeatWithRetry(
+      const result = await composeBeatWithRetry(
         {
           beat,
           designMd,
@@ -521,50 +548,94 @@ export async function executeComposeScenesWithSkills(
         },
         overrides,
       );
+
+      const compositionPath = join(compositionsDir, `scene-${beat.id}.html`);
+      await mkdir(dirname(compositionPath), { recursive: true });
+      await writeFile(compositionPath, result.html, "utf-8");
+
+      if (result.cached) {
+        onProgress({
+          type: "beat-cached",
+          beatId: beat.id,
+          beatIndex,
+          totalBeats,
+          lintAttempts: result.lintAttempts,
+        });
+      } else {
+        onProgress({
+          type: "beat-fresh",
+          beatId: beat.id,
+          beatIndex,
+          totalBeats,
+          lintAttempts: result.lintAttempts,
+          costUsd: result.costUsd,
+          latencyMs: result.latencyMs,
+        });
+      }
+
+      return { ok: true, beatId: beat.id, beatIndex, path: compositionPath, result };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return {
-        success: false,
-        outputPath: projectRoot,
-        error: `compose-scenes-with-skills failed at beat "${beat.id}": ${message}`,
-        data: {
-          beats: beats.length,
-          written,
-          totalCostUsd,
-          totalTokensIn,
-          totalTokensOut,
-          cacheHits,
-        },
-      };
+      onProgress({ type: "beat-failed", beatId: beat.id, beatIndex, totalBeats, error: message });
+      return { ok: false, beatId: beat.id, beatIndex, error: message };
     }
+  });
 
-    const compositionPath = join(compositionsDir, `scene-${beat.id}.html`);
-    await mkdir(dirname(compositionPath), { recursive: true });
-    await writeFile(compositionPath, result.html, "utf-8");
+  const outcomes = await Promise.all(tasks);
 
+  // Aggregate metadata in beat order. `outcomes` is already ordered by
+  // input position (Promise.all preserves order).
+  const written: ComposeScenesActionResult["data"] extends infer D
+    ? D extends { written: infer W } ? W : never
+    : never = [];
+  const failures: Array<{ beatId: string; error: string }> = [];
+  let totalCostUsd = 0;
+  let totalTokensIn = 0;
+  let totalTokensOut = 0;
+  let cacheHits = 0;
+
+  for (const outcome of outcomes) {
+    if (!outcome.ok) {
+      failures.push({ beatId: outcome.beatId, error: outcome.error });
+      continue;
+    }
+    const r = outcome.result;
     written.push({
-      beatId: beat.id,
-      path: compositionPath,
-      cached: result.cached,
-      lintAttempts: result.lintAttempts,
-      costUsd: result.costUsd,
+      beatId: outcome.beatId,
+      path: outcome.path,
+      cached: r.cached,
+      lintAttempts: r.lintAttempts,
+      costUsd: r.costUsd,
     });
-    if (result.cached) cacheHits++;
-    if (result.costUsd) totalCostUsd += result.costUsd;
-    if (result.inputTokens) totalTokensIn += result.inputTokens;
-    if (result.outputTokens) totalTokensOut += result.outputTokens;
+    if (r.cached) cacheHits++;
+    if (r.costUsd) totalCostUsd += r.costUsd;
+    if (r.inputTokens) totalTokensIn += r.inputTokens;
+    if (r.outputTokens) totalTokensOut += r.outputTokens;
+  }
+
+  const aggregateData = {
+    beats: beats.length,
+    written,
+    totalCostUsd: Number(totalCostUsd.toFixed(4)),
+    totalTokensIn,
+    totalTokensOut,
+    cacheHits,
+  };
+
+  if (failures.length > 0) {
+    return {
+      success: false,
+      outputPath: projectRoot,
+      error: failures.length === 1
+        ? `compose-scenes-with-skills failed at beat "${failures[0].beatId}": ${failures[0].error}`
+        : `compose-scenes-with-skills failed at ${failures.length} beats:\n${failures.map((f) => `  - ${f.beatId}: ${f.error}`).join("\n")}`,
+      data: aggregateData,
+    };
   }
 
   return {
     success: true,
     outputPath: projectRoot,
-    data: {
-      beats: beats.length,
-      written,
-      totalCostUsd: Number(totalCostUsd.toFixed(4)),
-      totalTokensIn,
-      totalTokensOut,
-      cacheHits,
-    },
+    data: aggregateData,
   };
 }


### PR DESCRIPTION
## Summary

**v0.59 C6.** Replaces C5's sequential `for` loop with `Promise.all` per-beat fanout + optional progress callback.

Wall-clock for N-beat compose drops from `N × 8s` to `~8s` (max of single beats). Cost scales with N unchanged.

## API additions

\`\`\`ts
ComposeScenesParams.onProgress?: (event: ComposeProgressEvent) => void

ComposeProgressEvent =
  | { type: "beat-start";  beatId; beatIndex; totalBeats }
  | { type: "beat-cached"; beatId; beatIndex; totalBeats; lintAttempts }
  | { type: "beat-fresh";  beatId; beatIndex; totalBeats; lintAttempts; costUsd?; latencyMs? }
  | { type: "beat-failed"; beatId; beatIndex; totalBeats; error }
\`\`\`

Events fire from inside each task's async function — interleaved across beats. Caller spinner / pipeline reporter handles ordering.

## Failure aggregation

`Promise.allSettled`-style behaviour using a typed `FanoutOutcome` union (`{ ok: true | false, … }`).

- **No fail-fast.** Pre-flight noted in-flight Anthropic calls can't be cancelled — paying then aborting wastes budget without shortening user feedback.
- **Aggregated error message** when ≥1 beat fails:
  \`\`\`
  compose-scenes-with-skills failed at 2 beats:
    - 1: <msg>
    - 2: <msg>
  \`\`\`
- `data.written` reports beats that DID succeed even when the action overall returns `success: false` — caller decides partial-output semantics.

## Verification

- 37/37 tests pass (was 34, +3 new: onProgress events, beat-cached on second run, multi-beat failure aggregation)
- `tsc --noEmit` exits 0
- `lint` 0 errors