### PR TITLE
test(v0.59): end-to-end smoke harness for compose-scenes-with-skills (C8)

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -166,6 +166,7 @@ Run 'vibe schema run' for structured parameter info.
             output: s.output,
             duration: s.duration,
             error: s.error,
+            data: s.data,
           })),
         });
       } else {

--- a/tests/v059/smoke.sh
+++ b/tests/v059/smoke.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# tests/v059/smoke.sh
+#
+# End-to-end smoke for v0.59 `compose-scenes-with-skills`. Runs the
+# canonical example (`examples/vibeframe-promo/`) through the pipeline
+# twice — fresh + cached — and asserts:
+#
+#   1. Pipeline succeeds with exit 0 + ok status
+#   2. All 3 expected composition HTMLs are written
+#   3. `vibe scene lint --project <project>` passes (errorCount: 0)
+#   4. Second run hits cache: cacheHits == 3 and totalCostUsd == 0
+#
+# Cost: ≈ $0.18 on the fresh run, $0 on the cached run.
+#
+# Gating: skipped (exit 0) when `ANTHROPIC_API_KEY` is unset, so contributors
+# without the key don't trip CI. CI is configured to run this smoke as an
+# OPTIONAL job; failures here block release branches but don't block PRs
+# from contributors lacking the key.
+#
+# Isolation: a temp HOME is set so the input-hash cache lives in
+# $TMP/.vibeframe/cache/compose-scenes/ instead of the user's real cache.
+# This guarantees the "fresh" run is actually fresh and the "cached" run
+# verifies cache write-then-read.
+
+set -euo pipefail
+
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "[skip] ANTHROPIC_API_KEY not set — v0.59 smoke skipped"
+  exit 0
+fi
+
+REPO=$(cd "$(dirname "$0")/../.." && pwd)
+EXAMPLE="$REPO/examples/vibeframe-promo"
+
+if [ ! -d "$EXAMPLE" ]; then
+  echo "FAIL: $EXAMPLE missing — run on a tree that has v0.59 C7 landed"
+  exit 2
+fi
+
+CLI="$REPO/packages/cli/dist/index.js"
+if [ ! -f "$CLI" ]; then
+  echo "[setup] building CLI bundle …"
+  (cd "$REPO" && pnpm -F @vibeframe/cli build) > /dev/null
+fi
+
+command -v jq > /dev/null || (echo "FAIL: jq is required (brew install jq / apt install jq)"; exit 3)
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+
+cp -R "$EXAMPLE/." "$TMP/project/"
+
+export HOME="$TMP/home"
+mkdir -p "$HOME"
+
+cd "$TMP/project"
+
+# `-o .` aligns the executor's `outputDir` with the project root (default
+# is `<cwd>/<pipeline-name>-output/`, which would shift `params.project: .`
+# off the actual DESIGN.md location). Same pattern documented in the
+# example README.
+
+# ── 1. Dry-run plan + budget ────────────────────────────────────────────
+echo "[1/4] dry-run plan + cost"
+DRY=$(node "$CLI" run vibeframe-promo.yaml -o . --dry-run 2>&1)
+echo "$DRY" | jq -e '.totalSteps == 1' > /dev/null \
+  || (echo "FAIL: dry-run missing 1 step in plan"; echo "$DRY"; exit 4)
+echo "$DRY" | jq -e '.steps[0].action == "compose-scenes-with-skills"' > /dev/null \
+  || (echo "FAIL: dry-run plan didn't surface compose-scenes-with-skills"; exit 4)
+
+# ── 2. First execution — fresh ──────────────────────────────────────────
+echo "[2/4] first execution (fresh, ≈8 s, ≈\$0.18)"
+T0=$(date +%s)
+RUN1=$(node "$CLI" run vibeframe-promo.yaml -o . --json 2>&1)
+T1=$(($(date +%s) - T0))
+
+echo "$RUN1" | jq -e '.success == true' > /dev/null \
+  || (echo "FAIL: pipeline did not succeed"; echo "$RUN1"; exit 5)
+
+WRITTEN=$(echo "$RUN1" | jq -r '.steps[0].data.written | length')
+[ "$WRITTEN" = "3" ] || (echo "FAIL: expected 3 compositions written, got $WRITTEN"; exit 5)
+
+CACHE_HITS_1=$(echo "$RUN1" | jq -r '.steps[0].data.cacheHits')
+COST_1=$(echo "$RUN1" | jq -r '.steps[0].data.totalCostUsd')
+[ "$CACHE_HITS_1" = "0" ] || (echo "FAIL: fresh run had $CACHE_HITS_1 cache hits, expected 0"; exit 5)
+
+echo "  -> ${T1}s wall-clock | \$$COST_1 cost | 3 fresh"
+
+for beat in hook claim close; do
+  if [ ! -f "compositions/scene-${beat}.html" ]; then
+    echo "FAIL: compositions/scene-${beat}.html missing"
+    exit 5
+  fi
+done
+
+# ── 3. Lint pass ────────────────────────────────────────────────────────
+echo "[3/4] vibe scene lint --project ."
+LINT=$(node "$CLI" scene lint --project . --json 2>&1)
+echo "$LINT" | jq -e '.ok == true' > /dev/null \
+  || (echo "FAIL: lint not clean"; echo "$LINT" | jq '.files[].findings'; exit 6)
+
+# ── 4. Second execution — cached ───────────────────────────────────────
+echo "[4/4] second execution (cached, ≈\$0)"
+T0=$(date +%s)
+RUN2=$(node "$CLI" run vibeframe-promo.yaml -o . --json 2>&1)
+T2=$(($(date +%s) - T0))
+
+CACHE_HITS_2=$(echo "$RUN2" | jq -r '.steps[0].data.cacheHits')
+COST_2=$(echo "$RUN2" | jq -r '.steps[0].data.totalCostUsd')
+[ "$CACHE_HITS_2" = "3" ] || (echo "FAIL: cached run had $CACHE_HITS_2 cache hits, expected 3"; exit 7)
+[ "$COST_2" = "0" ] || (echo "FAIL: cached run cost \$$COST_2, expected \$0"; exit 7)
+
+echo "  -> ${T2}s wall-clock | \$$COST_2 cost | 3 cached"
+
+# ── Summary ─────────────────────────────────────────────────────────────
+echo ""
+echo "v0.59 smoke passed"
+echo "  Fresh:  ${T1}s | \$$COST_1 | 3 compositions written + lint-clean"
+echo "  Cached: ${T2}s | \$$COST_2 | 3 cache hits"


### PR DESCRIPTION
## Summary

**v0.59 C8 — final commit of the series.**

End-to-end smoke that runs `examples/vibeframe-promo/` through the pipeline twice and asserts: success exit, 3 compositions written, lint clean, second run hits cache (`cacheHits: 3`, `totalCostUsd: 0`).

Gating: skipped (exit 0) when `ANTHROPIC_API_KEY` is unset → contributors without the key don't trip CI.

## Live verification

\`\`\`
[1/4] dry-run plan + cost
[2/4] first execution (fresh, ≈8 s, ≈$0.18)
  -> 39s wall-clock | $0.1807 cost | 3 fresh
[3/4] vibe scene lint --project .
[4/4] second execution (cached, ≈$0)
  -> 0s wall-clock | $0 cost | 3 cached

v0.59 smoke passed
  Fresh:  39s | $0.1807 | 3 compositions written + lint-clean
  Cached: 0s | $0 | 3 cache hits
\`\`\`

Validates the central architectural bet from PR #111 pre-flight: **cache by INPUT hash hits 100 % on identical re-runs**, parallel fanout brings wall-clock to single-beat latency.

## Side fix in `run.ts`

`--json` step output now includes `data` field (was filtered at line 162-169 of the JSON mapper, which made the smoke — and any pipeline introspection / agent loop — unable to read `cacheHits`, `totalCostUsd`, `written`, etc.). Single-line diff.

## Isolation

- Temp HOME so the cache lives in `$TMP/.vibeframe/cache/` instead of the user's real dir — the "fresh" run is actually fresh and the "cached" run verifies write-then-read.
- Temp project copy so the canonical `examples/vibeframe-promo/` working tree isn't dirtied by composition writes.
- Invokes YAML with `-o .` so executor's `outputDir` aligns with the project root.

## v0.59 series complete

| | Title | PR |
|---|---|---|
| C1 | HF skill bundle | #122 |
| C2 | STORYBOARD parser | #123 |
| C3 | Composer + cache | #124 |
| C4 | Lint retry loop | #125 |
| C5 | Pipeline action register | #126 |
| C6 | Per-beat fanout + onProgress | #127 |
| C7 | Example end-to-end | #128 |
| **C8** | **Smoke harness** | **this PR** |

Next: bump to v0.59.0 + npm publish; v0.60 demo MP4 from this pipeline.