### PR TITLE
fix(cli): drop -q shorthand from quality flags (collides with --quiet)

### DIFF
--- a/packages/cli/src/commands/ai-image.ts
+++ b/packages/cli/src/commands/ai-image.ts
@@ -39,7 +39,9 @@ aiCommand
   .option("-o, --output <path>", "Output file path (downloads image)")
   .option("-s, --size <size>", "Image size (openai: 1024x1024, 1536x1024, 1024x1536)", "1024x1024")
   .option("-r, --ratio <ratio>", "Aspect ratio (gemini: 1:1, 1:4, 1:8, 4:1, 8:1, 16:9, 9:16, 3:4, 4:3, etc.)", "1:1")
-  .option("-q, --quality <quality>", "Quality: standard, hd (openai only)", "standard")
+  // `-q` shorthand intentionally omitted: collides with global `vibe -q,--quiet`,
+  // which previously ate the value silently and dropped the prompt positional.
+  .option("--quality <quality>", "Quality: standard, hd (openai only)", "standard")
   .option("--style <style>", "Style: vivid, natural (openai only)", "vivid")
   .option("-n, --count <n>", "Number of images to generate", "1")
   .option("-m, --model <model>", "Model. Gemini: flash, 3.1-flash, latest, pro. OpenAI: 1.5 (default), 2 (gpt-image-2)")

--- a/packages/cli/src/commands/ai-video-fx.ts
+++ b/packages/cli/src/commands/ai-video-fx.ts
@@ -115,7 +115,8 @@ export function registerVideoFxCommands(ai: Command): void {
     .option("-o, --output <path>", "Output file path")
     .option("-f, --factor <number>", "Slow motion factor: 2, 4, or 8", "2")
     .option("--fps <number>", "Target output FPS")
-    .option("-q, --quality <mode>", "Quality: fast or quality", "quality")
+    // `-q` shorthand intentionally omitted: collides with global `vibe -q,--quiet`.
+    .option("--quality <mode>", "Quality: fast or quality", "quality")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (videoPath: string, options) => {
       try {

--- a/packages/cli/src/commands/edit-cmd.ts
+++ b/packages/cli/src/commands/edit-cmd.ts
@@ -823,7 +823,8 @@ editCommand
   .option("-o, --output <path>", "Output file path")
   .option("-f, --factor <number>", "Slow motion factor: 2, 4, or 8", "2")
   .option("--fps <number>", "Target output FPS")
-  .option("-q, --quality <mode>", "Quality: fast or quality", "quality")
+  // `-q` shorthand intentionally omitted: collides with global `vibe -q,--quiet`.
+  .option("--quality <mode>", "Quality: fast or quality", "quality")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
     try {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -120,7 +120,9 @@ generateCommand
   .option("-o, --output <path>", "Output file path (downloads image)")
   .option("-s, --size <size>", "Image size (openai: 1024x1024, 1536x1024, 1024x1536)", "1024x1024")
   .option("-r, --ratio <ratio>", "Aspect ratio (gemini: 1:1, 1:4, 1:8, 4:1, 8:1, 16:9, 9:16, 3:4, 4:3, etc.)", "1:1")
-  .option("-q, --quality <quality>", "Quality: standard, hd (openai only)", "standard")
+  // `-q` shorthand intentionally omitted: collides with global `vibe -q,--quiet`,
+  // which previously ate the value silently and dropped the prompt positional.
+  .option("--quality <quality>", "Quality: standard, hd (openai only)", "standard")
   .option("--style <style>", "Style: vivid, natural (openai only)", "vivid")
   .option("-n, --count <n>", "Number of images to generate", "1")
   .option("-m, --model <model>", "Model. Gemini: flash, 3.1-flash, latest, pro. OpenAI: 1.5 (default), 2 (gpt-image-2)")

--- a/packages/cli/src/commands/q-flag-collision.test.ts
+++ b/packages/cli/src/commands/q-flag-collision.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression cover for the `-q` flag collision (project memory:
+ * `project_q_flag_collision.md`). The root `vibe` program declares
+ * `-q, --quiet` (boolean), and four subcommands previously declared their
+ * own `-q, --quality <quality>` shorthand. Commander resolves `-q` at the
+ * parent level, so `vibe generate image -p openai -q hd "real prompt"`
+ * silently parsed as `--quiet=true`, then `hd` became the `[prompt]`
+ * positional, and the real prompt was dropped without error — users got a
+ * generic stock-image hallucination from gpt-image-2.
+ *
+ * This test is a static guard against regressions: any subcommand that
+ * registers `-q` as a value-taking shorthand is the bug coming back.
+ */
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const FILES_THAT_PREVIOUSLY_HAD_DASH_Q = [
+  "generate.ts",
+  "ai-image.ts",
+  "edit-cmd.ts",
+  "ai-video-fx.ts",
+];
+
+describe("-q flag collision regression", () => {
+  it.each(FILES_THAT_PREVIOUSLY_HAD_DASH_Q)(
+    "%s does not register -q shorthand for --quality (collides with global --quiet)",
+    async (filename) => {
+      const path = resolve(here, filename);
+      const src = await readFile(path, "utf8");
+      // Match `.option("-q, ...` or `.option('-q, ...` — the exact form that
+      // collided with the global `vibe -q,--quiet` flag.
+      const offending = /\.option\s*\(\s*["']-q\s*,/.test(src);
+      expect(offending, `${filename} re-introduced -q shorthand`).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Four CLI subcommands (`generate image`, `ai image`, `edit slow-motion`, `ai video-fx slow-motion`) declared `-q, --quality`, silently colliding with the root program's `-q, --quiet` flag. Commander resolves `-q` at the parent level, so a user running:

```
vibe generate image -p openai -s 1536x1024 -q hd "Abstract minimalist tech backdrop, electric blue glow"
```

would have argv parsed as:
- `--quiet = true`
- `[prompt]` positional = `"hd"` (the value the user meant for `-q`)
- the real prompt — silently dropped

Result: OpenAI received `prompt: "hd"`, returned a generic stock hallucination (mountain landscape for tech-aesthetic prompts), and the user burned API budget with **no error message**.

## Changes

- Drop `-q` shorthand from all four subcommands; `--quality` long-form preserved
- New static regression test (`q-flag-collision.test.ts`) asserts no `.option("-q,"` re-introduction in the affected files

## Discovered while

Generating gpt-image-2 backdrops for the v0.60 cinematic demo. Direct `curl` to OpenAI honored the prompt perfectly; CLI returned mountain photos. Debug-instrumented the request body in dist and saw `{"prompt":"hd",...}` — root cause identified in argv parsing, not API.

## Test plan

- [x] `npx vitest run q-flag-collision` — 4/4 pass
- [x] Full CLI suite — 578 pass / 11 skipped
- [x] `pnpm build` — clean
- [x] `pnpm lint` — 0 errors
- [x] End-to-end: `vibe generate image -p openai --quality hd -o /tmp/x.png "Electric blue circuit pattern on black"` → returns proper circuit imagery