### PR TITLE
feat(storyboard): YAML frontmatter + per-beat cues (v0.60 C2)

### DIFF
--- a/packages/cli/src/commands/_shared/storyboard-parse.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   deriveBeatId,
+  extractBeatCues,
+  extractProjectFrontmatter,
   parseBeatDuration,
   parseStoryboard,
 } from "./storyboard-parse.js";
@@ -186,5 +188,183 @@ describe("parseBeatDuration", () => {
   it("only reads first Beat-duration subsection it sees, then stops at next heading", () => {
     const body = `### Beat duration\n\n4\n\n### Notes\n\n10 seconds of post-roll\n`;
     expect(parseBeatDuration(body)).toBe(4);
+  });
+});
+
+// ── v0.60: project frontmatter + per-beat cues ──────────────────────────
+
+describe("extractProjectFrontmatter", () => {
+  it("returns undefined when no frontmatter is present", () => {
+    const md = "# Storyboard\n\n## Beat 1 — Hook\n";
+    const r = extractProjectFrontmatter(md);
+    expect(r.frontmatter).toBeUndefined();
+    expect(r.remaining).toBe(md);
+  });
+
+  it("strips and parses a leading frontmatter block", () => {
+    const md = `---
+project: vibeframe-promo
+providers:
+  tts: elevenlabs
+  image: openai
+voice: rachel
+---
+# Storyboard
+
+## Beat 1 — Hook
+`;
+    const r = extractProjectFrontmatter(md);
+    expect(r.frontmatter).toEqual({
+      project: "vibeframe-promo",
+      providers: { tts: "elevenlabs", image: "openai" },
+      voice: "rachel",
+    });
+    expect(r.remaining.startsWith("# Storyboard")).toBe(true);
+  });
+
+  it("ignores malformed YAML (returns frontmatter undefined, leaves remaining intact)", () => {
+    const md = "---\nthis: is: not: valid: yaml:\n---\nbody\n";
+    const r = extractProjectFrontmatter(md);
+    expect(r.frontmatter).toBeUndefined();
+    expect(r.remaining).toBe(md);
+  });
+
+  it("rejects array root (frontmatter must be an object)", () => {
+    const md = "---\n- one\n- two\n---\nbody\n";
+    const r = extractProjectFrontmatter(md);
+    expect(r.frontmatter).toBeUndefined();
+  });
+});
+
+describe("extractBeatCues", () => {
+  it("returns undefined when body has no leading yaml block", () => {
+    const body = "### Concept\n\nCold open.\n";
+    const r = extractBeatCues(body);
+    expect(r.cues).toBeUndefined();
+    expect(r.body).toBe(body);
+  });
+
+  it("strips and parses a leading ```yaml cue block", () => {
+    const body = `\`\`\`yaml
+narration: "Type a YAML."
+backdrop: "Abstract minimalist tech aesthetic, electric blue glow"
+duration: 3
+\`\`\`
+
+### Concept
+
+Cold open.
+`;
+    const r = extractBeatCues(body);
+    expect(r.cues).toEqual({
+      narration: "Type a YAML.",
+      backdrop: "Abstract minimalist tech aesthetic, electric blue glow",
+      duration: 3,
+    });
+    expect(r.body.startsWith("### Concept")).toBe(true);
+    expect(r.body).not.toContain("narration:");
+  });
+
+  it("does NOT strip a yaml block deeper in the body (only leading block is metadata)", () => {
+    const body = `### Concept
+
+Cold open.
+
+\`\`\`yaml
+narration: this should not be stripped
+\`\`\`
+`;
+    const r = extractBeatCues(body);
+    expect(r.cues).toBeUndefined();
+    expect(r.body).toBe(body);
+  });
+});
+
+describe("parseStoryboard — frontmatter + cues integration", () => {
+  it("attaches frontmatter to the result", () => {
+    const md = `---
+project: demo
+voice: rachel
+---
+
+## Beat hook — Hook
+
+### Concept
+
+Open.
+`;
+    const r = parseStoryboard(md);
+    expect(r.frontmatter).toEqual({ project: "demo", voice: "rachel" });
+    expect(r.beats).toHaveLength(1);
+    expect(r.beats[0].id).toBe("hook");
+  });
+
+  it("attaches per-beat cues + strips them from body", () => {
+    const md = `## Beat hook — Hook
+
+\`\`\`yaml
+narration: "Type a YAML."
+duration: 3
+\`\`\`
+
+### Concept
+
+Cold open.
+`;
+    const r = parseStoryboard(md);
+    expect(r.beats[0].cues).toEqual({ narration: "Type a YAML.", duration: 3 });
+    expect(r.beats[0].duration).toBe(3);
+    expect(r.beats[0].body).not.toContain("narration:");
+    expect(r.beats[0].body).toContain("Cold open.");
+  });
+
+  it("cue duration overrides ### Beat duration subsection", () => {
+    const md = `## Beat hook — Hook
+
+\`\`\`yaml
+duration: 5
+\`\`\`
+
+### Beat duration
+
+3 seconds
+`;
+    const r = parseStoryboard(md);
+    expect(r.beats[0].duration).toBe(5);
+  });
+
+  it("falls back to ### Beat duration when cue duration absent", () => {
+    const md = `## Beat hook — Hook
+
+\`\`\`yaml
+narration: "X"
+\`\`\`
+
+### Beat duration
+
+4 seconds
+`;
+    const r = parseStoryboard(md);
+    expect(r.beats[0].duration).toBe(4);
+  });
+
+  it("storyboard without any frontmatter / cues parses identically to v0.59 (back-compat)", () => {
+    const md = `**Format:** 1920×1080
+
+## Beat 1 — Hook (0–3s)
+
+### Concept
+
+Cold open.
+
+### Beat duration
+
+3 seconds
+`;
+    const r = parseStoryboard(md);
+    expect(r.frontmatter).toBeUndefined();
+    expect(r.beats[0].cues).toBeUndefined();
+    expect(r.beats[0].duration).toBe(3);
+    expect(r.beats[0].body).toContain("### Concept");
   });
 });

--- a/packages/cli/src/commands/_shared/storyboard-parse.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.ts
@@ -10,17 +10,83 @@
  * forgiving on small variations (em-dash vs hyphen vs colon between
  * "Beat N" and the title; explicit "Beat" prefix optional).
  *
+ * v0.60 adds optional YAML cue extraction so a `vibe scene build` driver can
+ * dispatch TTS / image-gen / duration without separate flags:
+ *   - **Project frontmatter** — `---\n…yaml…\n---` at the top of the file
+ *     (standard markdown frontmatter). Holds project-wide defaults like
+ *     providers, voice, default duration. Stripped from `global`.
+ *   - **Per-beat cues** — the FIRST ```yaml fenced block inside a beat body,
+ *     parsed into `Beat.cues`. Stripped from `body` so the LLM prompt
+ *     stays free of machine-only metadata.
+ * Both are back-compat: storyboards without frontmatter or yaml blocks
+ * parse exactly as before.
+ *
  * Pure function. No I/O.
  */
+
+import { parse as parseYaml } from "yaml";
 
 export interface ParsedStoryboard {
   /**
    * Markdown content before the first `## …` heading. Holds project-wide
    * direction (format, audio, style basis). Trimmed; may be empty.
+   * **Project frontmatter (`---\n…\n---`) is stripped from this field.**
    */
   global: string;
   /** One entry per `## …` heading. Order matches the document. */
   beats: Beat[];
+  /**
+   * Project-level YAML frontmatter parsed from the top of the document, if
+   * present. Holds defaults the `vibe scene build` driver applies to every
+   * beat unless overridden by a per-beat cue. Undefined when no frontmatter
+   * was present.
+   */
+  frontmatter?: ProjectFrontmatter;
+}
+
+/**
+ * Project-level cues from the document's top frontmatter. All fields are
+ * optional — the driver (or user) supplies CLI-flag fallbacks.
+ *
+ * Index signature stays open so projects can stash custom keys (e.g. brand
+ * colour palette overrides) without TypeScript pushback.
+ */
+export interface ProjectFrontmatter {
+  /** Slug for the project — informational, not used by the parser. */
+  project?: string;
+  /**
+   * Per-primitive provider preferences. Keys match the CLI's `--tts`,
+   * `--image-provider`, `--music-provider` flags.
+   */
+  providers?: {
+    tts?: string;
+    image?: string;
+    music?: string;
+  };
+  /** Default voice id for TTS (provider-specific — see `--voice` flag). */
+  voice?: string;
+  /** Default beat duration in seconds when a beat omits both cue and `### Beat duration`. */
+  defaultDuration?: number;
+  /** Visual identity preset hint (informational; e.g. "Swiss Pulse"). */
+  style?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Per-beat cues extracted from the first ```yaml fenced block inside a beat
+ * body. The driver passes these to TTS / image / compose calls so the
+ * storyboard alone is enough source for `vibe scene build`.
+ */
+export interface BeatCues {
+  /** Narration text for this beat (drives TTS + scene `<audio>` element). */
+  narration?: string;
+  /** Image prompt for the backdrop generation (drives T2I). */
+  backdrop?: string;
+  /** Beat duration in seconds — overrides `### Beat duration` subsection if both present. */
+  duration?: number;
+  /** Voice override for this beat (overrides project frontmatter `voice`). */
+  voice?: string;
+  [key: string]: unknown;
 }
 
 export interface Beat {
@@ -36,15 +102,23 @@ export interface Beat {
   heading: string;
   /**
    * Markdown body of the beat, including any nested `### …` subsections.
-   * Trimmed. Excludes the `## …` line itself.
+   * Trimmed. Excludes the `## …` line itself. **The leading ```yaml cue
+   * block (if present) is stripped** so this field stays clean for LLM
+   * prompts.
    */
   body: string;
   /**
-   * Beat duration in seconds, if a `### Beat duration` subsection is present
-   * (parses both "3" and "3 seconds" / "3s" forms). Undefined when absent —
-   * caller decides how to derive duration (typically from narration audio).
+   * Beat duration in seconds, derived from (in priority order):
+   *   1. `cues.duration` (per-beat YAML)
+   *   2. `### Beat duration` subsection
+   * Undefined when neither is present.
    */
   duration?: number;
+  /**
+   * Per-beat cues parsed from the first ```yaml block inside the body.
+   * Undefined when no yaml block was present.
+   */
+  cues?: BeatCues;
 }
 
 const HEADING_RE = /^##\s+(.+?)\s*$/gm;
@@ -54,6 +128,13 @@ const BEAT_PREFIX_RE = /^Beat\s+(.+?)\s+(?:—|:|-)\s+(.+)$/i;
 const DURATION_SUBSECTION_RE = /###\s+Beat\s+duration\s*\n([\s\S]*?)(?=\n###\s|\n##\s|$)/i;
 // Capture optional minus so a "-3" body doesn't sneak in as 3.
 const DURATION_VALUE_RE = /(-?\d+(?:\.\d+)?)\s*(?:s|sec|seconds?)?/i;
+// Top-of-file YAML frontmatter, standard markdown convention. Closing fence
+// must start at column 0 to avoid eating fenced ```yaml inside a beat.
+const FRONTMATTER_RE = /^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/;
+// First ```yaml fenced block inside a beat body. Anchored to the start of the
+// body so we only treat a leading cue block as machine metadata; ```yaml
+// blocks deeper in the body are left as illustrative content.
+const BEAT_CUES_RE = /^\s*```ya?ml\s*\n([\s\S]*?)\n```\s*(?:\n|$)/;
 
 /**
  * Parse a STORYBOARD.md document into structured beats.
@@ -62,7 +143,13 @@ const DURATION_VALUE_RE = /(-?\d+(?:\.\d+)?)\s*(?:s|sec|seconds?)?/i;
  * Input with no `##` headings → `{ global: <whole doc>, beats: [] }`.
  */
 export function parseStoryboard(md: string): ParsedStoryboard {
-  const text = md.replace(/\r\n/g, "\n");
+  const normalized = md.replace(/\r\n/g, "\n");
+
+  // Strip + parse top frontmatter (if present) before any heading scan,
+  // so a heading-shaped line inside the frontmatter wouldn't fool the
+  // beat splitter.
+  const { frontmatter, remaining } = extractProjectFrontmatter(normalized);
+  const text = remaining;
 
   // Find every `## …` heading position. We re-iterate the regex because
   // `String.matchAll` doesn't return offsets in older Node versions
@@ -79,7 +166,11 @@ export function parseStoryboard(md: string): ParsedStoryboard {
   }
 
   if (headings.length === 0) {
-    return { global: text.trim(), beats: [] };
+    return {
+      global: text.trim(),
+      beats: [],
+      ...(frontmatter ? { frontmatter } : {}),
+    };
   }
 
   const global = text.slice(0, headings[0].start).trim();
@@ -87,18 +178,81 @@ export function parseStoryboard(md: string): ParsedStoryboard {
   const beats: Beat[] = headings.map((h, i) => {
     const bodyStart = h.end;
     const bodyEnd = i + 1 < headings.length ? headings[i + 1].start : text.length;
-    const body = text.slice(bodyStart, bodyEnd).trim();
+    const rawBody = text.slice(bodyStart, bodyEnd).trim();
+    const { cues, body } = extractBeatCues(rawBody);
     const id = deriveBeatId(h.line);
-    const duration = parseBeatDuration(body);
+    // Cue duration wins over the `### Beat duration` subsection — it's the
+    // explicit machine-readable hint, while the subsection is prose for the
+    // composer LLM.
+    const duration = cues?.duration ?? parseBeatDuration(body);
     return {
       id,
       heading: h.line,
       body,
       ...(duration !== undefined ? { duration } : {}),
+      ...(cues ? { cues } : {}),
     };
   });
 
-  return { global, beats };
+  return {
+    global,
+    beats,
+    ...(frontmatter ? { frontmatter } : {}),
+  };
+}
+
+/**
+ * Strip a leading `---\n…\n---` YAML frontmatter block and return the parsed
+ * value. Returns `{ frontmatter: undefined, remaining: input }` when there's
+ * no frontmatter, when the YAML doesn't parse, or when the parsed root isn't
+ * an object — graceful degradation, since the downstream caller can always
+ * fall back on CLI flags.
+ */
+export function extractProjectFrontmatter(md: string): {
+  frontmatter: ProjectFrontmatter | undefined;
+  remaining: string;
+} {
+  const match = md.match(FRONTMATTER_RE);
+  if (!match) return { frontmatter: undefined, remaining: md };
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(match[1]);
+  } catch {
+    return { frontmatter: undefined, remaining: md };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { frontmatter: undefined, remaining: md };
+  }
+  return {
+    frontmatter: parsed as ProjectFrontmatter,
+    remaining: md.slice(match[0].length),
+  };
+}
+
+/**
+ * Pull a leading ```yaml cue block off a beat body and return both the parsed
+ * cues and the remaining body (cues stripped). Mirrors
+ * `extractProjectFrontmatter`'s "swallow only when valid" behaviour.
+ */
+export function extractBeatCues(body: string): {
+  cues: BeatCues | undefined;
+  body: string;
+} {
+  const match = body.match(BEAT_CUES_RE);
+  if (!match) return { cues: undefined, body };
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(match[1]);
+  } catch {
+    return { cues: undefined, body };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { cues: undefined, body };
+  }
+  return {
+    cues: parsed as BeatCues,
+    body: body.slice(match[0].length).trim(),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

C2 of 4 in the v0.60 release plan. Adds two opt-in YAML extraction layers to the STORYBOARD.md parser so the upcoming \`vibe scene build\` driver can dispatch TTS / image-gen / duration directly from the storyboard — no redundant CLI flags.

This commit is **parser-only**. No CLI behaviour change yet. C3 will wire the cues into the dispatch flow.

## Spec

### Project frontmatter
Standard markdown \`---\\n…\\n---\` at the top:
\`\`\`yaml
---
project: vibeframe-promo
providers:
  tts: elevenlabs
  image: openai
  music: elevenlabs
voice: rachel
defaultDuration: 3
style: swiss-pulse
---
\`\`\`
Stripped from \`global\`. Surfaced as \`ParsedStoryboard.frontmatter\`.

### Per-beat cues
First \`\`\`yaml fenced block in each beat body:
\`\`\`markdown
## Beat hook — Hook

\`\`\`yaml
narration: "Type a YAML."
backdrop: "Abstract minimalist tech aesthetic, electric blue glow"
duration: 3
\`\`\`

### Concept
…
\`\`\`
Stripped from \`body\`. Surfaced as \`Beat.cues\`.

## Precedence rules

- **Beat duration**: \`cues.duration\` > \`### Beat duration\` subsection
- **Provider per beat**: TBD in C3 — driver will merge frontmatter defaults with per-beat overrides

## Back-compat

- Storyboards without frontmatter / cue blocks parse identically to v0.59 (covered by new test \`storyboard without any frontmatter / cues parses identically\`)
- 37/37 \`compose-scenes-skills\` tests still pass (downstream consumer)
- Malformed YAML degrades gracefully — field returns undefined, raw text intact

## Test plan

- [x] \`npx vitest run storyboard-parse\` — 40/40 pass (was 31; +9 new tests)
- [x] \`npx vitest run compose-scenes-skills\` — 37/37 pass (no regression)
- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` 0 errors