### PR TITLE
feat(scene): vibe scene build — one-shot storyboard → MP4 (v0.60 C3)

### DIFF
--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Smoke tests for the v0.60 `vibe scene build` orchestrator. Real TTS / image
+ * / compose / render calls are mocked at the module-import boundary so the
+ * test verifies *fanout + idempotence + flag plumbing* without spending API
+ * budget or starting Chrome.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { executeSceneBuild } from "./scene-build.js";
+
+// ── Module mocks (must be hoisted before the imported module loads) ─────
+
+vi.mock("./tts-resolve.js", () => ({
+  resolveTtsProvider: vi.fn(),
+  TtsKeyMissingError: class TtsKeyMissingError extends Error {},
+}));
+
+vi.mock("@vibeframe/ai-providers", () => ({
+  OpenAIImageProvider: vi.fn(),
+}));
+
+vi.mock("./compose-scenes-skills.js", () => ({
+  executeComposeScenesWithSkills: vi.fn(),
+}));
+
+vi.mock("./scene-render.js", () => ({
+  executeSceneRender: vi.fn(),
+}));
+
+import { resolveTtsProvider } from "./tts-resolve.js";
+import { OpenAIImageProvider } from "@vibeframe/ai-providers";
+import { executeComposeScenesWithSkills } from "./compose-scenes-skills.js";
+import { executeSceneRender } from "./scene-render.js";
+
+const STORYBOARD_WITH_CUES = `---
+project: scene-build-test
+providers:
+  tts: kokoro
+  image: openai
+voice: af_heart
+---
+
+## Beat hook — Hook
+
+\`\`\`yaml
+narration: "Type a YAML."
+backdrop: "Abstract dark tech background"
+duration: 3
+\`\`\`
+
+### Concept
+
+Cold open.
+
+## Beat close — Close
+
+\`\`\`yaml
+narration: "VibeFrame."
+\`\`\`
+
+### Concept
+
+End frame.
+`;
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "scene-build-test-"));
+  mkdirSync(join(projectDir, "compositions"), { recursive: true });
+  writeFileSync(join(projectDir, "STORYBOARD.md"), STORYBOARD_WITH_CUES);
+  writeFileSync(join(projectDir, "DESIGN.md"), "# Design\n");
+  writeFileSync(join(projectDir, "index.html"), "<!doctype html><body></body>");
+
+  vi.mocked(resolveTtsProvider).mockResolvedValue({
+    provider: "kokoro",
+    audioExtension: "wav",
+    call: vi.fn().mockResolvedValue({
+      success: true,
+      audioBuffer: Buffer.from([1, 2, 3, 4]),
+    }),
+  });
+
+  vi.mocked(OpenAIImageProvider).mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    generateImage: vi.fn().mockResolvedValue({
+      success: true,
+      images: [{ base64: Buffer.from([5, 6, 7, 8]).toString("base64") }],
+    }),
+  } as unknown as InstanceType<typeof OpenAIImageProvider>));
+
+  vi.mocked(executeComposeScenesWithSkills).mockResolvedValue({
+    success: true,
+    outputPath: projectDir,
+    data: { beats: 2, written: [], totalCostUsd: 0.05, totalTokensIn: 0, totalTokensOut: 0, cacheHits: 0 },
+  });
+
+  vi.mocked(executeSceneRender).mockResolvedValue({
+    success: true,
+    outputPath: join(projectDir, "renders", "out.mp4"),
+    audioCount: 2,
+    audioMuxApplied: true,
+  });
+
+  process.env.OPENAI_API_KEY = "test-key";
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+  delete process.env.OPENAI_API_KEY;
+});
+
+describe("executeSceneBuild", () => {
+  it("dispatches narration + backdrop per beat with cues, then composes + renders", async () => {
+    const r = await executeSceneBuild({ projectDir });
+
+    expect(r.success).toBe(true);
+    expect(r.beats).toHaveLength(2);
+    // Hook has both narration + backdrop cues
+    expect(r.beats[0].narrationStatus).toBe("generated");
+    expect(r.beats[0].narrationPath).toBe("assets/narration-hook.wav");
+    expect(r.beats[0].backdropStatus).toBe("generated");
+    expect(r.beats[0].backdropPath).toBe("assets/backdrop-hook.png");
+    // Close only has narration
+    expect(r.beats[1].narrationStatus).toBe("generated");
+    expect(r.beats[1].backdropStatus).toBe("no-cue");
+
+    expect(r.outputPath).toBeDefined();
+    expect(executeComposeScenesWithSkills).toHaveBeenCalledOnce();
+    expect(executeSceneRender).toHaveBeenCalledOnce();
+  });
+
+  it("is idempotent: skips dispatch when asset already exists", async () => {
+    // Pre-create the narration asset for hook
+    mkdirSync(join(projectDir, "assets"), { recursive: true });
+    writeFileSync(join(projectDir, "assets", "narration-hook.wav"), Buffer.from([1]));
+    writeFileSync(join(projectDir, "assets", "backdrop-hook.png"), Buffer.from([2]));
+
+    const r = await executeSceneBuild({ projectDir });
+
+    expect(r.beats[0].narrationStatus).toBe("cached");
+    expect(r.beats[0].backdropStatus).toBe("cached");
+    expect(r.beats[1].narrationStatus).toBe("generated");
+  });
+
+  it("respects --force to re-dispatch even when assets exist", async () => {
+    mkdirSync(join(projectDir, "assets"), { recursive: true });
+    writeFileSync(join(projectDir, "assets", "narration-hook.wav"), Buffer.from([99]));
+
+    await executeSceneBuild({ projectDir, force: true });
+
+    // Force re-dispatch overwrites with mock buffer ([1,2,3,4])
+    const written = readFileSync(join(projectDir, "assets", "narration-hook.wav"));
+    expect(Array.from(written)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("--skip-narration / --skip-backdrop short-circuit primitive dispatch", async () => {
+    const r = await executeSceneBuild({
+      projectDir,
+      skipNarration: true,
+      skipBackdrop: true,
+    });
+
+    expect(r.beats[0].narrationStatus).toBe("skipped");
+    expect(r.beats[0].backdropStatus).toBe("skipped");
+    expect(resolveTtsProvider).not.toHaveBeenCalled();
+    expect(OpenAIImageProvider).not.toHaveBeenCalled();
+  });
+
+  it("--skip-render runs compose but skips render", async () => {
+    const r = await executeSceneBuild({ projectDir, skipRender: true });
+    expect(r.success).toBe(true);
+    expect(r.outputPath).toBeUndefined();
+    expect(executeSceneRender).not.toHaveBeenCalled();
+  });
+
+  it("frontmatter providers.tts is used as the default when no CLI flag", async () => {
+    await executeSceneBuild({ projectDir });
+    expect(resolveTtsProvider).toHaveBeenCalledWith("kokoro");
+  });
+
+  it("CLI ttsProvider flag overrides frontmatter", async () => {
+    await executeSceneBuild({ projectDir, ttsProvider: "elevenlabs" });
+    expect(resolveTtsProvider).toHaveBeenCalledWith("elevenlabs");
+  });
+
+  it("returns structured failure when STORYBOARD.md missing", async () => {
+    rmSync(join(projectDir, "STORYBOARD.md"));
+    const r = await executeSceneBuild({ projectDir });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("STORYBOARD.md not found");
+  });
+
+  it("returns structured failure when storyboard has no beats", async () => {
+    writeFileSync(join(projectDir, "STORYBOARD.md"), "# Empty\n");
+    const r = await executeSceneBuild({ projectDir });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("no `## Beat …` headings");
+  });
+
+  it("compose failure surfaces with beat outcomes preserved", async () => {
+    vi.mocked(executeComposeScenesWithSkills).mockResolvedValueOnce({
+      success: false,
+      error: "rate limited",
+    });
+    const r = await executeSceneBuild({ projectDir });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("compose failed: rate limited");
+    expect(r.beats).toHaveLength(2); // primitives still ran
+  });
+
+  it("propagates frontmatter voice as default when --voice not set", async () => {
+    const ttsCall = vi.fn().mockResolvedValue({ success: true, audioBuffer: Buffer.from([1]) });
+    vi.mocked(resolveTtsProvider).mockResolvedValue({
+      provider: "kokoro",
+      audioExtension: "wav",
+      call: ttsCall,
+    });
+
+    await executeSceneBuild({ projectDir });
+
+    expect(ttsCall).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ voice: "af_heart" }),
+    );
+  });
+});

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -1,0 +1,359 @@
+/**
+ * @module _shared/scene-build
+ *
+ * v0.60 one-shot driver: read STORYBOARD.md (with frontmatter + per-beat
+ * cues from C2), dispatch the AI primitives the cues call for, run
+ * `compose-scenes-with-skills`, then optionally render to MP4.
+ *
+ * The intent is to make the storyboard the single source of truth — `vibe
+ * scene build` walks it and produces an MP4. Per-beat cues drive TTS +
+ * image generation; project frontmatter sets defaults. CLI flags override.
+ *
+ * Idempotent: assets that already exist on disk are reused unless `force`.
+ *
+ * Scope held tight for v0.60:
+ *   - TTS via `resolveTtsProvider` (ElevenLabs / Kokoro auto-fallback)
+ *   - T2I via OpenAI gpt-image-2 only (Gemini/Grok routing in a follow-up)
+ *   - No Whisper transcribe step (compose handles its own)
+ *   - No root `index.html` synthesis — driver expects the project to
+ *     already have one with sub-composition references.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import { OpenAIImageProvider, type ImageOptions } from "@vibeframe/ai-providers";
+
+import {
+  executeComposeScenesWithSkills,
+  type ComposeEffort,
+  type ComposeProgressEvent,
+  type ComposeScenesActionResult,
+} from "./compose-scenes-skills.js";
+import { executeSceneRender, type SceneRenderResult } from "./scene-render.js";
+import { parseStoryboard, type Beat } from "./storyboard-parse.js";
+import {
+  resolveTtsProvider,
+  TtsKeyMissingError,
+  type TtsProviderName,
+} from "./tts-resolve.js";
+
+// ── Public types ─────────────────────────────────────────────────────────
+
+export type SceneBuildProgressEvent =
+  | { type: "phase-start"; phase: "primitives" | "compose" | "render" }
+  | { type: "narration-cached"; beatId: string; path: string }
+  | { type: "narration-generated"; beatId: string; path: string; provider: string }
+  | { type: "narration-failed"; beatId: string; error: string }
+  | { type: "narration-skipped"; beatId: string; reason: string }
+  | { type: "backdrop-cached"; beatId: string; path: string }
+  | { type: "backdrop-generated"; beatId: string; path: string; provider: string }
+  | { type: "backdrop-failed"; beatId: string; error: string }
+  | { type: "backdrop-skipped"; beatId: string; reason: string }
+  | ComposeProgressEvent
+  | { type: "render-start" }
+  | { type: "render-done"; outputPath: string };
+
+export type PrimitiveStatus =
+  | "generated"
+  | "cached"
+  | "skipped"
+  | "failed"
+  | "no-cue";
+
+export interface BeatBuildOutcome {
+  beatId: string;
+  narrationStatus: PrimitiveStatus;
+  narrationPath?: string;
+  narrationError?: string;
+  backdropStatus: PrimitiveStatus;
+  backdropPath?: string;
+  backdropError?: string;
+}
+
+export interface SceneBuildOptions {
+  /** Project directory containing STORYBOARD.md, DESIGN.md, index.html. */
+  projectDir: string;
+  /** Compose effort tier — passed through to `compose-scenes-with-skills`. */
+  effort?: ComposeEffort;
+  skipNarration?: boolean;
+  skipBackdrop?: boolean;
+  skipRender?: boolean;
+  /** Override frontmatter providers.tts. Defaults to "auto". */
+  ttsProvider?: TtsProviderName;
+  /** Voice override (TTS-provider-specific id). */
+  voice?: string;
+  /** Override frontmatter providers.image. Currently only "openai" supported. */
+  imageProvider?: "openai";
+  /** OpenAI image quality — see `vibe generate image --quality`. */
+  imageQuality?: "standard" | "hd";
+  /** OpenAI image size. Default 1536x1024 for cinematic 16:9-ish framing. */
+  imageSize?: ImageOptions["size"];
+  /** Force re-dispatch even when the asset already exists. */
+  force?: boolean;
+  /** Compose-scenes cache override (tests). */
+  cacheDir?: string;
+  /** Progress callback. */
+  onProgress?: (e: SceneBuildProgressEvent) => void;
+}
+
+export interface SceneBuildResult {
+  success: boolean;
+  error?: string;
+  beats: BeatBuildOutcome[];
+  /** MP4 path when `skipRender` is false and render succeeded. */
+  outputPath?: string;
+  composeData?: ComposeScenesActionResult["data"];
+  renderResult?: SceneRenderResult;
+  /** Wall-clock total. */
+  totalLatencyMs: number;
+}
+
+// ── Driver ───────────────────────────────────────────────────────────────
+
+export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneBuildResult> {
+  const startedAt = Date.now();
+  const projectDir = resolve(opts.projectDir);
+  const onProgress = opts.onProgress ?? (() => {});
+
+  const storyboardPath = join(projectDir, "STORYBOARD.md");
+  if (!existsSync(storyboardPath)) {
+    return failBeforePrimitives(`STORYBOARD.md not found at ${storyboardPath}`, startedAt);
+  }
+  const storyboardMd = await readFile(storyboardPath, "utf-8");
+  const parsed = parseStoryboard(storyboardMd);
+  if (parsed.beats.length === 0) {
+    return failBeforePrimitives(
+      `STORYBOARD.md at ${storyboardPath} has no \`## Beat …\` headings.`,
+      startedAt,
+    );
+  }
+
+  // Resolve providers — CLI flags > frontmatter > defaults.
+  const ttsProvider = opts.ttsProvider
+    ?? (parsed.frontmatter?.providers?.tts as TtsProviderName | undefined)
+    ?? "auto";
+  const imageProvider = (opts.imageProvider
+    ?? parsed.frontmatter?.providers?.image
+    ?? "openai") as "openai";
+  const voice = opts.voice ?? parsed.frontmatter?.voice;
+
+  // ── Phase 1: per-beat primitive fanout ────────────────────────────────
+  onProgress({ type: "phase-start", phase: "primitives" });
+  const beatOutcomes = await Promise.all(
+    parsed.beats.map((beat) => buildBeatPrimitives(beat, {
+      projectDir,
+      ttsProvider,
+      voice,
+      imageProvider,
+      imageQuality: opts.imageQuality ?? "hd",
+      imageSize: opts.imageSize ?? "1536x1024",
+      skipNarration: opts.skipNarration ?? false,
+      skipBackdrop: opts.skipBackdrop ?? false,
+      force: opts.force ?? false,
+      onProgress,
+    })),
+  );
+
+  // ── Phase 2: compose ──────────────────────────────────────────────────
+  onProgress({ type: "phase-start", phase: "compose" });
+  const composeResult = await executeComposeScenesWithSkills(
+    {
+      project: ".",
+      effort: opts.effort,
+      cacheDir: opts.cacheDir,
+      onProgress: (e) => onProgress(e),
+    },
+    projectDir,
+  );
+  if (!composeResult.success) {
+    return {
+      success: false,
+      error: `compose failed: ${composeResult.error ?? "unknown"}`,
+      beats: beatOutcomes,
+      composeData: composeResult.data,
+      totalLatencyMs: Date.now() - startedAt,
+    };
+  }
+
+  // ── Phase 3: render (optional) ────────────────────────────────────────
+  let outputPath: string | undefined;
+  let renderResult: SceneRenderResult | undefined;
+  if (!opts.skipRender) {
+    onProgress({ type: "phase-start", phase: "render" });
+    onProgress({ type: "render-start" });
+    renderResult = await executeSceneRender({ projectDir });
+    if (!renderResult.success) {
+      return {
+        success: false,
+        error: `render failed: ${renderResult.error ?? "unknown"}`,
+        beats: beatOutcomes,
+        composeData: composeResult.data,
+        renderResult,
+        totalLatencyMs: Date.now() - startedAt,
+      };
+    }
+    outputPath = renderResult.outputPath;
+    if (outputPath) onProgress({ type: "render-done", outputPath });
+  }
+
+  return {
+    success: true,
+    beats: beatOutcomes,
+    outputPath,
+    composeData: composeResult.data,
+    renderResult,
+    totalLatencyMs: Date.now() - startedAt,
+  };
+}
+
+// ── Per-beat primitive dispatch ──────────────────────────────────────────
+
+interface BeatDispatchContext {
+  projectDir: string;
+  ttsProvider: TtsProviderName;
+  voice?: string;
+  imageProvider: "openai";
+  imageQuality: "standard" | "hd";
+  imageSize: ImageOptions["size"];
+  skipNarration: boolean;
+  skipBackdrop: boolean;
+  force: boolean;
+  onProgress: (e: SceneBuildProgressEvent) => void;
+}
+
+async function buildBeatPrimitives(beat: Beat, ctx: BeatDispatchContext): Promise<BeatBuildOutcome> {
+  const [narration, backdrop] = await Promise.all([
+    ctx.skipNarration
+      ? skipped("narration", beat.id, "--skip-narration", ctx)
+      : dispatchNarration(beat, ctx),
+    ctx.skipBackdrop
+      ? skipped("backdrop", beat.id, "--skip-backdrop", ctx)
+      : dispatchBackdrop(beat, ctx),
+  ]);
+  return {
+    beatId: beat.id,
+    narrationStatus: narration.status,
+    narrationPath: narration.path,
+    narrationError: narration.error,
+    backdropStatus: backdrop.status,
+    backdropPath: backdrop.path,
+    backdropError: backdrop.error,
+  };
+}
+
+interface PrimitiveOutcome {
+  status: PrimitiveStatus;
+  path?: string;
+  error?: string;
+}
+
+async function dispatchNarration(beat: Beat, ctx: BeatDispatchContext): Promise<PrimitiveOutcome> {
+  const text = beat.cues?.narration;
+  if (!text) return { status: "no-cue" };
+
+  // Idempotent check: any existing narration audio for this beat (mp3 or wav).
+  for (const ext of ["mp3", "wav"] as const) {
+    const rel = `assets/narration-${beat.id}.${ext}`;
+    if (existsSync(join(ctx.projectDir, rel)) && !ctx.force) {
+      ctx.onProgress({ type: "narration-cached", beatId: beat.id, path: rel });
+      return { status: "cached", path: rel };
+    }
+  }
+
+  let resolution;
+  try {
+    resolution = await resolveTtsProvider(ctx.ttsProvider);
+  } catch (err) {
+    const error = err instanceof TtsKeyMissingError ? err.message : (err as Error).message;
+    ctx.onProgress({ type: "narration-failed", beatId: beat.id, error });
+    return { status: "failed", error };
+  }
+
+  const result = await resolution.call(text, { voice: ctx.voice });
+  if (!result.success || !result.audioBuffer) {
+    const error = result.error ?? "unknown TTS failure";
+    ctx.onProgress({ type: "narration-failed", beatId: beat.id, error });
+    return { status: "failed", error };
+  }
+
+  const rel = `assets/narration-${beat.id}.${resolution.audioExtension}`;
+  const abs = join(ctx.projectDir, rel);
+  await mkdir(dirname(abs), { recursive: true });
+  await writeFile(abs, result.audioBuffer);
+  ctx.onProgress({
+    type: "narration-generated",
+    beatId: beat.id,
+    path: rel,
+    provider: resolution.provider,
+  });
+  return { status: "generated", path: rel };
+}
+
+async function dispatchBackdrop(beat: Beat, ctx: BeatDispatchContext): Promise<PrimitiveOutcome> {
+  const prompt = beat.cues?.backdrop;
+  if (!prompt) return { status: "no-cue" };
+
+  if (ctx.imageProvider !== "openai") {
+    const error = `image provider "${ctx.imageProvider}" not yet supported (use openai)`;
+    ctx.onProgress({ type: "backdrop-failed", beatId: beat.id, error });
+    return { status: "failed", error };
+  }
+
+  const rel = `assets/backdrop-${beat.id}.png`;
+  const abs = join(ctx.projectDir, rel);
+  if (existsSync(abs) && !ctx.force) {
+    ctx.onProgress({ type: "backdrop-cached", beatId: beat.id, path: rel });
+    return { status: "cached", path: rel };
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY ?? "";
+  if (!apiKey) {
+    const error = "OPENAI_API_KEY not set — cannot dispatch backdrop";
+    ctx.onProgress({ type: "backdrop-failed", beatId: beat.id, error });
+    return { status: "failed", error };
+  }
+
+  const provider = new OpenAIImageProvider();
+  await provider.initialize({ apiKey });
+  const result = await provider.generateImage(prompt, {
+    model: "gpt-image-2",
+    size: ctx.imageSize,
+    quality: ctx.imageQuality,
+  });
+  if (!result.success || !result.images?.[0]?.base64) {
+    const error = result.error ?? "no image data returned";
+    ctx.onProgress({ type: "backdrop-failed", beatId: beat.id, error });
+    return { status: "failed", error };
+  }
+
+  await mkdir(dirname(abs), { recursive: true });
+  await writeFile(abs, Buffer.from(result.images[0].base64, "base64"));
+  ctx.onProgress({
+    type: "backdrop-generated",
+    beatId: beat.id,
+    path: rel,
+    provider: "openai",
+  });
+  return { status: "generated", path: rel };
+}
+
+async function skipped(
+  kind: "narration" | "backdrop",
+  beatId: string,
+  reason: string,
+  ctx: BeatDispatchContext,
+): Promise<PrimitiveOutcome> {
+  ctx.onProgress({ type: `${kind}-skipped` as const, beatId, reason });
+  return { status: "skipped" };
+}
+
+function failBeforePrimitives(error: string, startedAt: number): SceneBuildResult {
+  return {
+    success: false,
+    error,
+    beats: [],
+    totalLatencyMs: Date.now() - startedAt,
+  };
+}

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -66,6 +66,10 @@ import {
   type RenderQuality,
 } from "./_shared/scene-render.js";
 import {
+  executeSceneBuild,
+  type SceneBuildProgressEvent,
+} from "./_shared/scene-build.js";
+import {
   exitWithError,
   generalError,
   usageError,
@@ -1005,3 +1009,144 @@ sceneCommand
       }
     }
   });
+
+// ── vibe scene build — v0.60 one-shot storyboard → MP4 ──────────────────
+
+sceneCommand
+  .command("build")
+  .description("One-shot: read STORYBOARD.md cues, dispatch TTS + image-gen per beat, compose, render to MP4 (v0.60)")
+  .argument("[project-dir]", "Project directory containing STORYBOARD.md", ".")
+  .option("--effort <level>", "Compose effort tier: low|medium|high", "medium")
+  .option("--skip-narration", "Don't dispatch TTS even when beats declare narration cues")
+  .option("--skip-backdrop", "Don't dispatch image-gen even when beats declare backdrop cues")
+  .option("--skip-render", "Compose only — don't render to MP4")
+  .option("--tts <provider>", "TTS provider: auto|elevenlabs|kokoro (overrides frontmatter)")
+  .option("--voice <id>", "Voice id (provider-specific — overrides frontmatter)")
+  .option("--image-provider <name>", "Image provider: openai (only one supported in v0.60)")
+  .option("--quality <q>", "Image quality: standard|hd", "hd")
+  .option("--image-size <s>", "Image size: 1024x1024|1536x1024|1024x1536", "1536x1024")
+  .option("--force", "Re-dispatch primitives even when assets already exist")
+  .option("--dry-run", "Preview parameters without dispatching")
+  .action(async (projectDirArg: string, options) => {
+    const projectDir = resolve(projectDirArg);
+
+    if (options.dryRun) {
+      outputResult({
+        dryRun: true,
+        command: "scene build",
+        params: {
+          projectDir,
+          effort: options.effort,
+          skipNarration: options.skipNarration ?? false,
+          skipBackdrop: options.skipBackdrop ?? false,
+          skipRender: options.skipRender ?? false,
+          ttsProvider: options.tts,
+          voice: options.voice,
+          imageProvider: options.imageProvider,
+          imageQuality: options.quality,
+          imageSize: options.imageSize,
+          force: options.force ?? false,
+        },
+      });
+      return;
+    }
+
+    const validEfforts = ["low", "medium", "high"] as const;
+    if (!validEfforts.includes(options.effort)) {
+      exitWithError(usageError(`Invalid --effort: ${options.effort}`, `Must be one of: ${validEfforts.join(", ")}`));
+    }
+
+    const spinner = isJsonMode() ? null : ora("Reading STORYBOARD.md...").start();
+
+    const result = await executeSceneBuild({
+      projectDir,
+      effort: options.effort,
+      skipNarration: options.skipNarration,
+      skipBackdrop: options.skipBackdrop,
+      skipRender: options.skipRender,
+      ttsProvider: options.tts,
+      voice: options.voice,
+      imageProvider: options.imageProvider,
+      imageQuality: options.quality,
+      imageSize: options.imageSize,
+      force: options.force,
+      onProgress: (e: SceneBuildProgressEvent) => {
+        if (!spinner) return;
+        if (e.type === "phase-start") {
+          spinner.text = `Phase: ${e.phase}...`;
+        } else if (e.type === "narration-generated") {
+          spinner.text = `Narration ${e.beatId} → ${e.path} (${e.provider})`;
+        } else if (e.type === "backdrop-generated") {
+          spinner.text = `Backdrop ${e.beatId} → ${e.path} (${e.provider})`;
+        } else if (e.type === "beat-fresh") {
+          spinner.text = `Composed beat ${e.beatId} ($${(e.costUsd ?? 0).toFixed(3)} · ${e.latencyMs ?? 0}ms)`;
+        } else if (e.type === "beat-cached") {
+          spinner.text = `Composed beat ${e.beatId} (cached)`;
+        } else if (e.type === "render-start") {
+          spinner.text = "Rendering...";
+        } else if (e.type === "render-done") {
+          spinner.text = `Rendered: ${e.outputPath}`;
+        }
+      },
+    });
+
+    if (!result.success) {
+      spinner?.fail(`Build failed: ${result.error}`);
+      if (isJsonMode()) {
+        outputResult({ command: "scene build", ...result });
+        process.exit(1);
+      }
+      exitWithError(generalError(result.error ?? "Build failed"));
+    }
+
+    if (isJsonMode()) {
+      outputResult({ command: "scene build", ...result });
+      return;
+    }
+
+    spinner?.succeed(chalk.green(
+      result.outputPath
+        ? `Build complete: ${result.outputPath}`
+        : "Build complete (compose only — render skipped)",
+    ));
+    console.log();
+    console.log(chalk.bold.cyan("Beats"));
+    console.log(chalk.dim("─".repeat(60)));
+    for (const b of result.beats) {
+      const narration = formatPrimitiveStatus(b.narrationStatus, b.narrationPath);
+      const backdrop = formatPrimitiveStatus(b.backdropStatus, b.backdropPath);
+      console.log(`  ${chalk.bold(b.beatId.padEnd(12))} narration: ${narration}   backdrop: ${backdrop}`);
+      if (b.narrationError) console.log(chalk.red(`    ! narration: ${b.narrationError}`));
+      if (b.backdropError) console.log(chalk.red(`    ! backdrop: ${b.backdropError}`));
+    }
+    if (result.composeData) {
+      console.log();
+      console.log(chalk.bold.cyan("Compose"));
+      console.log(chalk.dim("─".repeat(60)));
+      console.log(`  beats     ${result.composeData.beats}`);
+      console.log(`  cache     ${result.composeData.cacheHits} hit / ${result.composeData.beats - result.composeData.cacheHits} fresh`);
+      console.log(`  cost      $${result.composeData.totalCostUsd.toFixed(4)}`);
+    }
+    if (result.outputPath) {
+      console.log();
+      console.log(chalk.bold.cyan("Render"));
+      console.log(chalk.dim("─".repeat(60)));
+      console.log(`  output    ${chalk.bold(result.outputPath)}`);
+      if (result.renderResult?.audioCount && result.renderResult.audioCount > 0) {
+        console.log(`  audio     ${result.renderResult.audioCount} track${result.renderResult.audioCount === 1 ? "" : "s"} muxed`);
+      }
+    }
+    console.log();
+    console.log(chalk.dim(`Total: ${(result.totalLatencyMs / 1000).toFixed(1)}s`));
+  });
+
+function formatPrimitiveStatus(status: string, path?: string): string {
+  switch (status) {
+    case "generated": return chalk.green(`✓ ${path}`);
+    case "cached":    return chalk.dim(`◇ ${path} (cached)`);
+    case "skipped":   return chalk.dim("· skipped");
+    case "no-cue":    return chalk.dim("· no cue");
+    case "failed":    return chalk.red("✗ failed");
+    default:          return status;
+  }
+}


### PR DESCRIPTION
## Summary

C3 of 4 in the v0.60 release plan. **Stacked on top of #133 (C2)** — review/merge that one first.

Introduces the v0.60 \`vibe scene build [project-dir]\` driver that walks STORYBOARD.md (with the YAML frontmatter + per-beat cues from C2), dispatches TTS + image-gen per beat in parallel, runs \`compose-scenes-with-skills\`, then renders to MP4. **Single command from text source to playable file** — the v0.60 demo MP4 (#132) can now be reproduced in one shot.

## Resolution policy

CLI flag > frontmatter > default:

| Field | Flag | Frontmatter | Default |
|---|---|---|---|
| TTS provider | \`--tts\` | \`providers.tts\` | \`auto\` |
| Image provider | \`--image-provider\` | \`providers.image\` | \`openai\` |
| Voice | \`--voice\` | \`voice\` | (provider default) |

## Idempotent

If \`assets/narration-<id>.{mp3,wav}\` or \`assets/backdrop-<id>.png\` already exists, the dispatch is **skipped** — users can iterate on individual beats without re-burning API budget. \`--force\` overrides.

## Per-beat fanout

\`Promise.all\` parallelism — a 3-beat storyboard's primitive phase ≈ slowest single beat. Mirrors the compose-scenes fanout pattern from PR #127.

## Scope held tight

Intentional cuts deferred to v0.61:
- T2I via Gemini / Grok / Runway (only OpenAI gpt-image-2 wired here)
- Whisper transcribe wiring (compose handles word-sync separately)
- Root \`index.html\` synthesis (driver assumes \`vibe scene init\` already ran)
- I2V backdrop integration (motion video instead of stills)

## CLI surface

\`\`\`
vibe scene build [project-dir]
  --effort low|medium|high
  --skip-narration / --skip-backdrop / --skip-render
  --tts auto|elevenlabs|kokoro
  --voice <id>
  --image-provider openai
  --quality standard|hd
  --image-size 1024x1024|1536x1024|1024x1536
  --force
  --dry-run
\`\`\`

## Test plan

- [x] \`npx vitest run scene-build\` — 11/11 pass (mocked TTS / OpenAI / compose / render)
- [x] Full CLI suite — 601 pass / 11 skipped (was 578)
- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` 0 errors
- [x] \`vibe scene build --help\` registers correctly with all 12 options

## Stacking

Base = \`feat/storyboard-frontmatter\` (PR #133). After #133 merges, GitHub will retarget this PR to \`main\` automatically. Or rebase + retarget manually.