### PR TITLE
chore: bump version to 0.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.60.0] - 2026-04-26
+
+### Added
+
+- vibe scene build — one-shot storyboard → MP4 (v0.60 C3) (#135) *(scene)*
+- YAML frontmatter + per-beat cues (v0.60 C2) (#133) *(storyboard)*
+
+### Fixed
+
+- bake timeline-duration rule into compose-scenes prompt (v0.60 demo black-hold fix) (#131) *(scene)*
+- drop -q shorthand from quality flags (collides with --quiet) (#130) *(cli)*
+
+### Maintenance
+
+- commit v0.60 cinematic MP4 + restore MP4 hero on /demo (#132) *(demo)*
+
 ## [0.59.0] - 2026-04-26
 
 ### Added
@@ -59,7 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mark surface recordings 'coming soon' + rebuild DEMO.md follow-along (#108) *(demo)*
 - honest positioning vs Hyperframes (build-on, not compete) (#96) *(readme)*
 - refresh landing copy + share metadata for v0.57 defaults (#93) *(web)*
-- refresh AI provider list for v0.56 / v0.57 (#91) *(readme,web)*
 
 ### Fixed
 
@@ -67,7 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - z-index inversion eliminates mid-overlap luma dip (#101) *(scene)*
 - restore narration on the v0.55 self-promo MP4 (audio was missing) (#99) *(demo)*
 - MCP tool count is 58, not 59 (test fixtures over-count) (#97) *(counts)*
-- refresh onboarding for fal + Kokoro defaults (v0.57.3) (#92) *(cli)*
 
 ### Maintenance
 
@@ -75,6 +89,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - drop orphan binaries + components after hero pivot (#106) *(demo)*
 - drop synthesised hero MP4, lead with asciinema, set v0.58 roadmap (#105) *(demo)*
 - broaden sync drift detection (catches today's 7 missed cases) (#95) *(hooks)*
+
+## [0.57.3] - 2026-04-25
+
+### Documentation
+
+- refresh AI provider list for v0.56 / v0.57 (#91) *(readme,web)*
+
+### Fixed
+
+- refresh onboarding for fal + Kokoro defaults (v0.57.3) (#92) *(cli)*
 
 ## [0.57.2] - 2026-04-25
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

C4 of 4 — final v0.60 release commit.

Bumps every workspace package.json from 0.59.0 → 0.60.0 and regenerates \`CHANGELOG.md\` via git-cliff.

## v0.60 highlights

### Added
- **\`vibe scene build\`** — one-shot driver: STORYBOARD.md → MP4 in one command (#135)
- **STORYBOARD frontmatter spec** — project-level YAML + per-beat \`\`\`yaml cue blocks for narration / backdrop / duration cues (#133)
- **Cinematic v0.60 demo MP4** — \`assets/demos/cinematic-v060.mp4\` committed; /demo landing hero restored (#132)

### Fixed
- **\`-q\` flag collision** in \`generate image\` / \`ai image\` / \`edit slow-motion\` / \`ai video-fx slow-motion\` — global \`--quiet\` was silently eating \`--quality\` shorthand and dropping prompts (#130)
- **Scene timeline-duration rule** — \`compose-scenes-with-skills\` prompt now requires GSAP timeline to span the full beat duration (fixes black hold-phase rendering) (#131)

## Release process

After merge:
1. \`git tag v0.60.0\` on \`main\` and push
2. The auto-publish workflow (\`.github/workflows/publish.yml\`) handles npm publish
3. Verify: \`npm view @vibeframe/cli@0.60.0\`

## Test plan

- [x] \`pnpm install\` clean (lockfile resolves)
- [x] \`pnpm -F @vibeframe/cli build\` clean
- [x] CHANGELOG matches commit history (4 commits + 1 release commit since v0.59.0)
- [x] All 7 package.json files synced at 0.60.0