### PR TITLE
docs: refresh README + ROADMAP for v0.60.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ JSON config block, no CLI install needed (`npx` pulls the bundle on demand).
   </a>
 </p>
 
-> **New in v0.58 (not yet in the recordings above):** `vibe scene init --visual-style "Swiss Pulse"` seeds a `DESIGN.md` hard-gate; `vibe scene styles` browses 8 named visual identities (Swiss Pulse, Velvet Standard, Deconstructed, Maximalist Type, Data Drift, Soft Signal, Folk Frequency, Shadow Cut). The cinematic-craft path runs through Hyperframes' `/hyperframes` skill in Claude Code — `npx skills add heygen-com/hyperframes`. See [`docs/ROADMAP-v0.58.md`](docs/ROADMAP-v0.58.md) for the v0.59 / v0.60 plan.
+> **New in v0.60:** `vibe scene build` is the one-shot driver — write a `STORYBOARD.md` with per-beat YAML cues (narration / backdrop / duration), and a single command dispatches TTS + GPT Image 2 + composes scene HTML via the `compose-scenes-with-skills` pipeline (v0.59) and renders to MP4. `vibe scene init --visual-style "Swiss Pulse"` (v0.58) still seeds the `DESIGN.md` hard-gate + 8 named visual identities. Hyperframes' `/hyperframes` skill (`npx skills add heygen-com/hyperframes`) is loaded as the LLM system prompt for composition craft.
 
 [`assets/demos/claude-code-walkthrough.md`](assets/demos/claude-code-walkthrough.md) has the full 5-prompt walkthrough plus the recording recipe.
 
@@ -319,8 +319,37 @@ vibe scene render -o promo.mp4         # requires Chrome
 ```
 
 Scene projects are bilingual — they work with both `vibe` and
-[`npx hyperframes`](https://github.com/heygen-com/hyperframes). To produce a
-full scenes project from a written script in one shot:
+[`npx hyperframes`](https://github.com/heygen-com/hyperframes).
+
+### One-shot build (v0.60)
+
+When the project has a `STORYBOARD.md` with per-beat YAML cues, a single
+command dispatches all primitives + composes + renders:
+
+```bash
+vibe scene build my-promo                 # storyboard → narration + backdrops + MP4
+vibe scene build --skip-render            # compose only (review HTML before rendering)
+vibe scene build --tts kokoro --voice af_heart   # override frontmatter providers
+```
+
+Per-beat cues live as a fenced \`\`\`yaml block at the start of each beat body:
+
+```markdown
+## Beat hook — Hook
+
+\`\`\`yaml
+narration: "Type a YAML."
+backdrop: "Abstract minimalist tech aesthetic, electric blue glow"
+duration: 3
+\`\`\`
+```
+
+Idempotent: existing assets are reused, `--force` overrides. See
+[`examples/vibeframe-promo/`](examples/vibeframe-promo/) for the
+end-to-end fixture (the same project that produced the cinematic hero
+above).
+
+### Or: from a written script in one shot
 
 ```bash
 vibe pipeline script-to-video "..." --format scenes -o my-promo/ -a 16:9
@@ -370,7 +399,7 @@ Every command supports `--help`. Run `vibe --help` for a full list.
 | **`vibe analyze`** | `media`, `video`, `review`, `suggest` | `vibe analyze media video.mp4 "summarize"` |
 | **`vibe audio`** | `transcribe` (Whisper), `tts` (ElevenLabs · Kokoro local fallback), `voices`, `isolate`, `voice-clone`, `dub`, `duck` | `vibe audio transcribe audio.mp3` |
 | **`vibe pipeline`** | `script-to-video`, `highlights`, `auto-shorts`, `regenerate-scene`, `animated-caption` | `vibe pipeline script-to-video "..." -a 9:16` |
-| **`vibe scene`** | `init`, `add`, `lint`, `render` | `vibe scene add intro --style announcement --headline "..."` |
+| **`vibe scene`** | `init`, `add`, `lint`, `render`, `build` (v0.60) | `vibe scene build my-promo` |
 | **`vibe project`** | `create`, `info`, `set` | `vibe project create "name"` |
 | **`vibe timeline`** | `add-source`, `add-clip`, `split`, `trim`, `move`, `delete`, `list` | `vibe timeline add-source project file` |
 | **`vibe batch`** | `import`, `concat`, `apply-effect` | `vibe batch import project dir/` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ silence-cut, jump-cut, caption, grade, reframe, speed-ramp, fade, noise-reduce, 
 TTS (ElevenLabs + Kokoro local fallback), voice-clone, dub, duck, music generation, sound effects, isolation.
 
 ### Scene authoring (Hyperframes-backed)
-`vibe scene init/add/lint/render` produces editable per-scene HTML instead of opaque MP4s. v0.58 added the DESIGN.md hard-gate + 8 named visual styles. **The agent-driven craft path is now the focus** — see [`docs/ROADMAP-v0.58.md`](docs/ROADMAP-v0.58.md) for the v0.59 (`compose-scenes-with-skills`) and v0.60 (new demo MP4 + landing reorg) plan.
+`vibe scene init/add/lint/render/build` produces editable per-scene HTML instead of opaque MP4s. v0.58 added the DESIGN.md hard-gate + 8 named visual styles. v0.59 shipped `compose-scenes-with-skills` (Claude + vendored Hyperframes skill bundle, sha256 cache, per-beat fanout). v0.60 added `vibe scene build` — one-shot STORYBOARD.md → MP4 with per-beat YAML cues for narration / backdrop / duration. The cinematic demo MP4 (`assets/demos/cinematic-v060.mp4`) is the first end-to-end output of this stack.
 
 ### CLI UX
 Aliases (`gen`, `ed`, `az`, `pipe`, …), `--describe`, `--dry-run` cost preview, `--json`/auto-JSON, `--quiet`, `--fields`, structured exit codes (0–6), provider auto-fallback, `vibe doctor`, `vibe context`, `vibe demo`, smart error hints, `--budget-usd` ceiling.
@@ -47,11 +47,16 @@ Aliases (`gen`, `ed`, `az`, `pipe`, …), `--describe`, `--dry-run` cost preview
 ### Demo & showcase
 - [x] Asciinema recordings (CLI / agent / Claude Code) — README hero
 - [x] [`DEMO.md`](DEMO.md) three-surface follow-along
-- [ ] Cinematic-finish demo MP4 — pending v0.60.0 (`compose-scenes-with-skills`)
+- [x] Cinematic-finish demo MP4 (v0.60.0) — [`assets/demos/cinematic-v060.mp4`](assets/demos/cinematic-v060.mp4), produced by `vibe scene build` end-to-end
 - [ ] Output gallery / interactive web demo
 
-### Open items in Phase 4
+### Open items in Phase 4 (v0.61+ candidates)
+- **I2V backdrop integration** — replace still + Ken-Burns backdrops in `vibe scene build` with motion video from Runway / Kling / Veo / fal.ai
+- **Multi-provider T2I in `scene build`** — currently OpenAI gpt-image-2 only; add Gemini / Grok routing
+- **`compose-scenes-with-skills` narration awareness** — pass word-level transcript so Claude can word-sync animations to audio
+- **`--format scenes` default flip** on `vibe pipeline script-to-video` (deferred from v0.54 plan)
 - **Real-Time Subject Tracking** — local MediaPipe / YOLO / SAM-2 for fast-moving subject reframing, replacing today's Claude Vision keyframe approach (`vibe edit reframe --track`).
+- **`vibe init` setup wizard** — post-install one-shot that scaffolds `CLAUDE.md` / `AGENTS.md` / `.claude/skills/` / `.env.example` based on detected agent host (Claude Code, Cursor, plain shell).
 
 ---
 


### PR DESCRIPTION
## Summary

Post-release doc cleanup. Updates README + ROADMAP to reflect v0.60.0 actually shipping.

## README

- **v0.58 callout** at top of Demo section pointed at "the v0.59 / v0.60 plan" as if it were future. Replaced with **v0.60 callout** naming \`vibe scene build\` as the one-shot driver.
- New **"One-shot build (v0.60)"** section under Scene Authoring with the per-beat YAML cue block example + idempotent / \`--force\` semantics. Linked to \`examples/vibeframe-promo/\`.
- CLI Reference table: \`vibe scene\` row now includes \`build\` and uses \`vibe scene build my-promo\` as the example command.

## ROADMAP

- Marked **cinematic demo MP4** as shipped ✓ (was \`[ ] pending v0.60.0\`).
- Rewrote scene-authoring summary to describe v0.59 (compose-scenes-with-skills) + v0.60 (scene build) — was still pointing at the v0.58-era plan doc.
- Refactored "Open items in Phase 4" into a v0.61+ candidate list: I2V backdrop, multi-provider T2I, narration-aware compose, \`--format scenes\` default flip, **post-install wizard** (\`vibe init\` that scaffolds CLAUDE.md / AGENTS.md / .claude/skills/ / .env.example).

## CLAUDE.md

Left untouched — file is project-Claude-instructions scope (commands + conventions), not feature-catalog scope. v0.60 features don't belong there.

## Test plan

- [x] Markdown renders correctly (manual review)
- [x] No links to deleted files
- [x] CLI reference table reflects actual command surface