### PR TITLE
feat(cli): vibe setup overhaul — user-scope wizard + agent host detection (v0.61 C1)

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -24,6 +24,10 @@ import {
   hasTTY,
 } from "../utils/tty.js";
 import { loadEnv } from "../utils/api-key.js";
+import {
+  detectedAgentHosts,
+  summariseAgentHosts,
+} from "../utils/agent-host-detect.js";
 
 export const setupCommand = new Command("setup")
   .description("Configure VibeFrame (LLM provider, API keys)")
@@ -129,8 +133,14 @@ const AI_FEATURES: AIFeature[] = [
  */
 async function runSetupWizard(fullSetup = false): Promise<void> {
   console.log();
-  console.log(chalk.bold.magenta("VibeFrame Setup"));
+  console.log(chalk.bold.magenta("VibeFrame Setup") + chalk.dim(" — user scope"));
   console.log(chalk.dim("─".repeat(40)));
+  console.log();
+
+  // Show detected agent hosts up-front so the user knows VibeFrame can
+  // tell what they have. Informational only — never blocks setup.
+  const hosts = detectedAgentHosts();
+  console.log(chalk.dim(`Agent hosts: ${summariseAgentHosts(hosts)}`));
   console.log();
 
   // Load existing config or create default
@@ -415,9 +425,23 @@ function showComplete(
   }
   console.log();
   console.log(chalk.bold("  Next steps:"));
-  console.log(chalk.dim("    vibe doctor         Check system health + available commands"));
-  console.log(chalk.dim("    vibe schema --list  Discover all 69 commands"));
-  console.log(chalk.dim("    vibe setup          Re-run setup anytime"));
+  console.log(chalk.dim("    cd <project>; vibe init   Scaffold AGENTS.md / CLAUDE.md / .env.example (project scope)"));
+  console.log(chalk.dim("    vibe doctor               Check system health + available commands"));
+  console.log(chalk.dim("    vibe schema --list        Discover all 69 commands"));
+  console.log(chalk.dim("    vibe setup                Re-run user-scope setup anytime"));
+
+  // Tailored hint when an agent host is detected — points at the file
+  // `vibe init` will scaffold for that host.
+  const hosts = detectedAgentHosts();
+  const primary = hosts[0];
+  if (primary) {
+    console.log();
+    console.log(
+      chalk.dim(
+        `  Detected ${primary.label} — \`vibe init\` will scaffold ${primary.projectFiles.join(" + ")} in your project.`,
+      ),
+    );
+  }
   console.log();
 }
 

--- a/packages/cli/src/utils/agent-host-detect.test.ts
+++ b/packages/cli/src/utils/agent-host-detect.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Need to mock os.homedir() before the module loads — set up the mock
+// here, then dynamic-import the module fresh per test.
+let HOME: string;
+let PATH_DIR: string;
+
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    homedir: () => HOME,
+  };
+});
+
+import { detectAgentHosts, detectedAgentHosts, summariseAgentHosts } from "./agent-host-detect.js";
+
+beforeEach(() => {
+  HOME = mkdtempSync(join(tmpdir(), "vibe-agent-host-home-"));
+  PATH_DIR = mkdtempSync(join(tmpdir(), "vibe-agent-host-path-"));
+});
+
+afterEach(() => {
+  rmSync(HOME, { recursive: true, force: true });
+  rmSync(PATH_DIR, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+function makeBinary(name: string): void {
+  const path = join(PATH_DIR, name);
+  writeFileSync(path, "#!/bin/sh\nexit 0\n");
+  chmodSync(path, 0o755);
+}
+
+function makeConfigDir(rel: string): void {
+  mkdirSync(join(HOME, rel), { recursive: true });
+}
+
+describe("detectAgentHosts", () => {
+  it("returns all 4 hosts with detected=false in a clean environment", () => {
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    expect(hosts).toHaveLength(4);
+    for (const h of hosts) {
+      expect(h.detected).toBe(false);
+      expect(h.signals).toEqual([]);
+    }
+    expect(hosts.map((h) => h.id)).toEqual([
+      "claude-code",
+      "codex",
+      "cursor",
+      "aider",
+    ]);
+  });
+
+  it("detects Claude Code via binary on PATH", () => {
+    makeBinary("claude");
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    const claude = hosts.find((h) => h.id === "claude-code")!;
+    expect(claude.detected).toBe(true);
+    expect(claude.signals).toEqual([{ kind: "binary", name: "claude" }]);
+  });
+
+  it("detects Claude Code via ~/.claude config dir even when binary is missing", () => {
+    makeConfigDir(".claude");
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    const claude = hosts.find((h) => h.id === "claude-code")!;
+    expect(claude.detected).toBe(true);
+    expect(claude.signals).toEqual([
+      { kind: "configDir", path: join(HOME, ".claude") },
+    ]);
+  });
+
+  it("emits both signals when binary AND config dir are present", () => {
+    makeBinary("claude");
+    makeConfigDir(".claude");
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    const claude = hosts.find((h) => h.id === "claude-code")!;
+    expect(claude.signals).toHaveLength(2);
+    expect(claude.signals.map((s) => s.kind).sort()).toEqual(["binary", "configDir"]);
+  });
+
+  it("detects Codex via .codex config dir", () => {
+    makeConfigDir(".codex");
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    const codex = hosts.find((h) => h.id === "codex")!;
+    expect(codex.detected).toBe(true);
+  });
+
+  it("aider has no config-dir signal — binary-only detection", () => {
+    // Aider is binary-only; even if .aider exists in HOME it won't match.
+    makeConfigDir(".aider");
+    const noBinary = detectAgentHosts({ PATH: PATH_DIR });
+    expect(noBinary.find((h) => h.id === "aider")!.detected).toBe(false);
+
+    makeBinary("aider");
+    const withBinary = detectAgentHosts({ PATH: PATH_DIR });
+    expect(withBinary.find((h) => h.id === "aider")!.detected).toBe(true);
+  });
+});
+
+describe("detectedAgentHosts", () => {
+  it("filters to detected only and orders Claude Code first", () => {
+    makeBinary("codex");
+    makeBinary("claude");
+    const detected = detectedAgentHosts({ PATH: PATH_DIR });
+    expect(detected.map((h) => h.id)).toEqual(["claude-code", "codex"]);
+  });
+
+  it("returns empty array when nothing detected", () => {
+    expect(detectedAgentHosts({ PATH: PATH_DIR })).toEqual([]);
+  });
+});
+
+describe("summariseAgentHosts", () => {
+  it("returns '(none detected)' for empty environment", () => {
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    expect(summariseAgentHosts(hosts)).toBe("(none detected)");
+  });
+
+  it("formats single host with its signal types", () => {
+    makeBinary("claude");
+    makeConfigDir(".claude");
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    expect(summariseAgentHosts(hosts)).toBe("Claude Code (binary + config)");
+  });
+
+  it("comma-joins multiple detected hosts", () => {
+    makeBinary("claude");
+    makeBinary("codex");
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    expect(summariseAgentHosts(hosts)).toBe(
+      "Claude Code (binary), Codex (OpenAI) (binary)",
+    );
+  });
+});

--- a/packages/cli/src/utils/agent-host-detect.ts
+++ b/packages/cli/src/utils/agent-host-detect.ts
@@ -1,0 +1,178 @@
+/**
+ * @module utils/agent-host-detect
+ *
+ * Detect which agent hosts the user has installed so the v0.61 setup
+ * wizard (`vibe setup`) and project scaffolder (`vibe init`) can tailor
+ * what to write where.
+ *
+ * Detection is best-effort and *informational* — it never blocks setup,
+ * never shells out beyond `which`, and never reads the contents of the
+ * config dirs (just whether they exist).
+ *
+ * Two signals per host:
+ *   - **binary** — found via `which`/`PATH` lookup (fast, exact)
+ *   - **configDir** — known config directory exists in `$HOME` (catches
+ *     installs where the binary isn't on PATH for the current shell)
+ *
+ * A host is "detected" if either signal fires. The caller decides how to
+ * use that — typically `vibe setup` shows them in a summary, `vibe init`
+ * uses them to pick which agent files to scaffold.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Agent hosts VibeFrame knows how to scaffold for. */
+export type AgentHostId = "claude-code" | "codex" | "cursor" | "aider";
+
+export interface AgentHostInfo {
+  id: AgentHostId;
+  /** Human-friendly name for prompts and UI. */
+  label: string;
+  /** True when at least one signal fired. */
+  detected: boolean;
+  /** Signals that fired (empty array when `detected` is false). */
+  signals: AgentHostSignal[];
+  /**
+   * Files this host expects in a project. Used by `vibe init` to know
+   * what to scaffold; informational here.
+   */
+  projectFiles: string[];
+}
+
+export type AgentHostSignal =
+  | { kind: "binary"; name: string }
+  | { kind: "configDir"; path: string };
+
+/**
+ * Scan the current environment for known agent hosts. Synchronous because
+ * every check is cheap (`existsSync` + `process.env.PATH` walk).
+ */
+export function detectAgentHosts(env: NodeJS.ProcessEnv = process.env): AgentHostInfo[] {
+  const home = homedir();
+  return [
+    {
+      id: "claude-code",
+      label: "Claude Code",
+      detected: false,
+      signals: [],
+      projectFiles: ["CLAUDE.md", ".claude/skills/"],
+    },
+    {
+      id: "codex",
+      label: "Codex (OpenAI)",
+      detected: false,
+      signals: [],
+      projectFiles: ["AGENTS.md"],
+    },
+    {
+      id: "cursor",
+      label: "Cursor",
+      detected: false,
+      signals: [],
+      projectFiles: ["AGENTS.md", ".cursor/rules/"],
+    },
+    {
+      id: "aider",
+      label: "Aider",
+      detected: false,
+      signals: [],
+      projectFiles: ["AGENTS.md", ".aider.conf.yml"],
+    },
+  ].map((host) => {
+    const signals: AgentHostSignal[] = [];
+
+    // Binary lookup via PATH
+    const binaryName = HOST_BINARIES[host.id as AgentHostId];
+    if (binaryName && isOnPath(binaryName, env)) {
+      signals.push({ kind: "binary", name: binaryName });
+    }
+
+    // Config directory in $HOME
+    const configDirRel = HOST_CONFIG_DIRS[host.id as AgentHostId];
+    if (configDirRel) {
+      const path = join(home, configDirRel);
+      if (existsSync(path)) {
+        signals.push({ kind: "configDir", path });
+      }
+    }
+
+    return {
+      ...host,
+      id: host.id as AgentHostId,
+      detected: signals.length > 0,
+      signals,
+    };
+  });
+}
+
+/**
+ * Return only detected hosts, ordered by VibeFrame's recommendation:
+ * Claude Code first (we ship slash commands for it), then alphabetical.
+ */
+export function detectedAgentHosts(env: NodeJS.ProcessEnv = process.env): AgentHostInfo[] {
+  return detectAgentHosts(env)
+    .filter((h) => h.detected)
+    .sort((a, b) => {
+      if (a.id === "claude-code") return -1;
+      if (b.id === "claude-code") return 1;
+      return a.id.localeCompare(b.id);
+    });
+}
+
+/**
+ * One-line status summary suitable for spinners / setup wizards.
+ *
+ * Examples:
+ *   "Claude Code (binary + config), Codex (config)"
+ *   "(none — install Claude Code, Codex, or Cursor for agent integration)"
+ */
+export function summariseAgentHosts(hosts: AgentHostInfo[]): string {
+  const detected = hosts.filter((h) => h.detected);
+  if (detected.length === 0) {
+    return "(none detected)";
+  }
+  return detected
+    .map((h) => {
+      const sigs = h.signals.map((s) => (s.kind === "binary" ? "binary" : "config"));
+      return `${h.label} (${sigs.join(" + ")})`;
+    })
+    .join(", ");
+}
+
+// ── Internals ────────────────────────────────────────────────────────────
+
+const HOST_BINARIES: Record<AgentHostId, string | null> = {
+  "claude-code": "claude",
+  codex: "codex",
+  cursor: "cursor",
+  aider: "aider",
+};
+
+/**
+ * Per-host `$HOME`-relative config directory. Set to `null` when the host
+ * doesn't keep a stable config dir (signal becomes binary-only).
+ */
+const HOST_CONFIG_DIRS: Record<AgentHostId, string | null> = {
+  "claude-code": ".claude",
+  codex: ".codex",
+  cursor: ".cursor", // some installs; macOS app stores prefs elsewhere
+  aider: null,
+};
+
+/**
+ * Lightweight `which` — walks `$PATH` for an executable. Avoids spawning
+ * a subprocess; works on POSIX + Windows (`PATHEXT` not handled — fine for
+ * agent host CLIs which all ship POSIX-style binaries).
+ */
+function isOnPath(binary: string, env: NodeJS.ProcessEnv): boolean {
+  const path = env.PATH ?? env.Path ?? "";
+  const sep = process.platform === "win32" ? ";" : ":";
+  for (const dir of path.split(sep)) {
+    if (!dir) continue;
+    if (existsSync(join(dir, binary))) return true;
+    if (process.platform === "win32" && existsSync(join(dir, `${binary}.exe`))) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

C1 of 3 in the v0.61 wizard plan. Establishes the **user / project scope** split:
- \`vibe setup\` = user scope (this PR — clarified) — one-time, per machine
- \`vibe init\` = project scope (C2 — next PR) — per project, scaffolds AGENTS.md / CLAUDE.md / .env.example
- \`vibe doctor\` = scope-aware status (C3) — points at the next missing step

## What this PR does

**New \`utils/agent-host-detect.ts\` module** — best-effort detection of which agent hosts the user has installed:

| Host | Binary signal | Config-dir signal |
|---|---|---|
| Claude Code | \`claude\` | \`~/.claude\` |
| Codex (OpenAI) | \`codex\` | \`~/.codex\` |
| Cursor | \`cursor\` | \`~/.cursor\` |
| Aider | \`aider\` | (binary-only) |

Either signal fires → host is "detected". Used informationally by setup, will drive scaffolding decisions in \`vibe init\`.

**\`setup.ts\` changes** — additive only, no behaviour change beyond new output lines:
- Header now reads **"VibeFrame Setup — user scope"** so scope is obvious from line 1
- Wizard start shows detected hosts: \`Agent hosts: Claude Code (binary + config), Codex (config)\`
- Completion screen leads with \`cd <project>; vibe init\` as the next step, plus a tailored hint (\"Detected Claude Code — \`vibe init\` will scaffold CLAUDE.md + .claude/skills/ in your project.\")

Existing wizard flow, prompts, config save path are untouched.

## Test plan

- [x] \`npx vitest run agent-host-detect\` — 11/11 pass
- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` 0 errors
- [x] \`vibe setup --claude-code\` still works (manual smoke)