### PR TITLE
feat(cli): vibe doctor — scope-aware diagnostics + next-step hint (v0.61 C3)

### DIFF
--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Black-box tests for `vibe doctor` v0.61 scope diagnostics. Spawns the
+ * CLI binary with a clean $HOME and a fresh cwd so we know exactly what
+ * the scope status should be.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const CLI = resolve(__dirname, "..", "..", "dist", "index.js");
+
+let projectDir: string;
+let fakeHome: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "vibe-doctor-test-"));
+  fakeHome = mkdtempSync(join(tmpdir(), "vibe-doctor-home-"));
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
+});
+
+function runDoctor(): { json: ReturnType<typeof JSON.parse>; stderr: string } {
+  const out = execFileSync(
+    process.execPath,
+    [CLI, "doctor", "--json"],
+    {
+      cwd: projectDir,
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        PATH: "/usr/bin:/bin",
+        NO_COLOR: "1",
+      },
+      encoding: "utf-8",
+    },
+  );
+  return { json: JSON.parse(out), stderr: "" };
+}
+
+describe("vibe doctor — scope diagnostics", () => {
+  it("reports user scope unconfigured + project uninitialized in a fresh environment", () => {
+    const { json } = runDoctor();
+    const scope = json.result.scope;
+
+    expect(scope.user.configured).toBe(false);
+    expect(scope.project.initialized).toBe(false);
+    expect(scope.project.files).toHaveLength(3);
+    expect(scope.project.files.map((f: { path: string }) => f.path).sort()).toEqual([
+      "AGENTS.md",
+      "CLAUDE.md",
+      "vibe.project.yaml",
+    ]);
+    expect(scope.project.files.every((f: { exists: boolean }) => !f.exists)).toBe(true);
+  });
+
+  it("flips project.initialized=true when AGENTS.md is present", () => {
+    writeFileSync(join(projectDir, "AGENTS.md"), "# AGENTS\n");
+    const { json } = runDoctor();
+    expect(json.result.scope.project.initialized).toBe(true);
+
+    const agents = json.result.scope.project.files.find((f: { path: string }) => f.path === "AGENTS.md");
+    expect(agents.exists).toBe(true);
+  });
+
+  it("flips user.configured=true when ~/.vibeframe/config.yaml exists", () => {
+    mkdirSync(join(fakeHome, ".vibeframe"));
+    writeFileSync(join(fakeHome, ".vibeframe", "config.yaml"), "providers: {}\n");
+    const { json } = runDoctor();
+    expect(json.result.scope.user.configured).toBe(true);
+    expect(json.result.scope.user.configPath).toContain(".vibeframe");
+  });
+
+  it("agentHosts.detected is empty in a sterilised environment", () => {
+    const { json } = runDoctor();
+    expect(json.result.scope.agentHosts.detected).toEqual([]);
+    expect(json.result.scope.agentHosts.summary).toBe("(none detected)");
+  });
+
+  it("agentHosts.detected picks up Claude Code via ~/.claude config dir", () => {
+    mkdirSync(join(fakeHome, ".claude"));
+    const { json } = runDoctor();
+    expect(json.result.scope.agentHosts.detected).toContain("Claude Code");
+  });
+});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -5,11 +5,14 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { access } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { CONFIG_PATH } from "../config/index.js";
 import { PROVIDER_ENV_VARS } from "../config/schema.js";
 import { commandExists } from "../utils/exec-safe.js";
 import { execSafe } from "../utils/exec-safe.js";
 import { loadEnv } from "../utils/api-key.js";
+import { detectAgentHosts, summariseAgentHosts } from "../utils/agent-host-detect.js";
 import { outputResult } from "./output.js";
 
 /** Mapping of env vars to the commands they unlock */
@@ -163,6 +166,29 @@ interface DiagnosticResults {
     config: { path: string; ok: boolean };
     optionalTools?: Record<string, OptionalToolStatus>;
   };
+  /**
+   * v0.61: scope-aware status. The "what should I run next?" hint at the
+   * bottom of the report uses these flags directly.
+   */
+  scope: {
+    user: {
+      /** `~/.vibeframe/config.json` exists — `vibe setup` has been run. */
+      configured: boolean;
+      configPath: string;
+    };
+    project: {
+      /** Current working directory. */
+      cwd: string;
+      /** True when ANY of (AGENTS.md / CLAUDE.md / vibe.project.yaml) exists. */
+      initialized: boolean;
+      /** Per-file existence — each entry is informational for the report. */
+      files: { path: string; exists: boolean }[];
+    };
+    agentHosts: {
+      detected: string[];
+      summary: string;
+    };
+  };
   providers: Record<
     string,
     { envVar: string; configured: boolean; commands: string[] }
@@ -272,12 +298,28 @@ async function runDiagnostics(): Promise<DiagnosticResults> {
     }
   }
 
+  // v0.61: scope diagnostics ─────────────────────────────────────────────
+  const cwd = process.cwd();
+  const projectFiles = ["AGENTS.md", "CLAUDE.md", "vibe.project.yaml"].map((rel) => ({
+    path: rel,
+    exists: existsSync(resolve(cwd, rel)),
+  }));
+  const projectInitialized = projectFiles.some((f) => f.exists);
+
+  const hosts = detectAgentHosts();
+  const detectedNames = hosts.filter((h) => h.detected).map((h) => h.label);
+
   return {
     system: {
       node: { version: nodeVersion, ok: true },
       ffmpeg: { version: ffmpegVersion, ok: ffmpegExists, ...(ffmpegFilters ? { filters: ffmpegFilters } : {}) },
       config: { path: CONFIG_PATH, ok: configExists },
       ...(Object.keys(optionalTools).length > 0 ? { optionalTools } : {}),
+    },
+    scope: {
+      user: { configured: configExists, configPath: CONFIG_PATH },
+      project: { cwd, initialized: projectInitialized, files: projectFiles },
+      agentHosts: { detected: detectedNames, summary: summariseAgentHosts(hosts) },
     },
     providers,
     readyCount,
@@ -334,14 +376,26 @@ function printReport(results: DiagnosticResults): void {
     }
   }
 
-  // Config
-  if (results.system.config.ok) {
-    console.log(`    Config     ${chalk.green("OK")}  ${chalk.dim(results.system.config.path)}`);
+  console.log();
+  console.log(chalk.bold("  Scope"));
+
+  // User scope — vibe setup status
+  if (results.scope.user.configured) {
+    console.log(`    User       ${chalk.green("OK")}       ${chalk.dim(results.scope.user.configPath)}`);
   } else {
-    console.log(
-      `    Config     ${chalk.yellow("NOT SET")}  ${chalk.dim("Run: vibe setup")}`
-    );
+    console.log(`    User       ${chalk.yellow("NOT SET")}  ${chalk.dim("Run: vibe setup")}`);
   }
+
+  // Project scope — vibe init status
+  if (results.scope.project.initialized) {
+    const present = results.scope.project.files.filter((f) => f.exists).map((f) => f.path);
+    console.log(`    Project    ${chalk.green("OK")}       ${chalk.dim(present.join(", "))}`);
+  } else {
+    console.log(`    Project    ${chalk.yellow("NOT INIT")} ${chalk.dim(`Run: vibe init  (cwd: ${results.scope.project.cwd})`)}`);
+  }
+
+  // Agent hosts — informational
+  console.log(`    Agents     ${chalk.dim(results.scope.agentHosts.summary)}`);
 
   console.log();
   console.log(chalk.bold("  API Keys"));
@@ -382,8 +436,32 @@ function printReport(results: DiagnosticResults): void {
     `  Ready: ${readyColor(`${results.readyCount}/${results.totalCount}`)} commands (${pct}%)`
   );
 
-  if (missing.length > 0) {
-    console.log(chalk.dim(`  Run 'vibe setup' to configure more providers.`));
+  // ── v0.61: scope-aware "what to do next" hint ────────────────────────
+  // Prioritise scope problems over provider gaps — a user without setup
+  // configured can't run 'vibe setup' to add providers either.
+  const nextStep = pickNextStep(results, missing.length > 0);
+  if (nextStep) {
+    console.log(chalk.dim(`  ${nextStep}`));
   }
   console.log();
+}
+
+/**
+ * Pick the single most-helpful next-step suggestion for the user. Order:
+ *  1. user scope unset → run setup
+ *  2. project scope uninitialized → run init
+ *  3. some providers missing → setup again to add more keys
+ *  4. everything ok → no hint
+ */
+function pickNextStep(results: DiagnosticResults, hasMissingProviders: boolean): string | null {
+  if (!results.scope.user.configured) {
+    return "Next: run 'vibe setup' to configure your user scope (API keys + LLM provider).";
+  }
+  if (!results.scope.project.initialized) {
+    return "Next: run 'vibe init' in your project directory to scaffold AGENTS.md / CLAUDE.md / .env.example.";
+  }
+  if (hasMissingProviders) {
+    return "Run 'vibe setup' to add more provider keys.";
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

C3 of 3 — closes the v0.61 wizard trio. **Stacked on #139 (C2)**, which is stacked on #138 (C1).

Doctor now answers "what should I do next?" by surfacing the user/project scope split alongside existing system + provider checks.

## New Scope section

\`\`\`
  Scope
    User       NOT SET   Run: vibe setup
    Project    NOT INIT  Run: vibe init  (cwd: /home/u/my-promo)
    Agents     Claude Code (binary + config), Codex (config)
\`\`\`

JSON output gains a \`scope\` block:
\`\`\`json
{
  "scope": {
    "user": { "configured": false, "configPath": "~/.vibeframe/config.yaml" },
    "project": {
      "cwd": "...",
      "initialized": false,
      "files": [
        { "path": "AGENTS.md", "exists": false },
        { "path": "CLAUDE.md", "exists": false },
        { "path": "vibe.project.yaml", "exists": false }
      ]
    },
    "agentHosts": { "detected": [...], "summary": "..." }
  }
}
\`\`\`

## Next-step hint (prioritised)

The bottom of the report shows one suggestion:
1. user not set → \`vibe setup\`
2. project not init → \`vibe init\`
3. some providers missing → \`vibe setup\` again
4. all good → no hint

## Test plan

- [x] \`npx vitest run doctor\` — 5/5 pass (black-box with sterilised \$HOME + cwd)
- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` 0 errors
- [x] Manual smoke: fresh /tmp dir + clean \$HOME → doctor reports both scopes unset