### PR TITLE
feat(pipeline): scene-build + scene-render pipeline actions (v0.62 C1)

### DIFF
--- a/examples/scene-promo-pipeline.yaml
+++ b/examples/scene-promo-pipeline.yaml
@@ -1,0 +1,34 @@
+# scene-promo-pipeline.yaml
+#
+# v0.62 reference pipeline — STORYBOARD.md → MP4 in one declarative file.
+# Replaces the earlier "scene add → scene render" two-step manual flow.
+#
+# How to run:
+#   vibe run examples/scene-promo-pipeline.yaml --dry-run    # cost preview
+#   vibe run examples/scene-promo-pipeline.yaml              # actually build
+#
+# Project layout assumed:
+#   examples/vibeframe-promo/
+#     STORYBOARD.md       — beats with `narration:` / `backdrop:` cues
+#     DESIGN.md           — visual identity hard-gate
+#     index.html          — root composition referencing scene HTML
+#     vibe.project.yaml
+#
+# This pipeline reproduces the cinematic-v060.mp4 demo end-to-end. See
+# `assets/demos/cinematic-v060.mp4` for the rendered output.
+
+name: scene-promo
+budget:
+  costUsd: 2.00          # cap total spend — scene-build composes via Sonnet 4.6
+  maxToolErrors: 1
+effort: medium
+
+steps:
+  # Single action does it all: TTS per beat (cues), backdrops per beat
+  # (cues), compose scene HTML via skills, render to MP4.
+  - id: build
+    action: scene-build
+    project: vibeframe-promo
+    quality: hd            # gpt-image-2 quality for backdrops
+    # Idempotent by default — pre-existing assets/narration-*.mp3 +
+    # assets/backdrop-*.png are reused. Pass `force: true` to redo.

--- a/packages/cli/src/pipeline/executor.ts
+++ b/packages/cli/src/pipeline/executor.ts
@@ -235,6 +235,64 @@ async function ensureActionsRegistered(): Promise<void> {
       error: r.error,
     };
   });
+
+  // v0.62: STORYBOARD → MP4 in one action. Reads frontmatter + per-beat
+  // cues, dispatches TTS + image-gen per beat, runs compose-scenes-with-
+  // skills, then renders. Idempotent — existing assets are reused.
+  registerAction("scene-build", async (params, outputDir) => {
+    const { executeSceneBuild } = await import("../commands/_shared/scene-build.js");
+    const projectRel = (params.project as string | undefined) ?? ".";
+    const r = await executeSceneBuild({
+      projectDir: resolve(outputDir, projectRel),
+      effort: params.effort as "low" | "medium" | "high" | undefined,
+      skipNarration: params.skipNarration as boolean | undefined,
+      skipBackdrop: params.skipBackdrop as boolean | undefined,
+      skipRender: params.skipRender as boolean | undefined,
+      ttsProvider: params.tts as "auto" | "elevenlabs" | "kokoro" | undefined,
+      voice: params.voice as string | undefined,
+      imageProvider: params.imageProvider as "openai" | undefined,
+      imageQuality: params.quality as "standard" | "hd" | undefined,
+      force: params.force as boolean | undefined,
+    });
+    return {
+      id: "",
+      action: "scene-build",
+      success: r.success,
+      output: r.outputPath,
+      data: { beats: r.beats, totalLatencyMs: r.totalLatencyMs, composeData: r.composeData ?? null } as Record<string, unknown>,
+      error: r.error,
+    };
+  });
+
+  // v0.62: render-only escape hatch for pipelines that author scene HTML
+  // by hand (or via compose-scenes-with-skills) and only need the
+  // Hyperframes producer pass + audio mux at the end.
+  registerAction("scene-render", async (params, outputDir) => {
+    const { executeSceneRender } = await import("../commands/_shared/scene-render.js");
+    const projectRel = (params.project as string | undefined) ?? ".";
+    const r = await executeSceneRender({
+      projectDir: resolve(outputDir, projectRel),
+      root: params.root as string | undefined,
+      output: params.output as string | undefined,
+      fps: params.fps as 24 | 30 | 60 | undefined,
+      quality: params.quality as "draft" | "standard" | "high" | undefined,
+      format: params.format as "mp4" | "webm" | "mov" | undefined,
+      workers: params.workers as number | undefined,
+    });
+    return {
+      id: "",
+      action: "scene-render",
+      success: r.success,
+      output: r.outputPath,
+      data: {
+        durationMs: r.durationMs,
+        framesRendered: r.framesRendered,
+        audioCount: r.audioCount,
+        audioMuxApplied: r.audioMuxApplied,
+      } as Record<string, unknown>,
+      error: r.error,
+    };
+  });
 }
 
 // ── Pipeline Loader ─────────────────────────────────────────────────────

--- a/packages/cli/src/pipeline/scene-actions.test.ts
+++ b/packages/cli/src/pipeline/scene-actions.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Smoke tests for the v0.62 scene-build + scene-render pipeline actions.
+ * Mocks executeSceneBuild + executeSceneRender at the import boundary
+ * so we test ONLY the wiring between the executor and the underlying
+ * helpers — no Chrome, no API calls, no FS scans of real projects.
+ */
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../commands/_shared/scene-build.js", () => ({
+  executeSceneBuild: vi.fn(),
+}));
+
+vi.mock("../commands/_shared/scene-render.js", () => ({
+  executeSceneRender: vi.fn(),
+}));
+
+import { executePipeline, loadPipeline } from "./executor.js";
+import { executeSceneBuild } from "../commands/_shared/scene-build.js";
+import { executeSceneRender } from "../commands/_shared/scene-render.js";
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "scene-actions-test-"));
+  vi.clearAllMocks();
+});
+
+function writePipeline(yaml: string): string {
+  const path = join(workDir, "pipeline.yaml");
+  writeFileSync(path, yaml);
+  return path;
+}
+
+describe("pipeline action: scene-build", () => {
+  it("forwards storyboard cues to executeSceneBuild and surfaces the output path", async () => {
+    vi.mocked(executeSceneBuild).mockResolvedValueOnce({
+      success: true,
+      beats: [{ beatId: "hook", narrationStatus: "generated", backdropStatus: "generated" }],
+      outputPath: "/tmp/render.mp4",
+      totalLatencyMs: 1234,
+    });
+
+    const yamlPath = writePipeline(`
+name: scene-build-pipeline
+steps:
+  - id: build
+    action: scene-build
+    project: my-promo
+    tts: kokoro
+    voice: af_heart
+    quality: hd
+`);
+
+    const manifest = await loadPipeline(yamlPath);
+    const result = await executePipeline(manifest, { outputDir: workDir });
+
+    expect(result.success).toBe(true);
+    expect(executeSceneBuild).toHaveBeenCalledOnce();
+    const call = vi.mocked(executeSceneBuild).mock.calls[0][0];
+    expect(call.projectDir).toBe(join(workDir, "my-promo"));
+    expect(call.ttsProvider).toBe("kokoro");
+    expect(call.voice).toBe("af_heart");
+    expect(call.imageQuality).toBe("hd");
+
+    expect(result.steps[0].output).toBe("/tmp/render.mp4");
+    expect(result.steps[0].action).toBe("scene-build");
+  });
+
+  it("surfaces failure from executeSceneBuild as a failed step", async () => {
+    vi.mocked(executeSceneBuild).mockResolvedValueOnce({
+      success: false,
+      error: "STORYBOARD.md not found",
+      beats: [],
+      totalLatencyMs: 0,
+    });
+
+    const manifest = await loadPipeline(writePipeline(`
+name: x
+steps: [{ id: b, action: scene-build, project: missing }]
+`));
+
+    const result = await executePipeline(manifest, { outputDir: workDir });
+    expect(result.steps[0].success).toBe(false);
+    expect(result.steps[0].error).toContain("STORYBOARD.md not found");
+  });
+
+  it("respects --skip-render via params", async () => {
+    vi.mocked(executeSceneBuild).mockResolvedValueOnce({
+      success: true,
+      beats: [],
+      totalLatencyMs: 0,
+    });
+
+    const manifest = await loadPipeline(writePipeline(`
+name: x
+steps: [{ id: b, action: scene-build, skipRender: true }]
+`));
+
+    await executePipeline(manifest, { outputDir: workDir });
+    const call = vi.mocked(executeSceneBuild).mock.calls[0][0];
+    expect(call.skipRender).toBe(true);
+  });
+});
+
+describe("pipeline action: scene-render", () => {
+  it("forwards render params and surfaces audio metadata", async () => {
+    vi.mocked(executeSceneRender).mockResolvedValueOnce({
+      success: true,
+      outputPath: "/tmp/render.mp4",
+      durationMs: 5678,
+      framesRendered: 270,
+      audioCount: 3,
+      audioMuxApplied: true,
+    });
+
+    const manifest = await loadPipeline(writePipeline(`
+name: x
+steps:
+  - id: r
+    action: scene-render
+    project: my-promo
+    fps: 30
+    quality: high
+    format: mp4
+`));
+
+    const result = await executePipeline(manifest, { outputDir: workDir });
+    expect(result.success).toBe(true);
+    expect(executeSceneRender).toHaveBeenCalledOnce();
+
+    const call = vi.mocked(executeSceneRender).mock.calls[0][0];
+    expect(call.projectDir).toBe(join(workDir, "my-promo"));
+    expect(call.fps).toBe(30);
+    expect(call.quality).toBe("high");
+
+    const data = result.steps[0].data as { audioCount: number; audioMuxApplied: boolean };
+    expect(data.audioCount).toBe(3);
+    expect(data.audioMuxApplied).toBe(true);
+  });
+
+  it("project param defaults to '.' when omitted", async () => {
+    vi.mocked(executeSceneRender).mockResolvedValueOnce({
+      success: true,
+      outputPath: "/tmp/x.mp4",
+    });
+
+    const manifest = await loadPipeline(writePipeline(`
+name: x
+steps: [{ id: r, action: scene-render }]
+`));
+
+    await executePipeline(manifest, { outputDir: workDir });
+    expect(vi.mocked(executeSceneRender).mock.calls[0][0].projectDir).toBe(workDir);
+  });
+});
+
+describe("pipeline action: scene-build chained with scene-render", () => {
+  it("two steps run sequentially, $ref between them resolves", async () => {
+    vi.mocked(executeSceneBuild).mockResolvedValueOnce({
+      success: true,
+      beats: [],
+      outputPath: "/tmp/build-out",
+      totalLatencyMs: 0,
+    });
+    vi.mocked(executeSceneRender).mockResolvedValueOnce({
+      success: true,
+      outputPath: "/tmp/render.mp4",
+    });
+
+    const manifest = await loadPipeline(writePipeline(`
+name: x
+steps:
+  - id: build
+    action: scene-build
+    project: p
+    skipRender: true
+  - id: render
+    action: scene-render
+    project: p
+`));
+
+    const result = await executePipeline(manifest, { outputDir: workDir });
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(2);
+    expect(executeSceneBuild).toHaveBeenCalledOnce();
+    expect(executeSceneRender).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/pipeline/scene-actions.test.ts
+++ b/packages/cli/src/pipeline/scene-actions.test.ts
@@ -59,11 +59,12 @@ steps:
 
     expect(result.success).toBe(true);
     expect(executeSceneBuild).toHaveBeenCalledOnce();
-    const call = vi.mocked(executeSceneBuild).mock.calls[0][0];
-    expect(call.projectDir).toBe(join(workDir, "my-promo"));
-    expect(call.ttsProvider).toBe("kokoro");
-    expect(call.voice).toBe("af_heart");
-    expect(call.imageQuality).toBe("hd");
+    const call = vi.mocked(executeSceneBuild).mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call!.projectDir).toBe(join(workDir, "my-promo"));
+    expect(call!.ttsProvider).toBe("kokoro");
+    expect(call!.voice).toBe("af_heart");
+    expect(call!.imageQuality).toBe("hd");
 
     expect(result.steps[0].output).toBe("/tmp/render.mp4");
     expect(result.steps[0].action).toBe("scene-build");
@@ -100,8 +101,9 @@ steps: [{ id: b, action: scene-build, skipRender: true }]
 `));
 
     await executePipeline(manifest, { outputDir: workDir });
-    const call = vi.mocked(executeSceneBuild).mock.calls[0][0];
-    expect(call.skipRender).toBe(true);
+    const call = vi.mocked(executeSceneBuild).mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call!.skipRender).toBe(true);
   });
 });
 
@@ -131,10 +133,11 @@ steps:
     expect(result.success).toBe(true);
     expect(executeSceneRender).toHaveBeenCalledOnce();
 
-    const call = vi.mocked(executeSceneRender).mock.calls[0][0];
-    expect(call.projectDir).toBe(join(workDir, "my-promo"));
-    expect(call.fps).toBe(30);
-    expect(call.quality).toBe("high");
+    const call = vi.mocked(executeSceneRender).mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call!.projectDir).toBe(join(workDir, "my-promo"));
+    expect(call!.fps).toBe(30);
+    expect(call!.quality).toBe("high");
 
     const data = result.steps[0].data as { audioCount: number; audioMuxApplied: boolean };
     expect(data.audioCount).toBe(3);
@@ -153,7 +156,9 @@ steps: [{ id: r, action: scene-render }]
 `));
 
     await executePipeline(manifest, { outputDir: workDir });
-    expect(vi.mocked(executeSceneRender).mock.calls[0][0].projectDir).toBe(workDir);
+    const call = vi.mocked(executeSceneRender).mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call!.projectDir).toBe(workDir);
   });
 });
 

--- a/packages/cli/src/pipeline/types.ts
+++ b/packages/cli/src/pipeline/types.ts
@@ -45,6 +45,12 @@ export type PipelineAction =
   | "review-video"
   // Scene composition (v0.59+)
   | "compose-scenes-with-skills"
+  // Scene end-to-end (v0.62+) — STORYBOARD frontmatter cues drive
+  // primitive dispatch, then compose, then render to MP4 in one action.
+  | "scene-build"
+  // Scene render-only (v0.62+) — for pipelines that compose elsewhere
+  // and just need the Hyperframes producer pass at the end.
+  | "scene-render"
   // Meta
   | "export";
 


### PR DESCRIPTION
## Summary

C1 of 5 in the v0.62 cleanup + clarity plan. Closes the gap from v0.60: \`vibe scene build\` is a CLI command but wasn't a pipeline action — meaning YAML pipelines could compose (via \`compose-scenes-with-skills\`) but couldn't dispatch primitives or render in the same run.

After this change, a single YAML file drives the full flow:
\`\`\`yaml
steps:
  - id: build
    action: scene-build       # ← new
    project: my-promo
\`\`\`
→ STORYBOARD frontmatter → narration TTS → backdrop T2I → compose → render → MP4.

## New \`PipelineAction\` members

| Action | Wraps | Use case |
|---|---|---|
| \`scene-build\` | \`executeSceneBuild\` (v0.60) | Full storyboard → MP4 in one step |
| \`scene-render\` | \`executeSceneRender\` (v0.55) | Render-only — for pipelines that compose scenes elsewhere and just need the Hyperframes producer pass + audio mux at the end |

Both resolve \`project\` against the pipeline's \`outputDir\` so a YAML at the repo root can reference \`project: my-promo\` without absolute paths.

## Reference fixture

\`examples/scene-promo-pipeline.yaml\` — single \`scene-build\` step that reproduces the cinematic-v060 demo end-to-end. Run with:
\`\`\`bash
vibe run examples/scene-promo-pipeline.yaml --dry-run
vibe run examples/scene-promo-pipeline.yaml
\`\`\`

## Test plan

- [x] \`npx vitest run scene-actions\` — 6/6 pass (mocked executeSceneBuild + executeSceneRender)
- [x] Tests cover: forward params, surface output path, surface failure, --skip-render param, default project=".", chained scene-build → scene-render
- [x] Full CLI suite — 645 pass / 11 skipped
- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` 0 errors