### PR TITLE
chore(pipeline): deprecate script-to-video --format scenes (v0.62 C3)

### DIFF
--- a/packages/cli/src/commands/ai-script-pipeline-cli.ts
+++ b/packages/cli/src/commands/ai-script-pipeline-cli.ts
@@ -21,7 +21,7 @@ import {
   executeScriptToVideo,
   executeRegenerateScene,
 } from "./ai-script-pipeline.js";
-import { exitWithError, outputResult, authError, notFoundError, usageError, apiError, generalError } from "./output.js";
+import { exitWithError, outputResult, isJsonMode, authError, notFoundError, usageError, apiError, generalError } from "./output.js";
 import { validateOutputPath } from "./validate.js";
 
 export function registerScriptPipelineCommands(aiCommand: Command): void {
@@ -50,13 +50,24 @@ aiCommand
   .option("--text-style <style>", "Text overlay style: lower-third, center-bold, subtitle, minimal", "lower-third")
   .option("--review", "Run AI review after assembly (requires GOOGLE_API_KEY)")
   .option("--review-auto-apply", "Auto-apply fixable issues from AI review")
-  .option("--format <mode>", "Output format: mp4 (default, full pipeline) or scenes (editable HTML scene project)", "mp4")
+  .option("--format <mode>", "Output format: mp4 (default, full pipeline) or scenes (DEPRECATED in v0.62 — use `vibe scene build` with STORYBOARD frontmatter cues; removal scheduled for v0.63)", "mp4")
   .option("--scene-style <preset>", "Style preset for --format scenes: simple | announcement | explainer | kinetic-type | product-shot", "explainer")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (script: string, options) => {
     try {
       if (options.output) {
         validateOutputPath(options.output);
+      }
+
+      // v0.62: --format scenes deprecation warning fires before any other
+      // work so dry-runs surface the same notice production runs do.
+      // Removal scheduled for v0.63 — point users at `vibe scene build`.
+      if (options.format === "scenes" && !isJsonMode()) {
+        console.warn();
+        console.warn(chalk.yellow("⚠  --format scenes is deprecated and will be removed in v0.63."));
+        console.warn(chalk.dim("   Migrate to: write STORYBOARD.md with per-beat YAML cues, then `vibe scene build <project-dir>`."));
+        console.warn(chalk.dim("   See examples/scene-promo-pipeline.yaml for the v0.62 reference flow."));
+        console.warn();
       }
 
       if (options.dryRun) {


### PR DESCRIPTION
## Summary

C3 of 5 in the v0.62 cleanup plan. Adds a stderr deprecation warning when users invoke \`vibe pipeline script-to-video --format scenes\`. The flag still works this release; removal is scheduled for v0.63.

## Why deprecate

\`vibe scene build\` (v0.60) reaches the same outcome with less surprise:

| | \`pipeline script-to-video --format scenes\` | \`scene build\` (v0.60) |
|---|---|---|
| Input | free-form script string | STORYBOARD.md with per-beat YAML cues |
| Storyboard inference | LLM-generated (brittle, can hallucinate beats) | author writes it, LLM only generates HTML |
| Idempotent re-runs | no | yes — existing \`assets/narration-*\` / \`assets/backdrop-*\` reused |
| Per-beat overrides | no | yes (cue \`narration\` / \`backdrop\` / \`duration\` / \`voice\`) |
| Failure mode | retry the whole pipeline | retry per-beat or per-primitive |

## UX details

- Warning fires in **human mode** (TTY stdout) before any other work, so \`--dry-run\` users see it too
- **JSON mode** (\`--json\` or piped stdout via the existing auto-detection) suppresses the warning so automation isn't disrupted
- Help text on \`--format\` flag now flags the deprecation inline

## Manual smoke

\`\`\`bash
$ VIBE_HUMAN_OUTPUT=1 vibe pipeline script-to-video "..." --format scenes --dry-run

⚠  --format scenes is deprecated and will be removed in v0.63.
   Migrate to: write STORYBOARD.md with per-beat YAML cues, then \`vibe scene build <project-dir>\`.
   See examples/scene-promo-pipeline.yaml for the v0.62 reference flow.

# JSON mode (default when stdout is piped) — clean, no warning
$ vibe pipeline script-to-video "..." --format scenes --dry-run | jq .
{ "dryRun": true, ... }
\`\`\`

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` 0 errors
- [x] Manual smoke: warning appears in human mode, suppressed in JSON