### PR TITLE
chore: BUILD vs PROCESS framing — pipeline group + AGENTS.md template (v0.63 C3+C4)

### DIFF
--- a/packages/cli/src/commands/_shared/init-templates.test.ts
+++ b/packages/cli/src/commands/_shared/init-templates.test.ts
@@ -25,6 +25,17 @@ describe("AGENTS_MD template", () => {
     expect(AGENTS_MD).toContain("--dry-run");
     expect(AGENTS_MD).toContain("--stdin");
   });
+
+  it("v0.63: declares the BUILD vs PROCESS split so agents route correctly", () => {
+    expect(AGENTS_MD).toContain("BUILD");
+    expect(AGENTS_MD).toContain("PROCESS");
+    // BUILD path canonical command
+    expect(AGENTS_MD).toContain("vibe scene build");
+    // PROCESS path canonical commands
+    expect(AGENTS_MD).toContain("vibe pipeline highlights");
+    expect(AGENTS_MD).toContain("vibe edit silence-cut");
+    expect(AGENTS_MD).toContain("vibe audio dub");
+  });
 });
 
 describe("CLAUDE_MD template", () => {

--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -36,19 +36,57 @@ vibe schema generate.video     # JSON Schema for any single command
 vibe doctor                    # available providers + system health
 \`\`\`
 
+## Two flows — pick by intent
+
+VibeFrame splits cleanly into two flows. Routing the user's request
+correctly is the most important judgement call you'll make.
+
+**BUILD — create new video from text intent.**
+Use \`vibe scene build\` with a STORYBOARD.md + DESIGN.md. The
+skills-driven pipeline (v0.60+) dispatches narration TTS + backdrop
+image-gen per beat, composes scene HTML via the Hyperframes skill
+bundle, then renders to MP4. Idempotent re-runs reuse cached assets.
+
+**PROCESS — transform existing video / audio.**
+Use \`vibe pipeline\`, \`vibe edit\`, or \`vibe audio\`. One-shot,
+batch-oriented operations on a file the user already has on disk.
+
+Decision rule: if the user is starting from intent (a script, a brand,
+an idea), it's BUILD. If the user is starting from a media file, it's
+PROCESS.
+
 ## Common workflows
+
+### BUILD (new video from text)
 
 | Task | Command |
 |---|---|
-| Author scenes from a storyboard | \`vibe scene build [project-dir]\` |
+| One-shot storyboard → MP4 | \`vibe scene build [project-dir]\` |
 | Render an existing scene project | \`vibe scene render -o out.mp4\` |
+| Lint scene HTML | \`vibe scene lint --json\` |
 | Generate a single image | \`vibe generate image "prompt" -o img.png --quality hd\` |
 | Generate a single video | \`vibe generate video "prompt" -i image.png -o clip.mp4\` |
 | Generate narration | \`vibe generate speech "text" -o voice.mp3\` |
-| Remove silence from a clip | \`vibe edit silence-cut in.mp4 -o out.mp4\` |
-| Add captions to a clip | \`vibe edit caption in.mp4 -o out.mp4\` |
+
+### PROCESS (transform existing media)
+
+| Task | Command |
+|---|---|
+| Extract highlights from a long video | \`vibe pipeline highlights file.mp4 -d 60\` |
+| Long video → vertical shorts | \`vibe pipeline auto-shorts file.mp4 -n 3 --add-captions\` |
+| Add animated word-by-word captions | \`vibe pipeline animated-caption file.mp4 -s karaoke-sweep\` |
+| Remove silence | \`vibe edit silence-cut in.mp4 -o out.mp4\` |
+| Add static captions | \`vibe edit caption in.mp4 -o out.mp4\` |
+| Translate audio (transcribe → TTS) | \`vibe audio dub file.mp4 -t ko\` |
+| Transcribe (Whisper, word-level) | \`vibe audio transcribe file.mp4 --granularity word\` |
 | Analyze a video | \`vibe analyze video file.mp4 "summarise"\` |
+
+### Compose pipelines (Video as Code)
+
+| Task | Command |
+|---|---|
 | Run a YAML pipeline | \`vibe run pipeline.yaml --dry-run\` |
+| Resume from last checkpoint | \`vibe run pipeline.yaml --resume\` |
 
 ## Cost tiers
 

--- a/packages/cli/src/commands/pipeline.ts
+++ b/packages/cli/src/commands/pipeline.ts
@@ -34,31 +34,36 @@ import { isJsonMode, outputResult, exitWithError, notFoundError, usageError, api
 export const pipelineCommand = new Command("pipeline")
   .alias("pipe")
   .description(
-    "AI video pipelines (script-to-video, highlights, shorts, animated-caption)"
+    "AI media transformations on existing video / audio (highlights, auto-shorts, animated captions). For BUILD-from-text flows see `vibe scene build`."
   )
   .addHelpText(
     "after",
     `
-Examples:
-  $ vibe pipeline script-to-video "A day in the life..." -o ./output/ -g kling
-  $ vibe pipeline script-to-video "..." -o ./output/ --images-only
+Two flows — pick by intent:
+  BUILD     — text → MP4 (intent → AI generation → new video)
+              Use \`vibe scene build\` with a STORYBOARD.md + DESIGN.md.
+              Idempotent, agent-editable, skills-driven (v0.60+).
+  PROCESS   — existing video/audio → transformed media
+              Use \`vibe pipeline\` (this group) or \`vibe edit\` / \`vibe audio\`.
+              One-shot, batch-oriented, no storyboard required.
+
+Examples (PROCESS):
   $ vibe pipeline highlights long-video.mp4 -o highlights.json -d 60
   $ vibe pipeline auto-shorts long-video.mp4 -o shorts/ -n 3 --add-captions
   $ vibe pipeline animated-caption video.mp4 -o captioned.mp4 -s highlight
   $ vibe pipeline animated-caption video.mp4 -o out.mp4 -s karaoke-sweep --fast
 
-Required API Keys (pipelines use multiple providers):
-  script-to-video:     ANTHROPIC_API_KEY + GOOGLE_API_KEY + ELEVENLABS_API_KEY
-                       + video provider key (KLING_API_KEY / RUNWAY_API_SECRET / GOOGLE_API_KEY)
+Required API Keys:
   highlights:          GOOGLE_API_KEY (Gemini analysis)
   auto-shorts:         GOOGLE_API_KEY + OPENAI_API_KEY (optional captions)
   animated-caption:    OPENAI_API_KEY (Whisper transcription)
 
 Cost tiers:
-  script-to-video:     $$$ Very High (~$5-$50+ per video)
   highlights:          $   Low (~$0.05)
   auto-shorts:         $$  Medium (~$0.10-$1)
   animated-caption:    $   Low (~$0.01)
+
+  script-to-video:     $$$ DEPRECATED v0.63 — use \`vibe scene build\` (~$0.18 cached).
 
 Use '--dry-run' to preview parameters before execution.
 Run 'vibe schema pipeline.<command>' for structured parameter info.


### PR DESCRIPTION
## Summary

C3 + C4 of 4 in the v0.63 cleanup plan, bundled because they share a single user-visible point: agents should route requests by **intent**, not by guessing whether something is a "pipeline". **Stacked on #149 (C2)** — review/merge that one first; this PR will retarget to main automatically.

## C3 — \`vibe pipeline\` group description

Before:
> "AI video pipelines (script-to-video, highlights, shorts, animated-caption)"

After:
> "AI media transformations on existing video / audio. For BUILD-from-text flows see \`vibe scene build\`."

Help text now opens with the two-flow split:

| | Use when | Canonical command |
|---|---|---|
| **BUILD** | starting from intent (script / brand / idea) | \`vibe scene build\` |
| **PROCESS** | starting from a media file | \`vibe pipeline\` / \`vibe edit\` / \`vibe audio\` |

\`script-to-video\` re-tagged \`DEPRECATED v0.63\` inline in the cost-tier table.

## C4 — AGENTS.md template (used by \`vibe init\`)

Same BUILD vs PROCESS section added to the cross-tool agent guide. The flat "Common workflows" table becomes three nested groups: BUILD, PROCESS, Compose pipelines (Video as Code).

Decision rule appears in two places now (CLI help + AGENTS.md). That's fine — it's the highest-leverage routing decision an agent makes when picking up a fresh project, and AGENTS.md is what they read first.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm lint\` 0 errors
- [x] \`pnpm -r exec tsc --noEmit\` clean
- [x] \`vibe init\` template tests — 15/15 (positive cover for BUILD / PROCESS labels + canonical commands per branch)
- [x] \`vibe pipeline --help\` reads cleanly with new framing