### PR TITLE
chore: bump version to 0.63.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.63.0] - 2026-04-26
+
+### Added
+
+- add cinematic demo hero + drop redundant Features grid (v0.62 C5) (#146) *(web)*
+- scene-build + scene-render pipeline actions (v0.62 C1) (#142) *(pipeline)*
+- vibe doctor — scope-aware diagnostics + next-step hint (v0.61 C3) (#140) *(cli)*
+- vibe init — project-scope scaffold (v0.61 C2) (#141) *(cli)*
+- vibe setup overhaul — user-scope wizard + agent host detection (v0.61 C1) (#138) *(cli)*
+
+### Documentation
+
+- move ROADMAP-v0.58.md to docs/archive (v0.62 C4) (#145) *(archive)*
+- refresh README + ROADMAP for v0.60.0 (#137)
+
+### Maintenance
+
+- BUILD vs PROCESS framing — pipeline group + AGENTS.md template (v0.63 C3+C4) (#151)
+- delete viral / b-roll / narrate (v0.63 C2) (#149) *(pipeline)*
+- widen script-to-video deprecation to the whole command (v0.63 C1) (#148) *(pipeline)*
+- deprecate script-to-video --format scenes (v0.62 C3) (#144) *(pipeline)*
+- consolidate skill pack 4 → 2 (v0.62 C2) (#143) *(skills)*
+
 ## [0.60.0] - 2026-04-26
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.60.0",
+  "version": "0.63.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.60.0",
+  "version": "0.63.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.60.0",
+  "version": "0.63.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.60.0",
+  "version": "0.63.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.60.0",
+  "version": "0.63.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.60.0",
+  "version": "0.63.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.60.0",
+  "version": "0.63.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Single-bump release covering three feature waves landed since v0.60.0. The unreleased commits on main were sound but never tagged — landing at vibeframe.ai still showed v0.60 because \`apps/web/next.config.js\` reads \`pkg.version\` at build time and no bump had happened. This PR closes that gap.

## What's in v0.63.0

### v0.61 — wizard (#138, #140, #141)
- \`vibe setup\` overhaul: user-scope wizard with agent host detection
- \`vibe init\`: project-scope scaffolder (AGENTS.md cross-tool / CLAUDE.md / .env.example / .gitignore / vibe.project.yaml)
- \`vibe doctor\`: scope-aware diagnostics + suggested next-step

### v0.62 — cleanup + landing (#142–#146)
- \`scene-build\` + \`scene-render\` pipeline actions
- Skill pack consolidated 4 → 2 (\`/vibeframe\` + \`/vibe-script-to-video\` merged out)
- \`script-to-video --format scenes\` deprecated
- \`ROADMAP-v0.58.md\` archived
- Landing: cinematic-v060 hero added, redundant Features grid removed

### v0.63 — pipeline cleanup + framing (#148, #149, #151)
- \`script-to-video\` deprecation widened to the whole command (v0.64 removal)
- \`viral\` / \`b-roll\` / \`narrate\` removed entirely (-1850 LOC)
- \`vibe pipeline\` group description reframed: BUILD vs PROCESS distinction
- AGENTS.md template adds the BUILD/PROCESS decision rule

## Why one bump (not three)

The v0.61 → v0.62 → v0.63 arc reads as one coherent shift: from "vibe is a bag of pipeline commands" to "vibe is two flows — BUILD via skills + scene build, PROCESS via pipeline / edit / audio." Splitting into three release tags would fragment the story for users + npm consumers; one bump captures the arc.

## Release process

After merge:
1. \`git tag v0.63.0\` and push (auto-publish workflow handles \`npm publish\`)
2. Vercel rebuilds /landing and picks up \`pkg.version: 0.63.0\` from \`apps/web/package.json\`
3. Verify: \`npm view @vibeframe/cli@0.63.0 version\` and the badge on https://vibeframe.ai

## Test plan

- [x] \`pnpm install\` clean (lockfile resolves to 0.63.0)
- [x] \`pnpm -F @vibeframe/cli build\` clean
- [x] All 7 package.json files synced at 0.63.0
- [x] CHANGELOG matches commit history (15+ commits since v0.60.0 grouped by Added / Documentation / Maintenance)