### PR TITLE
v0.67 PR3 — manifest-driven SSOT counts (C9)

### DIFF
--- a/scripts/print-counts.mts
+++ b/scripts/print-counts.mts
@@ -1,0 +1,41 @@
+/**
+ * @file scripts/print-counts.ts
+ * @description Manifest-driven SSOT count printer. Replaces the regex grep
+ * counts that previously lived inline in `scripts/sync-counts.sh`.
+ *
+ * Outputs JSON on stdout — `sync-counts.sh` parses with `jq`. Run via
+ * `pnpm exec tsx scripts/print-counts.ts` (no build step needed; tsx
+ * resolves cross-workspace TS sources via dynamic import).
+ *
+ * Why dynamic import: tsx's static-import resolver routes through Node's
+ * CJS loader for workspace deps and trips on packages whose `exports` are
+ * fine but whose `main`/`module` lookup misbehaves under that path. The
+ * dynamic `import()` form uses the ESM resolver and works cleanly.
+ *
+ * Why this exists: the previous regex approach silently mis-counted whenever
+ * a new file or surface filter was introduced (v0.66 PR3 broke counts by
+ * lumping agent-only entries into MCP totals). One `manifest.filter(...)` is
+ * a lot harder to drift than four greps.
+ */
+
+const { manifest } = await import("../packages/cli/src/tools/manifest/index.js");
+
+const total = manifest.length;
+const mcp = manifest.filter((t) => !t.surfaces || t.surfaces.includes("mcp")).length;
+const agent = manifest.filter((t) => !t.surfaces || t.surfaces.includes("agent")).length;
+const agentOnly = manifest.filter(
+  (t) => t.surfaces && t.surfaces.length === 1 && t.surfaces[0] === "agent",
+).length;
+const mcpOnly = manifest.filter(
+  (t) => t.surfaces && t.surfaces.length === 1 && t.surfaces[0] === "mcp",
+).length;
+
+console.log(
+  JSON.stringify({
+    total,
+    mcp,
+    agent,
+    agentOnly,
+    mcpOnly,
+  }),
+);

--- a/scripts/sync-counts.sh
+++ b/scripts/sync-counts.sh
@@ -40,27 +40,15 @@ fi
 # `interface` (the type-only folder that defines the AIProvider contract).
 AI_PROVIDERS=$(find packages/ai-providers/src -mindepth 1 -maxdepth 1 -type d ! -name interface | wc -l | tr -d ' ')
 
-# MCP tool definitions. Counts every `defineTool({` in the manifest
-# (packages/cli/src/tools/manifest/*.ts) — pre-v0.65 also grepped
-# `'name: "'` in packages/mcp-server/src/tools/, but C6 deleted those
-# files and the manifest is now SSOT for both MCP + Agent surfaces.
-# C9 will replace this with `node packages/cli/dist/tools/print-counts.js`.
-# v0.66 PR3 introduced `manifest/agent-only.ts` (surfaces=["agent"]) — those
-# entries never reach MCP, so exclude them here to keep the MCP count honest.
-MCP_TOOLS=$(grep -rh --include='*.ts' --exclude='*.test.ts' --exclude='agent-only.ts' \
-  'defineTool({' packages/cli/src/tools/manifest/ 2>/dev/null | wc -l | tr -d ' ')
-
-# Agent tool definitions = manifest entries with agent surface (everything
-# except the MCP-only `pipeline_run`) plus the legacy register*Tools files.
-# Manifest agent-surface count: total manifest entries minus MCP-only ones
-# (currently just pipeline_run). Legacy: each `ToolDefinition = {` in
-# `agent/tools/*.ts`.
-MANIFEST_TOTAL=$(grep -rh --include='*.ts' --exclude='*.test.ts' 'defineTool({' \
-  packages/cli/src/tools/manifest/ 2>/dev/null | wc -l | tr -d ' ')
-MCP_ONLY=$(grep -rh --include='*.ts' --exclude='*.test.ts' 'surfaces: \["mcp"\]' \
-  packages/cli/src/tools/manifest/ 2>/dev/null | wc -l | tr -d ' ')
-LEGACY_AGENT=$(grep -r 'ToolDefinition = {' packages/cli/src/agent/tools/ 2>/dev/null | wc -l | tr -d ' ')
-AGENT_TOOLS=$(( MANIFEST_TOTAL - MCP_ONLY + LEGACY_AGENT ))
+# MCP + Agent tool counts come from the manifest itself (v0.67 PR3 / C9).
+# Pre-v0.67 PR3 the script grepped `defineTool({` and `surfaces: ["mcp"]`
+# against packages/cli/src/tools/manifest/*.ts — fragile, and broke twice
+# during the v0.66 agent-only migration when the regex didn't match the
+# new shape. `scripts/print-counts.mts` does one `manifest.filter(...)`
+# instead and emits JSON.
+COUNTS_JSON=$(pnpm exec tsx scripts/print-counts.mts 2>/dev/null)
+MCP_TOOLS=$(echo "$COUNTS_JSON" | jq -r .mcp 2>/dev/null || echo "?")
+AGENT_TOOLS=$(echo "$COUNTS_JSON" | jq -r .agent 2>/dev/null || echo "?")
 
 # LLM providers (LLMProvider type union)
 LLM_PROVIDERS=$(grep 'LLMProvider = ' packages/cli/src/agent/types.ts 2>/dev/null \


### PR DESCRIPTION
## Summary

\`scripts/print-counts.mts\` replaces the four regex greps that previously lived inline in \`scripts/sync-counts.sh\`. The script does \`manifest.filter(...)\` and emits JSON; \`sync-counts.sh\` parses with \`jq\`.

**Why:** the regex approach broke twice during v0.66:
- when \`agent-only.ts\` introduced \`surfaces: [\"agent\"]\` entries that the MCP_TOOLS regex didn't exclude (counts went 63 → 70 silently)
- when the LEGACY_AGENT grep matched against the wrong shape after legacy file deletes

One \`.filter()\` call is harder to drift than four greps.

**Implementation notes:**
- Dynamic \`import()\` + \`.mts\` extension. tsx's static-import resolver routes through Node's CJS loader for workspace deps and trips on packages whose \`exports\` are fine but whose \`main\`/\`module\` lookup misbehaves under that path.
- Dynamic \`import()\` uses the ESM resolver and works cleanly.
- \`.mts\` forces ESM mode which is required for top-level await.

Counts unchanged: MCP=63, Agent=79.

## Test plan

- [x] \`bash scripts/sync-counts.sh\` — informational mode prints same counts
- [x] \`bash scripts/sync-counts.sh --check\` — green
- [x] \`pnpm exec tsc --skipLibCheck scripts/print-counts.mts\` — clean typecheck
- [x] \`pnpm -r exec tsc --noEmit\` — 0 errors (cached)
- [x] \`pnpm lint\` — 0 errors (cached)
- [x] \`pnpm -F @vibeframe/cli test\` — 646 passed