### PR TITLE
chore: v0.67.0 release — bump version + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.67.0] - 2026-04-28
+
+This release closes the manifest-as-SSOT migration that began in v0.65.
+Every Agent and MCP tool now lives in a single Zod-typed manifest at
+`packages/cli/src/tools/manifest/`; legacy hand-written tool definitions
+in `packages/cli/src/agent/tools/*.ts` are gone, and the `MIGRATED` gating
+mechanism has been removed.
+
+### Manifest SSOT closure (v0.65/0.66 internal labels)
+
+- v0.65 (#154) — tool manifest as single source of truth (MCP + Agent)
+- v0.66 PR1 (#155) — fix Agent manifest silent overwrite
+- v0.66 PR2 (#156) — delete migrated legacy tool definitions
+- v0.66 PR3 (#157) — agent-only manifest entries (`fs_*`, `batch_*`)
+
+### v0.67 PRs
+
+- PR1 (#158) — migrate `media_*`, `timeline_clear`, `export_*` stubs into the manifest
+- PR2 (#159) — migrate `project_set/open/save` and remove the `MIGRATED` Set;
+  `ExecuteContext` gains an optional `agent?` field for the in-process agent's
+  mutable project pointer
+- PR3 (#160) — manifest-driven SSOT counts (`scripts/print-counts.mts`)
+  replaces fragile regex greps in `scripts/sync-counts.sh`
+
+### Other
+
+- VHS tape files for v0.61+ wizard flow + DEMO.md rewrite (#147) *(demo)*
+- align landing with v0.63 — drop deprecated script-to-video, add wizard section (#153) *(web)*
+
+### Counts
+
+`MCP=63 · Agent=79 · CLI=78 · 13 AI providers · 6 LLM providers`
+
 ## [0.63.0] - 2026-04-26
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.63.0",
+  "version": "0.67.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.63.0",
+  "version": "0.67.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.63.0",
+  "version": "0.67.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.63.0",
+  "version": "0.67.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.63.0",
+  "version": "0.67.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.63.0",
+  "version": "0.67.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.63.0",
+  "version": "0.67.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Aligns \`package.json\` versions with the v0.65/v0.66/v0.67 commit-label era. The previous release tag was v0.63.0; the manifest migration work (commits 8cc164b through aab1717) ran on main without a version bump, leaving npm at 0.63.0 while the codebase claimed v0.66/0.67 in PR titles.

Bumping straight to **0.67.0** (skipping 0.64–0.66 in the public version history) consolidates the entire manifest-SSOT migration into one release.

## Release contents

CHANGELOG annotates:
- **v0.65 (#154)** — tool manifest as single source of truth (MCP + Agent)
- **v0.66 PR1 (#155)** — fix Agent manifest silent overwrite
- **v0.66 PR2 (#156)** — delete migrated legacy tool definitions
- **v0.66 PR3 (#157)** — agent-only manifest entries (\`fs_*\`, \`batch_*\`)
- **v0.67 PR1 (#158)** — migrate \`media_*\`, \`timeline_clear\`, \`export_*\` stubs to manifest
- **v0.67 PR2 (#159)** — migrate \`project_set/open/save\` + remove \`MIGRATED\` Set
- **v0.67 PR3 (#160)** — manifest-driven SSOT counts (C9)
- VHS tape demo files (#147), web landing alignment (#153)

## Counts

\`MCP=63 · Agent=79 · CLI=78 · 13 AI providers · 6 LLM providers\`

## Post-merge

After this PR lands, on main:
1. Tag \`v0.67.0\` at HEAD and push
2. \`pnpm -F @vibeframe/cli publish --access public\` (only the cli is public on npm)

## Test plan

- [x] All 7 \`package.json\` files show 0.67.0 (root + 5 packages + 1 app)
- [x] \`pnpm build\` — green
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm -F @vibeframe/cli exec vitest run\` — 646 passed
- [x] \`bash scripts/sync-counts.sh --check\` — green
- [x] \`git-cliff --tag v0.67.0\` — CHANGELOG generated, manually annotated for v0.65/v0.66/v0.67 internal milestones (those commits don't use conventional-commit prefixes so git-cliff skipped them)