### PR TITLE
v0.68 PR1 — provider plugin registry (defineApiKey + defineProvider)

### DIFF
--- a/packages/ai-providers/src/api-keys.ts
+++ b/packages/ai-providers/src/api-keys.ts
@@ -1,0 +1,167 @@
+/**
+ * @module api-keys
+ * @description Centralized declarations for API credentials and virtual
+ * providers (those without a dedicated directory under `src/<id>/`).
+ *
+ * This file MUST be imported before any provider's `index.ts` — the provider
+ * `defineProvider` calls assert that the referenced apiKey configKey was
+ * already registered. `src/index.ts` enforces import order.
+ *
+ * Adding a new apiKey: append a `defineApiKey({...})` block. Adding a new
+ * provider: typically also adds a new directory and that directory's
+ * `index.ts` adds a `defineProvider` — see `define-provider.ts` for the
+ * shape.
+ *
+ * Virtual providers (no directory): declare `defineProvider` here too. As of
+ * v0.68 only `openrouter` qualifies (LLM-only, no class — agent uses
+ * OpenAI-compat HTTP). `veo` is virtual but lives in `gemini/index.ts` since
+ * it shares that directory.
+ */
+
+import { defineApiKey, defineProvider } from "./define-provider.js";
+
+// ─── API keys ───────────────────────────────────────────────────────────────
+
+defineApiKey({
+  configKey: "openai",
+  envVar: "OPENAI_API_KEY",
+  label: "OpenAI",
+  showInSetup: true,
+  setupDescription:
+    "gpt-image-2 image gen ($, default since v0.56), Whisper transcribe, Agent",
+  envExampleComment:
+    "OpenAI API Key (Whisper transcription, gpt-image-2 — default text-to-image since v0.56)",
+  envExampleUrl: "https://platform.openai.com/api-keys",
+});
+
+defineApiKey({
+  configKey: "google",
+  envVar: "GOOGLE_API_KEY",
+  label: "Google",
+  showInSetup: true,
+  setupDescription:
+    "Gemini — image gen (free tier), video analysis ($), Veo ($$)",
+  envExampleComment:
+    "Google API Key (Gemini auto-edit suggestions, image gen, Veo video)",
+  envExampleUrl: "https://aistudio.google.com/apikey",
+});
+
+defineApiKey({
+  configKey: "anthropic",
+  envVar: "ANTHROPIC_API_KEY",
+  label: "Anthropic",
+  showInSetup: true,
+  setupDescription:
+    "Claude — storyboard, color grade, reframe, Agent ($)",
+  envExampleComment: "Anthropic API Key (Claude motion graphics & storyboarding)",
+  envExampleUrl: "https://console.anthropic.com/",
+});
+
+defineApiKey({
+  configKey: "elevenlabs",
+  envVar: "ELEVENLABS_API_KEY",
+  label: "ElevenLabs",
+  showInSetup: true,
+  setupDescription:
+    "TTS ($), SFX, music, voice clone, dubbing — skip to use local Kokoro",
+  envExampleComment:
+    "ElevenLabs API Key (text-to-speech — Kokoro local fallback runs when this is unset, since v0.54)",
+  envExampleUrl: "https://elevenlabs.io/api",
+});
+
+defineApiKey({
+  configKey: "fal",
+  envVar: "FAL_KEY",
+  label: "fal.ai",
+  showInSetup: true,
+  setupDescription: "Seedance 2.0 video gen ($$, default since v0.57)",
+  envExampleComment:
+    "fal.ai API Key (Seedance 2.0 video — default text/image-to-video since v0.57, Artificial Analysis ELO #2)",
+  envExampleUrl: "https://fal.ai/dashboard/keys",
+});
+
+defineApiKey({
+  configKey: "xai",
+  envVar: "XAI_API_KEY",
+  label: "xAI",
+  showInSetup: true,
+  setupDescription:
+    "Grok — video gen with audio ($$), image ($), Agent",
+  envExampleComment:
+    "xAI API Key (Grok video generation — fallback when no FAL_KEY)",
+  envExampleUrl: "https://console.x.ai/",
+});
+
+defineApiKey({
+  configKey: "runway",
+  envVar: "RUNWAY_API_SECRET",
+  label: "Runway",
+  showInSetup: true,
+  setupDescription: "Gen-4.5 video generation ($$)",
+  envExampleComment: "Runway API Secret (Runway Gen-4.5 video generation)",
+  envExampleUrl: "https://app.runwayml.com/settings/api-keys",
+});
+
+defineApiKey({
+  configKey: "kling",
+  envVar: "KLING_API_KEY",
+  label: "Kling",
+  showInSetup: true,
+  setupDescription:
+    "v2.5/v3 video — std ($$) and pro ($$$) modes",
+  envExampleComment: "Kling API Key (Kling video generation)",
+  envExampleUrl: "https://platform.klingai.com/",
+  envExampleExtraLines: ["Format: ACCESS_KEY:SECRET_KEY"],
+});
+
+defineApiKey({
+  configKey: "replicate",
+  envVar: "REPLICATE_API_TOKEN",
+  label: "Replicate",
+  showInSetup: true,
+  setupDescription: "MusicGen background music ($, max 30s)",
+  envExampleComment:
+    "Replicate API Token (music generation, video upscale, audio restoration)",
+  envExampleUrl: "https://replicate.com/account/api-tokens",
+});
+
+defineApiKey({
+  configKey: "openrouter",
+  envVar: "OPENROUTER_API_KEY",
+  label: "OpenRouter",
+  showInSetup: true,
+  setupDescription:
+    "300+ models via one key — Agent only (pay per model)",
+  envExampleComment:
+    "OpenRouter API Key (300+ AI models via unified API, used by `vibe agent`)",
+  envExampleUrl: "https://openrouter.ai/keys",
+});
+
+defineApiKey({
+  configKey: "imgbb",
+  envVar: "IMGBB_API_KEY",
+  label: "ImgBB",
+  showInSetup: false, // not prompted in setup wizard — internal upload host
+  envExampleComment:
+    "ImgBB API Key (image hosting — used by Kling and fal.ai for image-to-video uploads)",
+  envExampleUrl: "https://api.imgbb.com/",
+  // ImgBB has no provider class (envvar-only); doctor still shows what it
+  // unlocks at the apiKey level.
+  commandsUnlocked: [
+    "generate video -p kling/fal (image-to-video upload host)",
+  ],
+});
+
+// ─── Virtual providers (no directory under src/) ───────────────────────────
+
+// Note: original COMMAND_KEY_MAP intentionally omits OPENROUTER_API_KEY
+// from doctor output. We preserve that behavior by leaving
+// `commandsUnlocked` empty here (not adding "agent -p openrouter"). If
+// we later want to surface it, drop a single line below — the rest of
+// the chain auto-derives.
+defineProvider({
+  id: "openrouter",
+  label: "OpenRouter",
+  apiKey: "openrouter",
+  kinds: ["llm"],
+});

--- a/packages/ai-providers/src/claude/index.ts
+++ b/packages/ai-providers/src/claude/index.ts
@@ -6,3 +6,21 @@ export {
   type RemotionComponent,
   type StoryboardSegment,
 } from "./ClaudeProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+defineProvider({
+  id: "claude",
+  label: "Claude (Anthropic)",
+  apiKey: "anthropic",
+  kinds: ["llm"],
+  commandsUnlocked: [
+    "agent -p claude",
+    "generate storyboard",
+    "generate motion",
+    "edit grade",
+    "edit reframe",
+    "edit speed-ramp",
+    "pipeline script-to-video",
+  ],
+});

--- a/packages/ai-providers/src/define-provider.ts
+++ b/packages/ai-providers/src/define-provider.ts
@@ -1,0 +1,225 @@
+/**
+ * @module define-provider
+ * @description Plugin-style registry for AI provider metadata (envvar, label,
+ * priority, doctor commands, .env.example shape). The CLI's provider-resolver,
+ * config schema, doctor, setup wizard, and `.env.example` generator all derive
+ * their data from this registry — adding a new provider becomes a single
+ * declaration (or a new directory + a single declaration in `api-keys.ts`).
+ *
+ * Why two registries (apiKey + provider):
+ *
+ *   provider ↔ apiKey is many-to-one. Examples:
+ *     - `google` apiKey → `gemini` (image/llm) + `veo` (video, virtual)
+ *     - `openai` apiKey → `openai` (llm/transcribe) + `openai-image` (image) +
+ *       `whisper` (transcription)
+ *     - `imgbb` apiKey → no provider class (envvar-only, image hosting)
+ *     - `openrouter` apiKey → no provider class (OpenAI-compat, LLM-only)
+ *
+ *   A single declaration that conflates "auth credential" with "service" can't
+ *   express any of these without escape hatches. Splitting them keeps each
+ *   declaration small and lets virtual providers (veo) and envvar-only
+ *   credentials (imgbb) coexist with normal cases.
+ *
+ * Separation from the existing `providerRegistry` in `interface/registry.ts`:
+ * that one holds AIProvider class instances for capability-based lookup at
+ * runtime ("which class handles `text-to-video`?"). This module holds
+ * declarative metadata for build-time / startup-time wiring ("which env var
+ * does the `fal` provider need?"). They never talk to each other.
+ */
+
+export type ProviderKind =
+  | "image"
+  | "video"
+  | "speech"
+  | "llm"
+  | "transcription"
+  | "music";
+
+/**
+ * An API credential. Some apiKeys back multiple providers (google → gemini +
+ * veo). Some apiKeys have no provider class at all (imgbb, openrouter — used
+ * only as envvar lookups).
+ */
+export interface ApiKeyMeta {
+  /** Stable identifier used as `VibeConfig.providers[configKey]` and as the
+   *  reference target from `ProviderMeta.apiKey`. */
+  configKey: string;
+  /** Environment variable name (e.g. `OPENAI_API_KEY`). */
+  envVar: string;
+  /** Display label for setup wizard / doctor output. */
+  label: string;
+  /** Whether the setup wizard prompts for this key in `--full` mode. */
+  showInSetup: boolean;
+  /** Brief one-line description shown next to the key in setup wizard. */
+  setupDescription?: string;
+  /** First line of the `.env.example` block (without leading `# `). */
+  envExampleComment: string;
+  /** URL where the user obtains the key (rendered as `# Get yours at: ...`). */
+  envExampleUrl: string;
+  /** Optional extra `.env.example` lines (e.g. format hints) inserted between
+   *  comment+URL and the `KEY=` line. */
+  envExampleExtraLines?: readonly string[];
+  /**
+   * Commands unlocked at the apiKey level — used for credentials that don't
+   * have a dedicated provider class (e.g. `imgbb` is just an upload host).
+   * Aggregated alongside provider-level `commandsUnlocked`.
+   */
+  commandsUnlocked?: readonly string[];
+}
+
+/**
+ * A service provider. Maps to a directory under `packages/ai-providers/src/`
+ * in most cases, except virtual entries (veo, openrouter) that share a
+ * directory or have none.
+ */
+export interface ProviderMeta {
+  /** Stable identifier — used as `-p <id>` flag value, resolver name, and
+   *  doctor diagnostics. Examples: `gemini`, `veo`, `openai-image`, `kokoro`. */
+  id: string;
+  /** Human-readable label (resolver UI, doctor output). */
+  label: string;
+  /** ApiKey configKey reference, or `null` for keyless providers (kokoro,
+   *  ollama). Multiple providers may share a configKey. */
+  apiKey: string | null;
+  /** Service kinds — drives which derived arrays the provider appears in. */
+  kinds: readonly ProviderKind[];
+  /**
+   * Lower number = higher priority within a kind. Default 999 (last). Used by
+   * `getProvidersFor(kind)` to sort the resolver candidate list. Per-kind
+   * because the same provider can rank differently across kinds (e.g. grok:
+   * image=3, video=2).
+   */
+  resolverPriority?: Partial<Record<ProviderKind, number>>;
+  /**
+   * Commands this provider unlocks when its apiKey is set. Used by `doctor`
+   * to render `KEY → ["generate image -p ...", ...]` mapping. Aggregated
+   * across providers sharing the same apiKey.
+   */
+  commandsUnlocked?: readonly string[];
+}
+
+const apiKeyRegistry = new Map<string, ApiKeyMeta>();
+const providerRegistry = new Map<string, ProviderMeta>();
+
+export function defineApiKey(meta: ApiKeyMeta): void {
+  if (apiKeyRegistry.has(meta.configKey)) {
+    throw new Error(
+      `defineApiKey: duplicate configKey "${meta.configKey}". Each API key must be declared once.`,
+    );
+  }
+  apiKeyRegistry.set(meta.configKey, meta);
+}
+
+export function defineProvider(meta: ProviderMeta): void {
+  if (providerRegistry.has(meta.id)) {
+    throw new Error(
+      `defineProvider: duplicate id "${meta.id}". Each provider must be declared once.`,
+    );
+  }
+  if (meta.apiKey !== null && !apiKeyRegistry.has(meta.apiKey)) {
+    throw new Error(
+      `defineProvider: provider "${meta.id}" references apiKey "${meta.apiKey}" but no defineApiKey call has registered it. Order issue? api-keys.ts must be imported before provider modules.`,
+    );
+  }
+  providerRegistry.set(meta.id, meta);
+}
+
+/** Shape consumed by `provider-resolver.ts` (image/video/speech arrays). */
+export interface ProviderCandidate {
+  name: string;
+  envVar: string | null;
+  label: string;
+}
+
+/**
+ * Sorted resolver candidates for a kind. Drop-in replacement for the
+ * hardcoded IMAGE_PROVIDERS / VIDEO_PROVIDERS / SPEECH_PROVIDERS arrays.
+ */
+export function getProvidersFor(kind: ProviderKind): ProviderCandidate[] {
+  return [...providerRegistry.values()]
+    .filter((p) => p.kinds.includes(kind))
+    .sort(
+      (a, b) =>
+        (a.resolverPriority?.[kind] ?? 999) -
+        (b.resolverPriority?.[kind] ?? 999),
+    )
+    .map((p) => ({
+      name: p.id,
+      envVar: p.apiKey ? (apiKeyRegistry.get(p.apiKey)?.envVar ?? null) : null,
+      label: p.label,
+    }));
+}
+
+/** Shape: `{ configKey: envVar }` — drop-in for `PROVIDER_ENV_VARS`. */
+export function getProviderEnvVars(): Record<string, string> {
+  return Object.fromEntries(
+    [...apiKeyRegistry.values()].map((k) => [k.configKey, k.envVar]),
+  );
+}
+
+/**
+ * Shape: `{ envVar: ["cmd1", "cmd2", ...] }` — drop-in for `COMMAND_KEY_MAP`.
+ * Aggregates `commandsUnlocked` across providers sharing the same apiKey.
+ * Order within each list follows provider declaration order.
+ */
+export function getCommandKeyMap(): Record<string, readonly string[]> {
+  const map: Record<string, string[]> = {};
+  for (const p of providerRegistry.values()) {
+    if (!p.apiKey) continue;
+    if (!p.commandsUnlocked || p.commandsUnlocked.length === 0) continue;
+    const envVar = apiKeyRegistry.get(p.apiKey)?.envVar;
+    if (!envVar) continue;
+    if (!map[envVar]) map[envVar] = [];
+    map[envVar].push(...p.commandsUnlocked);
+  }
+  // Layer apiKey-level commandsUnlocked on top (handles envvar-only keys
+  // like IMGBB that have no provider class).
+  for (const k of apiKeyRegistry.values()) {
+    if (!k.commandsUnlocked || k.commandsUnlocked.length === 0) continue;
+    if (!map[k.envVar]) map[k.envVar] = [];
+    map[k.envVar].push(...k.commandsUnlocked);
+  }
+  return map;
+}
+
+/** Shape consumed by `setup.ts` allProviders array. */
+export interface SetupProviderEntry {
+  key: string;
+  name: string;
+  env: string;
+  desc: string;
+}
+
+/**
+ * Setup wizard rows — only apiKeys with `showInSetup: true`. Order follows
+ * `defineApiKey` call order.
+ */
+export function getSetupProviders(): SetupProviderEntry[] {
+  return [...apiKeyRegistry.values()]
+    .filter((k) => k.showInSetup)
+    .map((k) => ({
+      key: k.configKey,
+      name: k.label,
+      env: k.envVar,
+      desc: k.setupDescription ?? "",
+    }));
+}
+
+/** All registered apiKeys in declaration order. Used by `print-env-example.mts`. */
+export function getAllApiKeys(): readonly ApiKeyMeta[] {
+  return [...apiKeyRegistry.values()];
+}
+
+/** All registered providers in declaration order. Mostly diagnostic / testing. */
+export function getAllProviders(): readonly ProviderMeta[] {
+  return [...providerRegistry.values()];
+}
+
+/**
+ * Test-only: clears both registries. Production code never needs this — the
+ * registries are filled exactly once at module load via side-effect imports.
+ */
+export function _resetRegistriesForTesting(): void {
+  apiKeyRegistry.clear();
+  providerRegistry.clear();
+}

--- a/packages/ai-providers/src/elevenlabs/index.ts
+++ b/packages/ai-providers/src/elevenlabs/index.ts
@@ -14,3 +14,21 @@ export {
   type VoiceCloneOptions,
   type VoiceCloneResult,
 } from "./ElevenLabsProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+defineProvider({
+  id: "elevenlabs",
+  label: "ElevenLabs",
+  apiKey: "elevenlabs",
+  kinds: ["speech", "music"],
+  resolverPriority: { speech: 1 },
+  commandsUnlocked: [
+    "generate speech",
+    "generate sound-effect",
+    "generate music",
+    "audio voices",
+    "audio voice-clone",
+    "audio dub",
+  ],
+});

--- a/packages/ai-providers/src/fal/index.ts
+++ b/packages/ai-providers/src/fal/index.ts
@@ -1,1 +1,16 @@
 export * from "./FalProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+defineProvider({
+  id: "fal",
+  label: "fal.ai (Seedance 2.0)",
+  apiKey: "fal",
+  kinds: ["video"],
+  resolverPriority: { video: 1 },
+  commandsUnlocked: [
+    "generate video -p fal (Seedance 2.0 — default since v0.57)",
+    "generate video -p fal -m fast (lower-latency variant)",
+    "generate video -p fal -i <image> (image-to-video)",
+  ],
+});

--- a/packages/ai-providers/src/gemini/index.ts
+++ b/packages/ai-providers/src/gemini/index.ts
@@ -1,2 +1,31 @@
 export * from "./GeminiProvider.js";
 export * from "./gemini-motion.js";
+
+import { defineProvider } from "../define-provider.js";
+
+// Gemini and Veo share the GOOGLE_API_KEY apiKey. Both are declared here
+// since they both live in the gemini/ directory (Veo is invoked via the
+// Gemini SDK / Google Generative AI client).
+defineProvider({
+  id: "gemini",
+  label: "Gemini",
+  apiKey: "google",
+  kinds: ["image", "llm"],
+  resolverPriority: { image: 2 },
+  commandsUnlocked: [
+    "generate image",
+    "edit image",
+    "analyze media",
+    "analyze video",
+    "analyze review",
+  ],
+});
+
+defineProvider({
+  id: "veo",
+  label: "Veo",
+  apiKey: "google",
+  kinds: ["video"],
+  resolverPriority: { video: 3 },
+  commandsUnlocked: ["generate video -p veo"],
+});

--- a/packages/ai-providers/src/grok/index.ts
+++ b/packages/ai-providers/src/grok/index.ts
@@ -1,1 +1,17 @@
 export { GrokProvider, grokProvider, type GrokModel, type GrokVideoOptions, type GrokImageOptions, type GrokEditOptions } from "./GrokProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+defineProvider({
+  id: "grok",
+  label: "Grok",
+  apiKey: "xai",
+  kinds: ["image", "video", "llm"],
+  resolverPriority: { image: 3, video: 2 },
+  commandsUnlocked: [
+    "agent -p xai",
+    "generate image -p grok",
+    "generate video -p grok",
+    "edit image -p grok",
+  ],
+});

--- a/packages/ai-providers/src/index.ts
+++ b/packages/ai-providers/src/index.ts
@@ -13,6 +13,26 @@
 export * from "./interface/index.js";
 export { providerRegistry, getBestProviderForCapability } from "./interface/registry.js";
 
+// Plugin metadata registry — must be imported before any provider's index.ts
+// since `defineProvider` calls assert their referenced apiKey was registered.
+// `api-keys.ts` declares all 11 apiKeys + 1 virtual provider (openrouter).
+import "./api-keys.js";
+export {
+  defineApiKey,
+  defineProvider,
+  getProvidersFor,
+  getProviderEnvVars,
+  getCommandKeyMap,
+  getSetupProviders,
+  getAllApiKeys,
+  getAllProviders,
+  type ApiKeyMeta,
+  type ProviderMeta,
+  type ProviderKind,
+  type ProviderCandidate,
+  type SetupProviderEntry,
+} from "./define-provider.js";
+
 // Individual providers
 export { WhisperProvider, whisperProvider } from "./whisper/index.js";
 export { GeminiProvider, geminiProvider } from "./gemini/index.js";

--- a/packages/ai-providers/src/kling/index.ts
+++ b/packages/ai-providers/src/kling/index.ts
@@ -1,1 +1,12 @@
 export * from "./KlingProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+defineProvider({
+  id: "kling",
+  label: "Kling",
+  apiKey: "kling",
+  kinds: ["video"],
+  resolverPriority: { video: 4 },
+  commandsUnlocked: ["generate video -p kling"],
+});

--- a/packages/ai-providers/src/kokoro/index.ts
+++ b/packages/ai-providers/src/kokoro/index.ts
@@ -1,1 +1,13 @@
 export * from "./KokoroProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+// Kokoro runs locally with no API key — always-available speech fallback
+// behind ElevenLabs.
+defineProvider({
+  id: "kokoro",
+  label: "Kokoro (local)",
+  apiKey: null,
+  kinds: ["speech"],
+  resolverPriority: { speech: 2 },
+});

--- a/packages/ai-providers/src/ollama/index.ts
+++ b/packages/ai-providers/src/ollama/index.ts
@@ -1,1 +1,11 @@
 export { OllamaProvider, ollamaProvider } from "./OllamaProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+// Ollama runs locally with no API key.
+defineProvider({
+  id: "ollama",
+  label: "Ollama (Local)",
+  apiKey: null,
+  kinds: ["llm"],
+});

--- a/packages/ai-providers/src/openai-image/index.ts
+++ b/packages/ai-providers/src/openai-image/index.ts
@@ -7,3 +7,9 @@ export {
   type ImageResult,
   type ImageEditOptions,
 } from "./OpenAIImageProvider.js";
+
+// No defineProvider call here — this directory is an implementation
+// detail of the user-facing "openai" provider (which is declared in
+// `../openai/index.ts` with kinds=["llm", "image", "transcription"]).
+// `OpenAIImageProvider` is the class instance that backs the image
+// service; the metadata layer stays at the user-facing id level.

--- a/packages/ai-providers/src/openai/index.ts
+++ b/packages/ai-providers/src/openai/index.ts
@@ -1,1 +1,23 @@
 export { OpenAIProvider, openaiProvider } from "./OpenAIProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+// "openai" is the user-facing provider id (`-p openai`). Internally three
+// classes back this single id: OpenAIProvider (chat/LLM), OpenAIImageProvider
+// (gpt-image-2), and WhisperProvider (transcription). The metadata layer
+// stays user-facing; the class wiring is in commands/_shared/*.
+defineProvider({
+  id: "openai",
+  label: "OpenAI",
+  apiKey: "openai",
+  kinds: ["llm", "image", "transcription"],
+  resolverPriority: { image: 1 },
+  commandsUnlocked: [
+    "agent -p openai",
+    "generate image -p openai",
+    "edit image -p openai",
+    "audio transcribe",
+    "edit caption",
+    "edit jump-cut",
+  ],
+});

--- a/packages/ai-providers/src/replicate/index.ts
+++ b/packages/ai-providers/src/replicate/index.ts
@@ -1,1 +1,11 @@
 export * from "./ReplicateProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+defineProvider({
+  id: "replicate",
+  label: "Replicate",
+  apiKey: "replicate",
+  kinds: ["music"],
+  commandsUnlocked: ["generate music -p replicate"],
+});

--- a/packages/ai-providers/src/runway/index.ts
+++ b/packages/ai-providers/src/runway/index.ts
@@ -1,1 +1,12 @@
 export * from "./RunwayProvider.js";
+
+import { defineProvider } from "../define-provider.js";
+
+defineProvider({
+  id: "runway",
+  label: "Runway",
+  apiKey: "runway",
+  kinds: ["video"],
+  resolverPriority: { video: 5 },
+  commandsUnlocked: ["generate video -p runway"],
+});

--- a/packages/ai-providers/src/whisper/index.ts
+++ b/packages/ai-providers/src/whisper/index.ts
@@ -1,1 +1,7 @@
 export * from "./WhisperProvider.js";
+
+// No defineProvider call here — Whisper transcription is an
+// implementation detail of the user-facing "openai" provider (declared
+// in `../openai/index.ts` with kinds including "transcription").
+// `WhisperProvider` is the class instance; the metadata layer stays at
+// the user-facing id level.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -9,63 +9,20 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { CONFIG_PATH } from "../config/index.js";
 import { PROVIDER_ENV_VARS } from "../config/schema.js";
+import { getCommandKeyMap } from "@vibeframe/ai-providers";
 import { commandExists } from "../utils/exec-safe.js";
 import { execSafe } from "../utils/exec-safe.js";
 import { loadEnv } from "../utils/api-key.js";
 import { detectAgentHosts, summariseAgentHosts } from "../utils/agent-host-detect.js";
 import { outputResult } from "./output.js";
 
-/** Mapping of env vars to the commands they unlock */
-const COMMAND_KEY_MAP: Record<string, string[]> = {
-  GOOGLE_API_KEY: [
-    "generate image",
-    "generate video -p veo",
-    "edit image",
-    "analyze media",
-    "analyze video",
-    "analyze review",
-  ],
-  OPENAI_API_KEY: [
-    "agent -p openai",
-    "generate image -p openai",
-    "edit image -p openai",
-    "audio transcribe",
-    "edit caption",
-    "edit jump-cut",
-  ],
-  ANTHROPIC_API_KEY: [
-    "agent -p claude",
-    "generate storyboard",
-    "generate motion",
-    "edit grade",
-    "edit reframe",
-    "edit speed-ramp",
-    "pipeline script-to-video",
-  ],
-  XAI_API_KEY: [
-    "agent -p xai",
-    "generate image -p grok",
-    "generate video -p grok",
-    "edit image -p grok",
-  ],
-  FAL_KEY: [
-    "generate video -p fal (Seedance 2.0 — default since v0.57)",
-    "generate video -p fal -m fast (lower-latency variant)",
-    "generate video -p fal -i <image> (image-to-video)",
-  ],
-  ELEVENLABS_API_KEY: [
-    "generate speech",
-    "generate sound-effect",
-    "generate music",
-    "audio voices",
-    "audio voice-clone",
-    "audio dub",
-  ],
-  KLING_API_KEY: ["generate video -p kling"],
-  RUNWAY_API_SECRET: ["generate video -p runway"],
-  REPLICATE_API_TOKEN: ["generate music -p replicate"],
-  IMGBB_API_KEY: ["generate video -p kling/fal (image-to-video upload host)"],
-};
+/**
+ * Mapping of env vars to the commands they unlock. Derived from the
+ * provider registry — each provider's `commandsUnlocked` aggregates by
+ * apiKey. Pre-v0.68 this was hand-maintained alongside the provider
+ * arrays; v0.68 collapsed both into the registry.
+ */
+const COMMAND_KEY_MAP: Record<string, readonly string[]> = getCommandKeyMap();
 
 /** Commands that need no API key (FFmpeg only) */
 const FREE_COMMANDS = [
@@ -191,7 +148,7 @@ interface DiagnosticResults {
   };
   providers: Record<
     string,
-    { envVar: string; configured: boolean; commands: string[] }
+    { envVar: string; configured: boolean; commands: readonly string[] }
   >;
   readyCount: number;
   totalCount: number;

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -50,6 +50,7 @@ import { uploadToImgbb } from "./ai-script-pipeline.js";
 import { downloadVideo, formatTime } from "./ai-helpers.js";
 import { rejectControlChars, validateOutputPath } from "./validate.js";
 import { resolveProvider } from "../utils/provider-resolver.js";
+import { getProvidersFor } from "@vibeframe/ai-providers";
 import { executeThumbnailBestFrame } from "./ai-image.js";
 import { registerMotionCommand } from "./ai-motion.js";
 import { executeOpenAIImageGenerate } from "./_shared/openai-image.js";
@@ -154,18 +155,41 @@ Examples:
 
       // Resolve provider:
       //  - explicit -p flag wins (validated, then key-presence checked)
-      //  - no flag → IMAGE_PROVIDERS priority list (openai > gemini > grok)
+      //  - no flag → image registry priority list (openai > gemini > grok)
       //  - if no keys at all → keep gemini as last-resort default so the
       //    later requireApiKey() prints a friendly Gemini-specific message
-      const validProviders = ["openai", "dalle", "gemini", "grok", "runway"];
-      const providerEnvMap: Record<string, string> = {
-        gemini: "GOOGLE_API_KEY", openai: "OPENAI_API_KEY", grok: "XAI_API_KEY",
+      //
+      // The registry (`@vibeframe/ai-providers`) is the source of truth for
+      // image-kind providers. `dalle` (deprecated alias) and `runway`
+      // (image variant accepted by CLI but not in auto-resolver) are
+      // explicit overrides — adding a new image provider in the registry
+      // auto-propagates here.
+      const imageRegistry = getProvidersFor("image");
+      const validProviders = [...imageRegistry.map((p) => p.name), "dalle", "runway"];
+      const providerEnvMap: Record<string, string> = Object.fromEntries(
+        imageRegistry
+          .filter((p): p is typeof p & { envVar: string } => p.envVar !== null)
+          .map((p) => [p.name, p.envVar]),
+      );
+      const envKeyMap: Record<string, string> = {
+        ...providerEnvMap,
+        dalle: "OPENAI_API_KEY",
+        runway: "RUNWAY_API_SECRET",
+      };
+      const providerNameMap: Record<string, string> = {
+        ...Object.fromEntries(imageRegistry.map((p) => [p.name, p.label])),
+        // Override Gemini's resolver label "Gemini" with the more specific
+        // "Google" used in error messages, and add aliases.
+        gemini: "Google",
+        grok: "xAI Grok",
+        dalle: "OpenAI",
+        runway: "Runway",
       };
       let provider: string;
       if (options.provider) {
         provider = options.provider.toLowerCase();
         if (!validProviders.includes(provider)) {
-          exitWithError(usageError(`Invalid provider: ${provider}`, `Available providers: openai, gemini, grok, runway`));
+          exitWithError(usageError(`Invalid provider: ${provider}`, `Available providers: ${imageRegistry.map((p) => p.name).join(", ")}, runway`));
         }
         // Explicit choice's key missing → fall back via resolver
         if (providerEnvMap[provider] && !hasApiKey(providerEnvMap[provider]) && !options.apiKey) {
@@ -191,21 +215,6 @@ Examples:
         return;
       }
 
-      // Get API key based on provider
-      const envKeyMap: Record<string, string> = {
-        openai: "OPENAI_API_KEY",
-        dalle: "OPENAI_API_KEY",
-        gemini: "GOOGLE_API_KEY",
-        grok: "XAI_API_KEY",
-        runway: "RUNWAY_API_SECRET",
-      };
-      const providerNameMap: Record<string, string> = {
-        openai: "OpenAI",
-        dalle: "OpenAI",
-        gemini: "Google",
-        grok: "xAI Grok",
-        runway: "Runway",
-      };
       const envKey = envKeyMap[provider];
       const providerName = providerNameMap[provider];
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -28,6 +28,7 @@ import {
   detectedAgentHosts,
   summariseAgentHosts,
 } from "../utils/agent-host-detect.js";
+import { getSetupProviders } from "@vibeframe/ai-providers";
 
 export const setupCommand = new Command("setup")
   .description("Configure VibeFrame (LLM provider, API keys)")
@@ -361,18 +362,11 @@ async function runCustomSetup(config: Awaited<ReturnType<typeof loadConfig>> & o
   console.log(chalk.dim("   Press Enter to skip any provider you don't need."));
   console.log();
 
-  const allProviders = [
-    { key: "openai", name: "OpenAI", env: "OPENAI_API_KEY", desc: "gpt-image-2 image gen ($, default since v0.56), Whisper transcribe, Agent" },
-    { key: "anthropic", name: "Anthropic", env: "ANTHROPIC_API_KEY", desc: "Claude — storyboard, color grade, reframe, Agent ($)" },
-    { key: "fal", name: "fal.ai", env: "FAL_KEY", desc: "Seedance 2.0 video gen ($$, default since v0.57)" },
-    { key: "google", name: "Google", env: "GOOGLE_API_KEY", desc: "Gemini — image gen (free tier), video analysis ($), Veo ($$)" },
-    { key: "xai", name: "xAI", env: "XAI_API_KEY", desc: "Grok — video gen with audio ($$), image ($), Agent" },
-    { key: "elevenlabs", name: "ElevenLabs", env: "ELEVENLABS_API_KEY", desc: "TTS ($), SFX, music, voice clone, dubbing — skip to use local Kokoro" },
-    { key: "runway", name: "Runway", env: "RUNWAY_API_SECRET", desc: "Gen-4.5 video generation ($$)" },
-    { key: "kling", name: "Kling", env: "KLING_API_KEY", desc: "v2.5/v3 video — std ($$) and pro ($$$) modes" },
-    { key: "openrouter", name: "OpenRouter", env: "OPENROUTER_API_KEY", desc: "300+ models via one key — Agent only (pay per model)" },
-    { key: "replicate", name: "Replicate", env: "REPLICATE_API_TOKEN", desc: "MusicGen background music ($, max 30s)" },
-  ];
+  // Derived from the provider registry — adding/editing a row means
+  // editing `defineApiKey({...setupDescription})` in
+  // `packages/ai-providers/src/api-keys.ts`. The order follows declaration
+  // order in api-keys.ts.
+  const allProviders = getSetupProviders();
 
   for (const p of allProviders) {
     const existing = config.providers[p.key as keyof typeof config.providers];

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -61,20 +61,16 @@ export const PROVIDER_NAMES: Record<LLMProvider, string> = {
   openrouter: "OpenRouter",
 };
 
-/** Environment variable mappings */
-export const PROVIDER_ENV_VARS: Record<string, string> = {
-  anthropic: "ANTHROPIC_API_KEY",
-  openai: "OPENAI_API_KEY",
-  google: "GOOGLE_API_KEY",
-  elevenlabs: "ELEVENLABS_API_KEY",
-  runway: "RUNWAY_API_SECRET",
-  kling: "KLING_API_KEY",
-  fal: "FAL_KEY",
-  imgbb: "IMGBB_API_KEY",
-  replicate: "REPLICATE_API_TOKEN",
-  xai: "XAI_API_KEY",
-  openrouter: "OPENROUTER_API_KEY",
-};
+/**
+ * Environment variable mappings, derived from the provider registry.
+ * Pre-v0.68 this was a hardcoded record cross-validated against four
+ * other files via `scripts/sync-counts.sh`. Now it auto-derives from
+ * `@vibeframe/ai-providers` `defineApiKey` declarations — adding a new
+ * apiKey is a single line in `api-keys.ts`.
+ */
+import { getProviderEnvVars } from "@vibeframe/ai-providers";
+
+export const PROVIDER_ENV_VARS: Record<string, string> = getProviderEnvVars();
 
 /** Default configuration */
 export function createDefaultConfig(): VibeConfig {

--- a/packages/cli/src/utils/provider-resolver.test.ts
+++ b/packages/cli/src/utils/provider-resolver.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Snapshot tests pinning the derived provider arrays + commandsKeyMap to
+ * the values that the previously-hardcoded source files expressed.
+ *
+ * These tests exist to catch silent regressions when `defineProvider` /
+ * `defineApiKey` declarations drift away from CLI surface expectations.
+ *
+ * If a test here fails after a deliberate change, update the snapshot in
+ * lockstep — but read the diff carefully: the resolver / doctor / setup
+ * outputs are user-facing and changing their order or names is a UX
+ * change, not just a refactor.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  getProvidersFor,
+  getProviderEnvVars,
+  getCommandKeyMap,
+  getSetupProviders,
+} from "@vibeframe/ai-providers";
+
+describe("provider registry — derived shapes match v0.67 hardcoded arrays", () => {
+  it("getProvidersFor('image') matches IMAGE_PROVIDERS", () => {
+    expect(getProvidersFor("image")).toEqual([
+      { name: "openai", envVar: "OPENAI_API_KEY", label: "OpenAI" },
+      { name: "gemini", envVar: "GOOGLE_API_KEY", label: "Gemini" },
+      { name: "grok", envVar: "XAI_API_KEY", label: "Grok" },
+    ]);
+  });
+
+  it("getProvidersFor('video') matches VIDEO_PROVIDERS", () => {
+    expect(getProvidersFor("video")).toEqual([
+      { name: "fal", envVar: "FAL_KEY", label: "fal.ai (Seedance 2.0)" },
+      { name: "grok", envVar: "XAI_API_KEY", label: "Grok" },
+      { name: "veo", envVar: "GOOGLE_API_KEY", label: "Veo" },
+      { name: "kling", envVar: "KLING_API_KEY", label: "Kling" },
+      { name: "runway", envVar: "RUNWAY_API_SECRET", label: "Runway" },
+    ]);
+  });
+
+  it("getProvidersFor('speech') matches SPEECH_PROVIDERS", () => {
+    expect(getProvidersFor("speech")).toEqual([
+      { name: "elevenlabs", envVar: "ELEVENLABS_API_KEY", label: "ElevenLabs" },
+      { name: "kokoro", envVar: null, label: "Kokoro (local)" },
+    ]);
+  });
+
+  it("getProviderEnvVars() matches schema PROVIDER_ENV_VARS", () => {
+    // Same set + same envvar mapping. Insertion order is preserved by
+    // defineApiKey calls in api-keys.ts; the schema constant relied on the
+    // declaration order in the original file. We compare as objects.
+    expect(getProviderEnvVars()).toEqual({
+      anthropic: "ANTHROPIC_API_KEY",
+      openai: "OPENAI_API_KEY",
+      google: "GOOGLE_API_KEY",
+      elevenlabs: "ELEVENLABS_API_KEY",
+      runway: "RUNWAY_API_SECRET",
+      kling: "KLING_API_KEY",
+      fal: "FAL_KEY",
+      imgbb: "IMGBB_API_KEY",
+      replicate: "REPLICATE_API_TOKEN",
+      xai: "XAI_API_KEY",
+      openrouter: "OPENROUTER_API_KEY",
+    });
+  });
+
+  it("getCommandKeyMap() preserves the same set of commands per env var as doctor.ts", () => {
+    // We compare as Sets because aggregating provider commandsUnlocked may
+    // shift display order. The set of commands per env var is the
+    // user-visible behavior we care about.
+    const map = getCommandKeyMap();
+
+    const original: Record<string, string[]> = {
+      GOOGLE_API_KEY: [
+        "generate image",
+        "generate video -p veo",
+        "edit image",
+        "analyze media",
+        "analyze video",
+        "analyze review",
+      ],
+      OPENAI_API_KEY: [
+        "agent -p openai",
+        "generate image -p openai",
+        "edit image -p openai",
+        "audio transcribe",
+        "edit caption",
+        "edit jump-cut",
+      ],
+      ANTHROPIC_API_KEY: [
+        "agent -p claude",
+        "generate storyboard",
+        "generate motion",
+        "edit grade",
+        "edit reframe",
+        "edit speed-ramp",
+        "pipeline script-to-video",
+      ],
+      XAI_API_KEY: [
+        "agent -p xai",
+        "generate image -p grok",
+        "generate video -p grok",
+        "edit image -p grok",
+      ],
+      FAL_KEY: [
+        "generate video -p fal (Seedance 2.0 — default since v0.57)",
+        "generate video -p fal -m fast (lower-latency variant)",
+        "generate video -p fal -i <image> (image-to-video)",
+      ],
+      ELEVENLABS_API_KEY: [
+        "generate speech",
+        "generate sound-effect",
+        "generate music",
+        "audio voices",
+        "audio voice-clone",
+        "audio dub",
+      ],
+      KLING_API_KEY: ["generate video -p kling"],
+      RUNWAY_API_SECRET: ["generate video -p runway"],
+      REPLICATE_API_TOKEN: ["generate music -p replicate"],
+      IMGBB_API_KEY: [
+        "generate video -p kling/fal (image-to-video upload host)",
+      ],
+    };
+
+    for (const [envVar, expected] of Object.entries(original)) {
+      const actual = map[envVar];
+      expect(actual, `missing entry for ${envVar}`).toBeDefined();
+      expect(new Set(actual)).toEqual(new Set(expected));
+    }
+
+    // No extra env vars beyond the original (intentional — preserves
+    // doctor display behavior; OPENROUTER_API_KEY is in PROVIDER_ENV_VARS
+    // but never appeared in COMMAND_KEY_MAP).
+    expect(new Set(Object.keys(map))).toEqual(new Set(Object.keys(original)));
+  });
+
+  it("getSetupProviders() matches setup.ts allProviders set", () => {
+    const result = getSetupProviders();
+    const keys = result.map((p) => p.key);
+    expect(new Set(keys)).toEqual(
+      new Set([
+        "openai",
+        "anthropic",
+        "fal",
+        "google",
+        "xai",
+        "elevenlabs",
+        "runway",
+        "kling",
+        "openrouter",
+        "replicate",
+      ]),
+    );
+    // imgbb is intentionally not in setup wizard (showInSetup: false).
+    expect(keys).not.toContain("imgbb");
+  });
+});

--- a/packages/cli/src/utils/provider-resolver.ts
+++ b/packages/cli/src/utils/provider-resolver.ts
@@ -2,69 +2,22 @@
  * Smart provider auto-resolution
  * 1. Check ~/.vibeframe/config.yaml defaults (if set)
  * 2. Fall back to first provider with a configured API key
+ *
+ * Provider candidate lists (image / video / speech) are derived from the
+ * `defineProvider` registry in `@vibeframe/ai-providers/api-keys.ts` +
+ * each provider's `index.ts`. Priority order, label, and envvar mapping
+ * all live there now — adding a new provider is a single declaration.
+ *
+ * Pre-v0.68 the IMAGE_PROVIDERS / VIDEO_PROVIDERS / SPEECH_PROVIDERS
+ * arrays were hardcoded here and cross-validated against four other
+ * files via `scripts/sync-counts.sh` category B. v0.68 collapsed all
+ * five into a single registry; the cross-validation became structural.
  */
 
+import { getProvidersFor, type ProviderCandidate } from "@vibeframe/ai-providers";
 import { hasApiKey } from "./api-key.js";
 
-interface ProviderCandidate {
-  name: string;
-  /**
-   * Environment variable that must be set for this provider to be available.
-   * `null` means the provider is always available (e.g. local on-device models
-   * with no API key).
-   */
-  envVar: string | null;
-  label: string;
-}
-
-// As of v0.56, OpenAI is the preferred image provider — gpt-image-2
-// holds Artificial Analysis ELO 1332 on the text-to-image leaderboard
-// (#1; ~70 ELO above any non-OpenAI model). Users without an OpenAI
-// key automatically fall through to Gemini, so Gemini-only setups are
-// unaffected. Set `defaults.imageProvider: gemini` in
-// `~/.vibeframe/config.yaml` to keep the previous behaviour even when
-// both keys are present.
-const IMAGE_PROVIDERS: ProviderCandidate[] = [
-  { name: "openai", envVar: "OPENAI_API_KEY", label: "OpenAI" },
-  { name: "gemini", envVar: "GOOGLE_API_KEY", label: "Gemini" },
-  { name: "grok", envVar: "XAI_API_KEY", label: "Grok" },
-];
-
-// As of v0.57, fal.ai (Seedance 2.0) leads when its key is set —
-// Artificial Analysis ELO 1270 #2 on text-to-video, 1347 #2 on
-// image-to-video (the only model ahead of it on either chart is
-// Alibaba's HappyHorse-1.0 which has no public API).
-//
-//   text-to-video  Seedance 2.0  1270 (#2)  vs Grok 1230 (#6) → +40 ELO
-//   image-to-video Seedance 2.0  1347 (#2)  vs Grok 1327 (#3) → +20 ELO
-//
-// References:
-//   https://artificialanalysis.ai/video/leaderboard/text-to-video
-//   https://artificialanalysis.ai/video/leaderboard/image-to-video
-//
-// Users without a FAL_KEY fall through to Grok / Veo / Kling / Runway
-// in that order, so existing setups are unchanged.
-const VIDEO_PROVIDERS: ProviderCandidate[] = [
-  { name: "fal", envVar: "FAL_KEY", label: "fal.ai (Seedance 2.0)" },
-  { name: "grok", envVar: "XAI_API_KEY", label: "Grok" },
-  { name: "veo", envVar: "GOOGLE_API_KEY", label: "Veo" },
-  { name: "kling", envVar: "KLING_API_KEY", label: "Kling" },
-  { name: "runway", envVar: "RUNWAY_API_SECRET", label: "Runway" },
-];
-
-// `kokoro` runs locally with no API key — it's the always-available fallback
-// behind ElevenLabs. Listing it last keeps existing key-holding users on
-// ElevenLabs by default while letting key-less users land on Kokoro.
-const SPEECH_PROVIDERS: ProviderCandidate[] = [
-  { name: "elevenlabs", envVar: "ELEVENLABS_API_KEY", label: "ElevenLabs" },
-  { name: "kokoro", envVar: null, label: "Kokoro (local)" },
-];
-
-const PROVIDER_MAP: Record<string, ProviderCandidate[]> = {
-  image: IMAGE_PROVIDERS,
-  video: VIDEO_PROVIDERS,
-  speech: SPEECH_PROVIDERS,
-};
+export type { ProviderCandidate };
 
 /** Cached config defaults (loaded once per process) */
 let configDefaults: Record<string, string> | null = null;
@@ -94,8 +47,8 @@ export async function loadProviderDefaults(): Promise<void> {
 export function resolveProvider(
   category: "image" | "video" | "speech"
 ): { name: string; label: string } | null {
-  const candidates = PROVIDER_MAP[category];
-  if (!candidates) return null;
+  const candidates = getProvidersFor(category);
+  if (candidates.length === 0) return null;
 
   // Check config default first
   if (configDefaults?.[category]) {

--- a/scripts/print-env-example.mts
+++ b/scripts/print-env-example.mts
@@ -1,0 +1,61 @@
+/**
+ * @file scripts/print-env-example.mts
+ * @description Regenerate `.env.example` from the `defineApiKey` registry in
+ * `@vibeframe/ai-providers/api-keys.ts`.
+ *
+ * Run via `pnpm exec tsx scripts/print-env-example.mts > .env.example` (or
+ * use `--check` to fail on drift). `sync-counts.sh` invokes this in
+ * `--check` mode as part of the pre-push hook.
+ *
+ * Why dynamic import + .mts: identical reasoning to `print-counts.mts` —
+ * tsx's static-import resolver routes through Node's CJS loader for
+ * workspace deps and trips on packages whose `exports` are fine but whose
+ * lookup misbehaves there. Dynamic `import()` uses the ESM resolver
+ * cleanly. `.mts` forces ESM mode for top-level await.
+ */
+
+import { readFile } from "node:fs/promises";
+import { resolve as resolvePath } from "node:path";
+
+const { getAllApiKeys } = await import(
+  "../packages/ai-providers/src/index.js"
+);
+
+const HEADER = `# VibeEdit Environment Variables
+# Copy this file to .env and fill in your API keys
+`;
+
+function render(): string {
+  const blocks = getAllApiKeys().map((k) => {
+    const lines = ["", `# ${k.envExampleComment}`];
+    // Extra lines (e.g. format hints) go BEFORE the "Get yours at" URL —
+    // matches the v0.67 layout in `.env.example`.
+    if (k.envExampleExtraLines) {
+      for (const extra of k.envExampleExtraLines) lines.push(`# ${extra}`);
+    }
+    lines.push(`# Get yours at: ${k.envExampleUrl}`);
+    lines.push(`${k.envVar}=`);
+    return lines.join("\n");
+  });
+  return HEADER + blocks.join("\n") + "\n";
+}
+
+const args = process.argv.slice(2);
+const checkMode = args.includes("--check");
+
+const generated = render();
+
+if (checkMode) {
+  const envExamplePath = resolvePath(import.meta.dirname, "..", ".env.example");
+  const current = await readFile(envExamplePath, "utf-8");
+  if (current.trim() !== generated.trim()) {
+    console.error(
+      ".env.example is out of sync with `defineApiKey` declarations.\n" +
+        "Run `pnpm exec tsx scripts/print-env-example.mts > .env.example` to regenerate.",
+    );
+    process.exit(1);
+  }
+  console.log(".env.example matches registry.");
+} else {
+  process.stdout.write(generated);
+}

--- a/scripts/sync-counts.sh
+++ b/scripts/sync-counts.sh
@@ -185,66 +185,21 @@ if grep -qE 'same [0-9]+ tools' apps/web/app/demo/page.tsx; then
     err "apps/web/app/demo/page.tsx: 'same ${D_TOOLS} tools' but agent tools = ${AGENT_TOOLS}"
 fi
 
-# ── B1. .env.example completeness vs PROVIDER_ENV_VARS ──────────────────
-# Every env var referenced in schema PROVIDER_ENV_VARS must have a
-# `KEY=` line in .env.example, with a `# ...` comment block above it.
+# ── B. Provider plugin registry validation ──────────────────────────────
+# v0.68 collapsed the previous 4-array cross-validation (provider-resolver,
+# schema PROVIDER_ENV_VARS, doctor COMMAND_KEY_MAP, setup allProviders)
+# into a single registry in `packages/ai-providers/src/api-keys.ts` +
+# each provider's `index.ts`. The arrays now structurally derive from the
+# registry — drift is impossible at the language level.
+#
+# What remains: `.env.example` is generated text (not a derived array),
+# so we still need a check. `print-env-example.mts --check` regenerates
+# from the registry and diffs against the committed file.
 
-SCHEMA_VARS=$(awk '/PROVIDER_ENV_VARS.*=.*\{/,/^\};/' packages/cli/src/config/schema.ts \
-  | grep -oE '"[A-Z_]+"' | tr -d '"' | grep -E '^[A-Z_]+_(KEY|SECRET|TOKEN)$|^FAL_KEY$' | sort -u)
-
-for var in $SCHEMA_VARS; do
-  LINE=$(grep -nE "^${var}=" .env.example | head -1 | cut -d: -f1)
-  if [ -z "$LINE" ]; then
-    err ".env.example missing '${var}=' line (defined in schema PROVIDER_ENV_VARS)"
-    continue
-  fi
-  # Walk upward until we hit a non-blank line; that line should be a # comment.
-  PREV=$((LINE - 1))
-  PREV_LINE=""
-  while [ "$PREV" -gt 0 ]; do
-    PREV_LINE=$(sed -n "${PREV}p" .env.example)
-    if [ -n "$PREV_LINE" ]; then
-      break
-    fi
-    PREV=$((PREV - 1))
-  done
-  if ! echo "$PREV_LINE" | grep -qE '^#.+'; then
-    err ".env.example: ${var} has no '# ...' comment block above it (other keys all have descriptive headers)"
-  fi
-done
-
-# ── B2. provider-resolver.ts envVars ⊂ schema PROVIDER_ENV_VARS ─────────
-
-RESOLVER_VARS=$(grep -oE 'envVar: "[A-Z_]+"' packages/cli/src/utils/provider-resolver.ts \
-  | grep -oE '"[A-Z_]+"' | tr -d '"' | sort -u)
-
-for var in $RESOLVER_VARS; do
-  if ! echo "$SCHEMA_VARS" | grep -qx "$var"; then
-    err "provider-resolver.ts uses ${var} but schema PROVIDER_ENV_VARS doesn't include it. Add it to packages/cli/src/config/schema.ts"
-  fi
-done
-
-# ── B3. doctor.ts COMMAND_KEY_MAP ⊇ provider-resolver envVars ───────────
-
-DOCTOR_VARS=$(awk '/^const COMMAND_KEY_MAP/,/^};/' packages/cli/src/commands/doctor.ts \
-  | grep -oE '^\s*[A-Z_]+:' | grep -oE '[A-Z_]+' | sort -u)
-
-for var in $RESOLVER_VARS; do
-  if ! echo "$DOCTOR_VARS" | grep -qx "$var"; then
-    err "doctor.ts COMMAND_KEY_MAP missing ${var} (used in provider-resolver.ts). 'vibe doctor' won't list any commands for this provider."
-  fi
-done
-
-# ── B4. setup.ts allProviders envVars ⊂ schema PROVIDER_ENV_VARS ────────
-
-SETUP_VARS=$(awk '/const allProviders/,/^\s*\];/' packages/cli/src/commands/setup.ts \
-  | grep -oE 'env: "[A-Z_]+"' | grep -oE '"[A-Z_]+"' | tr -d '"' | sort -u)
-
-for var in $SETUP_VARS; do
-  if ! echo "$SCHEMA_VARS" | grep -qx "$var"; then
-    err "setup.ts allProviders uses ${var} but schema PROVIDER_ENV_VARS doesn't include it"
-  fi
-done
+if ! pnpm exec tsx scripts/print-env-example.mts --check > /dev/null 2>&1; then
+  PRINT_OUTPUT=$(pnpm exec tsx scripts/print-env-example.mts --check 2>&1 || true)
+  err ".env.example out of sync with provider registry: $PRINT_OUTPUT"
+fi
 
 # ── D. Commander `-p` defaults vs resolver leaders ──────────────────────
 # Commander default *should* be empty so the resolver picks the priority


### PR DESCRIPTION
## Summary

Phase 1 of [Plan G](.claude/plans/logical-wibbling-sonnet.md) OSS-first refactor. Collapses the 8-place \"add a new AI provider\" matrix into a single declaration. Five derived consumers (provider-resolver IMAGE/VIDEO/SPEECH arrays, schema PROVIDER_ENV_VARS, doctor COMMAND_KEY_MAP, setup allProviders, .env.example) now structurally share one source of truth.

## Two registries (by design)

- **apiKeys (11)**: authentication credentials, including envvar-only ones (imgbb, openrouter) that have no provider class.
- **providers (~13)**: user-facing service ids matching \`-p <id>\` flag values. Multiple providers can share an apiKey:
  - \`google\` ← gemini + veo (virtual)
  - \`openai\` ← single user-facing entry with kinds=[llm,image,transcription] backed by 3 internal classes (OpenAI/OpenAIImage/Whisper)

## Behavior preservation

- All v0.67 hardcoded arrays produce byte-identical derived results (\`packages/cli/src/utils/provider-resolver.test.ts\` snapshot, +6 tests)
- Generated \`.env.example\` is byte-identical to v0.67 file
- \`doctor\` output: same set of commands per env var (display order may shift inside GOOGLE/OPENAI groups; set-equality preserved)

## Files

**New**: \`packages/ai-providers/src/{define-provider,api-keys}.ts\`, \`packages/cli/src/utils/provider-resolver.test.ts\`, \`scripts/print-env-example.mts\`

**Modified**: 13 provider \`index.ts\` files (each adds 1 \`defineProvider\` call), provider-resolver, schema, doctor, setup, generate (inline maps for \`vibe generate image\`), sync-counts.sh

**Stats**: 24 files changed, +897 / -218 (net +68 lines)

## sync-counts.sh

Category B (5-array cross-validation) deleted — drift is impossible at the language level now. Replaced by a single \`print-env-example.mts --check\` invocation.

## Out of scope (future phases)

- generate.ts split per-subcommand (Phase 2)
- ai-edit.ts / ai-script-pipeline.ts split (Phases 3/4)
- CONTRIBUTING.md \"Your First Provider PR\" walkthrough + scaffold scripts (Phase 5)
- LLMProvider type union → derived from registry kinds=[\"llm\"] (deferred — touches agent code)

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm -F @vibeframe/cli test\` — 652 passed (was 646, +6 snapshot tests)
- [x] \`pnpm -F @vibeframe/mcp-server test\` — 46 passed
- [x] \`bash scripts/sync-counts.sh --check\` — green
- [x] \`pnpm exec tsx scripts/print-env-example.mts --check\` — \`.env.example matches registry\`
- [x] \`pnpm -F @vibeframe/mcp-server build\` — bundle produces
- [x] \`vibe doctor --json\` smoke test — providers section intact