### PR TITLE
v0.69 PR1 (partial Phase 2) — generate.ts split: sound-effect, music-status, video-cancel

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -54,6 +54,15 @@ import { getProvidersFor } from "@vibeframe/ai-providers";
 import { executeThumbnailBestFrame } from "./ai-image.js";
 import { registerMotionCommand } from "./ai-motion.js";
 import { executeOpenAIImageGenerate } from "./_shared/openai-image.js";
+import { registerSoundEffectCommand } from "./generate/sound-effect.js";
+import { registerMusicStatusCommand } from "./generate/music-status.js";
+import { registerVideoCancelCommand } from "./generate/video-cancel.js";
+// Re-export for backward compat (pipeline/executor.ts and other consumers
+// import these from `./generate.js`).
+export { executeSoundEffect } from "./generate/sound-effect.js";
+export type { ExecuteSoundEffectOptions, ExecuteSoundEffectResult } from "./generate/sound-effect.js";
+export { executeMusicStatus } from "./generate/music-status.js";
+export type { ExecuteMusicStatusOptions, ExecuteMusicStatusResult } from "./generate/music-status.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -1128,65 +1137,10 @@ generateCommand
   });
 
 // ============================================================================
-// 4. Sound Effect (was: ai sfx)
-// Note: -p is reserved for --provider; --prompt-influence is long-only
+// 4. Sound Effect → moved to commands/generate/sound-effect.ts (v0.69 Phase 2)
 // ============================================================================
 
-generateCommand
-  .command("sound-effect")
-  .description("Generate sound effect using ElevenLabs")
-  .argument("<prompt>", "Description of the sound effect")
-  .option("-k, --api-key <key>", "ElevenLabs API key (or set ELEVENLABS_API_KEY env)")
-  .option("-o, --output <path>", "Output audio file path", "sound-effect.mp3")
-  .option("-d, --duration <seconds>", "Duration in seconds (0.5-22, default: auto)")
-  .option("--prompt-influence <value>", "Prompt influence (0-1, default: 0.3)")
-  .option("--dry-run", "Preview parameters without executing")
-  .action(async (prompt: string, options) => {
-    try {
-      rejectControlChars(prompt);
-      if (options.output) {
-        validateOutputPath(options.output);
-      }
-
-      if (options.dryRun) {
-        outputResult({ dryRun: true, command: "generate sound-effect", params: { prompt, duration: options.duration, promptInfluence: options.promptInfluence, output: options.output } });
-        return;
-      }
-
-      const apiKey = await requireApiKey("ELEVENLABS_API_KEY", "ElevenLabs", options.apiKey);
-
-      const spinner = ora("Generating sound effect...").start();
-
-      const elevenlabs = new ElevenLabsProvider();
-      await elevenlabs.initialize({ apiKey });
-
-      const result = await elevenlabs.generateSoundEffect(prompt, {
-        duration: options.duration ? parseFloat(options.duration) : undefined,
-        promptInfluence: options.promptInfluence ? parseFloat(options.promptInfluence) : undefined,
-      });
-
-      if (!result.success || !result.audioBuffer) {
-        spinner.fail(result.error || "Sound effect generation failed");
-        exitWithError(apiError(result.error || "Sound effect generation failed", true));
-      }
-
-      const outputPath = resolve(process.cwd(), options.output);
-      await writeFile(outputPath, result.audioBuffer);
-
-      spinner.succeed(chalk.green("Sound effect generated"));
-
-      if (isJsonMode()) {
-        outputResult({ success: true, outputPath });
-        return;
-      }
-
-      console.log(chalk.green(`Saved to: ${outputPath}`));
-      console.log();
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      exitWithError(apiError(`Sound effect generation failed: ${msg}`, true));
-    }
-  });
+registerSoundEffectCommand(generateCommand);
 
 // ============================================================================
 // 5. Music
@@ -1336,49 +1290,10 @@ generateCommand
   });
 
 // ============================================================================
-// 6. Music Status
+// 6. Music Status → moved to commands/generate/music-status.ts (v0.69 Phase 2)
 // ============================================================================
 
-generateCommand
-  .command("music-status", { hidden: true })
-  .description("Check music generation status")
-  .argument("<task-id>", "Task ID from music generation")
-  .option("-k, --api-key <key>", "Replicate API token (or set REPLICATE_API_TOKEN env)")
-  .action(async (taskId: string, options) => {
-    try {
-      const apiKey = await requireApiKey("REPLICATE_API_TOKEN", "Replicate", options.apiKey);
-
-      const replicate = new ReplicateProvider();
-      await replicate.initialize({ apiKey });
-
-      const result = await replicate.getMusicStatus(taskId);
-
-      if (isJsonMode()) {
-        const status = result.audioUrl ? "completed" : result.error ? "failed" : "processing";
-        outputResult({ success: true, taskId, status, audioUrl: result.audioUrl, error: result.error });
-        return;
-      }
-
-      console.log();
-      console.log(chalk.bold.cyan("Music Generation Status"));
-      console.log(chalk.dim("─".repeat(60)));
-      console.log(`Task ID: ${taskId}`);
-
-      if (result.audioUrl) {
-        console.log(`Status: ${chalk.green("completed")}`);
-        console.log(`Audio URL: ${result.audioUrl}`);
-      } else if (result.error) {
-        console.log(`Status: ${chalk.red("failed")}`);
-        console.log(`Error: ${result.error}`);
-      } else {
-        console.log(`Status: ${chalk.yellow("processing")}`);
-      }
-      console.log();
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      exitWithError(apiError(`Failed to get music status: ${msg}`, true));
-    }
-  });
+registerMusicStatusCommand(generateCommand);
 
 // ============================================================================
 // 7. Storyboard
@@ -1949,65 +1864,10 @@ generateCommand
   });
 
 // ============================================================================
-// 12. Video Cancel
+// 12. Video Cancel → moved to commands/generate/video-cancel.ts (v0.69 Phase 2)
 // ============================================================================
 
-generateCommand
-  .command("video-cancel", { hidden: true })
-  .description("Cancel video generation (Grok or Runway)")
-  .argument("<task-id>", "Task ID to cancel")
-  .option("-p, --provider <provider>", "Provider: grok, runway", "grok")
-  .option("-k, --api-key <key>", "API key (or set XAI_API_KEY / RUNWAY_API_SECRET env)")
-  .action(async (taskId: string, options) => {
-    try {
-      const provider = (options.provider || "grok").toLowerCase();
-
-      let success = false;
-
-      if (provider === "grok") {
-        const apiKey = await requireApiKey("XAI_API_KEY", "xAI", options.apiKey);
-
-        const spinner = ora("Cancelling generation...").start();
-        const grok = new GrokProvider();
-        await grok.initialize({ apiKey });
-        success = await grok.cancelGeneration(taskId);
-
-        if (success) {
-          spinner.succeed(chalk.green("Generation cancelled"));
-          if (isJsonMode()) {
-            outputResult({ success: true, taskId, provider: "grok", cancelled: true });
-            return;
-          }
-        } else {
-          spinner.fail("Failed to cancel generation");
-          exitWithError(apiError("Failed to cancel generation", true));
-        }
-      } else if (provider === "runway") {
-        const apiKey = await requireApiKey("RUNWAY_API_SECRET", "Runway", options.apiKey);
-
-        const spinner = ora("Cancelling generation...").start();
-        const runway = new RunwayProvider();
-        await runway.initialize({ apiKey });
-        success = await runway.cancelGeneration(taskId);
-
-        if (success) {
-          spinner.succeed(chalk.green("Generation cancelled"));
-          if (isJsonMode()) {
-            outputResult({ success: true, taskId, provider: "runway", cancelled: true });
-            return;
-          }
-        } else {
-          spinner.fail("Failed to cancel generation");
-          exitWithError(apiError("Failed to cancel generation", true));
-        }
-      } else {
-        exitWithError(usageError(`Invalid provider: ${provider}. Use grok or runway.`));
-      }
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      exitWithError(apiError(`Failed to cancel: ${msg}`, true));
-    }
-  });
+registerVideoCancelCommand(generateCommand);
 
 // ============================================================================
 // 13. Video Extend (merged: ai video-extend + ai veo-extend)
@@ -2264,45 +2124,7 @@ export async function executeSpeech(options: ExecuteSpeechOptions): Promise<Exec
   }
 }
 
-export interface ExecuteSoundEffectOptions {
-  prompt: string;
-  output?: string;
-  duration?: number;
-  promptInfluence?: number;
-}
-export interface ExecuteSoundEffectResult {
-  success: boolean;
-  outputPath?: string;
-  error?: string;
-}
-
-export async function executeSoundEffect(options: ExecuteSoundEffectOptions): Promise<ExecuteSoundEffectResult> {
-  try {
-    const apiKey = hasApiKey("ELEVENLABS_API_KEY")
-      ? (await getApiKeyFromConfig("elevenlabs") || process.env.ELEVENLABS_API_KEY!)
-      : null;
-    if (!apiKey) return { success: false, error: "ElevenLabs API key required. Set ELEVENLABS_API_KEY or run: vibe setup" };
-
-    const elevenlabs = new ElevenLabsProvider();
-    await elevenlabs.initialize({ apiKey });
-
-    const result = await elevenlabs.generateSoundEffect(options.prompt, {
-      duration: options.duration,
-      promptInfluence: options.promptInfluence,
-    });
-
-    if (!result.success || !result.audioBuffer) {
-      return { success: false, error: result.error || "Sound effect generation failed" };
-    }
-
-    const outputPath = resolve(process.cwd(), options.output || "sound-effect.mp3");
-    await writeFile(outputPath, result.audioBuffer);
-
-    return { success: true, outputPath };
-  } catch (error) {
-    return { success: false, error: `SFX failed: ${error instanceof Error ? error.message : String(error)}` };
-  }
-}
+// executeSoundEffect moved to commands/generate/sound-effect.ts (v0.69)
 
 export interface ExecuteMusicOptions {
   prompt: string;
@@ -2499,44 +2321,4 @@ export async function executeBackground(options: ExecuteBackgroundOptions): Prom
   }
 }
 
-export interface ExecuteMusicStatusOptions {
-  taskId: string;
-  apiKey?: string;
-}
-export interface ExecuteMusicStatusResult {
-  success: boolean;
-  taskId?: string;
-  status?: "completed" | "failed" | "processing";
-  audioUrl?: string;
-  error?: string;
-}
-
-export async function executeMusicStatus(options: ExecuteMusicStatusOptions): Promise<ExecuteMusicStatusResult> {
-  try {
-    const apiKey = options.apiKey
-      ?? (hasApiKey("REPLICATE_API_TOKEN")
-        ? ((await getApiKeyFromConfig("replicate")) || process.env.REPLICATE_API_TOKEN!)
-        : null);
-    if (!apiKey) return { success: false, error: "REPLICATE_API_TOKEN required for music status" };
-
-    const replicate = new ReplicateProvider();
-    await replicate.initialize({ apiKey });
-    const result = await replicate.getMusicStatus(options.taskId);
-
-    const status: "completed" | "failed" | "processing" = result.audioUrl
-      ? "completed"
-      : result.error
-      ? "failed"
-      : "processing";
-
-    return {
-      success: true,
-      taskId: options.taskId,
-      status,
-      audioUrl: result.audioUrl,
-      error: result.error,
-    };
-  } catch (error) {
-    return { success: false, error: `Music status check failed: ${error instanceof Error ? error.message : String(error)}` };
-  }
-}
+// executeMusicStatus moved to commands/generate/music-status.ts (v0.69)

--- a/packages/cli/src/commands/generate/music-status.ts
+++ b/packages/cli/src/commands/generate/music-status.ts
@@ -1,0 +1,124 @@
+/**
+ * @module generate/music-status
+ * @description `vibe generate music-status` (hidden) — Replicate music
+ * generation status check. Split out of `generate.ts` in v0.69 (Plan G
+ * Phase 2).
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { ReplicateProvider } from "@vibeframe/ai-providers";
+import { requireApiKey, hasApiKey } from "../../utils/api-key.js";
+import { getApiKeyFromConfig } from "../../config/index.js";
+import { isJsonMode, outputResult, exitWithError, apiError } from "../output.js";
+
+// ── Library: executeMusicStatus ─────────────────────────────────────────
+
+export interface ExecuteMusicStatusOptions {
+  taskId: string;
+  apiKey?: string;
+}
+export interface ExecuteMusicStatusResult {
+  success: boolean;
+  taskId?: string;
+  status?: "completed" | "failed" | "processing";
+  audioUrl?: string;
+  error?: string;
+}
+
+export async function executeMusicStatus(
+  options: ExecuteMusicStatusOptions,
+): Promise<ExecuteMusicStatusResult> {
+  try {
+    const apiKey =
+      options.apiKey ??
+      (hasApiKey("REPLICATE_API_TOKEN")
+        ? ((await getApiKeyFromConfig("replicate")) ||
+          process.env.REPLICATE_API_TOKEN!)
+        : null);
+    if (!apiKey)
+      return { success: false, error: "REPLICATE_API_TOKEN required for music status" };
+
+    const replicate = new ReplicateProvider();
+    await replicate.initialize({ apiKey });
+    const result = await replicate.getMusicStatus(options.taskId);
+
+    const status: "completed" | "failed" | "processing" = result.audioUrl
+      ? "completed"
+      : result.error
+        ? "failed"
+        : "processing";
+
+    return {
+      success: true,
+      taskId: options.taskId,
+      status,
+      audioUrl: result.audioUrl,
+      error: result.error,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Music status check failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+// ── CLI: vibe generate music-status (hidden) ────────────────────────────
+
+export function registerMusicStatusCommand(parent: Command): void {
+  parent
+    .command("music-status", { hidden: true })
+    .description("Check music generation status")
+    .argument("<task-id>", "Task ID from music generation")
+    .option("-k, --api-key <key>", "Replicate API token (or set REPLICATE_API_TOKEN env)")
+    .action(async (taskId: string, options) => {
+      try {
+        const apiKey = await requireApiKey(
+          "REPLICATE_API_TOKEN",
+          "Replicate",
+          options.apiKey,
+        );
+
+        const replicate = new ReplicateProvider();
+        await replicate.initialize({ apiKey });
+
+        const result = await replicate.getMusicStatus(taskId);
+
+        if (isJsonMode()) {
+          const status = result.audioUrl
+            ? "completed"
+            : result.error
+              ? "failed"
+              : "processing";
+          outputResult({
+            success: true,
+            taskId,
+            status,
+            audioUrl: result.audioUrl,
+            error: result.error,
+          });
+          return;
+        }
+
+        console.log();
+        console.log(chalk.bold.cyan("Music Generation Status"));
+        console.log(chalk.dim("─".repeat(60)));
+        console.log(`Task ID: ${taskId}`);
+
+        if (result.audioUrl) {
+          console.log(`Status: ${chalk.green("completed")}`);
+          console.log(`Audio URL: ${result.audioUrl}`);
+        } else if (result.error) {
+          console.log(`Status: ${chalk.red("failed")}`);
+          console.log(`Error: ${result.error}`);
+        } else {
+          console.log(`Status: ${chalk.yellow("processing")}`);
+        }
+        console.log();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        exitWithError(apiError(`Failed to get music status: ${msg}`, true));
+      }
+    });
+}

--- a/packages/cli/src/commands/generate/sound-effect.ts
+++ b/packages/cli/src/commands/generate/sound-effect.ts
@@ -1,0 +1,151 @@
+/**
+ * @module generate/sound-effect
+ * @description `vibe generate sound-effect` — ElevenLabs SFX generation.
+ * Split out of `generate.ts` in v0.69 (Plan G Phase 2).
+ */
+
+import type { Command } from "commander";
+import { resolve } from "node:path";
+import { writeFile } from "node:fs/promises";
+import chalk from "chalk";
+import ora from "ora";
+import { ElevenLabsProvider } from "@vibeframe/ai-providers";
+import { requireApiKey, hasApiKey } from "../../utils/api-key.js";
+import { getApiKeyFromConfig } from "../../config/index.js";
+import { isJsonMode, outputResult, exitWithError, apiError } from "../output.js";
+import { rejectControlChars, validateOutputPath } from "../validate.js";
+
+// ── Library: executeSoundEffect (used by pipeline executor + manifest) ──
+
+export interface ExecuteSoundEffectOptions {
+  prompt: string;
+  output?: string;
+  duration?: number;
+  promptInfluence?: number;
+}
+export interface ExecuteSoundEffectResult {
+  success: boolean;
+  outputPath?: string;
+  error?: string;
+}
+
+export async function executeSoundEffect(
+  options: ExecuteSoundEffectOptions,
+): Promise<ExecuteSoundEffectResult> {
+  try {
+    const apiKey = hasApiKey("ELEVENLABS_API_KEY")
+      ? ((await getApiKeyFromConfig("elevenlabs")) || process.env.ELEVENLABS_API_KEY!)
+      : null;
+    if (!apiKey)
+      return {
+        success: false,
+        error:
+          "ElevenLabs API key required. Set ELEVENLABS_API_KEY or run: vibe setup",
+      };
+
+    const elevenlabs = new ElevenLabsProvider();
+    await elevenlabs.initialize({ apiKey });
+
+    const result = await elevenlabs.generateSoundEffect(options.prompt, {
+      duration: options.duration,
+      promptInfluence: options.promptInfluence,
+    });
+
+    if (!result.success || !result.audioBuffer) {
+      return {
+        success: false,
+        error: result.error || "Sound effect generation failed",
+      };
+    }
+
+    const outputPath = resolve(
+      process.cwd(),
+      options.output || "sound-effect.mp3",
+    );
+    await writeFile(outputPath, result.audioBuffer);
+
+    return { success: true, outputPath };
+  } catch (error) {
+    return {
+      success: false,
+      error: `SFX failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+// ── CLI: vibe generate sound-effect ─────────────────────────────────────
+
+export function registerSoundEffectCommand(parent: Command): void {
+  parent
+    .command("sound-effect")
+    .description("Generate sound effect using ElevenLabs")
+    .argument("<prompt>", "Description of the sound effect")
+    .option("-k, --api-key <key>", "ElevenLabs API key (or set ELEVENLABS_API_KEY env)")
+    .option("-o, --output <path>", "Output audio file path", "sound-effect.mp3")
+    .option("-d, --duration <seconds>", "Duration in seconds (0.5-22, default: auto)")
+    .option("--prompt-influence <value>", "Prompt influence (0-1, default: 0.3)")
+    .option("--dry-run", "Preview parameters without executing")
+    .action(async (prompt: string, options) => {
+      try {
+        rejectControlChars(prompt);
+        if (options.output) {
+          validateOutputPath(options.output);
+        }
+
+        if (options.dryRun) {
+          outputResult({
+            dryRun: true,
+            command: "generate sound-effect",
+            params: {
+              prompt,
+              duration: options.duration,
+              promptInfluence: options.promptInfluence,
+              output: options.output,
+            },
+          });
+          return;
+        }
+
+        const apiKey = await requireApiKey(
+          "ELEVENLABS_API_KEY",
+          "ElevenLabs",
+          options.apiKey,
+        );
+
+        const spinner = ora("Generating sound effect...").start();
+
+        const elevenlabs = new ElevenLabsProvider();
+        await elevenlabs.initialize({ apiKey });
+
+        const result = await elevenlabs.generateSoundEffect(prompt, {
+          duration: options.duration ? parseFloat(options.duration) : undefined,
+          promptInfluence: options.promptInfluence
+            ? parseFloat(options.promptInfluence)
+            : undefined,
+        });
+
+        if (!result.success || !result.audioBuffer) {
+          spinner.fail(result.error || "Sound effect generation failed");
+          exitWithError(
+            apiError(result.error || "Sound effect generation failed", true),
+          );
+        }
+
+        const outputPath = resolve(process.cwd(), options.output);
+        await writeFile(outputPath, result.audioBuffer);
+
+        spinner.succeed(chalk.green("Sound effect generated"));
+
+        if (isJsonMode()) {
+          outputResult({ success: true, outputPath });
+          return;
+        }
+
+        console.log(chalk.green(`Saved to: ${outputPath}`));
+        console.log();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        exitWithError(apiError(`Sound effect generation failed: ${msg}`, true));
+      }
+    });
+}

--- a/packages/cli/src/commands/generate/video-cancel.ts
+++ b/packages/cli/src/commands/generate/video-cancel.ts
@@ -1,0 +1,82 @@
+/**
+ * @module generate/video-cancel
+ * @description `vibe generate video-cancel` (hidden) — cancel in-flight Grok
+ * or Runway video generation. Split out of `generate.ts` in v0.69 (Plan G
+ * Phase 2).
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import ora from "ora";
+import { GrokProvider, RunwayProvider } from "@vibeframe/ai-providers";
+import { requireApiKey } from "../../utils/api-key.js";
+import {
+  isJsonMode,
+  outputResult,
+  exitWithError,
+  apiError,
+  usageError,
+} from "../output.js";
+
+export function registerVideoCancelCommand(parent: Command): void {
+  parent
+    .command("video-cancel", { hidden: true })
+    .description("Cancel video generation (Grok or Runway)")
+    .argument("<task-id>", "Task ID to cancel")
+    .option("-p, --provider <provider>", "Provider: grok, runway", "grok")
+    .option("-k, --api-key <key>", "API key (or set XAI_API_KEY / RUNWAY_API_SECRET env)")
+    .action(async (taskId: string, options) => {
+      try {
+        const provider = (options.provider || "grok").toLowerCase();
+
+        let success = false;
+
+        if (provider === "grok") {
+          const apiKey = await requireApiKey("XAI_API_KEY", "xAI", options.apiKey);
+
+          const spinner = ora("Cancelling generation...").start();
+          const grok = new GrokProvider();
+          await grok.initialize({ apiKey });
+          success = await grok.cancelGeneration(taskId);
+
+          if (success) {
+            spinner.succeed(chalk.green("Generation cancelled"));
+            if (isJsonMode()) {
+              outputResult({ success: true, taskId, provider: "grok", cancelled: true });
+              return;
+            }
+          } else {
+            spinner.fail("Failed to cancel generation");
+            exitWithError(apiError("Failed to cancel generation", true));
+          }
+        } else if (provider === "runway") {
+          const apiKey = await requireApiKey(
+            "RUNWAY_API_SECRET",
+            "Runway",
+            options.apiKey,
+          );
+
+          const spinner = ora("Cancelling generation...").start();
+          const runway = new RunwayProvider();
+          await runway.initialize({ apiKey });
+          success = await runway.cancelGeneration(taskId);
+
+          if (success) {
+            spinner.succeed(chalk.green("Generation cancelled"));
+            if (isJsonMode()) {
+              outputResult({ success: true, taskId, provider: "runway", cancelled: true });
+              return;
+            }
+          } else {
+            spinner.fail("Failed to cancel generation");
+            exitWithError(apiError("Failed to cancel generation", true));
+          }
+        } else {
+          exitWithError(usageError(`Invalid provider: ${provider}. Use grok or runway.`));
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        exitWithError(apiError(`Failed to cancel: ${msg}`, true));
+      }
+    });
+}


### PR DESCRIPTION
## Summary

Plan G Phase 2 first batch — generate.ts per-subcommand split. **Partial**: 3 of 13 subcommands moved to \`packages/cli/src/commands/generate/\`. Remaining 10 ship in follow-up PRs.

## Pattern established

Each \`commands/generate/<subcommand>.ts\` has the shape:
1. Library: \`executeXxx\` + \`ExecuteXxxOptions\` / \`ExecuteXxxResult\` (when the subcommand has one — used by pipeline executor / manifest)
2. CLI: \`registerXxxCommand(parent: Command): void\` wrapping the original commander chain

\`generate.ts\` imports each \`register*Command\` and calls it on the top-level command. Re-exports library functions for backward compat (\`from \"./generate.js\"\` paths in pipeline/executor.ts still work).

## Splits in this PR

| File | Lines | Source |
|---|---:|---|
| \`generate/sound-effect.ts\` | 151 | ElevenLabs SFX |
| \`generate/music-status.ts\` | 124 | Replicate status check |
| \`generate/video-cancel.ts\` | 82 | Grok/Runway cancellation |

**\`generate.ts\`**: 2,542 → 2,324 lines (−218 net).

## Why partial

Full Phase 2 split is ~2,500 lines moved across 13 files. Mechanical but voluminous — doesn't fit a single session well. Pattern validation matters more than completeness for the first ship; subsequent PRs are pure repetition of this pattern.

## Out of scope (future PRs)

- 10 remaining subcommands: image (414L), video (477L), speech (130L), music (147L), storyboard (111L), thumbnail (148L), background (98L), video-status (211L), video-extend (210L)
- Final \`generate.ts\` barrel collapse (~80 lines) — after all 13 split
- Manifest path updates (still goes through re-export shim)
- v0.69.0 version bump — waits until Phase 2 fully done

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm -F @vibeframe/cli test\` — 652 passed
- [x] \`pnpm -F @vibeframe/mcp-server test\` — 46 passed
- [x] \`bash scripts/sync-counts.sh --check\` — green
- [x] \`vibe generate sound-effect --help\` — output preserved
- [x] \`vibe generate music-status --help\` (hidden) — output preserved
- [x] \`vibe generate video-cancel --help\` (hidden) — output preserved