### PR TITLE
v0.69 PR5 (partial Phase 4) — ai-script-pipeline.ts split: video-utils + video-providers

### DIFF
--- a/packages/cli/src/commands/_shared/video-providers.ts
+++ b/packages/cli/src/commands/_shared/video-providers.ts
@@ -1,0 +1,219 @@
+/**
+ * @module _shared/video-providers
+ * @description Per-provider `generateVideoWithRetry*` helpers used by the
+ * script-to-video pipeline. Each wraps a single AI provider's video
+ * generation API in a retry loop with onProgress callbacks. Split out of
+ * `ai-script-pipeline.ts` in v0.69 (Plan G Phase 4).
+ */
+
+import chalk from "chalk";
+import type {
+  GeminiProvider,
+  GrokProvider,
+  KlingProvider,
+  RunwayProvider,
+} from "@vibeframe/ai-providers";
+import { sleep, RETRY_DELAY_MS, type StoryboardSegment } from "./video-utils.js";
+
+/** Generate video with retry logic for Grok provider. */
+export async function generateVideoWithRetryGrok(
+  grok: GrokProvider,
+  segment: StoryboardSegment,
+  options: {
+    duration: number;
+    aspectRatio: "16:9" | "9:16" | "1:1";
+    referenceImage?: string;
+  },
+  maxRetries: number,
+  onProgress?: (message: string) => void,
+): Promise<{ requestId: string } | null> {
+  const prompt = segment.visualStyle
+    ? `${segment.visuals}. Style: ${segment.visualStyle}`
+    : segment.visuals;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await grok.generateVideo(prompt, {
+        prompt,
+        duration: options.duration,
+        aspectRatio: options.aspectRatio,
+        referenceImage: options.referenceImage,
+      });
+
+      if (result.status !== "failed" && result.id) {
+        return { requestId: result.id };
+      }
+
+      const providerErr = result.error || "Grok returned failed status";
+      if (attempt < maxRetries) {
+        onProgress?.(
+          `⚠ ${providerErr.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`,
+        );
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        console.error(chalk.dim(`\n  [Grok error: ${providerErr}]`));
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (attempt < maxRetries) {
+        onProgress?.(`⚠ Error: ${errMsg.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        console.error(chalk.dim(`\n  [Grok error: ${errMsg}]`));
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Generate video with retry logic for Kling provider.
+ * Supports image-to-video with URL (v2.5/v2.6 models).
+ */
+export async function generateVideoWithRetryKling(
+  kling: KlingProvider,
+  segment: StoryboardSegment,
+  options: {
+    duration: 5 | 10;
+    aspectRatio: "16:9" | "9:16" | "1:1";
+    referenceImage?: string; // Optional: base64 or URL for image2video
+  },
+  maxRetries: number,
+  onProgress?: (message: string) => void,
+): Promise<{ taskId: string; type: "text2video" | "image2video" } | null> {
+  const prompt = segment.visualStyle
+    ? `${segment.visuals}. Style: ${segment.visualStyle}`
+    : segment.visuals;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await kling.generateVideo(prompt, {
+        prompt,
+        // Pass reference image (base64 or URL) - KlingProvider handles v1.5 fallback for base64
+        referenceImage: options.referenceImage,
+        duration: options.duration,
+        aspectRatio: options.aspectRatio,
+        mode: "std", // std mode for faster generation
+      });
+
+      if (result.status !== "failed" && result.id) {
+        return {
+          taskId: result.id,
+          type: options.referenceImage ? "image2video" : "text2video",
+        };
+      }
+
+      const providerErr = result.error || "Kling returned failed status";
+      if (attempt < maxRetries) {
+        onProgress?.(`⚠ ${providerErr.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        console.error(chalk.dim(`\n  [Kling error: ${providerErr}]`));
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (attempt < maxRetries) {
+        onProgress?.(`⚠ Error: ${errMsg.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        console.error(chalk.dim(`\n  [Kling error: ${errMsg}]`));
+      }
+    }
+  }
+  return null;
+}
+
+/** Generate video with retry logic for Runway provider. */
+export async function generateVideoWithRetryRunway(
+  runway: RunwayProvider,
+  segment: StoryboardSegment,
+  referenceImage: string,
+  options: {
+    duration: 5 | 10;
+    aspectRatio: "16:9" | "9:16";
+  },
+  maxRetries: number,
+  onProgress?: (message: string) => void,
+): Promise<{ taskId: string } | null> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await runway.generateVideo(segment.visuals, {
+        prompt: segment.visuals,
+        referenceImage,
+        duration: options.duration,
+        aspectRatio: options.aspectRatio,
+      });
+
+      if (result.status !== "failed" && result.id) {
+        return { taskId: result.id };
+      }
+
+      const providerErr = result.error || "Runway returned failed status";
+      if (attempt < maxRetries) {
+        onProgress?.(`⚠ ${providerErr.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        console.error(chalk.dim(`\n  [Runway error: ${providerErr}]`));
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (attempt < maxRetries) {
+        onProgress?.(`⚠ Error: ${errMsg.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        console.error(chalk.dim(`\n  [Runway error: ${errMsg}]`));
+      }
+    }
+  }
+  return null;
+}
+
+/** Generate video with retry logic for Veo (Gemini) provider. */
+export async function generateVideoWithRetryVeo(
+  gemini: GeminiProvider,
+  segment: StoryboardSegment,
+  options: {
+    duration: 4 | 6 | 8;
+    aspectRatio: "16:9" | "9:16" | "1:1";
+    referenceImage?: string;
+  },
+  maxRetries: number,
+  onProgress?: (message: string) => void,
+): Promise<{ operationName: string } | null> {
+  const prompt = segment.visualStyle
+    ? `${segment.visuals}. Style: ${segment.visualStyle}`
+    : segment.visuals;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await gemini.generateVideo(prompt, {
+        prompt,
+        referenceImage: options.referenceImage,
+        duration: options.duration,
+        aspectRatio: options.aspectRatio,
+        model: "veo-3.1-fast-generate-preview",
+      });
+
+      if (result.status !== "failed" && result.id) {
+        return { operationName: result.id };
+      }
+
+      const providerErr = result.error || "Veo returned failed status";
+      if (attempt < maxRetries) {
+        onProgress?.(`⚠ ${providerErr.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        console.error(chalk.dim(`\n  [Veo error: ${providerErr}]`));
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (attempt < maxRetries) {
+        onProgress?.(`⚠ Error: ${errMsg.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        console.error(chalk.dim(`\n  [Veo error: ${errMsg}]`));
+      }
+    }
+  }
+  return null;
+}

--- a/packages/cli/src/commands/_shared/video-utils.ts
+++ b/packages/cli/src/commands/_shared/video-utils.ts
@@ -1,0 +1,280 @@
+/**
+ * @module _shared/video-utils
+ * @description Shared helpers for the script-to-video pipeline:
+ * StoryboardSegment type, retry constants, ImgBB upload, FFmpeg/Kling
+ * video extension, error logging, and the generic wait-for-completion
+ * loop. Split out of `ai-script-pipeline.ts` in v0.69 (Plan G Phase 4).
+ */
+
+import { writeFile, unlink, rename } from "node:fs/promises";
+import { resolve, basename } from "node:path";
+import chalk from "chalk";
+import type { KlingProvider, RunwayProvider } from "@vibeframe/ai-providers";
+import { getVideoDuration, extendVideoNaturally } from "../../utils/audio.js";
+import { execSafe } from "../../utils/exec-safe.js";
+import { downloadVideo } from "../ai-helpers.js";
+
+/** A single scene segment from the Claude-generated storyboard. */
+export interface StoryboardSegment {
+  /** 1-based scene index (assigned during generation) */
+  index?: number;
+  /** Narrative description of the scene */
+  description: string;
+  /** Visual prompt for image/video generation */
+  visuals: string;
+  /** Art style directive (e.g. "cinematic", "anime") */
+  visualStyle?: string;
+  /** Character appearance description for consistency */
+  characterDescription?: string;
+  /** Reference to previous scene for continuity */
+  previousSceneLink?: string;
+  /** Voiceover narration text */
+  narration?: string;
+  /** Audio direction (e.g. "upbeat music") */
+  audio?: string;
+  /** Text lines to overlay on the video */
+  textOverlays?: string[];
+  /** Scene duration in seconds (updated to match narration) */
+  duration: number;
+  /** Cumulative start time in seconds */
+  startTime: number;
+}
+
+/** Default retry count for video generation API calls. */
+export const DEFAULT_VIDEO_RETRIES = 2;
+/** Delay between retries in milliseconds. */
+export const RETRY_DELAY_MS = 5000;
+
+/** Sleep helper. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Upload image to ImgBB and return the URL.
+ * Used for Kling v2.5/v2.6 image-to-video which requires URL (not base64).
+ */
+export async function uploadToImgbb(
+  imageBuffer: Buffer,
+  apiKey: string,
+): Promise<{ success: boolean; url?: string; error?: string }> {
+  try {
+    const base64Image = imageBuffer.toString("base64");
+
+    const formData = new URLSearchParams();
+    formData.append("key", apiKey);
+    formData.append("image", base64Image);
+
+    const response = await fetch("https://api.imgbb.com/1/upload", {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `ImgBB API error (${response.status}): ${response.statusText}`,
+      };
+    }
+
+    const data = (await response.json()) as {
+      success?: boolean;
+      data?: { url?: string };
+      error?: { message?: string };
+    };
+
+    if (data.success && data.data?.url) {
+      return { success: true, url: data.data.url };
+    } else {
+      return { success: false, error: data.error?.message || "Upload failed" };
+    }
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+/**
+ * Extend a video to target duration using Kling extend API when possible,
+ * with fallback to FFmpeg-based extendVideoNaturally.
+ *
+ * When the extension ratio > 1.4 and a Kling provider + videoId are available,
+ * uses the Kling video-extend API for natural continuation instead of freeze frames.
+ */
+export async function extendVideoToTarget(
+  videoPath: string,
+  targetDuration: number,
+  outputDir: string,
+  sceneLabel: string,
+  options?: {
+    kling?: KlingProvider;
+    videoId?: string;
+    onProgress?: (message: string) => void;
+  },
+): Promise<void> {
+  const actualDuration = await getVideoDuration(videoPath);
+  if (actualDuration >= targetDuration - 0.1) return;
+
+  const ratio = targetDuration / actualDuration;
+  const extendedPath = resolve(outputDir, `${basename(videoPath, ".mp4")}-extended.mp4`);
+
+  // Try Kling extend API for large gaps (ratio > 1.4) where freeze frames look bad
+  if (ratio > 1.4 && options?.kling && options?.videoId) {
+    try {
+      options.onProgress?.(`${sceneLabel}: Extending via Kling API...`);
+      const extendResult = await options.kling.extendVideo(options.videoId, {
+        duration: "5",
+      });
+
+      if (extendResult.status !== "failed" && extendResult.id) {
+        const waitResult = await options.kling.waitForExtendCompletion(
+          extendResult.id,
+          (status) => {
+            options.onProgress?.(`${sceneLabel}: extend ${status.status}...`);
+          },
+          600000,
+        );
+
+        if (waitResult.status === "completed" && waitResult.videoUrl) {
+          // Download extended video
+          const extendedVideoPath = resolve(
+            outputDir,
+            `${basename(videoPath, ".mp4")}-kling-ext.mp4`,
+          );
+          const buffer = await downloadVideo(waitResult.videoUrl);
+          await writeFile(extendedVideoPath, buffer);
+
+          // Concatenate original + extension
+          const concatPath = resolve(
+            outputDir,
+            `${basename(videoPath, ".mp4")}-concat.mp4`,
+          );
+          const listPath = resolve(
+            outputDir,
+            `${basename(videoPath, ".mp4")}-concat.txt`,
+          );
+          await writeFile(
+            listPath,
+            `file '${videoPath}'\nfile '${extendedVideoPath}'`,
+            "utf-8",
+          );
+          await execSafe("ffmpeg", [
+            "-y", "-f", "concat", "-safe", "0", "-i", listPath,
+            "-c", "copy", concatPath,
+          ]);
+
+          // Trim to exact target duration if concatenated video is longer
+          const concatDuration = await getVideoDuration(concatPath);
+          if (concatDuration > targetDuration + 0.5) {
+            await execSafe("ffmpeg", [
+              "-y", "-i", concatPath, "-t", targetDuration.toFixed(2),
+              "-c", "copy", extendedPath,
+            ]);
+            await unlink(concatPath);
+          } else {
+            await rename(concatPath, extendedPath);
+          }
+
+          // Cleanup temp files
+          await unlink(extendedVideoPath).catch(() => {});
+          await unlink(listPath).catch(() => {});
+          await unlink(videoPath);
+          await rename(extendedPath, videoPath);
+          return;
+        }
+      }
+      // If Kling extend failed, fall through to FFmpeg fallback
+      options.onProgress?.(
+        `${sceneLabel}: Kling extend failed, using FFmpeg fallback...`,
+      );
+    } catch {
+      options.onProgress?.(
+        `${sceneLabel}: Kling extend error, using FFmpeg fallback...`,
+      );
+    }
+  }
+
+  // FFmpeg-based fallback (slowdown + frame interpolation + freeze frame)
+  await extendVideoNaturally(videoPath, targetDuration, extendedPath);
+  await unlink(videoPath);
+  await rename(extendedPath, videoPath);
+}
+
+/**
+ * Log a provider failure to stderr. Centralizes the "what went wrong" output
+ * so call sites stop silently dropping provider errors into failedScenes.
+ */
+export function logSceneFailure(
+  provider: string,
+  sceneLabel: string,
+  err: unknown,
+): void {
+  let msg: string;
+  if (err instanceof Error) {
+    msg = err.message;
+  } else if (typeof err === "string") {
+    msg = err;
+  } else if (
+    err &&
+    typeof err === "object" &&
+    "error" in err &&
+    typeof (err as { error: unknown }).error === "string"
+  ) {
+    msg = (err as { error: string }).error;
+  } else {
+    msg = String(err);
+  }
+  console.error(chalk.dim(`\n  [${provider} ${sceneLabel}: ${msg}]`));
+}
+
+/**
+ * Wait for video completion with retry logic.
+ */
+export async function waitForVideoWithRetry(
+  provider: KlingProvider | RunwayProvider,
+  taskId: string,
+  providerType: "kling" | "runway",
+  maxRetries: number,
+  onProgress?: (message: string) => void,
+  timeout?: number,
+): Promise<{ videoUrl: string } | null> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      let result;
+      if (providerType === "kling") {
+        result = await (provider as KlingProvider).waitForCompletion(
+          taskId,
+          "image2video",
+          (status) => onProgress?.(status.status || "processing"),
+          timeout || 600000,
+        );
+      } else {
+        result = await (provider as RunwayProvider).waitForCompletion(
+          taskId,
+          (status) => {
+            const progress =
+              status.progress !== undefined ? `${status.progress}%` : status.status;
+            onProgress?.(progress || "processing");
+          },
+          timeout || 300000,
+        );
+      }
+
+      if (result.status === "completed" && result.videoUrl) {
+        return { videoUrl: result.videoUrl };
+      }
+
+      // If failed, signal need for resubmission
+      if (attempt < maxRetries) {
+        onProgress?.(`⚠ Failed, will need resubmission...`);
+        return null;
+      }
+    } catch (err) {
+      if (attempt < maxRetries) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        onProgress?.(`⚠ Error waiting (${errMsg.slice(0, 30)}), retry ${attempt + 1}/${maxRetries}...`);
+        await sleep(RETRY_DELAY_MS);
+      }
+    }
+  }
+  return null;
+}

--- a/packages/cli/src/commands/ai-script-pipeline.ts
+++ b/packages/cli/src/commands/ai-script-pipeline.ts
@@ -17,10 +17,9 @@
  */
 
 import { readFile, writeFile, mkdir, unlink, rename } from "node:fs/promises";
-import { resolve, basename, dirname, extname } from "node:path";
+import { resolve, dirname, extname } from "node:path";
 import { existsSync } from "node:fs";
 import { stringify as yamlStringify, parse as yamlParse } from "yaml";
-import chalk from "chalk";
 import {
   GeminiProvider,
   OpenAIProvider,
@@ -37,453 +36,43 @@ import { Project } from "../engine/index.js";
 import { getAudioDuration, getVideoDuration, extendVideoNaturally } from "../utils/audio.js";
 import { applyTextOverlays, type TextOverlayStyle, type VideoReviewFeedback } from "./ai-edit.js";
 import { executeReview } from "./ai-review.js";
-import { execSafe } from "../utils/exec-safe.js";
 import { downloadVideo } from "./ai-helpers.js";
 
-/** A single scene segment from the Claude-generated storyboard. */
-export interface StoryboardSegment {
-  /** 1-based scene index (assigned during generation) */
-  index?: number;
-  /** Narrative description of the scene */
-  description: string;
-  /** Visual prompt for image/video generation */
-  visuals: string;
-  /** Art style directive (e.g. "cinematic", "anime") */
-  visualStyle?: string;
-  /** Character appearance description for consistency */
-  characterDescription?: string;
-  /** Reference to previous scene for continuity */
-  previousSceneLink?: string;
-  /** Voiceover narration text */
-  narration?: string;
-  /** Audio direction (e.g. "upbeat music") */
-  audio?: string;
-  /** Text lines to overlay on the video */
-  textOverlays?: string[];
-  /** Scene duration in seconds (updated to match narration) */
-  duration: number;
-  /** Cumulative start time in seconds */
-  startTime: number;
-}
+// Helpers split out to commands/_shared/ in v0.69 Phase 4. Imported here
+// for executeScriptToVideo + executeRegenerateScene below, and re-exported
+// for backward compat (consumers like generate.ts and commands/ai-video.ts
+// continue to import from this file unchanged).
+import {
+  type StoryboardSegment,
+  DEFAULT_VIDEO_RETRIES,
+  RETRY_DELAY_MS,
+  sleep,
+  uploadToImgbb,
+  extendVideoToTarget,
+  logSceneFailure,
+  waitForVideoWithRetry,
+} from "./_shared/video-utils.js";
+import {
+  generateVideoWithRetryGrok,
+  generateVideoWithRetryKling,
+  generateVideoWithRetryRunway,
+  generateVideoWithRetryVeo,
+} from "./_shared/video-providers.js";
 
-/** Default retry count for video generation API calls. */
-export const DEFAULT_VIDEO_RETRIES = 2;
-/** Delay between retries in milliseconds. */
-export const RETRY_DELAY_MS = 5000;
-
-/**
- * Sleep helper
- */
-export function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Upload image to ImgBB and return the URL
- * Used for Kling v2.5/v2.6 image-to-video which requires URL (not base64)
- */
-export async function uploadToImgbb(
-  imageBuffer: Buffer,
-  apiKey: string
-): Promise<{ success: boolean; url?: string; error?: string }> {
-  try {
-    const base64Image = imageBuffer.toString("base64");
-
-    const formData = new URLSearchParams();
-    formData.append("key", apiKey);
-    formData.append("image", base64Image);
-
-    const response = await fetch("https://api.imgbb.com/1/upload", {
-      method: "POST",
-      body: formData,
-    });
-
-    if (!response.ok) {
-      return { success: false, error: `ImgBB API error (${response.status}): ${response.statusText}` };
-    }
-
-    const data = (await response.json()) as {
-      success?: boolean;
-      data?: { url?: string };
-      error?: { message?: string };
-    };
-
-    if (data.success && data.data?.url) {
-      return { success: true, url: data.data.url };
-    } else {
-      return { success: false, error: data.error?.message || "Upload failed" };
-    }
-  } catch (err) {
-    return { success: false, error: String(err) };
-  }
-}
-
-/**
- * Extend a video to target duration using Kling extend API when possible,
- * with fallback to FFmpeg-based extendVideoNaturally.
- *
- * When the extension ratio > 1.4 and a Kling provider + videoId are available,
- * uses the Kling video-extend API for natural continuation instead of freeze frames.
- */
-export async function extendVideoToTarget(
-  videoPath: string,
-  targetDuration: number,
-  outputDir: string,
-  sceneLabel: string,
-  options?: {
-    kling?: KlingProvider;
-    videoId?: string;
-    onProgress?: (message: string) => void;
-  }
-): Promise<void> {
-  const actualDuration = await getVideoDuration(videoPath);
-  if (actualDuration >= targetDuration - 0.1) return;
-
-  const ratio = targetDuration / actualDuration;
-  const extendedPath = resolve(outputDir, `${basename(videoPath, ".mp4")}-extended.mp4`);
-
-  // Try Kling extend API for large gaps (ratio > 1.4) where freeze frames look bad
-  if (ratio > 1.4 && options?.kling && options?.videoId) {
-    try {
-      options.onProgress?.(`${sceneLabel}: Extending via Kling API...`);
-      const extendResult = await options.kling.extendVideo(options.videoId, {
-        duration: "5",
-      });
-
-      if (extendResult.status !== "failed" && extendResult.id) {
-        const waitResult = await options.kling.waitForExtendCompletion(
-          extendResult.id,
-          (status) => {
-            options.onProgress?.(`${sceneLabel}: extend ${status.status}...`);
-          },
-          600000
-        );
-
-        if (waitResult.status === "completed" && waitResult.videoUrl) {
-          // Download extended video
-          const extendedVideoPath = resolve(outputDir, `${basename(videoPath, ".mp4")}-kling-ext.mp4`);
-          const buffer = await downloadVideo(waitResult.videoUrl);
-          await writeFile(extendedVideoPath, buffer);
-
-          // Concatenate original + extension
-          const concatPath = resolve(outputDir, `${basename(videoPath, ".mp4")}-concat.mp4`);
-          const listPath = resolve(outputDir, `${basename(videoPath, ".mp4")}-concat.txt`);
-          await writeFile(listPath, `file '${videoPath}'\nfile '${extendedVideoPath}'`, "utf-8");
-          await execSafe("ffmpeg", ["-y", "-f", "concat", "-safe", "0", "-i", listPath, "-c", "copy", concatPath]);
-
-          // Trim to exact target duration if concatenated video is longer
-          const concatDuration = await getVideoDuration(concatPath);
-          if (concatDuration > targetDuration + 0.5) {
-            await execSafe("ffmpeg", ["-y", "-i", concatPath, "-t", targetDuration.toFixed(2), "-c", "copy", extendedPath]);
-            await unlink(concatPath);
-          } else {
-            await rename(concatPath, extendedPath);
-          }
-
-          // Cleanup temp files
-          await unlink(extendedVideoPath).catch(() => {});
-          await unlink(listPath).catch(() => {});
-          await unlink(videoPath);
-          await rename(extendedPath, videoPath);
-          return;
-        }
-      }
-      // If Kling extend failed, fall through to FFmpeg fallback
-      options.onProgress?.(`${sceneLabel}: Kling extend failed, using FFmpeg fallback...`);
-    } catch {
-      options.onProgress?.(`${sceneLabel}: Kling extend error, using FFmpeg fallback...`);
-    }
-  }
-
-  // FFmpeg-based fallback (slowdown + frame interpolation + freeze frame)
-  await extendVideoNaturally(videoPath, targetDuration, extendedPath);
-  await unlink(videoPath);
-  await rename(extendedPath, videoPath);
-}
-
-/**
- * Log a provider failure to stderr. Centralizes the "what went wrong" output
- * so call sites stop silently dropping provider errors into failedScenes.
- * Safe to call with unknown errors, string messages, or VideoResult shapes.
- */
-export function logSceneFailure(
-  provider: string,
-  sceneLabel: string,
-  err: unknown
-): void {
-  let msg: string;
-  if (err instanceof Error) {
-    msg = err.message;
-  } else if (typeof err === "string") {
-    msg = err;
-  } else if (err && typeof err === "object" && "error" in err && typeof (err as { error: unknown }).error === "string") {
-    msg = (err as { error: string }).error;
-  } else {
-    msg = String(err);
-  }
-  console.error(chalk.dim(`\n  [${provider} ${sceneLabel}: ${msg}]`));
-}
-
-/**
- * Generate video with retry logic for Grok provider
- */
-export async function generateVideoWithRetryGrok(
-  grok: GrokProvider,
-  segment: StoryboardSegment,
-  options: {
-    duration: number;
-    aspectRatio: "16:9" | "9:16" | "1:1";
-    referenceImage?: string;
-  },
-  maxRetries: number,
-  onProgress?: (message: string) => void
-): Promise<{ requestId: string } | null> {
-  const prompt = segment.visualStyle
-    ? `${segment.visuals}. Style: ${segment.visualStyle}`
-    : segment.visuals;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const result = await grok.generateVideo(prompt, {
-        prompt,
-        duration: options.duration,
-        aspectRatio: options.aspectRatio,
-        referenceImage: options.referenceImage,
-      });
-
-      if (result.status !== "failed" && result.id) {
-        return { requestId: result.id };
-      }
-
-      // Provider returned status: "failed" with an error message — don't
-      // discard it. Surface via onProgress + stderr so the caller can see WHY.
-      const providerErr = result.error || "Grok returned failed status";
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ ${providerErr.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
-        await sleep(RETRY_DELAY_MS);
-      } else {
-        console.error(chalk.dim(`\n  [Grok error: ${providerErr}]`));
-      }
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ Error: ${errMsg.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
-        await sleep(RETRY_DELAY_MS);
-      } else {
-        console.error(chalk.dim(`\n  [Grok error: ${errMsg}]`));
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Generate video with retry logic for Kling provider
- * Supports image-to-video with URL (v2.5/v2.6 models)
- */
-export async function generateVideoWithRetryKling(
-  kling: KlingProvider,
-  segment: StoryboardSegment,
-  options: {
-    duration: 5 | 10;
-    aspectRatio: "16:9" | "9:16" | "1:1";
-    referenceImage?: string; // Optional: base64 or URL for image2video
-  },
-  maxRetries: number,
-  onProgress?: (message: string) => void
-): Promise<{ taskId: string; type: "text2video" | "image2video" } | null> {
-  // Build detailed prompt from storyboard segment
-  const prompt = segment.visualStyle
-    ? `${segment.visuals}. Style: ${segment.visualStyle}`
-    : segment.visuals;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const result = await kling.generateVideo(prompt, {
-        prompt,
-        // Pass reference image (base64 or URL) - KlingProvider handles v1.5 fallback for base64
-        referenceImage: options.referenceImage,
-        duration: options.duration,
-        aspectRatio: options.aspectRatio,
-        mode: "std", // Use std mode for faster generation
-      });
-
-      if (result.status !== "failed" && result.id) {
-        return {
-          taskId: result.id,
-          type: options.referenceImage ? "image2video" : "text2video",
-        };
-      }
-
-      const providerErr = result.error || "Kling returned failed status";
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ ${providerErr.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
-        await sleep(RETRY_DELAY_MS);
-      } else {
-        console.error(chalk.dim(`\n  [Kling error: ${providerErr}]`));
-      }
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ Error: ${errMsg.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
-        await sleep(RETRY_DELAY_MS);
-      } else {
-        console.error(chalk.dim(`\n  [Kling error: ${errMsg}]`));
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Generate video with retry logic for Runway provider
- */
-export async function generateVideoWithRetryRunway(
-  runway: RunwayProvider,
-  segment: StoryboardSegment,
-  referenceImage: string,
-  options: {
-    duration: 5 | 10;
-    aspectRatio: "16:9" | "9:16";
-  },
-  maxRetries: number,
-  onProgress?: (message: string) => void
-): Promise<{ taskId: string } | null> {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const result = await runway.generateVideo(segment.visuals, {
-        prompt: segment.visuals,
-        referenceImage,
-        duration: options.duration,
-        aspectRatio: options.aspectRatio,
-      });
-
-      if (result.status !== "failed" && result.id) {
-        return { taskId: result.id };
-      }
-
-      const providerErr = result.error || "Runway returned failed status";
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ ${providerErr.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
-        await sleep(RETRY_DELAY_MS);
-      } else {
-        console.error(chalk.dim(`\n  [Runway error: ${providerErr}]`));
-      }
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ Error: ${errMsg.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
-        await sleep(RETRY_DELAY_MS);
-      } else {
-        console.error(chalk.dim(`\n  [Runway error: ${errMsg}]`));
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Generate video with retry logic for Veo (Gemini) provider
- */
-export async function generateVideoWithRetryVeo(
-  gemini: GeminiProvider,
-  segment: StoryboardSegment,
-  options: {
-    duration: 4 | 6 | 8;
-    aspectRatio: "16:9" | "9:16" | "1:1";
-    referenceImage?: string;
-  },
-  maxRetries: number,
-  onProgress?: (message: string) => void
-): Promise<{ operationName: string } | null> {
-  const prompt = segment.visualStyle
-    ? `${segment.visuals}. Style: ${segment.visualStyle}`
-    : segment.visuals;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const result = await gemini.generateVideo(prompt, {
-        prompt,
-        referenceImage: options.referenceImage,
-        duration: options.duration,
-        aspectRatio: options.aspectRatio,
-        model: "veo-3.1-fast-generate-preview",
-      });
-
-      if (result.status !== "failed" && result.id) {
-        return { operationName: result.id };
-      }
-
-      const providerErr = result.error || "Veo returned failed status";
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ ${providerErr.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
-        await sleep(RETRY_DELAY_MS);
-      } else {
-        console.error(chalk.dim(`\n  [Veo error: ${providerErr}]`));
-      }
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ Error: ${errMsg.slice(0, 50)}... retry ${attempt + 1}/${maxRetries}`);
-        await sleep(RETRY_DELAY_MS);
-      } else {
-        console.error(chalk.dim(`\n  [Veo error: ${errMsg}]`));
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Wait for video completion with retry logic
- */
-export async function waitForVideoWithRetry(
-  provider: KlingProvider | RunwayProvider,
-  taskId: string,
-  providerType: "kling" | "runway",
-  maxRetries: number,
-  onProgress?: (message: string) => void,
-  timeout?: number
-): Promise<{ videoUrl: string } | null> {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      let result;
-      if (providerType === "kling") {
-        result = await (provider as KlingProvider).waitForCompletion(
-          taskId,
-          "image2video",
-          (status) => onProgress?.(status.status || "processing"),
-          timeout || 600000
-        );
-      } else {
-        result = await (provider as RunwayProvider).waitForCompletion(
-          taskId,
-          (status) => {
-            const progress = status.progress !== undefined ? `${status.progress}%` : status.status;
-            onProgress?.(progress || "processing");
-          },
-          timeout || 300000
-        );
-      }
-
-      if (result.status === "completed" && result.videoUrl) {
-        return { videoUrl: result.videoUrl };
-      }
-
-      // If failed, try resubmitting on next attempt
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ Failed, will need resubmission...`);
-        return null; // Signal need for resubmission
-      }
-    } catch (err) {
-      if (attempt < maxRetries) {
-        onProgress?.(`⚠ Error waiting, retry ${attempt + 1}/${maxRetries}...`);
-        await sleep(RETRY_DELAY_MS);
-      }
-    }
-  }
-  return null;
-}
+export {
+  DEFAULT_VIDEO_RETRIES,
+  RETRY_DELAY_MS,
+  sleep,
+  uploadToImgbb,
+  extendVideoToTarget,
+  logSceneFailure,
+  waitForVideoWithRetry,
+  generateVideoWithRetryGrok,
+  generateVideoWithRetryKling,
+  generateVideoWithRetryRunway,
+  generateVideoWithRetryVeo,
+};
+export type { StoryboardSegment };
 
 /** Options for {@link executeScriptToVideo}. */
 export interface ScriptToVideoOptions {


### PR DESCRIPTION
## Summary

Begins Plan G Phase 4 (ai-script-pipeline.ts split). 2 helper modules extracted into \`commands/_shared/\`:

| File | Lines | Source |
|---|---:|---|
| \`_shared/video-utils.ts\` | 280 | StoryboardSegment, retry constants, sleep, uploadToImgbb, extendVideoToTarget, logSceneFailure, waitForVideoWithRetry |
| \`_shared/video-providers.ts\` | 219 | generateVideoWithRetry{Grok,Kling,Runway,Veo} (4 retry helpers) |

\`ai-script-pipeline.ts\`: 1,976 → 1,567 lines (−409). Re-exports kept for backward compat (consumers in generate.ts, ai-video.ts, etc. unchanged).

## Scope

Helpers only. The two large execute functions remain in \`ai-script-pipeline.ts\`:
- \`executeScriptToVideo\` (~800 L)
- \`executeRegenerateScene\` (~140 L)

Splitting these is a larger refactor (each is internally a multi-stage pipeline with significant internal coupling) — future PR if motivated.

## edit_fill_gaps manifest entry — deferred

The other Phase 4 deliverable (\`edit_fill_gaps\` in manifest) requires extracting the ~400-line \`.action()\` body in \`ai-fill-gaps.ts\` into an \`executeFillGaps\` function — non-trivial because the body is tightly coupled to ora spinners, \`console.log\`, and \`exitWithError\` CLI semantics. Better as its own focused PR.

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm -F @vibeframe/cli test\` — 652 passed
- [x] All re-exports preserve external import paths