### PR TITLE
v0.69 PR6 (Phase 5 partial) — scaffold scripts + CONTRIBUTING walkthroughs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,82 +61,85 @@ pnpm test
 7. Commit your changes with a conventional commit message
 8. Push to your fork and submit a Pull Request
 
-## Adding a New AI Command
+## Adding a New AI Provider
 
-VibeFrame has a specific pattern for adding AI commands. Follow these steps:
+Post-v0.68 (Plan G Phase 1) the provider plugin pattern collapses what used to be **8 file edits** into **1–2 declarations**. The CLI's provider-resolver, config schema, doctor, setup wizard, and `.env.example` all derive from a single registry, so adding a provider auto-propagates.
 
-### 1. Create or extend a command module
+### Quickest path: scaffold
 
-Commands live in `packages/cli/src/commands/`. Each module group has its own file:
-
-| File | Commands |
-|------|----------|
-| `ai-image.ts` | Image generation |
-| `ai-video.ts` | Video generation |
-| `ai-audio.ts` | Audio (TTS, SFX, music) |
-| `ai-edit.ts` | Post-production editing |
-| `ai-highlights.ts` | Highlights and auto-shorts |
-| `ai-script-pipeline.ts` | Script-to-video pipeline |
-| `ai-review.ts` | AI review and auto-fix |
-| `ai-analyze.ts` | Media analysis |
-| `ai-motion.ts` | Motion graphics |
-
-### 2. Export an execute function
-
-```typescript
-// packages/cli/src/commands/ai-example.ts
-export interface MyCommandOptions {
-  input: string;
-  // ...
-}
-
-export interface MyCommandResult {
-  success: boolean;
-  outputPath: string;
-}
-
-export async function executeMyCommand(options: MyCommandOptions): Promise<MyCommandResult> {
-  // Implementation
-}
-
-export function registerMyCommands(ai: Command): void {
-  ai.command("my-command")
-    .description("Description here")
-    .argument("<input>", "Input file")
-    .action(async (input, options) => {
-      const result = await executeMyCommand({ input, ...options });
-    });
-}
+```bash
+pnpm scaffold:provider <name>      # e.g. pnpm scaffold:provider stability
 ```
 
-### 3. Register in `ai.ts`
+This creates `packages/ai-providers/src/<name>/` with a stub `<Name>Provider.ts` (implements `AIProvider` interface) + `index.ts` (calls `defineProvider({...})`), and adds the re-export line to `packages/ai-providers/src/index.ts`.
 
-```typescript
-// packages/cli/src/commands/ai.ts
-import { registerMyCommands } from "./ai-example.js";
-registerMyCommands(ai);
+### Then fill in the metadata
+
+1. **`packages/ai-providers/src/<name>/<Name>Provider.ts`** — implement the methods you need from the `AIProvider` interface. The base contract is in `packages/ai-providers/src/interface/types.ts`. Common methods: `initialize`, `isConfigured`, `generateImage`, `generateVideo`, `transcribe`.
+
+2. **`packages/ai-providers/src/<name>/index.ts`** — fill in the `defineProvider({...})` block:
+   - `apiKey`: reference an existing configKey from `api-keys.ts` (e.g. `"openai"`, `"google"`), or set to `null` if your provider runs locally.
+   - `kinds`: array of `"image" | "video" | "speech" | "llm" | "transcription" | "music"`.
+   - `commandsUnlocked`: list of CLI command strings shown in `vibe doctor`.
+   - `resolverPriority` (optional): `{ image: 4 }` — lower = higher priority.
+
+3. **(If new credential)** Add a `defineApiKey({...})` block to `packages/ai-providers/src/api-keys.ts` with the configKey, envVar, label, setup wizard description, and `.env.example` comment/URL. Skip this step if your provider shares an existing apiKey (e.g. another OpenAI service uses the existing `"openai"` configKey).
+
+### Verify
+
+```bash
+pnpm -F @vibeframe/ai-providers build   # compile the new provider class
+pnpm -r exec tsc --noEmit               # 0 errors
+pnpm -F @vibeframe/cli test             # snapshot tests catch resolver drift
+bash scripts/sync-counts.sh --check     # verifies .env.example regen
 ```
 
-### 4. Add Agent tool (if applicable)
+`vibe doctor --json` should show your new provider under `result.providers`. The setup wizard (`vibe setup --full`) prompts for the apiKey if `showInSetup: true`.
 
-If the command benefits from natural language invocation, add an Agent tool wrapper:
+That's it. No need to edit `provider-resolver.ts`, `schema.ts`, `doctor.ts`, `setup.ts`, or `.env.example` — the registry derives them all.
 
-```typescript
-// packages/cli/src/agent/tools/ai.ts
-import { executeMyCommand } from "../../commands/ai-example.js";
+## Adding a New CLI Subcommand
 
-const myCommandTool: ToolDefinition = {
-  name: "ai_my_command",
-  description: "...",
-  parameters: { /* ... */ }
-};
+Each `vibe <group> <name>` command is a self-contained file. Post-v0.69 (Plan G Phase 2/3), `generate.ts` and `ai-edit.ts` are barrels that call register functions from per-subcommand files.
+
+### Quickest path: scaffold
+
+```bash
+pnpm scaffold:command <group> <name>        # e.g. pnpm scaffold:command generate my-feature
 ```
 
-### 5. Update documentation
+Supported groups: `generate`, `edit`.
 
-- `CLAUDE.md` - Update tool counts and tables
-- `ROADMAP.md` - Mark completed items
-- `MODELS.md` - If adding a new AI model/provider
+For `generate`: creates `packages/cli/src/commands/generate/<name>.ts` and adds the `register*Command(generateCommand)` call to `commands/generate.ts`.
+
+For `edit`: creates `packages/cli/src/commands/_shared/edit/<name>.ts` and adds re-exports to the `ai-edit.ts` barrel.
+
+### Then fill in the logic
+
+Each scaffolded file contains:
+- `XxxOptions` and `XxxResult` interfaces — define the shape of inputs/outputs.
+- `executeXxx(options)` — pure function returning `{ success, ... }`. Used by the manifest layer (MCP/Agent) and the CLI handler.
+- `registerXxxCommand(parent)` — wraps `executeXxx` in a Commander chain with options, action handler, JSON-mode output, etc.
+
+The split makes new contributions a single file edit. The CLI surface auto-updates because the parent group file already registers the new command.
+
+### Optional: expose to MCP/Agent
+
+If the command should be available as an MCP tool or agent tool, add a `defineTool({...})` entry to the appropriate `packages/cli/src/tools/manifest/<group>.ts`. The manifest is the single source of truth for both surfaces — see `packages/cli/src/tools/define-tool.ts` for the schema.
+
+### Verify
+
+```bash
+pnpm -F @vibeframe/cli build
+node packages/cli/dist/index.js <group> <name> --help
+pnpm -F @vibeframe/cli test
+```
+
+### 5. Update documentation (when changing user-visible surface)
+
+- `CLAUDE.md` — tool counts and tables
+- `ROADMAP.md` — mark completed items
+- `MODELS.md` — if adding a new AI model/provider
 
 ## Commit Message Guidelines
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "format": "prettier --write \"**/*.{ts,tsx,md,json}\"",
     "clean": "turbo clean && rm -rf node_modules",
     "vibe": "tsx packages/cli/src/index.ts",
-    "mcp": "tsx packages/mcp-server/src/index.ts"
+    "mcp": "tsx packages/mcp-server/src/index.ts",
+    "scaffold:provider": "tsx scripts/scaffold-provider.mts",
+    "scaffold:command": "tsx scripts/scaffold-command.mts"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/scripts/scaffold-command.mts
+++ b/scripts/scaffold-command.mts
@@ -1,0 +1,301 @@
+/**
+ * @file scripts/scaffold-command.mts
+ * @description Generate a new CLI subcommand scaffold under
+ * `packages/cli/src/commands/<group>/<name>.ts`. Creates the file with
+ * a `register*Command` + `executeXxx` stub, and inserts a registration
+ * line in the parent group file (`commands/<group>.ts`).
+ *
+ * Usage:
+ *   pnpm scaffold:command <group> <name>
+ *
+ * Supported groups (post-v0.69 splits):
+ *   - generate (output: packages/cli/src/commands/generate/<name>.ts,
+ *               registered in commands/generate.ts)
+ *   - edit     (output: packages/cli/src/commands/_shared/edit/<name>.ts,
+ *               re-exported via commands/ai-edit.ts barrel)
+ *
+ * Example:
+ *   pnpm scaffold:command generate my-feature
+ *
+ * The scaffold gives you:
+ *   - schema scaffold (commander options)
+ *   - executeXxx stub returning a typed Result
+ *   - registerXxxCommand wrapping it for CLI use
+ *
+ * For a manifest-only entry (MCP/Agent without a CLI command), edit
+ * `packages/cli/src/tools/manifest/<group>.ts` directly with
+ * `defineTool({...})`.
+ */
+
+import { existsSync } from "node:fs";
+import { writeFile, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const args = process.argv.slice(2);
+const group = args[0];
+const rawName = args[1];
+
+const SUPPORTED_GROUPS = ["generate", "edit"];
+
+if (!group || !rawName) {
+  console.error("Usage: pnpm scaffold:command <group> <name>");
+  console.error(`Supported groups: ${SUPPORTED_GROUPS.join(", ")}`);
+  console.error("Example: pnpm scaffold:command generate my-feature");
+  process.exit(2);
+}
+
+if (!SUPPORTED_GROUPS.includes(group)) {
+  console.error(`Unsupported group "${group}".`);
+  console.error(`Supported: ${SUPPORTED_GROUPS.join(", ")}`);
+  process.exit(2);
+}
+
+if (!/^[a-z][a-z0-9-]*$/.test(rawName)) {
+  console.error(
+    `Invalid name "${rawName}". Use lowercase letters, digits, and hyphens (e.g. "my-feature").`,
+  );
+  process.exit(2);
+}
+
+const id = rawName;
+// "my-feature" → "MyFeature"
+const pascalName = rawName
+  .split("-")
+  .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+  .join("");
+// "my-feature" → "myFeature"
+const camelName = pascalName.charAt(0).toLowerCase() + pascalName.slice(1);
+
+const repoRoot = resolve(import.meta.dirname, "..");
+
+let outputFile: string;
+let parentFile: string;
+let parentInsertion: string;
+let importInsertion: string;
+let isShared = false;
+
+if (group === "generate") {
+  outputFile = resolve(
+    repoRoot,
+    `packages/cli/src/commands/generate/${id}.ts`,
+  );
+  parentFile = resolve(repoRoot, "packages/cli/src/commands/generate.ts");
+  importInsertion = `import { register${pascalName}Command } from "./generate/${id}.js";\n`;
+  parentInsertion = `\n// ============================================================================\n// ${pascalName} → commands/generate/${id}.ts (added via scaffold)\n// ============================================================================\n\nregister${pascalName}Command(generateCommand);\n`;
+} else {
+  // group === "edit"
+  isShared = true;
+  outputFile = resolve(
+    repoRoot,
+    `packages/cli/src/commands/_shared/edit/${id}.ts`,
+  );
+  parentFile = resolve(repoRoot, "packages/cli/src/commands/ai-edit.ts");
+  importInsertion = "";
+  parentInsertion = `\n// ${pascalName} (added via scaffold)\nexport { execute${pascalName} } from "./_shared/edit/${id}.js";\nexport type { ${pascalName}Options, ${pascalName}Result } from "./_shared/edit/${id}.js";\n`;
+}
+
+if (existsSync(outputFile)) {
+  console.error(`File already exists: ${outputFile}`);
+  process.exit(1);
+}
+
+// File source
+const stubSource = isShared
+  ? generateEditStub(pascalName, camelName, id)
+  : generateGenerateStub(pascalName, camelName, id);
+
+await writeFile(outputFile, stubSource, "utf-8");
+
+// Parent file insertion
+const parentContent = await readFile(parentFile, "utf-8");
+let updatedParent = parentContent;
+if (importInsertion && !parentContent.includes(importInsertion.trim())) {
+  // Insert import after the last existing import line.
+  const lines = parentContent.split("\n");
+  let lastImportIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^import\s/.test(lines[i])) lastImportIdx = i;
+  }
+  if (lastImportIdx >= 0) {
+    lines.splice(lastImportIdx + 1, 0, importInsertion.trim());
+    updatedParent = lines.join("\n");
+  }
+}
+if (!updatedParent.includes(parentInsertion.trim())) {
+  updatedParent += parentInsertion;
+}
+await writeFile(parentFile, updatedParent, "utf-8");
+
+console.log(`✓ Created ${outputFile}`);
+console.log(`  - register${pascalName}Command + execute${pascalName} stubs`);
+console.log(`✓ Updated ${parentFile}`);
+console.log("");
+console.log("Next steps:");
+console.log(`  1. Edit ${outputFile}`);
+console.log(`     to implement the command logic.`);
+console.log(`  2. Run \`pnpm -F @vibeframe/cli build\` to verify.`);
+console.log(`  3. Try it out:`);
+if (group === "generate") {
+  console.log(`       node packages/cli/dist/index.js generate ${id} --help`);
+} else {
+  console.log(`       (edit subcommands are wired through edit-cmd.ts;`);
+  console.log(`        register the new ${pascalName} via registerEditCommands)`);
+}
+console.log("");
+console.log("To add a manifest entry (for MCP/Agent surfaces), edit");
+console.log(`packages/cli/src/tools/manifest/${group}.ts and call`);
+console.log(`defineTool({ name: "${group}_${id.replace(/-/g, "_")}", ... }).`);
+
+// ── Stub generators ───────────────────────────────────────────────────────
+
+function generateGenerateStub(
+  Pascal: string,
+  camel: string,
+  fileId: string,
+): string {
+  void camel;
+  return `/**
+ * @module generate/${fileId}
+ * @description \`vibe generate ${fileId}\` — TODO describe what this command does.
+ * Generated by \`pnpm scaffold:command generate ${fileId}\`.
+ */
+
+import type { Command } from "commander";
+import { isJsonMode, outputResult, exitWithError, apiError } from "../output.js";
+
+// ── Library: execute${Pascal} (used by manifest / pipeline) ───────────
+
+export interface ${Pascal}Options {
+  // TODO: define option fields
+  /** Example required prompt argument. */
+  prompt: string;
+  /** Optional output path. */
+  output?: string;
+}
+
+export interface ${Pascal}Result {
+  success: boolean;
+  outputPath?: string;
+  error?: string;
+}
+
+export async function execute${Pascal}(
+  options: ${Pascal}Options,
+): Promise<${Pascal}Result> {
+  try {
+    // TODO: implement the actual logic. Return { success: true, ... } on
+    // happy path, or { success: false, error: "..." } on failure.
+    void options;
+    return { success: false, error: "Not implemented" };
+  } catch (error) {
+    return {
+      success: false,
+      error: \`${Pascal} failed: \${error instanceof Error ? error.message : String(error)}\`,
+    };
+  }
+}
+
+// ── CLI: vibe generate ${fileId} ──────────────────────────────────────
+
+export function register${Pascal}Command(parent: Command): void {
+  parent
+    .command("${fileId}")
+    .description("TODO short description shown in \`vibe generate --help\`")
+    .argument("<prompt>", "TODO describe the required argument")
+    .option("-o, --output <path>", "Output file path")
+    .option("--dry-run", "Preview parameters without executing")
+    .action(async (prompt: string, options) => {
+      try {
+        if (options.dryRun) {
+          outputResult({
+            dryRun: true,
+            command: "generate ${fileId}",
+            params: { prompt, output: options.output },
+          });
+          return;
+        }
+
+        const result = await execute${Pascal}({ prompt, output: options.output });
+
+        if (!result.success) {
+          exitWithError(apiError(result.error ?? "${Pascal} failed", true));
+        }
+
+        if (isJsonMode()) {
+          outputResult({ success: true, outputPath: result.outputPath });
+          return;
+        }
+
+        console.log(\`✓ ${Pascal} done. Output: \${result.outputPath ?? "(none)"}\`);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        exitWithError(apiError(\`${Pascal} failed: \${msg}\`, true));
+      }
+    });
+}
+`;
+}
+
+function generateEditStub(
+  Pascal: string,
+  camel: string,
+  fileId: string,
+): string {
+  void camel;
+  return `/**
+ * @module _shared/edit/${fileId}
+ * @description \`execute${Pascal}\` — TODO describe what this edit operation does.
+ * Generated by \`pnpm scaffold:command edit ${fileId}\`.
+ *
+ * After editing, re-export from \`commands/ai-edit.ts\` barrel and wire
+ * the CLI subcommand registration in \`commands/ai-edit-cli.ts\` if needed.
+ */
+
+import { existsSync } from "node:fs";
+import { execSafe, commandExists } from "../../../utils/exec-safe.js";
+
+export interface ${Pascal}Options {
+  /** Path to the input video/audio file */
+  inputPath: string;
+  /** Path for the output file */
+  outputPath: string;
+  // TODO: add more option fields
+}
+
+export interface ${Pascal}Result {
+  success: boolean;
+  outputPath?: string;
+  error?: string;
+}
+
+export async function execute${Pascal}(
+  options: ${Pascal}Options,
+): Promise<${Pascal}Result> {
+  const { inputPath, outputPath } = options;
+
+  if (!existsSync(inputPath)) {
+    return { success: false, error: \`Input not found: \${inputPath}\` };
+  }
+
+  if (!commandExists("ffmpeg")) {
+    return {
+      success: false,
+      error:
+        "FFmpeg not found. Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux). Run \`vibe doctor\` for details.",
+    };
+  }
+
+  try {
+    // TODO: implement the actual logic, e.g.:
+    // await execSafe("ffmpeg", ["-i", inputPath, ...filters, outputPath, "-y"], { ... });
+    void execSafe;
+    return { success: false, error: "Not implemented" };
+  } catch (error) {
+    return {
+      success: false,
+      error: \`${Pascal} failed: \${error instanceof Error ? error.message : String(error)}\`,
+    };
+  }
+}
+`;
+}

--- a/scripts/scaffold-provider.mts
+++ b/scripts/scaffold-provider.mts
@@ -1,0 +1,171 @@
+/**
+ * @file scripts/scaffold-provider.mts
+ * @description Generate a new AI provider scaffold under
+ * `packages/ai-providers/src/<name>/`. Creates the directory + stub
+ * Provider class + `index.ts` with `defineProvider` call. Updates
+ * `packages/ai-providers/src/index.ts` to add the re-export line.
+ *
+ * Usage:
+ *   pnpm scaffold:provider <name>
+ *
+ * Example:
+ *   pnpm scaffold:provider stability
+ *
+ * Then:
+ *   1. Edit `packages/ai-providers/src/stability/StabilityProvider.ts`
+ *      to implement the `AIProvider` interface.
+ *   2. (If using a NEW API credential) add `defineApiKey({...})` to
+ *      `packages/ai-providers/src/api-keys.ts`.
+ *   3. Edit `packages/ai-providers/src/stability/index.ts` to fill in
+ *      the `defineProvider({...})` metadata (kinds, apiKey, etc.).
+ *   4. Run `pnpm -r exec tsc --noEmit && pnpm -F @vibeframe/cli test`.
+ *
+ * The scaffold is intentionally minimal. The `defineProvider` call is
+ * the only place the new provider needs to register — the 5 derived
+ * consumers (provider-resolver, schema, doctor, setup, .env.example)
+ * auto-update.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, writeFile, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const args = process.argv.slice(2);
+const rawName = args[0];
+
+if (!rawName) {
+  console.error("Usage: pnpm scaffold:provider <name>");
+  console.error("Example: pnpm scaffold:provider stability");
+  process.exit(2);
+}
+
+if (!/^[a-z][a-z0-9-]*$/.test(rawName)) {
+  console.error(
+    `Invalid name "${rawName}". Use lowercase letters, digits, and hyphens (e.g. "stability", "openai-image").`,
+  );
+  process.exit(2);
+}
+
+// id: matches directory name. className: PascalCase + "Provider".
+const id = rawName;
+const className =
+  rawName
+    .split("-")
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join("") + "Provider";
+const instanceName = className.charAt(0).toLowerCase() + className.slice(1);
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const providerDir = resolve(repoRoot, "packages/ai-providers/src", id);
+const providerFile = resolve(providerDir, `${className}.ts`);
+const indexFile = resolve(providerDir, "index.ts");
+const aiProvidersIndex = resolve(repoRoot, "packages/ai-providers/src/index.ts");
+
+if (existsSync(providerDir)) {
+  console.error(`Provider directory already exists: ${providerDir}`);
+  process.exit(1);
+}
+
+await mkdir(providerDir, { recursive: true });
+
+// Stub Provider class
+const providerSource = `/**
+ * ${className} — TODO: describe what this provider does.
+ *
+ * Implement the methods you need from the \`AIProvider\` interface.
+ * Common ones: initialize, isConfigured, generateImage, generateVideo,
+ * transcribe, generateMusic, etc.
+ *
+ * See \`packages/ai-providers/src/interface/types.ts\` for the full contract.
+ */
+
+import type { AIProvider, AICapability, ProviderConfig } from "../interface/types.js";
+
+export class ${className} implements AIProvider {
+  id = "${id}";
+  name = "${className.replace(/Provider$/, "")}";
+  description = "TODO: short description shown in setup wizard";
+  capabilities: AICapability[] = [
+    // TODO: add AICapability values, e.g. "text-to-image", "text-to-video"
+  ];
+  isAvailable = true;
+
+  private apiKey: string | null = null;
+
+  async initialize(config: ProviderConfig): Promise<void> {
+    this.apiKey = config.apiKey ?? null;
+    // TODO: any other init (SDK client construction, etc.)
+  }
+
+  isConfigured(): boolean {
+    return this.apiKey !== null;
+  }
+
+  // TODO: implement provider methods here, e.g.
+  // async generateImage(prompt: string, options?: GenerateOptions): Promise<...> { ... }
+}
+
+export const ${instanceName} = new ${className}();
+`;
+
+await writeFile(providerFile, providerSource, "utf-8");
+
+// index.ts — re-exports + defineProvider stub
+const indexSource = `export { ${className}, ${instanceName} } from "./${className}.js";
+
+import { defineProvider } from "../define-provider.js";
+
+defineProvider({
+  id: "${id}",
+  label: "${className.replace(/Provider$/, "")}",
+  // TODO: reference an existing apiKey configKey from api-keys.ts (e.g.
+  //   "openai", "google", "fal"), OR add a new defineApiKey call there
+  //   first and reference it here. Keep as \`null\` if this provider runs
+  //   locally with no credential (like kokoro/ollama).
+  apiKey: null,
+  kinds: [
+    // TODO: which surfaces does this provider serve?
+    // "image" | "video" | "speech" | "llm" | "transcription" | "music"
+  ],
+  // resolverPriority: { image: 4 }, // optional: lower number = higher priority
+  commandsUnlocked: [
+    // TODO: list commands this provider unlocks for \`vibe doctor\`, e.g.
+    // "generate image -p ${id}",
+  ],
+});
+`;
+
+await writeFile(indexFile, indexSource, "utf-8");
+
+// Append re-export to ai-providers/src/index.ts
+const aiProvidersIndexContent = await readFile(aiProvidersIndex, "utf-8");
+const reExportLine = `export { ${className}, ${instanceName} } from "./${id}/index.js";\n`;
+
+if (!aiProvidersIndexContent.includes(reExportLine)) {
+  // Insert before the "// Re-export commonly used types" comment block, or at end if not found.
+  let updated: string;
+  const marker = "// Re-export commonly used types";
+  if (aiProvidersIndexContent.includes(marker)) {
+    updated = aiProvidersIndexContent.replace(marker, `${reExportLine}${marker}`);
+  } else {
+    updated = aiProvidersIndexContent + reExportLine;
+  }
+  await writeFile(aiProvidersIndex, updated, "utf-8");
+}
+
+console.log(`✓ Created ${providerDir}/`);
+console.log(`  - ${className}.ts (stub class)`);
+console.log(`  - index.ts (defineProvider call)`);
+console.log(`✓ Added re-export to packages/ai-providers/src/index.ts`);
+console.log("");
+console.log("Next steps:");
+console.log(`  1. Edit ${providerFile}`);
+console.log(`     to implement the AIProvider methods you need.`);
+console.log(`  2. Edit ${indexFile}`);
+console.log(`     to fill in the defineProvider metadata (kinds, apiKey, etc.).`);
+console.log(`  3. (If new credential) add a defineApiKey block to`);
+console.log(`     packages/ai-providers/src/api-keys.ts.`);
+console.log(`  4. Run \`pnpm -F @vibeframe/ai-providers build\` to compile.`);
+console.log(`  5. Run \`pnpm -r exec tsc --noEmit && pnpm -F @vibeframe/cli test\` to verify.`);
+console.log("");
+console.log("See docs/CONTRIBUTOR_GUIDE.md for a full walkthrough.");


### PR DESCRIPTION
## Summary

Plan G Phase 5: OSS contributor entry points. Two scaffold scripts that turn "add a new provider" and "add a new subcommand" into single-file PRs, plus CONTRIBUTING.md walkthroughs that replace the outdated pre-Plan G \"Adding an AI Command\" section.

## New scripts

- \`scripts/scaffold-provider.mts\` — \`pnpm scaffold:provider <name>\`
  - Generates \`packages/ai-providers/src/<name>/{<Name>Provider.ts, index.ts}\` with stubs (AIProvider interface skeleton + defineProvider call)
  - Appends the re-export line to \`ai-providers/src/index.ts\`

- \`scripts/scaffold-command.mts\` — \`pnpm scaffold:command <group> <name>\`
  - For \`generate\`: creates \`commands/generate/<name>.ts\` + wires \`register*Command(generateCommand)\` into \`commands/generate.ts\`
  - For \`edit\`: creates \`commands/_shared/edit/<name>.ts\` + adds re-exports to \`ai-edit.ts\` barrel
  - Stubs include \`executeXxx\` (library) + \`registerXxxCommand\` (CLI wrapper)

## CONTRIBUTING.md updates

Replaces the outdated \"Adding a New AI Command\" section with two walkthroughs:

- **Adding a New AI Provider** — scaffold + fill defineProvider metadata + (if new credential) defineApiKey. 5 derived consumers auto-update.
- **Adding a New CLI Subcommand** — scaffold + fill executeXxx + (optional) manifest entry for MCP/Agent surface.

## End-to-end verification

Both scaffolds tested with throwaway names (\`test-fake\` provider, \`test-cmd\` generate, \`test-edit\` edit). All:
- Generate clean files that typecheck on empty implementations
- Runtime registry import succeeds (provider registers correctly)
- Cleanly revert via \`git checkout\` (no leftover state)

## Out of scope (future PRs)

- \`docs/CONTRIBUTOR_GUIDE.md\` deeper "Your First Provider PR" walkthrough (script output references it)
- README.md "For Contributors" section
- Phase 4 finishing: \`edit_fill_gaps\` manifest extraction + \`executeScriptToVideo\` split

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors
- [x] \`bash scripts/sync-counts.sh --check\` — green
- [x] \`pnpm scaffold:provider test-fake\` → \`pnpm -r exec tsc --noEmit\` green; runtime \`getAllProviders()\` includes test-fake
- [x] \`pnpm scaffold:command generate test-cmd\` and \`edit test-edit\` → typecheck green