### PR TITLE
v0.69 PR7 (Phase 4 finish) — extract executeFillGaps + edit_fill_gaps manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VibeFrame
 
-**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 63 MCP tools bundled.
+**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 64 MCP tools bundled.
 
 [![GitHub stars](https://img.shields.io/github/stars/vericontext/vibeframe)](https://github.com/vericontext/vibeframe/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -75,7 +75,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | Layer | Hyperframes | VibeFrame |
 |---|---|---|
 | **AI generation** | — | OpenAI gpt-image-2 (image default since v0.56), fal.ai Seedance 2.0 (video default since v0.57), Veo, Kling, Runway, Grok, ElevenLabs, Replicate |
-| **Agent integrations** | — | MCP server (63 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
+| **Agent integrations** | — | MCP server (64 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
 | **Traditional editing** | — | `vibe edit` silence-cut · jump-cut · caption · grade · reframe · speed-ramp · fade · noise-reduce (84+ commands total) |
 | **AI analysis** | — | `vibe analyze` media/video/review/suggest (multimodal LLMs) |
 | **BUILD from text** | composition format only | `vibe scene build` (v0.60 one-shot driver) — STORYBOARD.md → MP4 |
@@ -84,7 +84,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | **Local Kokoro TTS** | ✅ Python `kokoro-onnx` | ✅ Node `kokoro-js` — same Kokoro-82M model, auto-fallback when no `ELEVENLABS_API_KEY` |
 | **Local Whisper transcribe** | ✅ whisper-cpp (offline) | OpenAI Whisper API (cloud, word-level) |
 | **Agent skills** | ✅ `npx skills add heygen-com/hyperframes` (5 skills via vercel-labs/skills) | ✅ ships `/vibe-pipeline`, `/vibe-scene` (overview lives in `AGENTS.md` scaffolded by `vibe init`) |
-| **MCP server** | ❌ | ✅ 63 tools |
+| **MCP server** | ❌ | ✅ 64 tools |
 | **Render** | ✅ native (BeginFrame, parity, HDR, Studio NLE) | uses Hyperframes backend or FFmpeg |
 | **License** | Apache 2.0 | MIT |
 
@@ -209,7 +209,7 @@ Prefer manual install? Copy [`.claude/skills/`](https://github.com/vericontext/v
 
 ## MCP Integration (Claude Desktop / Cursor)
 
-The CLI is the primary interface; MCP is the gateway for Claude Desktop & Cursor users (63 MCP tools exposed). No clone needed — add to your config and restart:
+The CLI is the primary interface; MCP is the gateway for Claude Desktop & Cursor users (64 MCP tools exposed). No clone needed — add to your config and restart:
 
 ```json
 {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,7 +11,7 @@ const inter = Inter({ subsets: ["latin"] });
 // directory listing + MCP tool name regex), so they stay in sync with the
 // source. Falls back to the post-v0.57 numbers if env var lookup fails.
 const AI_PROVIDERS = process.env.NEXT_PUBLIC_AI_PROVIDERS ?? "13";
-const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "63";
+const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "64";
 const SHARE_DESCRIPTION = `YAML pipelines, ${AI_PROVIDERS} AI providers, ${MCP_TOOLS} MCP tools bundled. Ship videos, not clicks.`;
 
 export const metadata: Metadata = {

--- a/packages/cli/src/agent/tools/integration.test.ts
+++ b/packages/cli/src/agent/tools/integration.test.ts
@@ -174,7 +174,7 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
     it("should register the full manifest", () => {
       // Manifest is the single source of truth post-v0.67 PR2.
       const tools = registry.getAll();
-      expect(tools.length).toBe(79);
+      expect(tools.length).toBe(80);
     });
 
     it("should register all project tools (5)", () => {
@@ -679,7 +679,7 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
       expect(fsTools.length).toBe(4);
       expect(mediaTools.length).toBe(12);  // +audio_isolate/voice_clone/dub/duck (Phase B v0.64)
       expect(generateTools.length).toBe(13);  // +background, video_status/cancel/extend, music_status (Phase B v0.64)
-      expect(editTools.length).toBe(14);  // +grade, speed_ramp, reframe, interpolate, upscale, animated_caption (Phase B+D v0.64)
+      expect(editTools.length).toBe(15);  // +grade, speed_ramp, reframe, interpolate, upscale, animated_caption (Phase B+D v0.64), edit_fill_gaps (Plan G Phase 4)
       expect(analyzeTools.length).toBe(4);  // video, media, review, suggest
       expect(pipelineTools.length).toBe(4);  // animated_caption renamed to edit_animated_caption (Phase D)
       expect(exportTools.length).toBe(3);
@@ -698,7 +698,7 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
           exportTools.length +
           batchTools.length +
           sceneTools.length;
-      expect(totalTools).toBe(79);
+      expect(totalTools).toBe(80);
     });
   });
 });

--- a/packages/cli/src/commands/_shared/execute-fill-gaps.ts
+++ b/packages/cli/src/commands/_shared/execute-fill-gaps.ts
@@ -1,0 +1,661 @@
+/**
+ * @module _shared/execute-fill-gaps
+ * @description `executeFillGaps` — fill timeline gaps with AI-generated
+ * video (Kling image-to-video). Extracted from the 562-line `.action()`
+ * body in `commands/ai-fill-gaps.ts` in v0.69 Phase 4 finishing piece.
+ *
+ * The CLI handler in ai-fill-gaps.ts now just wires onProgress to an
+ * ora spinner and prints humanLines on completion. The manifest entry
+ * (`edit_fill_gaps`) calls this same function without onProgress and
+ * returns humanLines as the result body — same logic, dual surface.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile, writeFile, mkdir, rename as renameFs } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { KlingProvider } from "@vibeframe/ai-providers";
+import { Project, type ProjectFile } from "../../engine/index.js";
+import { getApiKey } from "../../utils/api-key.js";
+import { execSafe, ffprobeDuration } from "../../utils/exec-safe.js";
+import { downloadVideo, formatTime } from "../ai-helpers.js";
+
+export interface ExecuteFillGapsOptions {
+  /** Project file path (resolved relative to cwd). */
+  projectPath: string;
+  /** Output project path. Defaults to overwriting the input. */
+  output?: string;
+  /** Directory for generated videos. Defaults to <projectDir>/footage. */
+  dir?: string;
+  /** Custom prompt for video generation. */
+  prompt?: string;
+  /** If true, only report gaps without generating. */
+  dryRun?: boolean;
+  /** Kling generation mode (std or pro). */
+  mode?: "std" | "pro";
+  /** Aspect ratio. */
+  ratio?: "16:9" | "9:16" | "1:1";
+  /** Override Kling API key. */
+  apiKey?: string;
+  /** Override ImgBB API key (used to host frames for Kling input). */
+  imgbbApiKey?: string;
+  /** Optional progress callback for streaming status updates. */
+  onProgress?: (message: string) => void;
+}
+
+export interface FillGapsGapReport {
+  start: number;
+  end: number;
+  duration: number;
+  /** How much of the gap can be filled by extending the previous clip. */
+  canExtendBefore: number;
+  /** How much can be filled by extending the next clip. */
+  canExtendAfter: number;
+  /** Remaining duration that needs AI generation. */
+  remainingGap: number;
+}
+
+export interface ExecuteFillGapsResult {
+  success: boolean;
+  /** Error message on failure. */
+  error?: string;
+  /** Human-readable status lines (CLI prints; manifest joins). */
+  humanLines: string[];
+  /** Per-gap analysis (always populated when success=true). */
+  gaps?: FillGapsGapReport[];
+  /** Gaps that need AI generation (subset of `gaps`). */
+  gapsNeedingAI?: FillGapsGapReport[];
+  /** Number of gaps actually filled (0 in dry-run / no-gaps cases). */
+  generatedCount?: number;
+  /** Final project path (input path or `options.output`). */
+  outputPath?: string;
+  /** True when no gaps were detected. */
+  noGaps?: boolean;
+  /** True when all gaps can be filled by extending adjacent clips. */
+  allExtendable?: boolean;
+  /** True when dry-run mode reported gaps without generating. */
+  dryRun?: boolean;
+}
+
+// ─── private helpers (also used by ai-fill-gaps.ts directly) ──────────────
+
+export function detectVideoGaps(
+  videoClips: Array<{ startTime: number; duration: number }>,
+  totalDuration: number,
+): Array<{ start: number; end: number }> {
+  const gaps: Array<{ start: number; end: number }> = [];
+  const sortedClips = [...videoClips].sort((a, b) => a.startTime - b.startTime);
+
+  if (sortedClips.length > 0 && sortedClips[0].startTime > 0.001) {
+    gaps.push({ start: 0, end: sortedClips[0].startTime });
+  }
+
+  for (let i = 0; i < sortedClips.length - 1; i++) {
+    const clipEnd = sortedClips[i].startTime + sortedClips[i].duration;
+    const nextStart = sortedClips[i + 1].startTime;
+    if (nextStart > clipEnd + 0.001) {
+      gaps.push({ start: clipEnd, end: nextStart });
+    }
+  }
+
+  if (sortedClips.length > 0) {
+    const lastClip = sortedClips[sortedClips.length - 1];
+    const lastClipEnd = lastClip.startTime + lastClip.duration;
+    if (totalDuration > lastClipEnd + 0.001) {
+      gaps.push({ start: lastClipEnd, end: totalDuration });
+    }
+  }
+
+  return gaps;
+}
+
+export function analyzeGapFillability(
+  gaps: Array<{ start: number; end: number }>,
+  videoClips: Array<{
+    startTime: number;
+    duration: number;
+    sourceId: string;
+    sourceStartOffset: number;
+    sourceEndOffset: number;
+  }>,
+  sources: Array<{ id: string; url: string; type: string; duration: number }>,
+): Array<{
+  gap: { start: number; end: number };
+  canExtendBefore: number;
+  canExtendAfter: number;
+  remainingGap: number;
+  gapStart: number;
+}> {
+  const sortedClips = [...videoClips].sort((a, b) => a.startTime - b.startTime);
+
+  return gaps.map((gap) => {
+    const gapDuration = gap.end - gap.start;
+    let canExtendBefore = 0;
+    let canExtendAfter = 0;
+
+    const clipBefore = sortedClips.find(
+      (c) => Math.abs(c.startTime + c.duration - gap.start) < 0.01,
+    );
+
+    if (clipBefore) {
+      const source = sources.find((s) => s.id === clipBefore.sourceId);
+      if (source && source.type === "video") {
+        const usedEndInSource = clipBefore.sourceEndOffset;
+        canExtendBefore = Math.max(0, source.duration - usedEndInSource);
+      }
+    }
+
+    const clipAfter = sortedClips.find(
+      (c) => Math.abs(c.startTime - gap.end) < 0.01,
+    );
+
+    if (clipAfter) {
+      const source = sources.find((s) => s.id === clipAfter.sourceId);
+      if (source && source.type === "video") {
+        canExtendAfter = Math.max(0, clipAfter.sourceStartOffset);
+      }
+    }
+
+    const totalExtendable = canExtendBefore + canExtendAfter;
+    const remainingGap = Math.max(0, gapDuration - totalExtendable);
+    const gapStart = gap.start + Math.min(canExtendBefore, gapDuration);
+
+    return { gap, canExtendBefore, canExtendAfter, remainingGap, gapStart };
+  });
+}
+
+async function uploadFrameToImgbb(
+  framePath: string,
+  imgbbApiKey: string,
+): Promise<{ url?: string; error?: string }> {
+  try {
+    const frameBuffer = await readFile(framePath);
+    const frameBase64 = frameBuffer.toString("base64");
+
+    const formData = new FormData();
+    formData.append("key", imgbbApiKey);
+    formData.append("image", frameBase64);
+
+    const response = await fetch("https://api.imgbb.com/1/upload", {
+      method: "POST",
+      body: formData,
+    });
+
+    const data = (await response.json()) as {
+      success: boolean;
+      data?: { url: string };
+      error?: { message: string };
+    };
+    if (!data.success || !data.data?.url) {
+      return { error: data.error?.message || "Upload failed" };
+    }
+    return { url: data.data.url };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ─── main entry point ────────────────────────────────────────────────────
+
+export async function executeFillGaps(
+  options: ExecuteFillGapsOptions,
+): Promise<ExecuteFillGapsResult> {
+  const onProgress = options.onProgress ?? (() => {});
+  const humanLines: string[] = [];
+
+  try {
+    onProgress("Loading project...");
+    const filePath = resolve(process.cwd(), options.projectPath);
+    if (!existsSync(filePath)) {
+      return {
+        success: false,
+        error: `Project file not found: ${filePath}`,
+        humanLines,
+      };
+    }
+
+    const content = await readFile(filePath, "utf-8");
+    const data: ProjectFile = JSON.parse(content);
+    const project = Project.fromJSON(data);
+
+    const clips = project.getClips().sort((a, b) => a.startTime - b.startTime);
+    const sources = project.getSources();
+
+    const videoClips = clips
+      .filter((clip) => {
+        const source = sources.find((s) => s.id === clip.sourceId);
+        return source && (source.type === "video" || source.type === "image");
+      })
+      .sort((a, b) => a.startTime - b.startTime);
+
+    if (videoClips.length === 0) {
+      return {
+        success: false,
+        error: "Project has no video clips",
+        humanLines,
+      };
+    }
+
+    // Determine total duration (use audio track if available)
+    const audioClips = clips.filter((clip) => {
+      const source = sources.find((s) => s.id === clip.sourceId);
+      return source && source.type === "audio";
+    });
+
+    const totalDuration =
+      audioClips.length > 0
+        ? Math.max(...audioClips.map((c) => c.startTime + c.duration))
+        : Math.max(...videoClips.map((c) => c.startTime + c.duration));
+
+    onProgress("Detecting gaps...");
+    const gaps = detectVideoGaps(videoClips, totalDuration);
+
+    if (gaps.length === 0) {
+      humanLines.push("No gaps found in timeline");
+      return {
+        success: true,
+        humanLines,
+        gaps: [],
+        gapsNeedingAI: [],
+        generatedCount: 0,
+        noGaps: true,
+        outputPath: filePath,
+      };
+    }
+
+    const gapAnalysis = analyzeGapFillability(gaps, videoClips, sources);
+
+    const gapReports: FillGapsGapReport[] = gapAnalysis.map((a) => ({
+      start: a.gap.start,
+      end: a.gap.end,
+      duration: a.gap.end - a.gap.start,
+      canExtendBefore: a.canExtendBefore,
+      canExtendAfter: a.canExtendAfter,
+      remainingGap: a.remainingGap,
+    }));
+
+    humanLines.push(`Found ${gaps.length} gap(s)`);
+    humanLines.push("");
+    humanLines.push("Timeline Gaps");
+
+    const gapsNeedingAIAnalysis: typeof gapAnalysis = [];
+
+    for (const analysis of gapAnalysis) {
+      const { gap, canExtendBefore, canExtendAfter, remainingGap } = analysis;
+      const gapDuration = gap.end - gap.start;
+
+      humanLines.push("");
+      humanLines.push(
+        `Gap: ${formatTime(gap.start)} - ${formatTime(gap.end)} (${gapDuration.toFixed(2)}s)`,
+      );
+
+      if (canExtendBefore > 0.01 || canExtendAfter > 0.01) {
+        const extendable = canExtendBefore + canExtendAfter;
+        humanLines.push(`  Can extend from adjacent clips: ${extendable.toFixed(2)}s`);
+      }
+
+      if (remainingGap > 0.01) {
+        humanLines.push(`  Needs AI generation: ${remainingGap.toFixed(2)}s`);
+        gapsNeedingAIAnalysis.push(analysis);
+      } else {
+        humanLines.push(`  ✓ Can be filled by extending clips`);
+      }
+    }
+    humanLines.push("");
+
+    const gapsNeedingAI: FillGapsGapReport[] = gapsNeedingAIAnalysis.map(
+      (a) => ({
+        start: a.gap.start,
+        end: a.gap.end,
+        duration: a.gap.end - a.gap.start,
+        canExtendBefore: a.canExtendBefore,
+        canExtendAfter: a.canExtendAfter,
+        remainingGap: a.remainingGap,
+      }),
+    );
+
+    if (gapsNeedingAI.length === 0) {
+      humanLines.push("All gaps can be filled by extending adjacent clips.");
+      humanLines.push("Run export with --gap-fill extend to apply.");
+      return {
+        success: true,
+        humanLines,
+        gaps: gapReports,
+        gapsNeedingAI: [],
+        generatedCount: 0,
+        allExtendable: true,
+        outputPath: filePath,
+      };
+    }
+
+    if (options.dryRun) {
+      humanLines.push("Dry run - no videos generated");
+      humanLines.push("");
+      humanLines.push(`${gapsNeedingAI.length} gap(s) need AI video generation:`);
+      for (const g of gapsNeedingAI) {
+        humanLines.push(
+          `  - ${formatTime(g.start)} - ${formatTime(g.end)} (${g.remainingGap.toFixed(2)}s)`,
+        );
+      }
+      return {
+        success: true,
+        humanLines,
+        gaps: gapReports,
+        gapsNeedingAI,
+        generatedCount: 0,
+        dryRun: true,
+        outputPath: filePath,
+      };
+    }
+
+    // Get Kling API key
+    const apiKey = options.apiKey || (await getApiKey("KLING_API_KEY", "Kling", undefined));
+    if (!apiKey) {
+      return {
+        success: false,
+        error: "KLING_API_KEY required for AI video generation",
+        humanLines,
+      };
+    }
+
+    const kling = new KlingProvider();
+    await kling.initialize({ apiKey });
+
+    if (!kling.isConfigured()) {
+      return {
+        success: false,
+        error: "Invalid KLING_API_KEY (expected ACCESS_KEY:SECRET_KEY format)",
+        humanLines,
+      };
+    }
+
+    // Determine output directory for generated videos
+    const projectDir = dirname(filePath);
+    const footageDir = options.dir
+      ? resolve(process.cwd(), options.dir)
+      : resolve(projectDir, "footage");
+
+    if (!existsSync(footageDir)) {
+      await mkdir(footageDir, { recursive: true });
+    }
+
+    humanLines.push("Generating AI Videos");
+
+    const imgbbApiKey =
+      options.imgbbApiKey || (await getApiKey("IMGBB_API_KEY", "imgbb", undefined));
+    if (!imgbbApiKey) {
+      return {
+        success: false,
+        error:
+          "IMGBB_API_KEY required for image hosting. Get a free API key at https://api.imgbb.com/",
+        humanLines,
+      };
+    }
+
+    let generatedCount = 0;
+
+    for (const analysis of gapsNeedingAIAnalysis) {
+      const { gap, remainingGap, gapStart } = analysis;
+
+      humanLines.push("");
+      humanLines.push(`Processing gap: ${formatTime(gap.start)} - ${formatTime(gap.end)}`);
+
+      // Find the clip before this gap to extract a frame
+      const clipBefore = videoClips.find(
+        (c) => Math.abs(c.startTime + c.duration - gap.start) < 0.1,
+      );
+
+      if (!clipBefore) {
+        humanLines.push("  No preceding clip found, skipping");
+        continue;
+      }
+
+      const sourceBefore = sources.find((s) => s.id === clipBefore.sourceId);
+      if (!sourceBefore || sourceBefore.type !== "video") {
+        humanLines.push("  Preceding clip is not a video, skipping");
+        continue;
+      }
+
+      // Extract last frame from preceding clip
+      onProgress("Extracting frame from preceding clip...");
+      const frameOffset = clipBefore.sourceStartOffset + clipBefore.duration - 0.1;
+      const framePath = resolve(footageDir, `frame-${gap.start.toFixed(2)}.png`);
+
+      try {
+        await execSafe("ffmpeg", [
+          "-i", sourceBefore.url, "-ss", String(frameOffset),
+          "-vframes", "1", "-f", "image2", "-y", framePath,
+        ]);
+      } catch (err) {
+        return {
+          success: false,
+          error: `Failed to extract frame: ${err instanceof Error ? err.message : String(err)}`,
+          humanLines,
+        };
+      }
+
+      // Upload frame to imgbb
+      onProgress("Uploading frame to imgbb...");
+      const upload = await uploadFrameToImgbb(framePath, imgbbApiKey);
+      if (!upload.url) {
+        return {
+          success: false,
+          error: `Failed to upload frame to imgbb: ${upload.error || "unknown"}`,
+          humanLines,
+        };
+      }
+      const frameUrl = upload.url;
+
+      const targetDuration = remainingGap;
+      let generatedDuration = 0;
+      const generatedVideos: string[] = [];
+
+      const initialDuration = Math.min(10, targetDuration);
+      const klingDuration = initialDuration > 5 ? "10" : "5";
+
+      onProgress(`Generating ${klingDuration}s video with Kling...`);
+
+      const prompt = options.prompt || "Continue the scene naturally with subtle motion";
+
+      const result = await kling.generateVideo(prompt, {
+        prompt,
+        referenceImage: frameUrl,
+        duration: parseInt(klingDuration) as 5 | 10,
+        aspectRatio: options.ratio || "16:9",
+        mode: options.mode || "std",
+      });
+
+      if (result.status === "failed") {
+        humanLines.push(`  Failed to start generation: ${result.error}`);
+        continue;
+      }
+
+      onProgress(`Generating video (task: ${result.id})...`);
+
+      const finalResult = await kling.waitForCompletion(
+        result.id,
+        "image2video",
+        (status) => onProgress(`Generating video... ${status.status}`),
+        600000,
+      );
+
+      if (
+        finalResult.status !== "completed" ||
+        !finalResult.videoUrl ||
+        !finalResult.videoId
+      ) {
+        humanLines.push(`  Generation failed: ${finalResult.error || "Unknown error"}`);
+        continue;
+      }
+
+      // Download the generated video
+      const videoFileName = `gap-fill-${gap.start.toFixed(2)}-${gap.end.toFixed(2)}.mp4`;
+      const videoPath = resolve(footageDir, videoFileName);
+
+      onProgress("Downloading generated video...");
+      const videoBuffer = await downloadVideo(finalResult.videoUrl);
+      await writeFile(videoPath, videoBuffer);
+
+      generatedDuration = finalResult.duration || parseInt(klingDuration);
+      generatedVideos.push(videoPath);
+
+      humanLines.push(`  Generated: ${videoFileName} (${generatedDuration}s)`);
+
+      // If we need more duration, generate additional segments
+      let segmentIndex = 1;
+      while (generatedDuration < targetDuration - 1) {
+        const remainingNeeded = targetDuration - generatedDuration;
+        const segmentDuration = remainingNeeded > 5 ? "10" : "5";
+
+        onProgress(`Generating additional ${segmentDuration}s segment...`);
+
+        const lastFramePath = resolve(
+          footageDir,
+          `frame-extend-${gap.start.toFixed(2)}-${segmentIndex}.png`,
+        );
+        try {
+          let videoDur: number;
+          try {
+            videoDur = await ffprobeDuration(videoPath);
+          } catch {
+            videoDur = generatedDuration;
+          }
+          const lastFrameTime = Math.max(0, videoDur - 0.1);
+
+          await execSafe("ffmpeg", [
+            "-i", videoPath, "-ss", String(lastFrameTime),
+            "-vframes", "1", "-f", "image2", "-y", lastFramePath,
+          ]);
+        } catch {
+          humanLines.push("  Failed to extract frame for continuation");
+          break;
+        }
+
+        const extUpload = await uploadFrameToImgbb(lastFramePath, imgbbApiKey);
+        if (!extUpload.url) {
+          humanLines.push("  Failed to upload continuation frame");
+          break;
+        }
+
+        const segResult = await kling.generateVideo(prompt, {
+          prompt,
+          referenceImage: extUpload.url,
+          duration: parseInt(segmentDuration) as 5 | 10,
+          aspectRatio: options.ratio || "16:9",
+          mode: options.mode || "std",
+        });
+
+        if (segResult.status === "failed") {
+          humanLines.push(`  Segment generation failed: ${segResult.error}`);
+          break;
+        }
+
+        const segFinalResult = await kling.waitForCompletion(
+          segResult.id,
+          "image2video",
+          (status) => onProgress(`Generating segment... ${status.status}`),
+          600000,
+        );
+
+        if (segFinalResult.status !== "completed" || !segFinalResult.videoUrl) {
+          humanLines.push(
+            `  Segment generation failed: ${segFinalResult.error || "Unknown error"}`,
+          );
+          break;
+        }
+
+        const segVideoPath = resolve(
+          footageDir,
+          `gap-fill-${gap.start.toFixed(2)}-${gap.end.toFixed(2)}-seg${segmentIndex}.mp4`,
+        );
+        const segVideoBuffer = await downloadVideo(segFinalResult.videoUrl);
+        await writeFile(segVideoPath, segVideoBuffer);
+
+        const concatListPath = resolve(footageDir, `concat-${gap.start.toFixed(2)}.txt`);
+        const concatList =
+          generatedVideos.map((v) => `file '${v}'`).join("\n") +
+          `\nfile '${segVideoPath}'`;
+        await writeFile(concatListPath, concatList);
+
+        const concatOutputPath = resolve(
+          footageDir,
+          `gap-fill-${gap.start.toFixed(2)}-${gap.end.toFixed(2)}-merged.mp4`,
+        );
+        try {
+          await execSafe("ffmpeg", [
+            "-f", "concat", "-safe", "0", "-i", concatListPath,
+            "-c", "copy", "-y", concatOutputPath,
+          ]);
+          await renameFs(concatOutputPath, videoPath);
+        } catch {
+          humanLines.push("  Failed to concatenate videos");
+          break;
+        }
+
+        generatedVideos.push(segVideoPath);
+        generatedDuration += segFinalResult.duration || parseInt(segmentDuration);
+        segmentIndex++;
+
+        humanLines.push(`  Added segment, total: ${generatedDuration.toFixed(1)}s`);
+      }
+
+      // Add the generated video to the project
+      const actualGapStart = gapStart;
+      const actualGapDuration = Math.min(remainingGap, generatedDuration);
+
+      let videoDuration = generatedDuration;
+      try {
+        videoDuration = await ffprobeDuration(videoPath);
+      } catch {
+        // Use estimated duration
+      }
+
+      const newSource = project.addSource({
+        name: videoFileName,
+        type: "video",
+        url: videoPath,
+        duration: videoDuration,
+      });
+
+      project.addClip({
+        sourceId: newSource.id,
+        trackId: videoClips[0].trackId,
+        startTime: actualGapStart,
+        duration: actualGapDuration,
+        sourceStartOffset: 0,
+        sourceEndOffset: actualGapDuration,
+      });
+
+      generatedCount++;
+      humanLines.push(
+        `  Added to timeline: ${formatTime(actualGapStart)} - ${formatTime(actualGapStart + actualGapDuration)}`,
+      );
+    }
+
+    humanLines.push("");
+
+    let outputPath: string = filePath;
+    if (generatedCount > 0) {
+      outputPath = options.output ? resolve(process.cwd(), options.output) : filePath;
+      await writeFile(outputPath, JSON.stringify(project.toJSON(), null, 2));
+      humanLines.push(`✔ Filled ${generatedCount} gap(s) with AI-generated video`);
+      humanLines.push(`Project saved: ${outputPath}`);
+    } else {
+      humanLines.push("No gaps were filled");
+    }
+
+    return {
+      success: true,
+      humanLines,
+      gaps: gapReports,
+      gapsNeedingAI,
+      generatedCount,
+      outputPath,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Fill gaps failed: ${error instanceof Error ? error.message : String(error)}`,
+      humanLines,
+    };
+  }
+}

--- a/packages/cli/src/commands/ai-fill-gaps.ts
+++ b/packages/cli/src/commands/ai-fill-gaps.ts
@@ -2,562 +2,77 @@
  * @module ai-fill-gaps
  * @description Fill timeline gaps with AI-generated video (Kling image-to-video).
  *
- * ## Commands: vibe ai fill-gaps
+ * ## Commands: vibe edit fill-gaps
  * ## Dependencies: Kling
  *
- * Extracted from ai.ts as part of modularisation.
- * ai.ts calls registerFillGapsCommand(aiCommand).
- * @see MODELS.md for AI model configuration
+ * Post-v0.69 Phase 4: the 562-line `.action()` body is extracted into
+ * `executeFillGaps` (commands/_shared/execute-fill-gaps.ts) so the
+ * manifest entry `edit_fill_gaps` can call the same logic. This file
+ * remains the CLI registration site — it wires `onProgress` to ora
+ * spinners and prints `humanLines` on completion.
  */
 
-import { type Command } from 'commander';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { resolve, dirname } from 'node:path';
-import { existsSync } from 'node:fs';
-import chalk from 'chalk';
-import ora from 'ora';
-import { KlingProvider } from '@vibeframe/ai-providers';
-import { Project, type ProjectFile } from '../engine/index.js';
-import { getApiKey } from '../utils/api-key.js';
-import { execSafe, ffprobeDuration } from '../utils/exec-safe.js';
-import { formatTime, downloadVideo } from './ai-helpers.js';
-import { exitWithError, authError, apiError, generalError } from './output.js';
+import { type Command } from "commander";
+import chalk from "chalk";
+import ora from "ora";
+import { exitWithError, apiError } from "./output.js";
 import { validateOutputPath } from "./validate.js";
-
-// ── Helper functions (module-private) ────────────────────────────────────────
-
-/**
- * Detect gaps in video timeline
- */
-function detectVideoGaps(
-  videoClips: Array<{ startTime: number; duration: number }>,
-  totalDuration: number
-): Array<{ start: number; end: number }> {
-  const gaps: Array<{ start: number; end: number }> = [];
-  const sortedClips = [...videoClips].sort((a, b) => a.startTime - b.startTime);
-
-  // Check for gap at the start
-  if (sortedClips.length > 0 && sortedClips[0].startTime > 0.001) {
-    gaps.push({ start: 0, end: sortedClips[0].startTime });
-  }
-
-  // Check for gaps between clips
-  for (let i = 0; i < sortedClips.length - 1; i++) {
-    const clipEnd = sortedClips[i].startTime + sortedClips[i].duration;
-    const nextStart = sortedClips[i + 1].startTime;
-    if (nextStart > clipEnd + 0.001) {
-      gaps.push({ start: clipEnd, end: nextStart });
-    }
-  }
-
-  // Check for gap at the end
-  if (sortedClips.length > 0) {
-    const lastClip = sortedClips[sortedClips.length - 1];
-    const lastClipEnd = lastClip.startTime + lastClip.duration;
-    if (totalDuration > lastClipEnd + 0.001) {
-      gaps.push({ start: lastClipEnd, end: totalDuration });
-    }
-  }
-
-  return gaps;
-}
-
-/**
- * Analyze whether gaps can be filled by extending adjacent clips
- */
-function analyzeGapFillability(
-  gaps: Array<{ start: number; end: number }>,
-  videoClips: Array<{ startTime: number; duration: number; sourceId: string; sourceStartOffset: number; sourceEndOffset: number }>,
-  sources: Array<{ id: string; url: string; type: string; duration: number }>
-): Array<{
-  gap: { start: number; end: number };
-  canExtendBefore: number;
-  canExtendAfter: number;
-  remainingGap: number;
-  gapStart: number; // Where the unfillable gap starts
-}> {
-  const sortedClips = [...videoClips].sort((a, b) => a.startTime - b.startTime);
-
-  return gaps.map((gap) => {
-    const gapDuration = gap.end - gap.start;
-    let canExtendBefore = 0;
-    let canExtendAfter = 0;
-
-    // Find clip BEFORE the gap (for extending forwards)
-    const clipBefore = sortedClips.find((c) =>
-      Math.abs(c.startTime + c.duration - gap.start) < 0.01
-    );
-
-    if (clipBefore) {
-      const source = sources.find((s) => s.id === clipBefore.sourceId);
-      if (source && source.type === "video") {
-        const usedEndInSource = clipBefore.sourceEndOffset;
-        canExtendBefore = Math.max(0, source.duration - usedEndInSource);
-      }
-    }
-
-    // Find clip AFTER the gap (for extending backwards)
-    const clipAfter = sortedClips.find((c) =>
-      Math.abs(c.startTime - gap.end) < 0.01
-    );
-
-    if (clipAfter) {
-      const source = sources.find((s) => s.id === clipAfter.sourceId);
-      if (source && source.type === "video") {
-        canExtendAfter = Math.max(0, clipAfter.sourceStartOffset);
-      }
-    }
-
-    const totalExtendable = canExtendBefore + canExtendAfter;
-    const remainingGap = Math.max(0, gapDuration - totalExtendable);
-
-    // Calculate where the unfillable gap starts
-    // (after we extend the clip before as much as possible)
-    const gapStart = gap.start + Math.min(canExtendBefore, gapDuration);
-
-    return {
-      gap,
-      canExtendBefore,
-      canExtendAfter,
-      remainingGap,
-      gapStart,
-    };
-  });
-}
-
-
-// ── Command registration ─────────────────────────────────────────────────────
+import { executeFillGaps } from "./_shared/execute-fill-gaps.js";
 
 export function registerFillGapsCommand(aiCommand: Command): void {
-// Fill Gaps command - AI video generation to fill timeline gaps
-aiCommand
-  .command("fill-gaps")
-  .description("Fill timeline gaps with AI-generated video (Kling image-to-video)")
-  .argument("<project>", "Project file path")
-  .option("-p, --provider <provider>", "AI provider (kling)", "kling")
-  .option("-o, --output <path>", "Output project path (default: overwrite)")
-  .option("-d, --dir <path>", "Directory to save generated videos")
-  .option("--prompt <text>", "Custom prompt for video generation")
-  .option("--dry-run", "Show gaps without generating")
-  .option("-m, --mode <mode>", "Generation mode: std or pro (Kling)", "std")
-  .option("-r, --ratio <ratio>", "Aspect ratio: 16:9, 9:16, or 1:1", "16:9")
-  .action(async (projectPath: string, options) => {
-    try {
-      if (options.output) {
-        validateOutputPath(options.output);
-      }
-
-      const spinner = ora("Loading project...").start();
-
-      // Load project
-      const filePath = resolve(process.cwd(), projectPath);
-      const content = await readFile(filePath, "utf-8");
-      const data: ProjectFile = JSON.parse(content);
-      const project = Project.fromJSON(data);
-
-      const clips = project.getClips().sort((a, b) => a.startTime - b.startTime);
-      const sources = project.getSources();
-
-      // Get video clips only
-      const videoClips = clips.filter((clip) => {
-        const source = sources.find((s) => s.id === clip.sourceId);
-        return source && (source.type === "video" || source.type === "image");
-      }).sort((a, b) => a.startTime - b.startTime);
-
-      if (videoClips.length === 0) {
-        spinner.fail("Project has no video clips");
-        exitWithError(generalError("Project has no video clips"));
-      }
-
-      // Determine total duration (use audio track if available)
-      const audioClips = clips.filter((clip) => {
-        const source = sources.find((s) => s.id === clip.sourceId);
-        return source && source.type === "audio";
-      });
-
-      let totalDuration: number;
-      if (audioClips.length > 0) {
-        totalDuration = Math.max(...audioClips.map((c) => c.startTime + c.duration));
-      } else {
-        totalDuration = Math.max(...videoClips.map((c) => c.startTime + c.duration));
-      }
-
-      // Detect gaps
-      spinner.text = "Detecting gaps...";
-      const gaps = detectVideoGaps(videoClips, totalDuration);
-
-      if (gaps.length === 0) {
-        spinner.succeed(chalk.green("No gaps found in timeline"));
-        process.exit(0);
-      }
-
-      // Analyze which gaps can be filled by extending adjacent clips
-      const gapAnalysis = analyzeGapFillability(gaps, videoClips, sources);
-
-      spinner.succeed(chalk.green(`Found ${gaps.length} gap(s)`));
-
-      console.log();
-      console.log(chalk.bold.cyan("Timeline Gaps"));
-      console.log(chalk.dim("─".repeat(60)));
-
-      const gapsNeedingAI: typeof gapAnalysis = [];
-
-      for (const analysis of gapAnalysis) {
-        const { gap, canExtendBefore, canExtendAfter, remainingGap } = analysis;
-        const gapDuration = gap.end - gap.start;
-
-        console.log();
-        console.log(chalk.yellow(`Gap: ${formatTime(gap.start)} - ${formatTime(gap.end)} (${gapDuration.toFixed(2)}s)`));
-
-        if (canExtendBefore > 0.01 || canExtendAfter > 0.01) {
-          const extendable = canExtendBefore + canExtendAfter;
-          console.log(chalk.dim(`  Can extend from adjacent clips: ${extendable.toFixed(2)}s`));
+  aiCommand
+    .command("fill-gaps")
+    .description("Fill timeline gaps with AI-generated video (Kling image-to-video)")
+    .argument("<project>", "Project file path")
+    .option("-p, --provider <provider>", "AI provider (kling)", "kling")
+    .option("-o, --output <path>", "Output project path (default: overwrite)")
+    .option("-d, --dir <path>", "Directory to save generated videos")
+    .option("--prompt <text>", "Custom prompt for video generation")
+    .option("--dry-run", "Show gaps without generating")
+    .option("-m, --mode <mode>", "Generation mode: std or pro (Kling)", "std")
+    .option("-r, --ratio <ratio>", "Aspect ratio: 16:9, 9:16, or 1:1", "16:9")
+    .action(async (projectPath: string, options) => {
+      try {
+        if (options.output) {
+          validateOutputPath(options.output);
         }
 
-        if (remainingGap > 0.01) {
-          console.log(chalk.red(`  Needs AI generation: ${remainingGap.toFixed(2)}s`));
-          gapsNeedingAI.push(analysis);
-        } else {
-          console.log(chalk.green(`  ✓ Can be filled by extending clips`));
-        }
-      }
+        const spinner = ora("Loading project...").start();
+        let lastProgressMessage = "";
 
-      console.log();
-
-      if (gapsNeedingAI.length === 0) {
-        console.log(chalk.green("All gaps can be filled by extending adjacent clips."));
-        console.log(chalk.dim("Run export with --gap-fill extend to apply."));
-        process.exit(0);
-      }
-
-      if (options.dryRun) {
-        console.log(chalk.dim("Dry run - no videos generated"));
-        console.log();
-        console.log(chalk.bold(`${gapsNeedingAI.length} gap(s) need AI video generation:`));
-        for (const analysis of gapsNeedingAI) {
-          console.log(`  - ${formatTime(analysis.gap.start)} - ${formatTime(analysis.gap.end)} (${analysis.remainingGap.toFixed(2)}s)`);
-        }
-        process.exit(0);
-      }
-
-      // Get Kling API key
-      const apiKey = await getApiKey("KLING_API_KEY", "Kling", undefined);
-      if (!apiKey) {
-        exitWithError(authError("KLING_API_KEY", "Kling"));
-      }
-
-      const kling = new KlingProvider();
-      await kling.initialize({ apiKey });
-
-      if (!kling.isConfigured()) {
-        exitWithError(authError("KLING_API_KEY", "Kling"));
-      }
-
-      // Determine output directory for generated videos
-      const projectDir = dirname(filePath);
-      const footageDir = options.dir
-        ? resolve(process.cwd(), options.dir)
-        : resolve(projectDir, "footage");
-
-      // Create footage directory if needed
-      if (!existsSync(footageDir)) {
-        await mkdir(footageDir, { recursive: true });
-      }
-
-      console.log(chalk.bold.cyan("Generating AI Videos"));
-      console.log(chalk.dim("─".repeat(60)));
-
-      let generatedCount = 0;
-
-      for (const analysis of gapsNeedingAI) {
-        const { gap, remainingGap, gapStart } = analysis;
-
-        console.log();
-        console.log(chalk.yellow(`Processing gap: ${formatTime(gap.start)} - ${formatTime(gap.end)}`));
-
-        // Find the clip before this gap to extract a frame
-        const clipBefore = videoClips.find((c) =>
-          Math.abs(c.startTime + c.duration - gap.start) < 0.1
-        );
-
-        if (!clipBefore) {
-          console.log(chalk.red(`  No preceding clip found, skipping`));
-          continue;
-        }
-
-        const sourceBefore = sources.find((s) => s.id === clipBefore.sourceId);
-        if (!sourceBefore || sourceBefore.type !== "video") {
-          console.log(chalk.red(`  Preceding clip is not a video, skipping`));
-          continue;
-        }
-
-        // Extract last frame from preceding clip
-        spinner.start("Extracting frame from preceding clip...");
-        const frameOffset = clipBefore.sourceStartOffset + clipBefore.duration - 0.1; // 100ms before end
-        const framePath = resolve(footageDir, `frame-${gap.start.toFixed(2)}.png`);
-
-        try {
-          await execSafe("ffmpeg", ["-i", sourceBefore.url, "-ss", String(frameOffset), "-vframes", "1", "-f", "image2", "-y", framePath]);
-        } catch (err) {
-          spinner.fail(chalk.red("Failed to extract frame"));
-          exitWithError(generalError(`Failed to extract frame: ${err instanceof Error ? err.message : String(err)}`));
-        }
-        spinner.succeed("Frame extracted");
-
-        // Upload frame to imgbb to get URL (Kling v2.5/v2.6 requires URL, not base64)
-        spinner.start("Uploading frame to imgbb...");
-        const imgbbApiKey = await getApiKey("IMGBB_API_KEY", "imgbb", undefined);
-        if (!imgbbApiKey) {
-          spinner.fail(chalk.red("IMGBB_API_KEY required for image hosting"));
-          exitWithError(apiError("IMGBB_API_KEY required for image hosting. Get a free API key at https://api.imgbb.com/", true));
-        }
-
-        const frameBuffer = await readFile(framePath);
-        const frameBase64 = frameBuffer.toString("base64");
-
-        let frameUrl: string;
-        try {
-          const formData = new FormData();
-          formData.append("key", imgbbApiKey);
-          formData.append("image", frameBase64);
-
-          const imgbbResponse = await fetch("https://api.imgbb.com/1/upload", {
-            method: "POST",
-            body: formData,
-          });
-
-          const imgbbData = await imgbbResponse.json() as { success: boolean; data?: { url: string }; error?: { message: string } };
-          if (!imgbbData.success || !imgbbData.data?.url) {
-            throw new Error(imgbbData.error?.message || "Upload failed");
-          }
-          frameUrl = imgbbData.data.url;
-        } catch (err) {
-          spinner.fail(chalk.red("Failed to upload frame to imgbb"));
-          exitWithError(apiError(`Failed to upload frame to imgbb: ${err instanceof Error ? err.message : String(err)}`, true));
-        }
-        spinner.succeed(`Frame uploaded: ${frameUrl}`);
-
-        // Calculate how many seconds to generate
-        // Kling can generate 5 or 10 second videos
-        // For longer gaps, we may need multiple generations or video-extend
-        const targetDuration = remainingGap;
-        let generatedDuration = 0;
-        const generatedVideos: string[] = [];
-
-        // Generate initial video (up to 10 seconds)
-        const initialDuration = Math.min(10, targetDuration);
-        const klingDuration = initialDuration > 5 ? "10" : "5";
-
-        spinner.start(`Generating ${klingDuration}s video with Kling...`);
-
-        const prompt = options.prompt || "Continue the scene naturally with subtle motion";
-
-        const result = await kling.generateVideo(prompt, {
-          prompt,
-          referenceImage: frameUrl,
-          duration: parseInt(klingDuration) as 5 | 10,
-          aspectRatio: options.ratio as "16:9" | "9:16" | "1:1",
-          mode: options.mode as "std" | "pro",
-        });
-
-        if (result.status === "failed") {
-          spinner.fail(chalk.red(`Failed to start generation: ${result.error}`));
-          continue;
-        }
-
-        spinner.text = `Generating video (task: ${result.id})...`;
-
-        const finalResult = await kling.waitForCompletion(
-          result.id,
-          "image2video",
-          (status) => {
-            spinner.text = `Generating video... ${status.status}`;
+        const result = await executeFillGaps({
+          projectPath,
+          output: options.output,
+          dir: options.dir,
+          prompt: options.prompt,
+          dryRun: options.dryRun,
+          mode: options.mode as "std" | "pro" | undefined,
+          ratio: options.ratio as "16:9" | "9:16" | "1:1" | undefined,
+          onProgress: (message: string) => {
+            lastProgressMessage = message;
+            spinner.text = message;
           },
-          600000
+        });
+
+        // Stop the spinner with a meaningful final state.
+        if (result.success) {
+          spinner.succeed(chalk.green(lastProgressMessage || "Done"));
+        } else {
+          spinner.fail(chalk.red(result.error || "Fill gaps failed"));
+          exitWithError(apiError(result.error || "Fill gaps failed", true));
+        }
+
+        // Print humanLines (the action body's previous console.log output).
+        for (const line of result.humanLines) {
+          console.log(line);
+        }
+      } catch (error) {
+        exitWithError(
+          apiError(
+            `Fill gaps failed: ${error instanceof Error ? error.message : String(error)}`,
+            true,
+          ),
         );
-
-        if (finalResult.status !== "completed" || !finalResult.videoUrl || !finalResult.videoId) {
-          spinner.fail(chalk.red(`Generation failed: ${finalResult.error || "Unknown error"}`));
-          continue;
-        }
-
-        // Download the generated video
-        const videoFileName = `gap-fill-${gap.start.toFixed(2)}-${gap.end.toFixed(2)}.mp4`;
-        const videoPath = resolve(footageDir, videoFileName);
-
-        spinner.text = "Downloading generated video...";
-        const currentVideoUrl = finalResult.videoUrl;
-        const response = await fetch(currentVideoUrl);
-        const videoBuffer = Buffer.from(await response.arrayBuffer());
-        await writeFile(videoPath, videoBuffer);
-
-        generatedDuration = finalResult.duration || parseInt(klingDuration);
-        generatedVideos.push(videoPath);
-        // videoId available via finalResult.videoId for future extend API usage
-
-        spinner.succeed(chalk.green(`Generated: ${videoFileName} (${generatedDuration}s)`));
-
-        // If we need more duration, generate additional videos using image-to-video
-        // (video-extend often fails, so we use a more reliable approach)
-        let segmentIndex = 1;
-        while (generatedDuration < targetDuration - 1) {
-          const remainingNeeded = targetDuration - generatedDuration;
-          const segmentDuration = remainingNeeded > 5 ? "10" : "5";
-
-          spinner.start(`Generating additional ${segmentDuration}s segment...`);
-
-          // Extract last frame from current video
-          const lastFramePath = resolve(footageDir, `frame-extend-${gap.start.toFixed(2)}-${segmentIndex}.png`);
-          try {
-            // Get video duration first
-            let videoDur: number;
-            try {
-              videoDur = await ffprobeDuration(videoPath);
-            } catch {
-              videoDur = generatedDuration;
-            }
-            const lastFrameTime = Math.max(0, videoDur - 0.1);
-
-            await execSafe("ffmpeg", ["-i", videoPath, "-ss", String(lastFrameTime), "-vframes", "1", "-f", "image2", "-y", lastFramePath]);
-          } catch (err) {
-            spinner.fail(chalk.yellow("Failed to extract frame for continuation"));
-            break;
-          }
-
-          // Upload to imgbb
-          const extFrameBuffer = await readFile(lastFramePath);
-          const extFrameBase64 = extFrameBuffer.toString("base64");
-
-          let extFrameUrl: string;
-          try {
-            const formData = new FormData();
-            formData.append("key", imgbbApiKey);
-            formData.append("image", extFrameBase64);
-
-            const imgbbResp = await fetch("https://api.imgbb.com/1/upload", {
-              method: "POST",
-              body: formData,
-            });
-
-            const imgbbData = await imgbbResp.json() as { success: boolean; data?: { url: string }; error?: { message: string } };
-            if (!imgbbData.success || !imgbbData.data?.url) {
-              throw new Error(imgbbData.error?.message || "Upload failed");
-            }
-            extFrameUrl = imgbbData.data.url;
-          } catch (err) {
-            spinner.fail(chalk.yellow("Failed to upload continuation frame"));
-            break;
-          }
-
-          // Generate next segment
-          const segResult = await kling.generateVideo(prompt, {
-            prompt,
-            referenceImage: extFrameUrl,
-            duration: parseInt(segmentDuration) as 5 | 10,
-            aspectRatio: options.ratio as "16:9" | "9:16" | "1:1",
-            mode: options.mode as "std" | "pro",
-          });
-
-          if (segResult.status === "failed") {
-            spinner.fail(chalk.yellow(`Segment generation failed: ${segResult.error}`));
-            break;
-          }
-
-          const segFinalResult = await kling.waitForCompletion(
-            segResult.id,
-            "image2video",
-            (status) => {
-              spinner.text = `Generating segment... ${status.status}`;
-            },
-            600000
-          );
-
-          if (segFinalResult.status !== "completed" || !segFinalResult.videoUrl) {
-            spinner.fail(chalk.yellow(`Segment generation failed: ${segFinalResult.error || "Unknown error"}`));
-            break;
-          }
-
-          // Download new segment
-          const segVideoPath = resolve(footageDir, `gap-fill-${gap.start.toFixed(2)}-${gap.end.toFixed(2)}-seg${segmentIndex}.mp4`);
-          const segVideoBuffer = await downloadVideo(segFinalResult.videoUrl);
-          await writeFile(segVideoPath, segVideoBuffer);
-
-          // Concatenate videos
-          const concatListPath = resolve(footageDir, `concat-${gap.start.toFixed(2)}.txt`);
-          const concatList = generatedVideos.map(v => `file '${v}'`).join("\n") + `\nfile '${segVideoPath}'`;
-          await writeFile(concatListPath, concatList);
-
-          const concatOutputPath = resolve(footageDir, `gap-fill-${gap.start.toFixed(2)}-${gap.end.toFixed(2)}-merged.mp4`);
-          try {
-            await execSafe("ffmpeg", ["-f", "concat", "-safe", "0", "-i", concatListPath, "-c", "copy", "-y", concatOutputPath]);
-            // Replace main video with concatenated version
-            const { rename: renameFs } = await import("node:fs/promises");
-            await renameFs(concatOutputPath, videoPath);
-          } catch (err) {
-            spinner.fail(chalk.yellow("Failed to concatenate videos"));
-            break;
-          }
-
-          generatedVideos.push(segVideoPath);
-          generatedDuration += segFinalResult.duration || parseInt(segmentDuration);
-          segmentIndex++;
-
-          spinner.succeed(chalk.green(`Added segment, total: ${generatedDuration.toFixed(1)}s`));
-        }
-
-        // Add the generated video to the project
-        const actualGapStart = gapStart;
-        const actualGapDuration = Math.min(remainingGap, generatedDuration);
-
-        // Get video info for source
-        let videoDuration = generatedDuration;
-        try {
-          videoDuration = await ffprobeDuration(videoPath);
-        } catch {
-          // Use estimated duration
-        }
-
-        // Add source
-        const newSource = project.addSource({
-          name: videoFileName,
-          type: "video",
-          url: videoPath,
-          duration: videoDuration,
-        });
-
-        // Add clip
-        project.addClip({
-          sourceId: newSource.id,
-          trackId: videoClips[0].trackId,
-          startTime: actualGapStart,
-          duration: actualGapDuration,
-          sourceStartOffset: 0,
-          sourceEndOffset: actualGapDuration,
-        });
-
-        generatedCount++;
-        console.log(chalk.green(`  Added to timeline: ${formatTime(actualGapStart)} - ${formatTime(actualGapStart + actualGapDuration)}`));
       }
-
-      console.log();
-
-      if (generatedCount > 0) {
-        // Save project
-        const outputPath = options.output
-          ? resolve(process.cwd(), options.output)
-          : filePath;
-
-        await writeFile(outputPath, JSON.stringify(project.toJSON(), null, 2));
-
-        console.log(chalk.bold.green(`✔ Filled ${generatedCount} gap(s) with AI-generated video`));
-        console.log(chalk.dim(`Project saved: ${outputPath}`));
-      } else {
-        console.log(chalk.yellow("No gaps were filled"));
-      }
-
-      console.log();
-    } catch (error) {
-      exitWithError(apiError(`Fill gaps failed: ${error instanceof Error ? error.message : String(error)}`, true));
-    }
-  });
+    });
 }

--- a/packages/cli/src/tools/manifest/edit.ts
+++ b/packages/cli/src/tools/manifest/edit.ts
@@ -1,14 +1,12 @@
 /**
  * @module manifest/edit
- * @description Editing tools spread across the legacy
- * `ai-editing.ts` (silence-cut/caption/fade/noise-reduce/jump-cut/text-overlay/translate-srt),
- * `ai-edit-advanced.ts` (grade/speed-ramp/reframe/interpolate/upscale), and
- * `ai-generation.ts` (edit_image/edit_animated_caption).
- *
- * `edit_fill_gaps` is intentionally NOT in the manifest: its CLI .action()
- * body is ~400 lines of stateful Kling i2v + imgbb + ffmpeg orchestration
- * that hasn't been refactored into an `executeFillGaps()` shape yet
- * (tracked in cli-sync.test.ts SYNC_TABLE as null/null TODO v0.65 follow-up).
+ * @description Manifest entries for `vibe edit *` subcommands. The
+ * underlying executes live in:
+ *   - `commands/_shared/edit/*.ts` (silence-cut, caption, fade, noise-reduce,
+ *     jump-cut, text-overlay, translate-srt — Plan G Phase 3 split)
+ *   - `commands/edit-cmd.ts` (grade, speed-ramp, reframe, interpolate, upscale)
+ *   - `commands/ai-animated-caption.ts` + `commands/ai-image.ts`
+ *   - `commands/_shared/execute-fill-gaps.ts` (Plan G Phase 4 finishing piece)
  */
 
 import { z } from "zod";
@@ -31,6 +29,7 @@ import {
 } from "../../commands/edit-cmd.js";
 import { executeAnimatedCaption } from "../../commands/ai-animated-caption.js";
 import { executeGeminiEdit } from "../../commands/ai-image.js";
+import { executeFillGaps } from "../../commands/_shared/execute-fill-gaps.js";
 
 // ── edit_silence_cut ────────────────────────────────────────────────────────
 
@@ -418,6 +417,52 @@ export const editImageTool = defineTool({
   },
 });
 
+// ── edit_fill_gaps ─────────────────────────────────────────────────────────
+
+export const editFillGapsTool = defineTool({
+  name: "edit_fill_gaps",
+  category: "edit",
+  cost: "high",
+  description:
+    "Fill timeline gaps with AI-generated video using Kling image-to-video. Detects empty regions in a project's timeline, extracts the last frame of the preceding clip, and generates a continuation video. Requires KLING_API_KEY and IMGBB_API_KEY (image hosting for Kling).",
+  schema: z.object({
+    projectPath: z.string().describe("Project file path (.vibe.json)"),
+    output: z.string().optional().describe("Output project path (default: overwrite input)"),
+    dir: z.string().optional().describe("Directory to save generated videos (default: <projectDir>/footage)"),
+    prompt: z.string().optional().describe("Custom prompt for video generation (default: 'Continue the scene naturally with subtle motion')"),
+    dryRun: z.boolean().optional().describe("Show gaps without generating videos"),
+    mode: z.enum(["std", "pro"]).optional().describe("Kling generation mode (default: std)"),
+    ratio: z.enum(["16:9", "9:16", "1:1"]).optional().describe("Aspect ratio (default: 16:9)"),
+  }),
+  async execute(args) {
+    const result = await executeFillGaps({
+      projectPath: args.projectPath,
+      output: args.output,
+      dir: args.dir,
+      prompt: args.prompt,
+      dryRun: args.dryRun,
+      mode: args.mode,
+      ratio: args.ratio,
+    });
+    if (!result.success) {
+      return { success: false, error: result.error ?? "Fill gaps failed" };
+    }
+    return {
+      success: true,
+      data: {
+        outputPath: result.outputPath,
+        generatedCount: result.generatedCount ?? 0,
+        gaps: result.gaps,
+        gapsNeedingAI: result.gapsNeedingAI,
+        noGaps: result.noGaps ?? false,
+        allExtendable: result.allExtendable ?? false,
+        dryRun: result.dryRun ?? false,
+      },
+      humanLines: result.humanLines,
+    };
+  },
+});
+
 export const editTools: readonly AnyTool[] = [
   editSilenceCutTool as unknown as AnyTool,
   editCaptionTool as unknown as AnyTool,
@@ -433,4 +478,5 @@ export const editTools: readonly AnyTool[] = [
   editUpscaleTool as unknown as AnyTool,
   editAnimatedCaptionTool as unknown as AnyTool,
   editImageTool as unknown as AnyTool,
+  editFillGapsTool as unknown as AnyTool,
 ];

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -16,8 +16,8 @@ describe("@vibeframe/mcp-server", () => {
       expect(tools.length).toBeGreaterThan(0);
     });
 
-    it("should have 63 tools total", () => {
-      expect(tools.length).toBe(63);
+    it("should have 64 tools total", () => {
+      expect(tools.length).toBe(64);
     });
 
     it("should have correct tool structure", () => {

--- a/packages/mcp-server/src/tools/cli-sync.test.ts
+++ b/packages/mcp-server/src/tools/cli-sync.test.ts
@@ -83,7 +83,7 @@ const CLI_TO_MANIFEST: Record<string, string | null> = {
   "edit fade":          "edit_fade",
   "edit translate-srt": "edit_translate_srt",
   "edit jump-cut":      "edit_jump_cut",
-  "edit fill-gaps":     null, // TODO v0.66 — extract executeFillGaps from ~400-line .action()
+  "edit fill-gaps":     "edit_fill_gaps",
   "edit grade":         "edit_grade",
   "edit text-overlay":  "edit_text_overlay",
   "edit speed-ramp":    "edit_speed_ramp",


### PR DESCRIPTION
## Summary

Completes Plan G Phase 4. The 562-line \`.action()\` body in \`commands/ai-fill-gaps.ts\` is extracted into \`executeFillGaps()\` under \`commands/_shared/\`, and the manifest entry \`edit_fill_gaps\` calls the same function — closing the cli-sync.test.ts SYNC_TABLE null TODO open since v0.65.

## Changes

### New: \`commands/_shared/execute-fill-gaps.ts\` (~570 L)

\`executeFillGaps(options)\` returns \`ExecuteFillGapsResult\` with:
- \`success\`, \`error\`, \`humanLines\` (CLI prints; manifest joins)
- \`gaps\`, \`gapsNeedingAI\`, \`generatedCount\`, \`outputPath\`
- \`noGaps\` / \`allExtendable\` / \`dryRun\` flags for early-exit cases

The 50+ ora spinner / console.log / exitWithError calls in the original action body collapse into one \`onProgress\` callback + a \`humanLines\` array + structured returns. No CLI primitive leaks into the function — agent surface gets the same logic.

### Refactored: \`commands/ai-fill-gaps.ts\` (562 → 70 L)

Thin CLI wrapper. The \`.action()\` handler:
- Wires \`onProgress\` → ora spinner.text
- \`result.success === false\` → \`spinner.fail\` + \`exitWithError\`
- Success → \`spinner.succeed\` + prints \`result.humanLines\`

Identical UX to the pre-refactor experience.

### Manifest: \`edit_fill_gaps\`

Added to \`tools/manifest/edit.ts\`:
- Zod schema for the 7 options (projectPath, output, dir, prompt, dryRun, mode, ratio)
- \`cost: \"high\"\` (Kling video generation, \$\$)
- Description explains the dual key requirement (KLING + IMGBB)
- Result wraps the function's structured return + humanLines

### \`cli-sync.test.ts\`

\`\"edit fill-gaps\": null\` (v0.65 TODO) → \`\"edit fill-gaps\": \"edit_fill_gaps\"\`.
Manifest count: 79 → 80 (Agent), 63 → 64 (MCP).

## Updated counts (count drift fixes)

- \`packages/cli\` integration tests: 79 → 80 (total agent), 14 → 15 (edit category)
- \`packages/mcp-server\` index.test.ts: 63 → 64
- \`apps/web/app/layout.tsx\` fallback: \"63\" → \"64\"
- \`README.md\`: \"63 MCP tools\" / \"63 tools\" → 64 (3 occurrences)

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm -F @vibeframe/cli test\` — 652 passed
- [x] \`pnpm -F @vibeframe/mcp-server test\` — 46 passed
- [x] \`bash scripts/sync-counts.sh --check\` — green