### PR TITLE
feat(scene): unlock multi-provider composer (Claude / OpenAI / Gemini)

### DIFF
--- a/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
@@ -35,8 +35,33 @@ const baseCtx = {
   designMd,
   storyboardGlobal: "**Format:** 1920×1080",
   skillBundle,
+  provider: "claude" as const,
   apiKey: "sk-test",
 };
+
+/**
+ * Build a `callLLM` override for tests. Mirrors `defaultCallLLM`'s return
+ * shape — `{text, inputTokens, outputTokens}` — without going near any
+ * SDK. Either pass a single resolution to use for every call, or a
+ * function for per-call control (e.g. retry sequencing).
+ */
+function mockCallLLM(
+  resolution:
+    | { text: string; inputTokens?: number; outputTokens?: number }
+    | ((req: {
+        provider: "claude" | "openai" | "gemini";
+        apiKey: string;
+        model: string;
+        maxTokens: number;
+        systemPrompt: string;
+        userPrompt: string;
+      }) => Promise<{ text: string; inputTokens?: number; outputTokens?: number }>),
+) {
+  return vi.fn(async (req) => {
+    const r = typeof resolution === "function" ? await resolution(req) : resolution;
+    return { text: r.text, inputTokens: r.inputTokens ?? 1, outputTokens: r.outputTokens ?? 1 };
+  });
+}
 
 // ── Pure helpers ────────────────────────────────────────────────────────
 
@@ -90,25 +115,29 @@ describe("buildUserPrompt", () => {
 });
 
 describe("computeCacheKey", () => {
-  it("returns a stable sha256 hex for the same triple", () => {
-    const a = computeCacheKey({ systemPrompt: "S", userPrompt: "U", model: "M" });
-    const b = computeCacheKey({ systemPrompt: "S", userPrompt: "U", model: "M" });
+  const claude = "claude" as const;
+
+  it("returns a stable sha256 hex for the same tuple", () => {
+    const a = computeCacheKey({ provider: claude, systemPrompt: "S", userPrompt: "U", model: "M" });
+    const b = computeCacheKey({ provider: claude, systemPrompt: "S", userPrompt: "U", model: "M" });
     expect(a).toBe(b);
     expect(a).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it("changes when system / user / model differs", () => {
-    const base = computeCacheKey({ systemPrompt: "S", userPrompt: "U", model: "M" });
-    expect(computeCacheKey({ systemPrompt: "S2", userPrompt: "U", model: "M" })).not.toBe(base);
-    expect(computeCacheKey({ systemPrompt: "S", userPrompt: "U2", model: "M" })).not.toBe(base);
-    expect(computeCacheKey({ systemPrompt: "S", userPrompt: "U", model: "M2" })).not.toBe(base);
+  it("changes when provider / system / user / model differs", () => {
+    const base = computeCacheKey({ provider: claude, systemPrompt: "S", userPrompt: "U", model: "M" });
+    expect(computeCacheKey({ provider: "openai", systemPrompt: "S", userPrompt: "U", model: "M" })).not.toBe(base);
+    expect(computeCacheKey({ provider: "gemini", systemPrompt: "S", userPrompt: "U", model: "M" })).not.toBe(base);
+    expect(computeCacheKey({ provider: claude, systemPrompt: "S2", userPrompt: "U", model: "M" })).not.toBe(base);
+    expect(computeCacheKey({ provider: claude, systemPrompt: "S", userPrompt: "U2", model: "M" })).not.toBe(base);
+    expect(computeCacheKey({ provider: claude, systemPrompt: "S", userPrompt: "U", model: "M2" })).not.toBe(base);
   });
 
   it("avoids prefix collisions via record separator", () => {
     // Without separators, "AB" + "C" and "A" + "BC" would hash identically.
     // With ␞ (RECORD SEPARATOR) between fields, they don't.
-    const a = computeCacheKey({ systemPrompt: "AB", userPrompt: "C", model: "M" });
-    const b = computeCacheKey({ systemPrompt: "A", userPrompt: "BC", model: "M" });
+    const a = computeCacheKey({ provider: claude, systemPrompt: "AB", userPrompt: "C", model: "M" });
+    const b = computeCacheKey({ provider: claude, systemPrompt: "A", userPrompt: "BC", model: "M" });
     expect(a).not.toBe(b);
   });
 });
@@ -153,21 +182,22 @@ describe("composeBeatHtml", () => {
   });
 
   it("calls the API on cache miss and persists the HTML", async () => {
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: "```html\n<template>fresh</template>\n```" }],
-      usage: { input_tokens: 100, output_tokens: 50 },
+    const callLLM = mockCallLLM({
+      text: "```html\n<template>fresh</template>\n```",
+      inputTokens: 100,
+      outputTokens: 50,
     });
-    const client = { messages: { create } } as never;
 
-    const r = await composeBeatHtml({ ...baseCtx, cacheDir }, { client });
+    const r = await composeBeatHtml({ ...baseCtx, cacheDir }, { callLLM });
 
     expect(r.cached).toBe(false);
     expect(r.html).toBe("<template>fresh</template>");
     expect(r.inputTokens).toBe(100);
     expect(r.outputTokens).toBe(50);
+    expect(r.provider).toBe("claude");
     // Sonnet 4.6: 100/M * $3 + 50/M * $15 = $0.000300 + $0.000750 = $0.00105
     expect(r.costUsd).toBeCloseTo(0.0011, 4);
-    expect(create).toHaveBeenCalledOnce();
+    expect(callLLM).toHaveBeenCalledOnce();
 
     // Cache file written
     const written = readFileSync(join(cacheDir, `${r.cacheKey}.html`), "utf-8");
@@ -176,21 +206,18 @@ describe("composeBeatHtml", () => {
 
   it("returns cached HTML on hit without calling the API", async () => {
     // First call seeds the cache
-    const create1 = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: "```html\n<template>seeded</template>\n```" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    });
-    const r1 = await composeBeatHtml({ ...baseCtx, cacheDir }, { client: { messages: { create: create1 } } as never });
+    const callLLM1 = mockCallLLM({ text: "```html\n<template>seeded</template>\n```" });
+    const r1 = await composeBeatHtml({ ...baseCtx, cacheDir }, { callLLM: callLLM1 });
 
     // Second call with same input → cache hit
-    const create2 = vi.fn();
-    const r2 = await composeBeatHtml({ ...baseCtx, cacheDir }, { client: { messages: { create: create2 } } as never });
+    const callLLM2 = vi.fn();
+    const r2 = await composeBeatHtml({ ...baseCtx, cacheDir }, { callLLM: callLLM2 });
 
     expect(r1.cached).toBe(false);
     expect(r2.cached).toBe(true);
     expect(r2.html).toBe(r1.html);
     expect(r2.cacheKey).toBe(r1.cacheKey);
-    expect(create2).not.toHaveBeenCalled();
+    expect(callLLM2).not.toHaveBeenCalled();
     // Cache-hit results don't surface fresh-call metrics
     expect(r2.inputTokens).toBeUndefined();
     expect(r2.costUsd).toBeUndefined();
@@ -198,33 +225,44 @@ describe("composeBeatHtml", () => {
   });
 
   it("retry feedback changes the cache key (different prompt → fresh call)", async () => {
-    const create1 = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: "```html\n<template>v1</template>\n```" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    });
-    await composeBeatHtml({ ...baseCtx, cacheDir }, { client: { messages: { create: create1 } } as never });
+    const callLLM1 = mockCallLLM({ text: "```html\n<template>v1</template>\n```" });
+    await composeBeatHtml({ ...baseCtx, cacheDir }, { callLLM: callLLM1 });
 
-    const create2 = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: "```html\n<template>v2-after-retry</template>\n```" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    });
+    const callLLM2 = mockCallLLM({ text: "```html\n<template>v2-after-retry</template>\n```" });
     const r2 = await composeBeatHtml(
       { ...baseCtx, cacheDir, retryFeedback: "ERROR: missing class=\"clip\"" },
-      { client: { messages: { create: create2 } } as never },
+      { callLLM: callLLM2 },
     );
 
     expect(r2.cached).toBe(false);
-    expect(create2).toHaveBeenCalledOnce();
+    expect(callLLM2).toHaveBeenCalledOnce();
     expect(r2.html).toBe("<template>v2-after-retry</template>");
   });
 
+  it("provider id changes the cache key (different provider → fresh call)", async () => {
+    const callLLMa = mockCallLLM({ text: "```html\n<template>claude</template>\n```" });
+    const ra = await composeBeatHtml(
+      { ...baseCtx, provider: "claude", cacheDir },
+      { callLLM: callLLMa },
+    );
+
+    const callLLMb = mockCallLLM({ text: "```html\n<template>gemini</template>\n```" });
+    const rb = await composeBeatHtml(
+      { ...baseCtx, provider: "gemini", cacheDir },
+      { callLLM: callLLMb },
+    );
+
+    expect(ra.cacheKey).not.toBe(rb.cacheKey);
+    expect(rb.cached).toBe(false);
+    expect(callLLMb).toHaveBeenCalledOnce();
+  });
+
   it("throws ComposeBeatError when API call fails", async () => {
-    const create = vi.fn().mockRejectedValue(new Error("network unreachable"));
-    const client = { messages: { create } } as never;
+    const callLLM = vi.fn().mockRejectedValue(new Error("network unreachable"));
 
     await expect(
-      composeBeatHtml({ ...baseCtx, cacheDir }, { client }),
-    ).rejects.toThrowError(/Anthropic API call failed: network unreachable/);
+      composeBeatHtml({ ...baseCtx, cacheDir }, { callLLM }),
+    ).rejects.toThrowError(/claude API call failed: network unreachable/);
   });
 
   it("throws missing-api-key error when apiKey is empty AND cache miss", async () => {
@@ -235,11 +273,8 @@ describe("composeBeatHtml", () => {
 
   it("uses the cached value even when apiKey is empty (cache hit doesn't need a key)", async () => {
     // Seed cache
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: "```html\n<template>seeded</template>\n```" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    });
-    await composeBeatHtml({ ...baseCtx, cacheDir }, { client: { messages: { create } } as never });
+    const callLLM = mockCallLLM({ text: "```html\n<template>seeded</template>\n```" });
+    await composeBeatHtml({ ...baseCtx, cacheDir }, { callLLM });
 
     // Now drop apiKey — cache hit should still work
     const r = await composeBeatHtml({ ...baseCtx, apiKey: "", cacheDir });
@@ -247,15 +282,13 @@ describe("composeBeatHtml", () => {
     expect(r.html).toBe("<template>seeded</template>");
   });
 
-  it("effort=high uses higher max_tokens", async () => {
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: "```html\n<template>x</template>\n```" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    });
-    await composeBeatHtml({ ...baseCtx, cacheDir, effort: "high" }, { client: { messages: { create } } as never });
+  it("effort=high uses higher maxTokens", async () => {
+    const callLLM = mockCallLLM({ text: "```html\n<template>x</template>\n```" });
+    await composeBeatHtml({ ...baseCtx, cacheDir, effort: "high" }, { callLLM });
 
-    const args = create.mock.calls[0][0];
-    expect(args.max_tokens).toBe(8_000);
+    const args = callLLM.mock.calls[0][0];
+    expect(args.maxTokens).toBe(8_000);
+    expect(args.provider).toBe("claude");
   });
 });
 
@@ -356,60 +389,41 @@ describe("composeBeatWithRetry", () => {
   });
 
   it("returns lintAttempts=1 when first shot lints clean", async () => {
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: fenced(validHtml) }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    });
+    const callLLM = mockCallLLM({ text: fenced(validHtml) });
 
-    const r = await composeBeatWithRetry(
-      { ...baseCtx, cacheDir },
-      { client: { messages: { create } } as never },
-    );
+    const r = await composeBeatWithRetry({ ...baseCtx, cacheDir }, { callLLM });
 
     expect(r.lintAttempts).toBe(1);
     expect(r.lint.errorCount).toBe(0);
-    expect(create).toHaveBeenCalledOnce();
+    expect(callLLM).toHaveBeenCalledOnce();
   });
 
   it("retries with feedback when first shot fails lint, returns lintAttempts=2 on success", async () => {
-    const create = vi.fn()
-      .mockResolvedValueOnce({
-        content: [{ type: "text", text: fenced(invalidHtml) }],
-        usage: { input_tokens: 1, output_tokens: 1 },
-      })
-      .mockResolvedValueOnce({
-        content: [{ type: "text", text: fenced(validHtml) }],
-        usage: { input_tokens: 1, output_tokens: 1 },
-      });
+    const callLLM = vi.fn()
+      .mockResolvedValueOnce({ text: fenced(invalidHtml), inputTokens: 1, outputTokens: 1 })
+      .mockResolvedValueOnce({ text: fenced(validHtml), inputTokens: 1, outputTokens: 1 });
 
-    const r = await composeBeatWithRetry(
-      { ...baseCtx, cacheDir },
-      { client: { messages: { create } } as never },
-    );
+    const r = await composeBeatWithRetry({ ...baseCtx, cacheDir }, { callLLM });
 
     expect(r.lintAttempts).toBe(2);
     expect(r.lint.errorCount).toBe(0);
-    expect(create).toHaveBeenCalledTimes(2);
+    expect(callLLM).toHaveBeenCalledTimes(2);
 
     // Retry call's user prompt must include the lint findings as feedback
-    const retryArgs = create.mock.calls[1][0];
-    const retryUserMsg = retryArgs.messages[0].content;
-    expect(retryUserMsg).toContain("Previous attempt failed lint");
+    const retryArgs = callLLM.mock.calls[1][0];
+    expect(retryArgs.userPrompt).toContain("Previous attempt failed lint");
   });
 
   it("throws lint-failed-after-retry when both attempts fail", async () => {
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: fenced(invalidHtml) }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    });
+    const callLLM = mockCallLLM({ text: fenced(invalidHtml) });
 
     await expect(
-      composeBeatWithRetry({ ...baseCtx, cacheDir }, { client: { messages: { create } } as never }),
+      composeBeatWithRetry({ ...baseCtx, cacheDir }, { callLLM }),
     ).rejects.toMatchObject({
       name: "ComposeBeatError",
       code: "lint-failed-after-retry",
     });
-    expect(create).toHaveBeenCalledTimes(2);
+    expect(callLLM).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -461,16 +475,9 @@ describe("executeComposeScenesWithSkills", () => {
       "# Design\n\n## Palette\n- `#000000`\n",
       "**Format:** 1920x1080\n\n## Beat 1 — Hook\n\nbody1\n\n## Beat 2 — Outro\n\nbody2\n",
     );
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: fenceHtml(validSceneHtml) }],
-      usage: { input_tokens: 10, output_tokens: 5 },
-    });
+    const callLLM = mockCallLLM({ text: fenceHtml(validSceneHtml), inputTokens: 10, outputTokens: 5 });
 
-    const r = await executeComposeScenesWithSkills(
-      { cacheDir },
-      projectRoot,
-      { client: { messages: { create } } as never },
-    );
+    const r = await executeComposeScenesWithSkills({ cacheDir }, projectRoot, { callLLM });
 
     expect(r.success).toBe(true);
     expect(r.outputPath).toBe(projectRoot);
@@ -487,7 +494,7 @@ describe("executeComposeScenesWithSkills", () => {
     expect(c1).toBe(validSceneHtml);
     expect(c2).toBe(validSceneHtml);
 
-    expect(create).toHaveBeenCalledTimes(2);
+    expect(callLLM).toHaveBeenCalledTimes(2);
   });
 
   it("returns failure when DESIGN.md is missing", async () => {
@@ -519,10 +526,7 @@ describe("executeComposeScenesWithSkills", () => {
       "# d",
       "## Beat 1 — A\n\nbody\n\n## Beat 2 — B\n\nbody\n",
     );
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: fenceHtml(validSceneHtml) }],
-      usage: { input_tokens: 10, output_tokens: 5 },
-    });
+    const callLLM = mockCallLLM({ text: fenceHtml(validSceneHtml), inputTokens: 10, outputTokens: 5 });
     const events: string[] = [];
 
     await executeComposeScenesWithSkills(
@@ -531,7 +535,7 @@ describe("executeComposeScenesWithSkills", () => {
         onProgress: (e) => events.push(`${e.type}:${e.beatId}:${e.beatIndex}`),
       },
       projectRoot,
-      { client: { messages: { create } } as never },
+      { callLLM },
     );
 
     // Both beats fired through start → fresh (no cache hits on first run).
@@ -544,17 +548,14 @@ describe("executeComposeScenesWithSkills", () => {
 
   it("emits beat-cached on second run when content already cached", async () => {
     seedProject(projectRoot, "# d", "## Beat 1 — A\n\nbody\n");
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: fenceHtml(validSceneHtml) }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    });
+    const callLLM = mockCallLLM({ text: fenceHtml(validSceneHtml) });
 
     // First run — fresh.
     const events1: string[] = [];
     await executeComposeScenesWithSkills(
       { cacheDir, onProgress: (e) => events1.push(e.type) },
       projectRoot,
-      { client: { messages: { create } } as never },
+      { callLLM },
     );
     expect(events1).toContain("beat-fresh");
 
@@ -563,7 +564,7 @@ describe("executeComposeScenesWithSkills", () => {
     await executeComposeScenesWithSkills(
       { cacheDir, onProgress: (e) => events2.push(e.type) },
       projectRoot,
-      { client: { messages: { create } } as never },
+      { callLLM },
     );
     expect(events2).toContain("beat-cached");
     expect(events2).not.toContain("beat-fresh");
@@ -576,16 +577,9 @@ describe("executeComposeScenesWithSkills", () => {
       "## Beat 1 — Bad\n\nbody\n\n## Beat 2 — AlsoBad\n\nbody\n",
     );
     // Every call returns invalid HTML → both beats fail twice → both throw.
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: fenceHtml("<template id=\"x\"><div>nope</div></template>") }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    });
+    const callLLM = mockCallLLM({ text: fenceHtml("<template id=\"x\"><div>nope</div></template>") });
 
-    const r = await executeComposeScenesWithSkills(
-      { cacheDir },
-      projectRoot,
-      { client: { messages: { create } } as never },
-    );
+    const r = await executeComposeScenesWithSkills({ cacheDir }, projectRoot, { callLLM });
 
     expect(r.success).toBe(false);
     // Both beat ids appear in the aggregated error (deriveBeatId → "1", "2")
@@ -593,7 +587,7 @@ describe("executeComposeScenesWithSkills", () => {
     expect(r.error).toContain("- 2: ");
     expect(r.error).toMatch(/failed at 2 beats/);
     // 4 calls total: 2 beats × 2 attempts (initial + retry)
-    expect(create).toHaveBeenCalledTimes(4);
+    expect(callLLM).toHaveBeenCalledTimes(4);
   });
 
   it("aborts on first beat failure and reports partial progress", async () => {
@@ -603,25 +597,12 @@ describe("executeComposeScenesWithSkills", () => {
       "## Beat 1 — Good\n\nbody\n\n## Beat 2 — Bad\n\nbody\n",
     );
     // First beat: good HTML. Second beat: invalid HTML → fails lint twice → throws.
-    const create = vi.fn()
-      .mockResolvedValueOnce({  // beat 1 — valid
-        content: [{ type: "text", text: fenceHtml(validSceneHtml) }],
-        usage: { input_tokens: 1, output_tokens: 1 },
-      })
-      .mockResolvedValueOnce({  // beat 2 first attempt — invalid
-        content: [{ type: "text", text: fenceHtml("<template id=\"x\"><div>nope</div></template>") }],
-        usage: { input_tokens: 1, output_tokens: 1 },
-      })
-      .mockResolvedValueOnce({  // beat 2 retry — also invalid
-        content: [{ type: "text", text: fenceHtml("<template id=\"x\"><div>still nope</div></template>") }],
-        usage: { input_tokens: 1, output_tokens: 1 },
-      });
+    const callLLM = vi.fn()
+      .mockResolvedValueOnce({ text: fenceHtml(validSceneHtml), inputTokens: 1, outputTokens: 1 })
+      .mockResolvedValueOnce({ text: fenceHtml("<template id=\"x\"><div>nope</div></template>"), inputTokens: 1, outputTokens: 1 })
+      .mockResolvedValueOnce({ text: fenceHtml("<template id=\"x\"><div>still nope</div></template>"), inputTokens: 1, outputTokens: 1 });
 
-    const r = await executeComposeScenesWithSkills(
-      { cacheDir },
-      projectRoot,
-      { client: { messages: { create } } as never },
-    );
+    const r = await executeComposeScenesWithSkills({ cacheDir }, projectRoot, { callLLM });
 
     expect(r.success).toBe(false);
     expect(r.error).toContain('compose-scenes-with-skills failed at beat "2"');

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.ts
@@ -26,6 +26,8 @@
  */
 
 import Anthropic from "@anthropic-ai/sdk";
+import OpenAI from "openai";
+import { GoogleGenerativeAI } from "@google/generative-ai";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
@@ -40,8 +42,13 @@ import {
 import { loadHyperframesSkillBundle } from "./hf-skill-bundle/bundle.js";
 import { filterSubCompFalsePositives, type LintFinding } from "./scene-lint.js";
 import { parseStoryboard, type Beat } from "./storyboard-parse.js";
+import {
+  type ComposerProvider,
+  resolveComposer,
+  composerEnvVar,
+} from "./composer-resolve.js";
 
-/** Effort level → model + token caps. */
+/** Effort level → token caps. Model is per-provider (see MODEL_SETTINGS_BY_PROVIDER). */
 export type ComposeEffort = "low" | "medium" | "high";
 
 interface ModelSettings {
@@ -52,11 +59,34 @@ interface ModelSettings {
   costPerMTokOut: number;
 }
 
-const MODEL_SETTINGS: Record<ComposeEffort, ModelSettings> = {
-  // Sonnet 4.6 — pre-flight validated default. $3/$15 per MTok.
-  low:    { model: "claude-sonnet-4-6", maxTokens: 4_000, costPerMTokIn: 3,  costPerMTokOut: 15 },
-  medium: { model: "claude-sonnet-4-6", maxTokens: 6_000, costPerMTokIn: 3,  costPerMTokOut: 15 },
-  high:   { model: "claude-sonnet-4-6", maxTokens: 8_000, costPerMTokIn: 3,  costPerMTokOut: 15 },
+/**
+ * Model + cost caps per (provider, effort). Tier currently only varies
+ * `maxTokens`; quality differences across tiers were collapsed in the v0.70
+ * spike (all three providers passed first-shot lint at every tier on the
+ * vibeframe-promo beats — see `scripts-spike-composer-providers.mts`).
+ */
+const MODEL_SETTINGS_BY_PROVIDER: Record<ComposerProvider, Record<ComposeEffort, ModelSettings>> = {
+  // Anthropic Claude Sonnet 4.6 — v0.69 baseline. ~9 s/beat, $3/$15 per MTok.
+  claude: {
+    low:    { model: "claude-sonnet-4-6", maxTokens: 4_000, costPerMTokIn: 3, costPerMTokOut: 15 },
+    medium: { model: "claude-sonnet-4-6", maxTokens: 6_000, costPerMTokIn: 3, costPerMTokOut: 15 },
+    high:   { model: "claude-sonnet-4-6", maxTokens: 8_000, costPerMTokIn: 3, costPerMTokOut: 15 },
+  },
+  // OpenAI gpt-5 — high reasoning latency (~70 s/beat in spike) but matches
+  // Claude on cost. Picked as default because spike-validated; users may
+  // prefer a faster/lower model via env override in a follow-up.
+  openai: {
+    low:    { model: "gpt-5", maxTokens: 4_000, costPerMTokIn: 1.25, costPerMTokOut: 10 },
+    medium: { model: "gpt-5", maxTokens: 6_000, costPerMTokIn: 1.25, costPerMTokOut: 10 },
+    high:   { model: "gpt-5", maxTokens: 8_000, costPerMTokIn: 1.25, costPerMTokOut: 10 },
+  },
+  // Google Gemini 2.5 Pro — ~2.6× cheaper than Claude per spike, ~20 s/beat.
+  // Strong instruction-following on the Hyperframes skill bundle.
+  gemini: {
+    low:    { model: "gemini-2.5-pro", maxTokens: 4_000, costPerMTokIn: 1.25, costPerMTokOut: 5 },
+    medium: { model: "gemini-2.5-pro", maxTokens: 6_000, costPerMTokIn: 1.25, costPerMTokOut: 5 },
+    high:   { model: "gemini-2.5-pro", maxTokens: 8_000, costPerMTokIn: 1.25, costPerMTokOut: 5 },
+  },
 };
 
 export interface ComposeBeatContext {
@@ -76,7 +106,13 @@ export interface ComposeBeatContext {
    * the cached first-shot HTML.
    */
   retryFeedback?: string;
-  /** Anthropic API key. */
+  /**
+   * LLM provider that powers the composer. Picked by `resolveComposer()` at
+   * the entry point (CLI flag → env auto-resolve). The `apiKey` field below
+   * is the matching key for this provider.
+   */
+  provider: ComposerProvider;
+  /** API key for {@link ComposeBeatContext.provider}. */
   apiKey: string;
   /**
    * Cache directory override. Defaults to `~/.vibeframe/cache/compose-scenes/`.
@@ -92,9 +128,9 @@ export interface ComposeBeatResult {
   cached: boolean;
   /** Cache key used (sha256 hex). */
   cacheKey: string;
-  /** Anthropic input tokens (only set on fresh API call). */
+  /** Provider input tokens (only set on fresh API call). */
   inputTokens?: number;
-  /** Anthropic output tokens (only set on fresh API call). */
+  /** Provider output tokens (only set on fresh API call). */
   outputTokens?: number;
   /** USD cost of this beat (only set on fresh API call). */
   costUsd?: number;
@@ -102,6 +138,8 @@ export interface ComposeBeatResult {
   latencyMs?: number;
   /** Resolved model id (e.g. "claude-sonnet-4-6"). */
   model: string;
+  /** Composer provider that produced this beat. */
+  provider: ComposerProvider;
 }
 
 // ── Prompt construction (pure) ──────────────────────────────────────────
@@ -274,15 +312,22 @@ ${ctx.retryFeedback.trim()}`;
   return baseRequirements;
 }
 
-/** Compute the sha256 cache key for a (system, user, model) triple. */
+/**
+ * Compute the sha256 cache key for a (provider, model, system, user) tuple.
+ * Provider id is folded in so switching `--composer` doesn't serve cached
+ * HTML produced by a different model.
+ */
 export function computeCacheKey(parts: {
+  provider: ComposerProvider;
   systemPrompt: string;
   userPrompt: string;
   model: string;
 }): string {
   return createHash("sha256")
-    .update(parts.model)
+    .update(parts.provider)
     .update("␞") // RECORD SEPARATOR
+    .update(parts.model)
+    .update("␞")
     .update(parts.systemPrompt)
     .update("␞")
     .update(parts.userPrompt)
@@ -321,24 +366,107 @@ export class ComposeBeatError extends Error {
   }
 }
 
+// ── Provider dispatch ───────────────────────────────────────────────────
+
+/** Raw text-completion result from any of the three providers. */
+export interface LLMCallResult {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/** Injectable LLM call function — used by tests to mock the SDK calls. */
+export type LLMCallFn = (req: {
+  provider: ComposerProvider;
+  apiKey: string;
+  model: string;
+  maxTokens: number;
+  systemPrompt: string;
+  userPrompt: string;
+}) => Promise<LLMCallResult>;
+
+const defaultCallLLM: LLMCallFn = async (req) => {
+  if (req.provider === "claude") {
+    const client = new Anthropic({ apiKey: req.apiKey });
+    const response = await client.messages.create({
+      model: req.model,
+      max_tokens: req.maxTokens,
+      system: req.systemPrompt,
+      messages: [{ role: "user", content: req.userPrompt }],
+    });
+    if (!("content" in response) || !Array.isArray(response.content)) {
+      throw new ComposeBeatError("unexpected-response-shape", "Anthropic response missing `content` array.");
+    }
+    const block = response.content.find((b) => b.type === "text");
+    if (!block || block.type !== "text") {
+      throw new ComposeBeatError("no-text-block", "Anthropic response had no text block.");
+    }
+    return {
+      text: block.text,
+      inputTokens: (response as { usage?: { input_tokens?: number } }).usage?.input_tokens ?? 0,
+      outputTokens: (response as { usage?: { output_tokens?: number } }).usage?.output_tokens ?? 0,
+    };
+  }
+  if (req.provider === "openai") {
+    const client = new OpenAI({ apiKey: req.apiKey });
+    const response = await client.chat.completions.create({
+      model: req.model,
+      max_completion_tokens: req.maxTokens,
+      messages: [
+        { role: "system", content: req.systemPrompt },
+        { role: "user", content: req.userPrompt },
+      ],
+    });
+    const text = response.choices[0]?.message?.content ?? "";
+    if (!text) {
+      throw new ComposeBeatError("no-text-block", "OpenAI response had no text content.");
+    }
+    return {
+      text,
+      inputTokens: response.usage?.prompt_tokens ?? 0,
+      outputTokens: response.usage?.completion_tokens ?? 0,
+    };
+  }
+  // gemini
+  const client = new GoogleGenerativeAI(req.apiKey);
+  const model = client.getGenerativeModel({ model: req.model, systemInstruction: req.systemPrompt });
+  const response = await model.generateContent({
+    contents: [{ role: "user", parts: [{ text: req.userPrompt }] }],
+    generationConfig: { maxOutputTokens: req.maxTokens },
+  });
+  const text = response.response.text();
+  if (!text) {
+    throw new ComposeBeatError("no-text-block", "Gemini response had no text content.");
+  }
+  const usage = response.response.usageMetadata;
+  return {
+    text,
+    inputTokens: usage?.promptTokenCount ?? 0,
+    outputTokens: usage?.candidatesTokenCount ?? 0,
+  };
+};
+
 // ── Main entry ──────────────────────────────────────────────────────────
 
 /**
- * Compose one beat into HTML. Cache-first; on miss, call Claude.
+ * Compose one beat into HTML. Cache-first; on miss, call the configured
+ * composer provider (Claude / OpenAI / Gemini — picked at the entry point
+ * via `resolveComposer()` and threaded through `ctx.provider`).
  *
- * @param overrides allows tests to inject a mock Anthropic client. In prod
- *   we always construct from `ctx.apiKey`.
+ * @param overrides allows tests to inject a mocked LLM call. In prod we use
+ *   `defaultCallLLM` which dispatches to the matching SDK.
  */
 export async function composeBeatHtml(
   ctx: ComposeBeatContext,
-  overrides?: { client?: Anthropic; now?: () => number },
+  overrides?: { callLLM?: LLMCallFn; now?: () => number },
 ): Promise<ComposeBeatResult> {
   const effort: ComposeEffort = ctx.effort ?? "medium";
-  const settings = MODEL_SETTINGS[effort];
+  const settings = MODEL_SETTINGS_BY_PROVIDER[ctx.provider][effort];
 
   const systemPrompt = buildSystemPrompt(ctx);
   const userPrompt = buildUserPrompt(ctx);
   const cacheKey = computeCacheKey({
+    provider: ctx.provider,
     systemPrompt,
     userPrompt,
     model: settings.model,
@@ -350,49 +478,41 @@ export async function composeBeatHtml(
   // Cache-first.
   if (existsSync(cachePath)) {
     const html = await readFile(cachePath, "utf-8");
-    return { html, cached: true, cacheKey, model: settings.model };
+    return { html, cached: true, cacheKey, model: settings.model, provider: ctx.provider };
   }
 
-  // Cache miss → call Claude.
+  // Cache miss → call provider.
   if (!ctx.apiKey) {
     throw new ComposeBeatError(
       "missing-api-key",
-      "ANTHROPIC_API_KEY required for compose-scenes-with-skills (set it in env or .env).",
+      `${composerEnvVar(ctx.provider)} required for compose-scenes-with-skills (set it in env or .env).`,
     );
   }
-  const client = overrides?.client ?? new Anthropic({ apiKey: ctx.apiKey });
+  const callLLM = overrides?.callLLM ?? defaultCallLLM;
   const now = overrides?.now ?? (() => Date.now());
 
   const t0 = now();
-  let response: Awaited<ReturnType<Anthropic["messages"]["create"]>>;
+  let result: LLMCallResult;
   try {
-    response = await client.messages.create({
+    result = await callLLM({
+      provider: ctx.provider,
+      apiKey: ctx.apiKey,
       model: settings.model,
-      max_tokens: settings.maxTokens,
-      system: systemPrompt,
-      messages: [{ role: "user", content: userPrompt }],
+      maxTokens: settings.maxTokens,
+      systemPrompt,
+      userPrompt,
     });
   } catch (err) {
+    if (err instanceof ComposeBeatError) throw err;
     throw new ComposeBeatError(
       "api-call-failed",
-      `Anthropic API call failed: ${err instanceof Error ? err.message : String(err)}`,
+      `${ctx.provider} API call failed: ${err instanceof Error ? err.message : String(err)}`,
       err,
     );
   }
   const latencyMs = now() - t0;
 
-  // Anthropic SDK v0.39 returns either a Message (non-streaming) or a stream.
-  // Our `stream` is unset so we get a Message. Narrow + extract text.
-  if (!("content" in response) || !Array.isArray(response.content)) {
-    throw new ComposeBeatError("unexpected-response-shape", "Anthropic response missing `content` array.");
-  }
-  const textBlock = response.content.find((b) => b.type === "text");
-  if (!textBlock || textBlock.type !== "text") {
-    throw new ComposeBeatError("no-text-block", "Anthropic response had no text block.");
-  }
-
-  // textBlock.type === "text" narrows to TextBlock which has `text: string`.
-  const html = extractHtml(textBlock.text);
+  const html = extractHtml(result.text);
 
   // Persist to cache (best-effort — failures don't surface as composer
   // errors; the html is still returned).
@@ -403,21 +523,19 @@ export async function composeBeatHtml(
     // ignore — caller still gets the HTML
   }
 
-  // SDK shape: response.usage.{input_tokens, output_tokens}. Both numbers.
-  const inputTokens = (response as { usage?: { input_tokens?: number } }).usage?.input_tokens ?? 0;
-  const outputTokens = (response as { usage?: { output_tokens?: number } }).usage?.output_tokens ?? 0;
-  const costUsd = (inputTokens / 1_000_000) * settings.costPerMTokIn
-    + (outputTokens / 1_000_000) * settings.costPerMTokOut;
+  const costUsd = (result.inputTokens / 1_000_000) * settings.costPerMTokIn
+    + (result.outputTokens / 1_000_000) * settings.costPerMTokOut;
 
   return {
     html,
     cached: false,
     cacheKey,
-    inputTokens,
-    outputTokens,
+    inputTokens: result.inputTokens,
+    outputTokens: result.outputTokens,
     costUsd: Number(costUsd.toFixed(4)),
     latencyMs,
     model: settings.model,
+    provider: ctx.provider,
   };
 }
 
@@ -491,7 +609,7 @@ export interface ComposeBeatWithRetryResult extends ComposeBeatResult {
  */
 export async function composeBeatWithRetry(
   ctx: ComposeBeatContext,
-  overrides?: { client?: Anthropic; now?: () => number },
+  overrides?: { callLLM?: LLMCallFn; now?: () => number },
 ): Promise<ComposeBeatWithRetryResult> {
   // Attempt 1 — no retry feedback (cache-friendly first shot).
   const first = await composeBeatHtml(ctx, overrides);
@@ -550,6 +668,11 @@ export interface ComposeScenesParams {
   project?: string;
   /** Effort tier — low/medium/high. Defaults to medium. */
   effort?: ComposeEffort;
+  /**
+   * Composer provider override. When undefined, `resolveComposer()` picks
+   * one based on env keys (`claude > gemini > openai` order).
+   */
+  composer?: ComposerProvider;
   /** Override the cache directory (tests). */
   cacheDir?: string;
   /** Optional per-beat progress callback (CLI spinner / pipeline reporter). */
@@ -590,7 +713,7 @@ export interface ComposeScenesActionResult {
 export async function executeComposeScenesWithSkills(
   params: ComposeScenesParams,
   outputDir: string,
-  overrides?: { client?: Anthropic; now?: () => number },
+  overrides?: { callLLM?: LLMCallFn; now?: () => number },
 ): Promise<ComposeScenesActionResult> {
   const projectRoot = params.project ? resolve(outputDir, params.project) : resolve(outputDir);
   const designPath = resolve(projectRoot, params.design ?? "DESIGN.md");
@@ -617,8 +740,25 @@ export async function executeComposeScenesWithSkills(
   const skillBundleLoaded = loadHyperframesSkillBundle();
   const skillBundle = { content: skillBundleLoaded.content, hash: skillBundleLoaded.hash };
 
-  // Allow cache hit even when no API key — only fail when an actual call would be made.
-  const apiKey = process.env.ANTHROPIC_API_KEY ?? "";
+  // Resolve the composer provider + key. Cache hits are still allowed when
+  // no key is present, so we only surface an error if a fresh call needs
+  // to be made (handled inside `composeBeatHtml`). For cache-only runs,
+  // pick the explicit provider if supplied, else default to claude (so the
+  // cache key matches whatever wrote the entry).
+  let provider: ComposerProvider;
+  let apiKey: string;
+  try {
+    const resolved = resolveComposer(params.composer);
+    provider = resolved.provider;
+    apiKey = resolved.apiKey;
+  } catch {
+    // No keys present — degrade gracefully so cache hits still work. The
+    // mismatch (e.g. cache was written by claude but we now report 'claude'
+    // even though the user has no Anthropic key) is fine: cache lookup
+    // succeeds → result returned without API call.
+    provider = params.composer ?? "claude";
+    apiKey = "";
+  }
 
   const compositionsDir = join(projectRoot, "compositions");
   await mkdir(compositionsDir, { recursive: true });
@@ -653,6 +793,7 @@ export async function executeComposeScenesWithSkills(
           designMd,
           storyboardGlobal,
           skillBundle,
+          provider,
           apiKey,
           effort: params.effort,
           cacheDir: params.cacheDir,

--- a/packages/cli/src/commands/_shared/composer-resolve.test.ts
+++ b/packages/cli/src/commands/_shared/composer-resolve.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ComposerResolveError,
+  composerEnvVar,
+  composerLabel,
+  isComposerProvider,
+  resolveComposer,
+} from "./composer-resolve.js";
+
+describe("composer-resolve", () => {
+  // Snapshot all three keys so tests can mutate freely without leaking state.
+  const originals = {
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+  };
+
+  beforeEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(originals)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  describe("isComposerProvider", () => {
+    it("accepts the three valid ids", () => {
+      expect(isComposerProvider("claude")).toBe(true);
+      expect(isComposerProvider("openai")).toBe(true);
+      expect(isComposerProvider("gemini")).toBe(true);
+    });
+    it("rejects anything else", () => {
+      expect(isComposerProvider("anthropic")).toBe(false);
+      expect(isComposerProvider("gpt")).toBe(false);
+      expect(isComposerProvider("")).toBe(false);
+      expect(isComposerProvider(undefined)).toBe(false);
+      expect(isComposerProvider(123)).toBe(false);
+    });
+  });
+
+  describe("composerEnvVar / composerLabel", () => {
+    it("maps each provider to its canonical env var", () => {
+      expect(composerEnvVar("claude")).toBe("ANTHROPIC_API_KEY");
+      expect(composerEnvVar("openai")).toBe("OPENAI_API_KEY");
+      expect(composerEnvVar("gemini")).toBe("GOOGLE_API_KEY");
+    });
+    it("returns a human label for each provider", () => {
+      expect(composerLabel("claude")).toContain("Claude");
+      expect(composerLabel("openai")).toContain("OpenAI");
+      expect(composerLabel("gemini")).toContain("Gemini");
+    });
+  });
+
+  describe("resolveComposer", () => {
+    it("auto-resolves to claude when ANTHROPIC_API_KEY is set", () => {
+      process.env.ANTHROPIC_API_KEY = "sk-ant-x";
+      const r = resolveComposer();
+      expect(r).toEqual({ provider: "claude", apiKey: "sk-ant-x" });
+    });
+
+    it("auto-resolves to gemini when only GOOGLE_API_KEY is set", () => {
+      process.env.GOOGLE_API_KEY = "key-google";
+      const r = resolveComposer();
+      expect(r).toEqual({ provider: "gemini", apiKey: "key-google" });
+    });
+
+    it("auto-resolves to openai when only OPENAI_API_KEY is set", () => {
+      process.env.OPENAI_API_KEY = "sk-openai";
+      const r = resolveComposer();
+      expect(r).toEqual({ provider: "openai", apiKey: "sk-openai" });
+    });
+
+    it("prefers claude > gemini > openai when multiple keys present", () => {
+      process.env.ANTHROPIC_API_KEY = "a";
+      process.env.GOOGLE_API_KEY = "g";
+      process.env.OPENAI_API_KEY = "o";
+      expect(resolveComposer().provider).toBe("claude");
+
+      delete process.env.ANTHROPIC_API_KEY;
+      expect(resolveComposer().provider).toBe("gemini");
+
+      delete process.env.GOOGLE_API_KEY;
+      expect(resolveComposer().provider).toBe("openai");
+    });
+
+    it("returns the explicit provider when set + key present", () => {
+      process.env.ANTHROPIC_API_KEY = "sk-ant";
+      process.env.GOOGLE_API_KEY = "key-google";
+      const r = resolveComposer("gemini");
+      expect(r).toEqual({ provider: "gemini", apiKey: "key-google" });
+    });
+
+    it("throws ComposerResolveError when no keys are set", () => {
+      try {
+        resolveComposer();
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ComposerResolveError);
+        expect((err as ComposerResolveError).code).toBe("no-key-available");
+        expect((err as Error).message).toContain("ANTHROPIC_API_KEY");
+        expect((err as Error).message).toContain("OPENAI_API_KEY");
+        expect((err as Error).message).toContain("GOOGLE_API_KEY");
+      }
+    });
+
+    it("throws ComposerResolveError when explicit provider's key is missing", () => {
+      process.env.ANTHROPIC_API_KEY = "sk-ant";
+      try {
+        resolveComposer("openai");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ComposerResolveError);
+        expect((err as ComposerResolveError).code).toBe("missing-explicit-key");
+        expect((err as ComposerResolveError).meta.requestedProvider).toBe("openai");
+        expect((err as Error).message).toContain("OPENAI_API_KEY");
+      }
+    });
+
+    it("treats empty-string keys as absent", () => {
+      process.env.ANTHROPIC_API_KEY = "";
+      process.env.GOOGLE_API_KEY = "valid";
+      expect(resolveComposer().provider).toBe("gemini");
+    });
+  });
+});

--- a/packages/cli/src/commands/_shared/composer-resolve.ts
+++ b/packages/cli/src/commands/_shared/composer-resolve.ts
@@ -1,0 +1,107 @@
+/**
+ * @module _shared/composer-resolve
+ *
+ * Picks the LLM provider that powers `compose-scenes-with-skills`. Until
+ * v0.69 the composer was hardcoded to Anthropic Claude Sonnet 4.6; v0.70
+ * exposes Claude / OpenAI / Gemini as interchangeable backends behind the
+ * same Hyperframes skill-bundle prompt (Phase 0 spike validated that all
+ * three pass first-shot lint on the same prompts — see
+ * `scripts-spike-composer-providers.mts` for the data).
+ *
+ * Auto-resolve preserves the v0.69 default (Claude) when the user has an
+ * `ANTHROPIC_API_KEY` set. Without one we fall back to Gemini (cheapest of
+ * the three per the spike) and then OpenAI. Explicit `--composer <name>`
+ * always wins.
+ */
+
+export type ComposerProvider = "claude" | "openai" | "gemini";
+
+export interface ComposerResolution {
+  provider: ComposerProvider;
+  apiKey: string;
+}
+
+const ENV_VAR: Record<ComposerProvider, string> = {
+  claude: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  gemini: "GOOGLE_API_KEY",
+};
+
+const PROVIDER_LABEL: Record<ComposerProvider, string> = {
+  claude: "Anthropic Claude",
+  openai: "OpenAI",
+  gemini: "Google Gemini",
+};
+
+/** Env var name for a provider's composer key. */
+export function composerEnvVar(provider: ComposerProvider): string {
+  return ENV_VAR[provider];
+}
+
+/** Human label for error messages. */
+export function composerLabel(provider: ComposerProvider): string {
+  return PROVIDER_LABEL[provider];
+}
+
+/** Read the API key for one provider from the current environment. */
+function readKey(provider: ComposerProvider): string | undefined {
+  const v = process.env[ENV_VAR[provider]];
+  return v && v.length > 0 ? v : undefined;
+}
+
+/** Validate a composer string supplied via CLI flag / pipeline YAML. */
+export function isComposerProvider(value: unknown): value is ComposerProvider {
+  return value === "claude" || value === "openai" || value === "gemini";
+}
+
+/**
+ * Resolve a composer provider + key.
+ *
+ * `explicit` takes precedence — if it's set, we require its key and return
+ * exactly that provider. With no `explicit`, we walk the auto-resolve order
+ * (`claude > gemini > openai`) and return the first provider whose key is
+ * present.
+ *
+ * Throws `ComposerResolveError` if (a) `explicit` was set but its key is
+ * missing, or (b) no provider's key is present.
+ */
+export function resolveComposer(explicit?: ComposerProvider): ComposerResolution {
+  if (explicit) {
+    const key = readKey(explicit);
+    if (!key) {
+      throw new ComposerResolveError(
+        "missing-explicit-key",
+        `${PROVIDER_LABEL[explicit]} requires ${ENV_VAR[explicit]} to be set in your env or .env file.`,
+        { requestedProvider: explicit },
+      );
+    }
+    return { provider: explicit, apiKey: key };
+  }
+
+  // Auto-resolve order picked by the v0.70 spike:
+  //   1. claude — fastest (~9 s/beat) and the v0.69 default (no breakage)
+  //   2. gemini — ~2.6× cheaper than Claude, ~20 s/beat
+  //   3. openai — comparable cost to Claude but ~70 s/beat (gpt-5 reasoning)
+  for (const candidate of ["claude", "gemini", "openai"] as const) {
+    const key = readKey(candidate);
+    if (key) return { provider: candidate, apiKey: key };
+  }
+
+  throw new ComposerResolveError(
+    "no-key-available",
+    `No composer API key found. Set one of: ${(["claude", "gemini", "openai"] as const)
+      .map((p) => ENV_VAR[p])
+      .join(", ")}.`,
+  );
+}
+
+export class ComposerResolveError extends Error {
+  constructor(
+    public readonly code: "missing-explicit-key" | "no-key-available",
+    message: string,
+    public readonly meta: { requestedProvider?: ComposerProvider } = {},
+  ) {
+    super(message);
+    this.name = "ComposerResolveError";
+  }
+}

--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -116,6 +116,22 @@ API keys live in \`.env\` (gitignored). Copy \`.env.example\` to start. Run
 \`vibe doctor\` to see which keys are currently detected and which providers
 they unlock.
 
+### Scene composer (LLM that writes scene HTML for \`scene build\`)
+
+\`vibe scene build\` runs an LLM with the vendored Hyperframes skill bundle
+to compose per-beat HTML. It auto-picks based on available keys
+(\`claude > gemini > openai\`) — pass \`--composer <name>\` to force one:
+
+| Provider | Env var | Spike notes (v0.70) |
+|---|---|---|
+| Claude (default) | \`ANTHROPIC_API_KEY\` | ~9 s/beat. Fastest, validated baseline. |
+| Gemini | \`GOOGLE_API_KEY\` | ~20 s/beat. ~2.6× cheaper than Claude. |
+| OpenAI | \`OPENAI_API_KEY\` | ~70 s/beat. gpt-5 reasoning latency — opt-in only. |
+
+All three pass first-shot lint at every effort tier on the \`vibeframe-promo\`
+fixture. Quality on more complex storyboards may differ — fall back to
+\`--composer claude\` if a non-default provider repeatedly fails lint.
+
 ## Project conventions
 
 <!-- Edit this section with YOUR project's specifics. Examples below. -->

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -31,6 +31,7 @@ import {
   type ComposeProgressEvent,
   type ComposeScenesActionResult,
 } from "./compose-scenes-skills.js";
+import type { ComposerProvider } from "./composer-resolve.js";
 import { executeSceneRender, type SceneRenderResult } from "./scene-render.js";
 import { parseStoryboard, type Beat } from "./storyboard-parse.js";
 import {
@@ -77,6 +78,12 @@ export interface SceneBuildOptions {
   projectDir: string;
   /** Compose effort tier — passed through to `compose-scenes-with-skills`. */
   effort?: ComposeEffort;
+  /**
+   * Composer LLM provider. Defaults to whatever `resolveComposer()` picks
+   * based on env keys (claude > gemini > openai). Pass an explicit value
+   * to require that provider's key.
+   */
+  composer?: ComposerProvider;
   skipNarration?: boolean;
   skipBackdrop?: boolean;
   skipRender?: boolean;
@@ -162,6 +169,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     {
       project: ".",
       effort: opts.effort,
+      composer: opts.composer,
       cacheDir: opts.cacheDir,
       onProgress: (e) => onProgress(e),
     },

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -1017,6 +1017,7 @@ sceneCommand
   .description("One-shot: read STORYBOARD.md cues, dispatch TTS + image-gen per beat, compose, render to MP4 (v0.60)")
   .argument("[project-dir]", "Project directory containing STORYBOARD.md", ".")
   .option("--effort <level>", "Compose effort tier: low|medium|high", "medium")
+  .option("--composer <provider>", "LLM that composes scene HTML: claude|openai|gemini (default: auto-resolve from available API keys, claude > gemini > openai)")
   .option("--skip-narration", "Don't dispatch TTS even when beats declare narration cues")
   .option("--skip-backdrop", "Don't dispatch image-gen even when beats declare backdrop cues")
   .option("--skip-render", "Compose only — don't render to MP4")
@@ -1037,6 +1038,7 @@ sceneCommand
         params: {
           projectDir,
           effort: options.effort,
+          composer: options.composer,
           skipNarration: options.skipNarration ?? false,
           skipBackdrop: options.skipBackdrop ?? false,
           skipRender: options.skipRender ?? false,
@@ -1056,11 +1058,17 @@ sceneCommand
       exitWithError(usageError(`Invalid --effort: ${options.effort}`, `Must be one of: ${validEfforts.join(", ")}`));
     }
 
+    const validComposers = ["claude", "openai", "gemini"] as const;
+    if (options.composer !== undefined && !validComposers.includes(options.composer)) {
+      exitWithError(usageError(`Invalid --composer: ${options.composer}`, `Must be one of: ${validComposers.join(", ")}`));
+    }
+
     const spinner = isJsonMode() ? null : ora("Reading STORYBOARD.md...").start();
 
     const result = await executeSceneBuild({
       projectDir,
       effort: options.effort,
+      composer: options.composer,
       skipNarration: options.skipNarration,
       skipBackdrop: options.skipBackdrop,
       skipRender: options.skipRender,

--- a/packages/cli/src/pipeline/executor.ts
+++ b/packages/cli/src/pipeline/executor.ts
@@ -223,6 +223,7 @@ async function ensureActionsRegistered(): Promise<void> {
         storyboard: params.storyboard as string | undefined,
         project: params.project as string | undefined,
         effort: params.effort as "low" | "medium" | "high" | undefined,
+        composer: params.composer as "claude" | "openai" | "gemini" | undefined,
       },
       outputDir,
     );
@@ -245,6 +246,7 @@ async function ensureActionsRegistered(): Promise<void> {
     const r = await executeSceneBuild({
       projectDir: resolve(outputDir, projectRel),
       effort: params.effort as "low" | "medium" | "high" | undefined,
+      composer: params.composer as "claude" | "openai" | "gemini" | undefined,
       skipNarration: params.skipNarration as boolean | undefined,
       skipBackdrop: params.skipBackdrop as boolean | undefined,
       skipRender: params.skipRender as boolean | undefined,

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -360,6 +360,7 @@ export const sceneRenderTool = defineTool({
 const sceneBuildSchema = z.object({
   projectDir: z.string().optional().describe("Project directory containing STORYBOARD.md, DESIGN.md, index.html. Defaults to the surface's cwd."),
   effort: z.enum(["low", "medium", "high"]).optional().describe("Compose effort tier passed to compose-scenes-with-skills. Default 'medium'."),
+  composer: z.enum(["claude", "openai", "gemini"]).optional().describe("LLM provider that composes the per-beat scene HTML. Default: auto-resolve from available API keys (ANTHROPIC_API_KEY > GOOGLE_API_KEY > OPENAI_API_KEY). All three pass first-shot lint per the v0.70 spike; Claude is fastest, Gemini cheapest."),
   skipNarration: z.boolean().optional().describe("Skip TTS for every beat (use existing audio assets if present)."),
   skipBackdrop: z.boolean().optional().describe("Skip image generation for every beat (use existing PNG assets if present)."),
   skipRender: z.boolean().optional().describe("Stop after compose — produces compositions/*.html but no final MP4."),
@@ -385,6 +386,7 @@ export const sceneBuildTool = defineTool({
     const result = await executeSceneBuild({
       projectDir,
       effort: args.effort,
+      composer: args.composer,
       skipNarration: args.skipNarration,
       skipBackdrop: args.skipBackdrop,
       skipRender: args.skipRender,


### PR DESCRIPTION
## Summary

Phase 1 of the composer multi-provider plan we agreed to after the Phase 0 spike. Removes the Anthropic-only lock-in from `vibe scene build` — users can now point the LLM that composes per-beat scene HTML at Claude, OpenAI, or Gemini, with auto-resolve based on which API keys are set.

## Why

`compose-scenes-with-skills` was previously hardcoded to call the Anthropic SDK directly. The Phase 0 spike (`scripts/spike-composer-providers.mts`, output in `/tmp/spike-composer/`) showed that all three providers pass first-shot lint on the `examples/vibeframe-promo` fixture with the **identical** system prompt (Hyperframes skill bundle + DESIGN.md hard-gate) and user prompt — so the unlock is mostly a dispatch refactor.

| Provider | Cost / beat | Latency / beat | Notes |
|---|---|---|---|
| Claude Sonnet 4.6 (default) | $0.060 | 9.4 s | Fastest, baseline |
| Gemini 2.5 Pro | $0.023 | 20 s | 2.6× cheaper |
| OpenAI gpt-5 | $0.056 | 71 s | gpt-5 reasoning latency — opt-in only |

Auto-resolve order is `claude > gemini > openai`, so users who already have `ANTHROPIC_API_KEY` see no behaviour change. Non-breaking.

## What changed

- **`commands/_shared/composer-resolve.ts`** (new) — picks `(provider, apiKey)` from `--composer <name>` or env. Throws `ComposerResolveError` with a helpful message when keys are missing.
- **`commands/_shared/compose-scenes-skills.ts`** — refactored from direct Anthropic SDK calls to a generic `LLMCallFn` injection. `defaultCallLLM` dispatches to Anthropic / OpenAI / Gemini SDKs based on `ctx.provider`. `MODEL_SETTINGS` is now keyed on (provider, effort). `computeCacheKey` folds provider id into the hash so switching composers doesn't serve a cache miss-aliased HTML.
- **`commands/_shared/scene-build.ts`** + **`commands/scene.ts`** — `executeSceneBuild` accepts `composer?: ComposerProvider` and the CLI exposes `vibe scene build --composer <claude|openai|gemini>` (with USAGE_ERROR validation).
- **`tools/manifest/scene.ts`** — `scene_build` schema gains the `composer` enum so MCP / Agent callers see the option.
- **`pipeline/executor.ts`** — `compose-scenes-with-skills` and `scene-build` YAML actions accept `composer` for parity.
- **`commands/_shared/init-templates.ts`** — `vibe init`'s AGENTS.md template gains a "Scene composer" subsection so Claude Code / Cursor / Codex / Aider / Cody all see the same guidance.

## Tests

- `composer-resolve.test.ts` (11 cases) — env-key auto-resolve order, explicit provider, missing keys, validation, empty-string treatment.
- `compose-scenes-skills.test.ts` — refactored from `client: { messages: { create } }` mocks to a `callLLM` injection helper (`mockCallLLM`). Added a new test pinning "provider id changes the cache key".

## Test plan

- [x] `pnpm -r exec tsc --noEmit`
- [x] `pnpm lint` (0 errors, 8 pre-existing warnings)
- [x] `pnpm -F @vibeframe/cli test` — **645 passed | 9 skipped**
- [x] `pnpm -F @vibeframe/mcp-server test` — 46 passed
- [x] `bash scripts/sync-counts.sh --check` green
- [x] Built bundle smoke-tested: `vibe scene build --composer gemini --dry-run --json` → correct `composer: "gemini"` in params
- [x] Built bundle smoke-tested: `vibe scene build --composer invalid` → USAGE_ERROR (exit code 2)
- [ ] CI green