### PR TITLE
feat(scene): install Hyperframes skill into user projects (Plan H — Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VibeFrame
 
-**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 63 MCP tools bundled.
+**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 64 MCP tools bundled.
 
 [![GitHub stars](https://img.shields.io/github/stars/vericontext/vibeframe)](https://github.com/vericontext/vibeframe/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -75,7 +75,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | Layer | Hyperframes | VibeFrame |
 |---|---|---|
 | **AI generation** | — | OpenAI gpt-image-2 (image default since v0.56), fal.ai Seedance 2.0 (video default since v0.57), Veo, Kling, Runway, Grok, ElevenLabs, Replicate |
-| **Agent integrations** | — | MCP server (63 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
+| **Agent integrations** | — | MCP server (64 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
 | **Traditional editing** | — | `vibe edit` silence-cut · jump-cut · caption · grade · reframe · speed-ramp · fade · noise-reduce (84+ commands total) |
 | **AI analysis** | — | `vibe analyze` media/video/review/suggest (multimodal LLMs) |
 | **BUILD from text** | composition format only | `vibe scene build` (v0.60 one-shot driver) — STORYBOARD.md → MP4 |
@@ -84,7 +84,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | **Local Kokoro TTS** | ✅ Python `kokoro-onnx` | ✅ Node `kokoro-js` — same Kokoro-82M model, auto-fallback when no `ELEVENLABS_API_KEY` |
 | **Local Whisper transcribe** | ✅ whisper-cpp (offline) | OpenAI Whisper API (cloud, word-level) |
 | **Agent skills** | ✅ `npx skills add heygen-com/hyperframes` (5 skills via vercel-labs/skills) | ✅ ships `/vibe-pipeline`, `/vibe-scene` (overview lives in `AGENTS.md` scaffolded by `vibe init`) |
-| **MCP server** | ❌ | ✅ 63 tools |
+| **MCP server** | ❌ | ✅ 64 tools |
 | **Render** | ✅ native (BeginFrame, parity, HDR, Studio NLE) | uses Hyperframes backend or FFmpeg |
 | **License** | Apache 2.0 | MIT |
 | **OSS provider plugin** | — | `defineProvider({...})` registry — adding an AI provider is a single declaration; resolver / config / setup / doctor / `.env.example` all auto-derive (`pnpm scaffold:provider <name>` for the boilerplate) |
@@ -210,7 +210,7 @@ Prefer manual install? Copy [`.claude/skills/`](https://github.com/vericontext/v
 
 ## MCP Integration (Claude Desktop / Cursor)
 
-The CLI is the primary interface; MCP is the gateway for Claude Desktop & Cursor users (63 MCP tools exposed). No clone needed — add to your config and restart:
+The CLI is the primary interface; MCP is the gateway for Claude Desktop & Cursor users (64 MCP tools exposed). No clone needed — add to your config and restart:
 
 ```json
 {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,7 +11,7 @@ const inter = Inter({ subsets: ["latin"] });
 // directory listing + MCP tool name regex), so they stay in sync with the
 // source. Falls back to the post-v0.57 numbers if env var lookup fails.
 const AI_PROVIDERS = process.env.NEXT_PUBLIC_AI_PROVIDERS ?? "13";
-const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "63";
+const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "64";
 const SHARE_DESCRIPTION = `YAML pipelines, ${AI_PROVIDERS} AI providers, ${MCP_TOOLS} MCP tools bundled. Ship videos, not clicks.`;
 
 export const metadata: Metadata = {

--- a/packages/cli/src/agent/tools/integration.test.ts
+++ b/packages/cli/src/agent/tools/integration.test.ts
@@ -162,7 +162,7 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
     it("should register the full manifest", () => {
       // Manifest is the single source of truth post-v0.67 PR2.
       const tools = registry.getAll();
-      expect(tools.length).toBe(79);
+      expect(tools.length).toBe(80);
     });
 
     it("should register all project tools (5)", () => {
@@ -573,9 +573,9 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
       expect(pipelineTools.length).toBe(3);  // pipeline_script_to_video removed (cleanup PR3); pipeline_animated_caption renamed to edit_animated_caption (Phase D)
       expect(exportTools.length).toBe(3);
       expect(batchTools.length).toBe(3);
-      expect(sceneTools.length).toBe(6);  // v0.66: scene_* surfaced via manifest (init/add/lint/render/build/styles)
+      expect(sceneTools.length).toBe(7);  // v0.70 H1: scene_install_skill added (init/add/lint/render/build/styles/install-skill)
 
-      // Total: 5+11+4+12+13+15+4+3+3+3+6 = 79
+      // Total: 5+11+4+12+13+15+4+3+3+3+7 = 80
       const totalTools = projectTools.length +
           timelineTools.length +
           fsTools.length +
@@ -587,7 +587,7 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
           exportTools.length +
           batchTools.length +
           sceneTools.length;
-      expect(totalTools).toBe(79);
+      expect(totalTools).toBe(80);
     });
   });
 });

--- a/packages/cli/src/agent/tools/scene.test.ts
+++ b/packages/cli/src/agent/tools/scene.test.ts
@@ -29,12 +29,13 @@ const sceneToolDefinitions = (): ReadonlyArray<ToolDefinition> =>
   registry.getDefinitions().filter((d) => d.name.startsWith("scene_"));
 
 describe("scene agent tools — registration + schema", () => {
-  it("registers exactly six scene_* tools", () => {
+  it("registers exactly seven scene_* tools", () => {
     const names = sceneToolDefinitions().map((t) => t.name).sort();
     expect(names).toEqual([
       "scene_add",
       "scene_build",
       "scene_init",
+      "scene_install_skill",
       "scene_lint",
       "scene_render",
       "scene_styles",

--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -116,11 +116,27 @@ API keys live in \`.env\` (gitignored). Copy \`.env.example\` to start. Run
 \`vibe doctor\` to see which keys are currently detected and which providers
 they unlock.
 
-### Scene composer (LLM that writes scene HTML for \`scene build\`)
+### Hyperframes skill (scene HTML rules)
 
-\`vibe scene build\` runs an LLM with the vendored Hyperframes skill bundle
-to compose per-beat HTML. It auto-picks based on available keys
-(\`claude > gemini > openai\`) — pass \`--composer <name>\` to force one:
+\`vibe scene init\` installs the Hyperframes skill into your project. The
+universal copy lives at \`SKILL.md\` (with \`references/*.md\`), and
+host-specific copies are placed where each agent expects them
+(\`.claude/skills/hyperframes/\` for Claude Code, \`.cursor/rules/hyperframes.mdc\`
+for Cursor). **Read \`SKILL.md\` before authoring any scene composition HTML
+under \`compositions/\`** — it defines the framework rules, motion
+principles, type system, and visual-identity hard-gate. The same skill
+governs \`vibe scene lint\` so your authored HTML and the linter stay in
+agreement.
+
+To retro-install on a project scaffolded before this command existed, run
+\`vibe scene install-skill [--host all]\`.
+
+### Scene composer (batch / non-agent fallback)
+
+When you don't want to author HTML yourself, \`vibe scene build\` runs an
+LLM internally with the same skill bundle. It auto-picks a provider based
+on available keys (\`claude > gemini > openai\`) — pass \`--composer <name>\`
+to force one:
 
 | Provider | Env var | Spike notes (v0.70) |
 |---|---|---|

--- a/packages/cli/src/commands/_shared/install-skill.test.ts
+++ b/packages/cli/src/commands/_shared/install-skill.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  deriveInstallHosts,
+  installHyperframesSkill,
+} from "./install-skill.js";
+
+describe("installHyperframesSkill", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "install-skill-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("writes universal SKILL.md + references regardless of host selection", async () => {
+    const r = await installHyperframesSkill({ projectDir, hosts: [] });
+
+    expect(r.success).toBe(true);
+    expect(existsSync(join(projectDir, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(projectDir, "references/house-style.md"))).toBe(true);
+    expect(existsSync(join(projectDir, "references/motion-principles.md"))).toBe(true);
+    expect(existsSync(join(projectDir, "references/typography.md"))).toBe(true);
+    expect(existsSync(join(projectDir, "references/transitions.md"))).toBe(true);
+  });
+
+  it("preserves the upstream Hyperframes frontmatter on the universal SKILL.md", async () => {
+    await installHyperframesSkill({ projectDir, hosts: [] });
+    const content = readFileSync(join(projectDir, "SKILL.md"), "utf-8");
+    // Upstream skill ships with `name: hyperframes` Agent-Skills frontmatter.
+    expect(content).toMatch(/^---\nname: hyperframes\n/);
+    expect(content).toContain("description:");
+  });
+
+  it("installs Claude Code layout under .claude/skills/hyperframes/", async () => {
+    await installHyperframesSkill({ projectDir, hosts: ["claude-code"] });
+
+    const claudeBase = join(projectDir, ".claude/skills/hyperframes");
+    expect(existsSync(join(claudeBase, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(claudeBase, "references/house-style.md"))).toBe(true);
+    expect(existsSync(join(claudeBase, "references/motion-principles.md"))).toBe(true);
+    expect(existsSync(join(claudeBase, "references/typography.md"))).toBe(true);
+    expect(existsSync(join(claudeBase, "references/transitions.md"))).toBe(true);
+  });
+
+  it("installs Cursor layout as a single .mdc with cursor-style frontmatter", async () => {
+    await installHyperframesSkill({ projectDir, hosts: ["cursor"] });
+
+    const cursorPath = join(projectDir, ".cursor/rules/hyperframes.mdc");
+    expect(existsSync(cursorPath)).toBe(true);
+
+    const content = readFileSync(cursorPath, "utf-8");
+    expect(content).toMatch(/^---\ndescription:/);
+    expect(content).toContain("globs:");
+    expect(content).toContain("alwaysApply: false");
+    // Cursor frontmatter replaces upstream's `name: hyperframes` block.
+    expect(content).not.toContain("\nname: hyperframes\n");
+    // But the body still has the rules.
+    expect(content).toContain("HARD-GATE");
+    // And the references are concatenated in.
+    expect(content).toContain("Reference: motion-principles.md");
+    expect(content).toContain("Reference: typography.md");
+  });
+
+  it("'all' installs every host-specific layout in addition to universal", async () => {
+    const r = await installHyperframesSkill({ projectDir, hosts: ["all"] });
+
+    expect(existsSync(join(projectDir, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(projectDir, ".claude/skills/hyperframes/SKILL.md"))).toBe(true);
+    expect(existsSync(join(projectDir, ".cursor/rules/hyperframes.mdc"))).toBe(true);
+
+    // 5 universal + 5 claude + 1 cursor = 11
+    expect(r.files).toHaveLength(11);
+    expect(r.files.every((f) => f.status === "wrote")).toBe(true);
+  });
+
+  it("skips existing files unless force is set", async () => {
+    // Pre-create a SKILL.md the user "customised"
+    writeFileSync(join(projectDir, "SKILL.md"), "# user wrote this", "utf-8");
+
+    const r = await installHyperframesSkill({ projectDir, hosts: [] });
+    const skillAction = r.files.find((f) => f.path === "SKILL.md");
+    expect(skillAction?.status).toBe("skipped-exists");
+
+    // Verify the user's content survived
+    expect(readFileSync(join(projectDir, "SKILL.md"), "utf-8")).toBe("# user wrote this");
+
+    // Force overwrites
+    const forced = await installHyperframesSkill({ projectDir, hosts: [], force: true });
+    const forcedAction = forced.files.find((f) => f.path === "SKILL.md");
+    expect(forcedAction?.status).toBe("wrote");
+    expect(readFileSync(join(projectDir, "SKILL.md"), "utf-8")).not.toBe("# user wrote this");
+    expect(readFileSync(join(projectDir, "SKILL.md"), "utf-8")).toMatch(/^---\nname: hyperframes\n/);
+  });
+
+  it("dry-run reports actions without writing", async () => {
+    const r = await installHyperframesSkill({ projectDir, hosts: ["all"], dryRun: true });
+
+    // Same number of would-write actions as a real install
+    expect(r.files).toHaveLength(11);
+    expect(r.files.every((f) => f.status === "would-write")).toBe(true);
+
+    // No files actually written
+    expect(existsSync(join(projectDir, "SKILL.md"))).toBe(false);
+    expect(existsSync(join(projectDir, "references"))).toBe(false);
+    expect(existsSync(join(projectDir, ".claude"))).toBe(false);
+    expect(existsSync(join(projectDir, ".cursor"))).toBe(false);
+  });
+
+  it("dry-run distinguishes would-write vs would-skip-exists", async () => {
+    mkdirSync(join(projectDir, "references"), { recursive: true });
+    writeFileSync(join(projectDir, "SKILL.md"), "existing", "utf-8");
+
+    const r = await installHyperframesSkill({ projectDir, hosts: [], dryRun: true });
+    const skillAction = r.files.find((f) => f.path === "SKILL.md");
+    expect(skillAction?.status).toBe("would-skip-exists");
+
+    const houseAction = r.files.find((f) => f.path === "references/house-style.md");
+    expect(houseAction?.status).toBe("would-write");
+  });
+
+  it("creates the project directory if it doesn't exist", async () => {
+    const fresh = join(projectDir, "nested/new-project");
+    expect(existsSync(fresh)).toBe(false);
+
+    const r = await installHyperframesSkill({ projectDir: fresh, hosts: [] });
+    expect(r.success).toBe(true);
+    expect(existsSync(join(fresh, "SKILL.md"))).toBe(true);
+  });
+
+  it("returns the bundle version (matches what loadHyperframesSkillBundle uses)", async () => {
+    const r = await installHyperframesSkill({ projectDir, hosts: [] });
+    // Format is `<sha>-<YYYY-MM-DD>` per BUNDLE_VERSION docstring.
+    expect(r.bundleVersion).toMatch(/^[0-9a-f]+-\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("deriveInstallHosts", () => {
+  it("maps claude-code + cursor through; drops codex + aider", () => {
+    expect(deriveInstallHosts(["claude-code"])).toEqual(["claude-code"]);
+    expect(deriveInstallHosts(["cursor"])).toEqual(["cursor"]);
+    expect(deriveInstallHosts(["claude-code", "cursor"])).toEqual(["claude-code", "cursor"]);
+    expect(deriveInstallHosts(["codex"])).toEqual([]);
+    expect(deriveInstallHosts(["aider"])).toEqual([]);
+    expect(deriveInstallHosts(["claude-code", "codex", "aider"])).toEqual(["claude-code"]);
+  });
+
+  it("returns empty when nothing detected", () => {
+    expect(deriveInstallHosts([])).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/_shared/install-skill.ts
+++ b/packages/cli/src/commands/_shared/install-skill.ts
@@ -1,0 +1,227 @@
+/**
+ * @module _shared/install-skill
+ *
+ * Phase H1 — install the vendored Hyperframes skill bundle into a user's
+ * scene project so that the host agent (Claude Code, Cursor, Codex, Aider,
+ * etc.) can read the framework rules + house style directly. This is the
+ * agentic-CLI-native pattern: the host agent is the sole LLM that reasons
+ * about scene composition, and it does so with the skill files in its
+ * context — VibeFrame's CLI is the deterministic toolbelt.
+ *
+ * Layout written:
+ *
+ *   <project>/
+ *     SKILL.md                              # universal — all agents see this
+ *     references/
+ *       house-style.md
+ *       motion-principles.md
+ *       typography.md
+ *       transitions.md
+ *     .claude/skills/hyperframes/           # if hosts includes "claude-code"
+ *       SKILL.md (copy)
+ *       references/{house-style,...}.md
+ *     .cursor/rules/hyperframes.mdc         # if hosts includes "cursor"
+ *
+ * Codex + Aider are AGENTS.md-driven hosts; they read the project root
+ * SKILL.md via an `@SKILL.md` reference in AGENTS.md (handled by the
+ * init-templates AGENTS_MD section, not here).
+ *
+ * The content is byte-identical to what `loadHyperframesSkillBundle()`
+ * uses — same vendored files, same `BUNDLE_VERSION`. After install, the
+ * agentic compose path (Phase H2) reads these files instead of the
+ * vendored TS string constants, so users can edit them per project.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+import {
+  HOUSE_STYLE_MD,
+  MOTION_PRINCIPLES_MD,
+  SKILL_MD,
+  TRANSITIONS_MD,
+  TYPOGRAPHY_MD,
+} from "./hf-skill-bundle/bundle-content.js";
+import { BUNDLE_VERSION } from "./hf-skill-bundle/bundle.js";
+import type { AgentHostId } from "../../utils/agent-host-detect.js";
+
+/** Hosts the install-skill command knows file layouts for. */
+export type InstallSkillHost = "claude-code" | "cursor" | "all";
+
+export interface InstallSkillOptions {
+  /** Project directory (must exist or be creatable). */
+  projectDir: string;
+  /**
+   * Hosts to install host-specific copies for. The universal `SKILL.md` +
+   * `references/` directory at the project root are always written.
+   * Pass `["all"]` to install every host-specific layout.
+   */
+  hosts: InstallSkillHost[];
+  /** Overwrite existing files. Default false (skip-on-exist). */
+  force?: boolean;
+  /** Don't write — just describe what would happen. */
+  dryRun?: boolean;
+}
+
+export type InstallSkillFileStatus =
+  | "wrote"
+  | "skipped-exists"
+  | "would-write"
+  | "would-skip-exists";
+
+export interface InstallSkillFileAction {
+  path: string;
+  status: InstallSkillFileStatus;
+  bytes: number;
+}
+
+export interface InstallSkillResult {
+  success: boolean;
+  bundleVersion: string;
+  files: InstallSkillFileAction[];
+}
+
+interface SkillFile {
+  /** Path relative to project root. */
+  relPath: string;
+  content: string;
+}
+
+/**
+ * Universal skill files written to project root. These are what
+ * AGENTS.md `@SKILL.md` references and what Codex / Aider / generic
+ * agents discover by walking the project tree.
+ */
+function universalFiles(): SkillFile[] {
+  return [
+    { relPath: "SKILL.md", content: SKILL_MD },
+    { relPath: "references/house-style.md", content: HOUSE_STYLE_MD },
+    { relPath: "references/motion-principles.md", content: MOTION_PRINCIPLES_MD },
+    { relPath: "references/typography.md", content: TYPOGRAPHY_MD },
+    { relPath: "references/transitions.md", content: TRANSITIONS_MD },
+  ];
+}
+
+/**
+ * Claude Code skill directory. Same content as universal but mounted
+ * under `.claude/skills/hyperframes/` so Claude Code's skill loader
+ * picks it up automatically.
+ */
+function claudeCodeFiles(): SkillFile[] {
+  const base = ".claude/skills/hyperframes";
+  return [
+    { relPath: `${base}/SKILL.md`, content: SKILL_MD },
+    { relPath: `${base}/references/house-style.md`, content: HOUSE_STYLE_MD },
+    { relPath: `${base}/references/motion-principles.md`, content: MOTION_PRINCIPLES_MD },
+    { relPath: `${base}/references/typography.md`, content: TYPOGRAPHY_MD },
+    { relPath: `${base}/references/transitions.md`, content: TRANSITIONS_MD },
+  ];
+}
+
+/**
+ * Cursor's `.mdc` rule file. Cursor's frontmatter is `description` +
+ * `globs` (auto-activate when matching files are open) + `alwaysApply`.
+ * The body concatenates SKILL.md + references so a single file is enough
+ * (Cursor doesn't traverse a directory the way Claude Code does).
+ */
+function cursorFiles(): SkillFile[] {
+  const body = [
+    SKILL_MD,
+    "\n\n## Reference: house-style.md\n\n" + HOUSE_STYLE_MD,
+    "\n\n## Reference: motion-principles.md\n\n" + MOTION_PRINCIPLES_MD,
+    "\n\n## Reference: typography.md\n\n" + TYPOGRAPHY_MD,
+    "\n\n## Reference: transitions.md\n\n" + TRANSITIONS_MD,
+  ].join("");
+
+  // Strip upstream Hyperframes frontmatter (Cursor uses its own shape) and
+  // wrap with cursor-style frontmatter. Globs target HTML inside scene
+  // projects so the rule auto-activates only when the user is editing
+  // composition files.
+  const stripped = body.replace(/^---\n[\s\S]*?\n---\n/, "");
+  const cursorFrontmatter = `---
+description: "Hyperframes composition rules — animation, type, transitions, scene HTML invariants. Auto-activates on composition HTML."
+globs: ["compositions/**/*.html", "**/scene-*.html"]
+alwaysApply: false
+---
+
+`;
+
+  return [
+    { relPath: ".cursor/rules/hyperframes.mdc", content: cursorFrontmatter + stripped },
+  ];
+}
+
+/** Resolve which host-specific layouts to install based on `hosts`. */
+function selectHostFiles(hosts: InstallSkillHost[]): SkillFile[] {
+  const wantsAll = hosts.includes("all");
+  const wantsClaude = wantsAll || hosts.includes("claude-code");
+  const wantsCursor = wantsAll || hosts.includes("cursor");
+  const out: SkillFile[] = [];
+  if (wantsClaude) out.push(...claudeCodeFiles());
+  if (wantsCursor) out.push(...cursorFiles());
+  return out;
+}
+
+/**
+ * Install Hyperframes skill files at the project + host-specific paths.
+ *
+ * Idempotent by default — existing files are skipped (logged as
+ * `skipped-exists`). Pass `force: true` to overwrite. `dryRun: true`
+ * reports the same actions but with `would-*` status and writes nothing.
+ */
+export async function installHyperframesSkill(opts: InstallSkillOptions): Promise<InstallSkillResult> {
+  const projectDir = resolve(opts.projectDir);
+  const force = opts.force ?? false;
+  const dryRun = opts.dryRun ?? false;
+
+  const files = [...universalFiles(), ...selectHostFiles(opts.hosts)];
+  const actions: InstallSkillFileAction[] = [];
+
+  if (!dryRun && !existsSync(projectDir)) {
+    await mkdir(projectDir, { recursive: true });
+  }
+
+  for (const file of files) {
+    const absPath = join(projectDir, file.relPath);
+    const exists = existsSync(absPath);
+    const bytes = Buffer.byteLength(file.content, "utf-8");
+
+    if (exists && !force) {
+      actions.push({
+        path: relative(projectDir, absPath) || file.relPath,
+        status: dryRun ? "would-skip-exists" : "skipped-exists",
+        bytes,
+      });
+      continue;
+    }
+
+    if (dryRun) {
+      actions.push({ path: file.relPath, status: "would-write", bytes });
+      continue;
+    }
+
+    await mkdir(dirname(absPath), { recursive: true });
+    await writeFile(absPath, file.content, "utf-8");
+    actions.push({ path: file.relPath, status: "wrote", bytes });
+  }
+
+  return {
+    success: true,
+    bundleVersion: BUNDLE_VERSION,
+    files: actions,
+  };
+}
+
+/**
+ * Map an `AgentHostId[]` (from `detectedAgentHosts()`) to the
+ * install-skill command's host vocabulary. Codex / Aider don't get
+ * host-specific layouts — they read the universal `SKILL.md` via
+ * AGENTS.md, so they're filtered out here.
+ */
+export function deriveInstallHosts(detected: AgentHostId[]): InstallSkillHost[] {
+  const out: InstallSkillHost[] = [];
+  if (detected.includes("claude-code")) out.push("claude-code");
+  if (detected.includes("cursor")) out.push("cursor");
+  return out;
+}

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -78,6 +78,12 @@ import {
 } from "./output.js";
 import { getApiKey } from "../utils/api-key.js";
 import { getAudioDuration } from "../utils/audio.js";
+import { detectedAgentHosts } from "../utils/agent-host-detect.js";
+import {
+  installHyperframesSkill,
+  deriveInstallHosts,
+  type InstallSkillHost,
+} from "./_shared/install-skill.js";
 
 const VALID_ASPECTS: SceneAspect[] = ["16:9", "9:16", "1:1", "4:5"];
 
@@ -173,6 +179,21 @@ sceneCommand
     try {
       const result = await scaffoldSceneProject({ dir, name, aspect, duration, visualStyle });
 
+      // Phase H1: drop the Hyperframes skill into the project so the host
+      // agent (Claude Code, Cursor, Codex, Aider, …) can read it directly.
+      // This is what unlocks the agentic compose path — without skill
+      // files in context, the agent can't reason about composition rules.
+      // Only host-specific layouts are written for hosts that the user
+      // actually has installed; the universal `SKILL.md` + `references/`
+      // are always written so AGENTS.md can `@SKILL.md`-reference them.
+      const detectedIds = detectedAgentHosts().map((h) => h.id);
+      const skillHosts = deriveInstallHosts(detectedIds);
+      const projectAbs = resolve(dir);
+      const skillResult = await installHyperframesSkill({
+        projectDir: projectAbs,
+        hosts: skillHosts,
+      });
+
       if (isJsonMode()) {
         outputResult({
           success: true,
@@ -185,6 +206,8 @@ sceneCommand
           created: result.created,
           merged: result.merged,
           skipped: result.skipped,
+          skillFiles: skillResult.files,
+          skillBundleVersion: skillResult.bundleVersion,
         });
         return;
       }
@@ -196,6 +219,18 @@ sceneCommand
       for (const f of result.created) console.log(chalk.green("  +"), f);
       for (const f of result.merged)  console.log(chalk.yellow("  ~"), f, chalk.dim("(merged)"));
       for (const f of result.skipped) console.log(chalk.dim("  ·"), f, chalk.dim("(kept existing)"));
+
+      const skillWritten = skillResult.files.filter((f) => f.status === "wrote");
+      const skillSkipped = skillResult.files.filter((f) => f.status === "skipped-exists");
+      if (skillWritten.length + skillSkipped.length > 0) {
+        console.log();
+        console.log(chalk.bold.cyan("Hyperframes skill"));
+        console.log(chalk.dim("─".repeat(60)));
+        for (const f of skillWritten) console.log(chalk.green("  +"), f.path);
+        for (const f of skillSkipped) console.log(chalk.dim("  ·"), f.path, chalk.dim("(kept existing)"));
+        console.log(chalk.dim(`  Bundle: ${skillResult.bundleVersion}`));
+      }
+
       console.log();
       console.log(chalk.bold.cyan("Next steps"));
       console.log(chalk.dim("─".repeat(60)));
@@ -204,14 +239,95 @@ sceneCommand
       } else {
         console.log(`  ${chalk.cyan("vibe scene styles")}        ${chalk.dim("# pick a named style for DESIGN.md")}`);
       }
-      console.log(`  ${chalk.cyan("npx skills add heygen-com/hyperframes")}  ${chalk.dim("# load the cinematic-craft skill set")}`);
-      console.log(`  ${chalk.cyan("vibe scene add")} <name>    ${chalk.dim("# fallback path: 5-preset emit")}`);
+      console.log(`  ${chalk.dim("Your agent now has Hyperframes rules in")} ${chalk.cyan("SKILL.md")} ${chalk.dim("— ask it to author scene HTML directly.")}`);
+      console.log(`  ${chalk.cyan("vibe scene add")} <name>    ${chalk.dim("# fallback: 5-preset emit (no agent)")}`);
       console.log(`  ${chalk.cyan("vibe scene lint")}          ${chalk.dim("# validate HTML")}`);
       console.log(`  ${chalk.cyan("vibe scene render")}        ${chalk.dim("# render to MP4")}`);
     } catch (error) {
       spinner?.fail("Failed to scaffold scene project");
       const msg = error instanceof Error ? error.message : String(error);
       exitWithError(generalError(`Failed to scaffold: ${msg}`));
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// `vibe scene install-skill` — drop the Hyperframes skill into a project
+// ---------------------------------------------------------------------------
+// Phase H1 — exposed as a separate subcommand for retroactive install on
+// existing scene projects (i.e. projects scaffolded before this command
+// existed). `vibe scene init` calls the same library function eagerly.
+
+const VALID_INSTALL_SKILL_HOSTS = ["claude-code", "cursor", "auto", "all"] as const;
+type InstallSkillHostFlag = (typeof VALID_INSTALL_SKILL_HOSTS)[number];
+
+sceneCommand
+  .command("install-skill")
+  .description("Install the Hyperframes skill into a scene project so the host agent can read it (Phase H1)")
+  .argument("[project-dir]", "Project directory containing STORYBOARD.md / DESIGN.md", ".")
+  .option("--host <id>", `Host layout target: ${VALID_INSTALL_SKILL_HOSTS.join(" | ")}`, "auto")
+  .option("--force", "Overwrite existing skill files (default: skip-on-exist)")
+  .option("--dry-run", "Preview which files would be written without changing anything")
+  .action(async (projectDirArg: string, options) => {
+    const hostFlag = (options.host as InstallSkillHostFlag) ?? "auto";
+    if (!VALID_INSTALL_SKILL_HOSTS.includes(hostFlag)) {
+      exitWithError(usageError(`Invalid --host: ${hostFlag}`, `Valid: ${VALID_INSTALL_SKILL_HOSTS.join(", ")}`));
+    }
+
+    const projectDir = resolve(projectDirArg);
+    const hosts: InstallSkillHost[] = (() => {
+      if (hostFlag === "all") return ["all"];
+      if (hostFlag === "auto") {
+        return deriveInstallHosts(detectedAgentHosts().map((h) => h.id));
+      }
+      return [hostFlag];
+    })();
+
+    const result = await installHyperframesSkill({
+      projectDir,
+      hosts,
+      force: options.force ?? false,
+      dryRun: options.dryRun ?? false,
+    });
+
+    if (isJsonMode()) {
+      outputResult({
+        success: true,
+        command: "scene install-skill",
+        projectDir,
+        host: hostFlag,
+        resolvedHosts: hosts,
+        bundleVersion: result.bundleVersion,
+        files: result.files,
+        dryRun: options.dryRun ?? false,
+      });
+      return;
+    }
+
+    console.log();
+    console.log(chalk.bold.cyan("Hyperframes skill install"));
+    console.log(chalk.dim("─".repeat(60)));
+    console.log(chalk.dim(`Project:   ${projectDir}`));
+    console.log(chalk.dim(`Host:      ${hostFlag}${hostFlag === "auto" ? ` (resolved → ${hosts.join(", ") || "universal-only"})` : ""}`));
+    console.log(chalk.dim(`Bundle:    ${result.bundleVersion}`));
+    console.log();
+
+    for (const f of result.files) {
+      const icon =
+        f.status === "wrote" ? chalk.green("+")
+        : f.status === "skipped-exists" ? chalk.dim("·")
+        : f.status === "would-write" ? chalk.cyan("~")
+        : chalk.dim("·");
+      const note =
+        f.status === "skipped-exists" ? chalk.dim(" (kept existing — pass --force to overwrite)")
+        : f.status === "would-write" ? chalk.dim(" (would write)")
+        : f.status === "would-skip-exists" ? chalk.dim(" (would skip — exists)")
+        : "";
+      console.log(`  ${icon} ${f.path}${note}`);
+    }
+
+    if (options.dryRun) {
+      console.log();
+      console.log(chalk.dim("Dry run — no files written. Re-run without --dry-run to apply."));
     }
   });
 

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -27,6 +27,12 @@ import {
 } from "../../commands/_shared/scene-render.js";
 import { executeSceneBuild } from "../../commands/_shared/scene-build.js";
 import type { ScenePreset } from "../../commands/_shared/scene-html-emit.js";
+import {
+  installHyperframesSkill,
+  deriveInstallHosts,
+  type InstallSkillHost,
+} from "../../commands/_shared/install-skill.js";
+import { detectedAgentHosts } from "../../utils/agent-host-detect.js";
 
 const SCENE_PRESETS = [
   "simple",
@@ -428,6 +434,60 @@ export const sceneBuildTool = defineTool({
   },
 });
 
+// ---------------------------------------------------------------------------
+// scene_install_skill — Phase H1 agentic-CLI primitive
+// ---------------------------------------------------------------------------
+
+const sceneInstallSkillSchema = z.object({
+  projectDir: z.string().describe("Project directory containing STORYBOARD.md / DESIGN.md. Required to keep cross-host calls explicit and prevent accidental installs in unintended cwd."),
+  host: z.enum(["claude-code", "cursor", "auto", "all"]).optional().describe("Host layout target. 'auto' (default) detects installed agent hosts; 'all' writes every layout; 'claude-code' / 'cursor' force a single host. Codex / Aider read the universal SKILL.md via AGENTS.md so don't need a host-specific layout."),
+  force: z.boolean().optional().describe("Overwrite existing skill files. Default: skip-on-exist (preserves user customisations)."),
+  dryRun: z.boolean().optional().describe("Report which files would be written without writing them."),
+});
+
+export const sceneInstallSkillTool = defineTool({
+  name: "scene_install_skill",
+  category: "scene",
+  cost: "free",
+  description:
+    "Install the vendored Hyperframes skill bundle into a scene project so the host agent (Claude Code, Cursor, Codex, Aider) can read framework rules + house style directly. Writes a universal SKILL.md + references/ at the project root, plus per-host layouts (.claude/skills/hyperframes/ for Claude Code, .cursor/rules/hyperframes.mdc for Cursor) when those hosts are detected. Phase H1 of the agentic-native composer plan — once installed, the host agent itself can author scene HTML using the rules instead of relying on vibe's internal LLM call.",
+  schema: sceneInstallSkillSchema,
+  async execute(args, ctx) {
+    const projectDir = resolve(ctx.workingDirectory, args.projectDir);
+
+    const hostFlag = args.host ?? "auto";
+    const hosts: InstallSkillHost[] = (() => {
+      if (hostFlag === "all") return ["all"];
+      if (hostFlag === "auto") {
+        return deriveInstallHosts(detectedAgentHosts().map((h) => h.id));
+      }
+      return [hostFlag];
+    })();
+
+    const result = await installHyperframesSkill({
+      projectDir,
+      hosts,
+      force: args.force ?? false,
+      dryRun: args.dryRun ?? false,
+    });
+
+    return {
+      success: true,
+      data: {
+        projectDir: relative(ctx.workingDirectory, projectDir) || ".",
+        host: hostFlag,
+        resolvedHosts: hosts,
+        bundleVersion: result.bundleVersion,
+        files: result.files,
+        dryRun: args.dryRun ?? false,
+      },
+      humanLines: [
+        `Installed Hyperframes skill (${result.bundleVersion}) — ${result.files.filter((f) => f.status === "wrote" || f.status === "would-write").length} file(s) ${args.dryRun ? "would be written" : "written"}.`,
+      ],
+    };
+  },
+});
+
 /** All scene-category manifest entries (type-erased for heterogeneous aggregation). */
 export const sceneTools: readonly AnyTool[] = [
   sceneInitTool as unknown as AnyTool,
@@ -436,4 +496,5 @@ export const sceneTools: readonly AnyTool[] = [
   sceneRenderTool as unknown as AnyTool,
   sceneBuildTool as unknown as AnyTool,
   sceneStylesTool as unknown as AnyTool,
+  sceneInstallSkillTool as unknown as AnyTool,
 ];

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -16,8 +16,8 @@ describe("@vibeframe/mcp-server", () => {
       expect(tools.length).toBeGreaterThan(0);
     });
 
-    it("should have 63 tools total", () => {
-      expect(tools.length).toBe(63);
+    it("should have 64 tools total", () => {
+      expect(tools.length).toBe(64);
     });
 
     it("should have correct tool structure", () => {

--- a/packages/mcp-server/src/tools/cli-sync.test.ts
+++ b/packages/mcp-server/src/tools/cli-sync.test.ts
@@ -32,7 +32,7 @@ interface CommanderLike {
 // `<group> <subname>` CLI invocation paired with the canonical manifest
 // tool name (or null if explicitly CLI-only).
 const CLI_TREE: Record<string, string[]> = {
-  scene:    ["init", "styles", "add", "lint", "render", "build"],
+  scene:    ["init", "styles", "add", "lint", "render", "build", "install-skill"],
   generate: ["image", "video", "video-status", "video-cancel", "video-extend", "speech", "sound-effect", "music", "music-status", "storyboard", "motion", "thumbnail", "background"],
   edit:     ["silence-cut", "caption", "noise-reduce", "fade", "translate-srt", "jump-cut", "fill-gaps", "grade", "text-overlay", "speed-ramp", "reframe", "image", "interpolate", "upscale-video"],
   audio:    ["transcribe", "voices", "isolate", "voice-clone", "dub", "duck"],
@@ -56,12 +56,13 @@ const CLI_ONLY_TOP_LEVEL = new Set([
 // manifest `edit_animated_caption`; `edit upscale-video` → `edit_upscale`).
 const CLI_TO_MANIFEST: Record<string, string | null> = {
   // scene
-  "scene init":   "scene_init",
-  "scene styles": "scene_styles",
-  "scene add":    "scene_add",
-  "scene lint":   "scene_lint",
-  "scene render": "scene_render",
-  "scene build":  "scene_build",
+  "scene init":          "scene_init",
+  "scene styles":        "scene_styles",
+  "scene add":           "scene_add",
+  "scene lint":          "scene_lint",
+  "scene render":        "scene_render",
+  "scene build":         "scene_build",
+  "scene install-skill": "scene_install_skill",
   // generate
   "generate image":         "generate_image",
   "generate video":         "generate_video",

--- a/packages/mcp-server/src/tools/scene.test.ts
+++ b/packages/mcp-server/src/tools/scene.test.ts
@@ -24,12 +24,13 @@ async function callScene(name: string, args: Record<string, unknown>): Promise<s
 }
 
 describe("MCP scene tools — registration", () => {
-  it("exports six tools with the canonical names", () => {
+  it("exports seven tools with the canonical names", () => {
     const names = sceneMcpTools.map((t) => t.name).sort();
     expect(names).toEqual([
       "scene_add",
       "scene_build",
       "scene_init",
+      "scene_install_skill",
       "scene_lint",
       "scene_render",
       "scene_styles",


### PR DESCRIPTION
## Summary

Phase H1 of the agentic-native composer plan. The Hyperframes skill bundle has been vendored inside the CLI binary since v0.59 — fine for the internal LLM call but invisible to host agents (Claude Code, Cursor, Codex, Aider). This phase drops the same skill files into the user's scene project so the host agent itself reads the framework rules + house style and authors scene HTML directly.

## Why

Per the agentic-CLI design pattern (skill files as injected context, drawn from [Justin Poehnelt's blog post](https://justin.poehnelt.com/posts/rewrite-your-cli-for-ai-agents/)), tacit knowledge belongs in markdown files agents can read, not vendored inside a CLI that calls its own LLM. Pre-H1 VibeFrame was weak on this:
- Hyperframes skill content was a TS template-literal constant in `_shared/hf-skill-bundle/bundle-content.ts`
- `vibe scene build` made its own LLM call with the bundle as system prompt
- Host agent could not see, customise, or reason about the rules

Post-H1 the skill files are normal markdown at known paths in the user's project. Phase H2 (agentic compose primitive) builds on this; H3 (mode dispatch) and H4 (multi-host detection wizard) follow.

## What changed

### New
- **`commands/_shared/install-skill.ts`** — `installHyperframesSkill({projectDir, hosts})` writes universal `SKILL.md` + `references/*.md` at project root, plus host-specific layouts:
  - `.claude/skills/hyperframes/SKILL.md` (Agent Skills standard, Claude Code)
  - `.cursor/rules/hyperframes.mdc` (Cursor frontmatter with `globs: ["compositions/**/*.html", "**/scene-*.html"]` — auto-activates only when editing scene HTML)
  - Codex / Aider read the universal `SKILL.md` via AGENTS.md, no host-specific copy needed.
- **`vibe scene install-skill [project-dir]`** — retroactive install for existing projects. `--host claude-code|cursor|auto|all`. `--force`, `--dry-run`.
- Manifest tool **`scene_install_skill`** exposes the primitive to MCP / Agent surfaces.

### Modified
- **`vibe scene init`** auto-runs the skill install for hosts the user has present (via `detectedAgentHosts()`).
- **AGENTS.md template** adds a "Hyperframes skill" subsection so cross-agent hosts find the universal SKILL.md reference.
- Counts: MCP 63 → 64, Agent stays at 80. README + landing fallback updated.

## Behaviour

- Idempotent: existing user-customised files are preserved (\`skipped-exists\`). Pass \`--force\` to overwrite.
- File sizes: 5 universal (~50 KB), 5 Claude Code copies (~50 KB), 1 Cursor combined (~50 KB) ≈ 150 KB total max. Negligible.
- Bundle version (\`970367f-2026-04-25\`) is reported in JSON output for cache-key correlation with the internal compose path (which still uses the same bundle).

## Tests

- \`install-skill.test.ts\` — 12 cases: universal install regardless of host, frontmatter preservation, Claude / Cursor layouts, \`all\`, skip-on-exist, force, dry-run with \`would-write\` vs \`would-skip-exists\`, project-dir auto-create, bundle version assertion. Plus \`deriveInstallHosts\` (codex / aider filtered out, claude / cursor passed through).
- Updated registration assertions in \`agent/tools/scene.test.ts\`, \`mcp-server/src/tools/scene.test.ts\`, \`mcp-server/src/index.test.ts\`, \`agent/tools/integration.test.ts\`.
- Updated \`cli-sync.test.ts\` SYNC_TABLE row.

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\`
- [x] \`pnpm lint\` (0 errors, 8 pre-existing warnings)
- [x] \`pnpm -F @vibeframe/cli test\` — 657 passed | 9 skipped
- [x] \`pnpm -F @vibeframe/mcp-server test\` — 47 passed
- [x] \`bash scripts/sync-counts.sh --check\` green
- [x] Built bundle smoke-tested: \`vibe scene install-skill /tmp/h1-test --host all --json\` → wrote 11 files with correct per-host frontmatter
- [x] Cursor \`.mdc\` frontmatter validated (\`description\`, \`globs\`, \`alwaysApply: false\`)
- [x] Claude Code \`SKILL.md\` retains upstream \`name: hyperframes\` Agent Skills frontmatter
- [ ] CI green