### PR TITLE
feat(scene): scene_compose_prompts agentic primitive (Plan H — Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VibeFrame
 
-**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 64 MCP tools bundled.
+**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 65 MCP tools bundled.
 
 [![GitHub stars](https://img.shields.io/github/stars/vericontext/vibeframe)](https://github.com/vericontext/vibeframe/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -75,7 +75,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | Layer | Hyperframes | VibeFrame |
 |---|---|---|
 | **AI generation** | — | OpenAI gpt-image-2 (image default since v0.56), fal.ai Seedance 2.0 (video default since v0.57), Veo, Kling, Runway, Grok, ElevenLabs, Replicate |
-| **Agent integrations** | — | MCP server (64 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
+| **Agent integrations** | — | MCP server (65 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
 | **Traditional editing** | — | `vibe edit` silence-cut · jump-cut · caption · grade · reframe · speed-ramp · fade · noise-reduce (84+ commands total) |
 | **AI analysis** | — | `vibe analyze` media/video/review/suggest (multimodal LLMs) |
 | **BUILD from text** | composition format only | `vibe scene build` (v0.60 one-shot driver) — STORYBOARD.md → MP4 |
@@ -84,7 +84,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | **Local Kokoro TTS** | ✅ Python `kokoro-onnx` | ✅ Node `kokoro-js` — same Kokoro-82M model, auto-fallback when no `ELEVENLABS_API_KEY` |
 | **Local Whisper transcribe** | ✅ whisper-cpp (offline) | OpenAI Whisper API (cloud, word-level) |
 | **Agent skills** | ✅ `npx skills add heygen-com/hyperframes` (5 skills via vercel-labs/skills) | ✅ ships `/vibe-pipeline`, `/vibe-scene` (overview lives in `AGENTS.md` scaffolded by `vibe init`) |
-| **MCP server** | ❌ | ✅ 64 tools |
+| **MCP server** | ❌ | ✅ 65 tools |
 | **Render** | ✅ native (BeginFrame, parity, HDR, Studio NLE) | uses Hyperframes backend or FFmpeg |
 | **License** | Apache 2.0 | MIT |
 | **OSS provider plugin** | — | `defineProvider({...})` registry — adding an AI provider is a single declaration; resolver / config / setup / doctor / `.env.example` all auto-derive (`pnpm scaffold:provider <name>` for the boilerplate) |
@@ -210,7 +210,7 @@ Prefer manual install? Copy [`.claude/skills/`](https://github.com/vericontext/v
 
 ## MCP Integration (Claude Desktop / Cursor)
 
-The CLI is the primary interface; MCP is the gateway for Claude Desktop & Cursor users (64 MCP tools exposed). No clone needed — add to your config and restart:
+The CLI is the primary interface; MCP is the gateway for Claude Desktop & Cursor users (65 MCP tools exposed). No clone needed — add to your config and restart:
 
 ```json
 {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,7 +11,7 @@ const inter = Inter({ subsets: ["latin"] });
 // directory listing + MCP tool name regex), so they stay in sync with the
 // source. Falls back to the post-v0.57 numbers if env var lookup fails.
 const AI_PROVIDERS = process.env.NEXT_PUBLIC_AI_PROVIDERS ?? "13";
-const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "64";
+const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "65";
 const SHARE_DESCRIPTION = `YAML pipelines, ${AI_PROVIDERS} AI providers, ${MCP_TOOLS} MCP tools bundled. Ship videos, not clicks.`;
 
 export const metadata: Metadata = {

--- a/packages/cli/src/agent/tools/integration.test.ts
+++ b/packages/cli/src/agent/tools/integration.test.ts
@@ -162,7 +162,7 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
     it("should register the full manifest", () => {
       // Manifest is the single source of truth post-v0.67 PR2.
       const tools = registry.getAll();
-      expect(tools.length).toBe(80);
+      expect(tools.length).toBe(81);
     });
 
     it("should register all project tools (5)", () => {
@@ -573,9 +573,9 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
       expect(pipelineTools.length).toBe(3);  // pipeline_script_to_video removed (cleanup PR3); pipeline_animated_caption renamed to edit_animated_caption (Phase D)
       expect(exportTools.length).toBe(3);
       expect(batchTools.length).toBe(3);
-      expect(sceneTools.length).toBe(7);  // v0.70 H1: scene_install_skill added (init/add/lint/render/build/styles/install-skill)
+      expect(sceneTools.length).toBe(8);  // v0.70 H1+H2: install-skill + compose-prompts (init/add/lint/render/build/styles/install-skill/compose-prompts)
 
-      // Total: 5+11+4+12+13+15+4+3+3+3+7 = 80
+      // Total: 5+11+4+12+13+15+4+3+3+3+8 = 81
       const totalTools = projectTools.length +
           timelineTools.length +
           fsTools.length +
@@ -587,7 +587,7 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
           exportTools.length +
           batchTools.length +
           sceneTools.length;
-      expect(totalTools).toBe(80);
+      expect(totalTools).toBe(81);
     });
   });
 });

--- a/packages/cli/src/agent/tools/scene.test.ts
+++ b/packages/cli/src/agent/tools/scene.test.ts
@@ -29,11 +29,12 @@ const sceneToolDefinitions = (): ReadonlyArray<ToolDefinition> =>
   registry.getDefinitions().filter((d) => d.name.startsWith("scene_"));
 
 describe("scene agent tools — registration + schema", () => {
-  it("registers exactly seven scene_* tools", () => {
+  it("registers exactly eight scene_* tools", () => {
     const names = sceneToolDefinitions().map((t) => t.name).sort();
     expect(names).toEqual([
       "scene_add",
       "scene_build",
+      "scene_compose_prompts",
       "scene_init",
       "scene_install_skill",
       "scene_lint",

--- a/packages/cli/src/commands/_shared/compose-prompts.test.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { getComposePrompts } from "./compose-prompts.js";
+
+describe("getComposePrompts", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "compose-prompts-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function seed(opts: { storyboard?: string; design?: string; withSkill?: boolean } = {}): void {
+    writeFileSync(
+      join(projectDir, "DESIGN.md"),
+      opts.design ?? "# Design\n\n## Palette\n- `#000000`\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(projectDir, "STORYBOARD.md"),
+      opts.storyboard
+        ?? "**Format:** 1920x1080\n\n## Beat hook — Hook (0–3s)\n\nbody1\n\n## Beat outro — Outro (3–6s)\n\nbody2\n",
+      "utf-8",
+    );
+    if (opts.withSkill) {
+      writeFileSync(
+        join(projectDir, "SKILL.md"),
+        "---\nname: hyperframes\n---\nFRAMEWORK RULES",
+        "utf-8",
+      );
+    }
+  }
+
+  it("returns one entry per beat with userPrompt + outputPath when storyboard is well-formed", async () => {
+    seed({ withSkill: true });
+    const r = await getComposePrompts({ projectDir });
+
+    expect(r.success).toBe(true);
+    expect(r.beats).toHaveLength(2);
+    expect(r.beats[0].id).toBe("hook");
+    expect(r.beats[0].outputPath).toBe("compositions/scene-hook.html");
+    expect(r.beats[0].userPrompt).toContain("compositions/scene-hook.html");
+    expect(r.beats[0].userPrompt).toContain('data-composition-id="scene-hook"');
+    expect(r.beats[1].id).toBe("outro");
+    expect(r.beats[1].outputPath).toBe("compositions/scene-outro.html");
+  });
+
+  it("does not call any LLM (function is purely synchronous I/O)", async () => {
+    // Indirect proof: providing zero API keys should not affect anything.
+    const originalEnv = { ...process.env };
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    try {
+      seed({ withSkill: true });
+      const r = await getComposePrompts({ projectDir });
+      expect(r.success).toBe(true);
+      expect(r.beats).toHaveLength(2);
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
+  it("flags compositions that already exist on disk", async () => {
+    seed({ withSkill: true });
+    mkdirSync(join(projectDir, "compositions"), { recursive: true });
+    writeFileSync(join(projectDir, "compositions/scene-hook.html"), "<existing/>", "utf-8");
+
+    const r = await getComposePrompts({ projectDir });
+    expect(r.beats[0].exists).toBe(true);
+    expect(r.beats[1].exists).toBe(false);
+  });
+
+  it("filters to a single beat when beatId is set", async () => {
+    seed({ withSkill: true });
+    const r = await getComposePrompts({ projectDir, beatId: "outro" });
+    expect(r.success).toBe(true);
+    expect(r.beats).toHaveLength(1);
+    expect(r.beats[0].id).toBe("outro");
+  });
+
+  it("returns an error when beatId doesn't match", async () => {
+    seed({ withSkill: true });
+    const r = await getComposePrompts({ projectDir, beatId: "nope" });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('Beat "nope" not found');
+    expect(r.error).toContain("hook");
+    expect(r.error).toContain("outro");
+  });
+
+  it("warns + skillReference=null when SKILL.md isn't installed", async () => {
+    seed({ withSkill: false });
+    const r = await getComposePrompts({ projectDir });
+    expect(r.success).toBe(true);
+    expect(r.skillReference).toBeNull();
+    expect(r.warnings.some((w) => w.includes("install-skill"))).toBe(true);
+    // Instructions tell the agent to install the skill first
+    expect(r.instructions[0]).toContain("install-skill");
+  });
+
+  it("populates skillReference + lint-friendly instructions when SKILL.md is installed", async () => {
+    seed({ withSkill: true });
+    const r = await getComposePrompts({ projectDir });
+    expect(r.skillReference).toBe("SKILL.md");
+    expect(r.warnings).toEqual([]);
+    expect(r.instructions[0]).toContain("SKILL.md");
+    expect(r.instructions.some((l) => l.includes("scene lint"))).toBe(true);
+    expect(r.instructions.some((l) => l.includes("scene render"))).toBe(true);
+  });
+
+  it("returns failure when DESIGN.md is missing", async () => {
+    writeFileSync(join(projectDir, "STORYBOARD.md"), "## Beat 1 — x\nbody\n");
+    const r = await getComposePrompts({ projectDir });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("DESIGN.md not found");
+    expect(r.beats).toEqual([]);
+  });
+
+  it("returns failure when STORYBOARD.md is missing", async () => {
+    writeFileSync(join(projectDir, "DESIGN.md"), "# d");
+    const r = await getComposePrompts({ projectDir });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("STORYBOARD.md not found");
+  });
+
+  it("returns failure when STORYBOARD.md has no beats", async () => {
+    seed({ storyboard: "Just prose, no headings.\n", withSkill: true });
+    const r = await getComposePrompts({ projectDir });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("no `## Beat …` headings");
+  });
+
+  it("surfaces beat duration from cue YAML when present", async () => {
+    seed({
+      withSkill: true,
+      storyboard: [
+        "**Format:** 1920x1080",
+        "",
+        "## Beat hook — Hook",
+        "",
+        "```yaml",
+        'narration: "Type a YAML."',
+        "duration: 3",
+        "```",
+        "",
+        "Cold open body.",
+        "",
+      ].join("\n"),
+    });
+    const r = await getComposePrompts({ projectDir });
+    expect(r.beats[0].duration).toBe(3);
+    expect(r.beats[0].cues).toMatchObject({ narration: "Type a YAML.", duration: 3 });
+  });
+
+  it("returns the bundle version (matches loadHyperframesSkillBundle / install-skill)", async () => {
+    seed({ withSkill: true });
+    const r = await getComposePrompts({ projectDir });
+    expect(r.bundleVersion).toMatch(/^[0-9a-f]+-\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/packages/cli/src/commands/_shared/compose-prompts.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.ts
@@ -1,0 +1,228 @@
+/**
+ * @module _shared/compose-prompts
+ *
+ * Phase H2 — agentic compose primitive. Reads `STORYBOARD.md` + `DESIGN.md`
+ * from a scene project and emits a structured plan for the host agent
+ * (Claude Code, Cursor, Codex, Aider) to author per-beat HTML files
+ * itself. **No LLM call from inside the CLI** — that's the point. The
+ * CLI is the deterministic toolbelt; the host agent is the sole reasoner.
+ *
+ * Output shape:
+ *
+ *   {
+ *     "projectDir": "<abs>",
+ *     "designReference":     "DESIGN.md",
+ *     "storyboardReference": "STORYBOARD.md",
+ *     "skillReference":      "SKILL.md",        // present after `scene install-skill`
+ *     "compositionsDir":     "compositions",
+ *     "beats": [
+ *       { "id": "hook", "outputPath": "compositions/scene-hook.html",
+ *         "userPrompt": "...", "body": "...", "cues": {...}, "exists": false }
+ *     ],
+ *     "instructions": [...]
+ *   }
+ *
+ * Pairs with H1 (`vibe scene install-skill`) — the host agent reads
+ * `SKILL.md` for framework rules, `DESIGN.md` for visual identity, then
+ * writes each `compositions/scene-<id>.html`. After authoring, runs
+ * `vibe scene lint --fix` to verify and `vibe scene render` to produce MP4.
+ *
+ * The internal-LLM path (`vibe scene build`, PR #176) still works — it's
+ * the batch / non-agent fallback. H3 will add mode dispatch so a single
+ * entry point picks between agentic and batch depending on context.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+
+import { parseStoryboard, type Beat } from "./storyboard-parse.js";
+import { buildUserPrompt } from "./compose-scenes-skills.js";
+import { BUNDLE_VERSION } from "./hf-skill-bundle/bundle.js";
+
+export interface ComposePromptsBeat {
+  /** Stable beat id from `parseStoryboard().deriveBeatId()`. */
+  id: string;
+  /** Original `## …` heading line (without the `## ` prefix). */
+  heading: string;
+  /** Path the agent should write the composition to (relative to projectDir). */
+  outputPath: string;
+  /** Beat duration in seconds (from cues or `### Beat duration` subsection), if known. */
+  duration?: number;
+  /** Per-beat YAML cues parsed from the leading code block of the body. */
+  cues?: Record<string, unknown>;
+  /** Beat body markdown (with the leading `\`\`\`yaml` cue block stripped). */
+  body: string;
+  /**
+   * Pre-built user prompt — the same shape `composeBeatHtml` would send to
+   * Claude / OpenAI / Gemini. The host agent consumes this directly so the
+   * agentic and batch paths produce equivalent HTML.
+   */
+  userPrompt: string;
+  /** True when `compositions/scene-<id>.html` already exists on disk. */
+  exists: boolean;
+}
+
+export interface ComposePromptsResult {
+  success: boolean;
+  /** Absolute project directory. */
+  projectDir: string;
+  /** Project-root-relative path to DESIGN.md (always "DESIGN.md"). */
+  designReference: string;
+  /** Project-root-relative path to STORYBOARD.md (always "STORYBOARD.md"). */
+  storyboardReference: string;
+  /**
+   * Project-root-relative path to the universal Hyperframes SKILL.md.
+   * `null` when the skill hasn't been installed — the
+   * `warnings` field then carries an actionable hint.
+   */
+  skillReference: string | null;
+  /** Project-root-relative compositions directory (always "compositions"). */
+  compositionsDir: string;
+  /** Per-beat plan, ordered by source document position. */
+  beats: ComposePromptsBeat[];
+  /** Step-by-step instructions for the host agent. */
+  instructions: string[];
+  /** Hyperframes bundle version — informational; ties cache keys back to the internal-LLM path. */
+  bundleVersion: string;
+  /** Non-fatal hints surfaced to the agent (e.g. missing SKILL.md). */
+  warnings: string[];
+  /** Set when {@link success} is false. */
+  error?: string;
+}
+
+export interface ComposePromptsOptions {
+  /** Project directory containing STORYBOARD.md / DESIGN.md. */
+  projectDir: string;
+  /**
+   * Restrict output to a single beat id. When unset, every beat in the
+   * storyboard is emitted.
+   */
+  beatId?: string;
+}
+
+/**
+ * Build the agent compose plan from a scene project on disk. Pure I/O —
+ * no network, no LLM, no mutation. Caller (CLI handler / manifest tool /
+ * MCP surface) decides how to surface the result.
+ */
+export async function getComposePrompts(opts: ComposePromptsOptions): Promise<ComposePromptsResult> {
+  const projectDir = resolve(opts.projectDir);
+  const designPath = join(projectDir, "DESIGN.md");
+  const storyboardPath = join(projectDir, "STORYBOARD.md");
+  const skillPath = join(projectDir, "SKILL.md");
+  const compositionsDir = join(projectDir, "compositions");
+
+  const warnings: string[] = [];
+  const baseError = (msg: string): ComposePromptsResult => ({
+    success: false,
+    projectDir,
+    designReference: "DESIGN.md",
+    storyboardReference: "STORYBOARD.md",
+    skillReference: existsSync(skillPath) ? "SKILL.md" : null,
+    compositionsDir: "compositions",
+    beats: [],
+    instructions: [],
+    bundleVersion: BUNDLE_VERSION,
+    warnings,
+    error: msg,
+  });
+
+  if (!existsSync(designPath)) {
+    return baseError(`DESIGN.md not found at ${designPath}. Run \`vibe scene init <dir>\` first.`);
+  }
+  if (!existsSync(storyboardPath)) {
+    return baseError(`STORYBOARD.md not found at ${storyboardPath}. Run \`vibe scene init <dir>\` first.`);
+  }
+
+  if (!existsSync(skillPath)) {
+    warnings.push(
+      "SKILL.md not installed — host agent won't have Hyperframes rules in context. " +
+      "Run `vibe scene install-skill` to install it.",
+    );
+  }
+
+  const storyboardMd = await readFile(storyboardPath, "utf-8");
+  const parsed = parseStoryboard(storyboardMd);
+
+  if (parsed.beats.length === 0) {
+    return baseError(`STORYBOARD.md has no \`## Beat …\` headings.`);
+  }
+
+  // Filter to one beat if requested.
+  let beats: Beat[];
+  if (opts.beatId !== undefined) {
+    const match = parsed.beats.find((b) => b.id === opts.beatId);
+    if (!match) {
+      return baseError(
+        `Beat "${opts.beatId}" not found. Available: ${parsed.beats.map((b) => b.id).join(", ")}`,
+      );
+    }
+    beats = [match];
+  } else {
+    beats = parsed.beats;
+  }
+
+  const result: ComposePromptsBeat[] = beats.map((beat) => {
+    const outputPathAbs = join(compositionsDir, `scene-${beat.id}.html`);
+    const outputPathRel = relative(projectDir, outputPathAbs);
+    const userPrompt = buildUserPrompt({
+      beat,
+      storyboardGlobal: parsed.global,
+    });
+    return {
+      id: beat.id,
+      heading: beat.heading,
+      outputPath: outputPathRel,
+      duration: beat.duration,
+      cues: beat.cues,
+      body: beat.body,
+      userPrompt,
+      exists: existsSync(outputPathAbs),
+    };
+  });
+
+  const skillRef = existsSync(skillPath) ? "SKILL.md" : null;
+  const instructions = buildInstructions({
+    skillRef,
+    beatCount: result.length,
+    filtered: opts.beatId !== undefined,
+  });
+
+  return {
+    success: true,
+    projectDir,
+    designReference: "DESIGN.md",
+    storyboardReference: "STORYBOARD.md",
+    skillReference: skillRef,
+    compositionsDir: "compositions",
+    beats: result,
+    instructions,
+    bundleVersion: BUNDLE_VERSION,
+    warnings,
+  };
+}
+
+function buildInstructions(args: {
+  skillRef: string | null;
+  beatCount: number;
+  filtered: boolean;
+}): string[] {
+  const lines: string[] = [];
+  if (args.skillRef) {
+    lines.push(`1. Read \`${args.skillRef}\` for the Hyperframes framework rules + house style. This is the visual-identity hard-gate.`);
+  } else {
+    lines.push(`1. Run \`vibe scene install-skill\` to install \`SKILL.md\` (Hyperframes rules) into this project, then re-read it.`);
+  }
+  lines.push(`2. Read \`DESIGN.md\` for project-specific palette, typography, motion signature.`);
+  lines.push(`3. For each beat in the \`beats\` array below, author HTML at \`outputPath\` matching the \`userPrompt\`. The beat \`body\` carries the narrative + visual + animation intent; \`cues\` carries machine-readable per-beat overrides (narration, duration, backdrop, voice).`);
+  if (args.beatCount > 1) {
+    lines.push(`4. After authoring all ${args.beatCount} beat(s), run \`vibe scene lint --fix\` to validate. Fix any remaining errors by editing the HTML directly.`);
+  } else if (args.filtered) {
+    lines.push(`4. After authoring this beat, run \`vibe scene lint --fix\` to validate. Author the remaining beats with the same flow (re-call this command without \`--beat\`).`);
+  } else {
+    lines.push(`4. After authoring, run \`vibe scene lint --fix\` to validate.`);
+  }
+  lines.push(`5. Run \`vibe scene render\` to produce the final MP4.`);
+  return lines;
+}

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -84,6 +84,7 @@ import {
   deriveInstallHosts,
   type InstallSkillHost,
 } from "./_shared/install-skill.js";
+import { getComposePrompts } from "./_shared/compose-prompts.js";
 
 const VALID_ASPECTS: SceneAspect[] = ["16:9", "9:16", "1:1", "4:5"];
 
@@ -329,6 +330,78 @@ sceneCommand
       console.log();
       console.log(chalk.dim("Dry run — no files written. Re-run without --dry-run to apply."));
     }
+  });
+
+// ---------------------------------------------------------------------------
+// `vibe scene compose-prompts` — Phase H2 agentic primitive
+// ---------------------------------------------------------------------------
+// Emit the prompt + skill-bundle reference plan for the host agent to
+// author per-beat HTML files itself. No LLM call from the CLI. Pairs
+// with `vibe scene install-skill` (H1) — skill files in the project,
+// reasoning in the host agent.
+
+sceneCommand
+  .command("compose-prompts")
+  .description("Emit the per-beat compose plan for the host agent to author HTML itself (Phase H2 — no LLM call)")
+  .argument("[project-dir]", "Project directory containing STORYBOARD.md / DESIGN.md", ".")
+  .option("--beat <id>", "Restrict the plan to a single beat by id (e.g. 'hook', '1')")
+  .action(async (projectDirArg: string, options) => {
+    const projectDir = resolve(projectDirArg);
+    const result = await getComposePrompts({
+      projectDir,
+      beatId: options.beat as string | undefined,
+    });
+
+    if (!result.success) {
+      if (isJsonMode()) {
+        outputResult({
+          command: "scene compose-prompts",
+          ...result,
+        });
+        process.exit(1);
+      }
+      exitWithError(generalError(result.error ?? "compose-prompts failed"));
+    }
+
+    if (isJsonMode()) {
+      outputResult({
+        command: "scene compose-prompts",
+        ...result,
+      });
+      return;
+    }
+
+    console.log();
+    console.log(chalk.bold.cyan("Scene compose plan"));
+    console.log(chalk.dim("─".repeat(60)));
+    console.log(chalk.dim(`Project:    ${projectDir}`));
+    console.log(chalk.dim(`Skill ref:  ${result.skillReference ?? chalk.yellow("not installed")}`));
+    console.log(chalk.dim(`Design ref: ${result.designReference}`));
+    console.log(chalk.dim(`Beats:      ${result.beats.length}${options.beat ? " (filtered)" : ""}`));
+    console.log(chalk.dim(`Bundle:     ${result.bundleVersion}`));
+    console.log();
+
+    if (result.warnings.length > 0) {
+      console.log(chalk.yellow("Warnings"));
+      console.log(chalk.dim("─".repeat(60)));
+      for (const w of result.warnings) console.log(chalk.yellow(`  ⚠ ${w}`));
+      console.log();
+    }
+
+    console.log(chalk.bold.cyan("Beats"));
+    console.log(chalk.dim("─".repeat(60)));
+    for (const b of result.beats) {
+      const status = b.exists ? chalk.dim("(exists)") : chalk.green("(new)");
+      const dur = b.duration !== undefined ? chalk.dim(` ${b.duration}s`) : "";
+      console.log(`  ${chalk.bold(b.id)}${dur} → ${b.outputPath} ${status}`);
+    }
+    console.log();
+
+    console.log(chalk.bold.cyan("Instructions for the host agent"));
+    console.log(chalk.dim("─".repeat(60)));
+    for (const line of result.instructions) console.log(`  ${line}`);
+    console.log();
+    console.log(chalk.dim("Re-run with --json to get the full per-beat userPrompt + cues for direct consumption."));
   });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -33,6 +33,7 @@ import {
   type InstallSkillHost,
 } from "../../commands/_shared/install-skill.js";
 import { detectedAgentHosts } from "../../utils/agent-host-detect.js";
+import { getComposePrompts } from "../../commands/_shared/compose-prompts.js";
 
 const SCENE_PRESETS = [
   "simple",
@@ -488,6 +489,51 @@ export const sceneInstallSkillTool = defineTool({
   },
 });
 
+// ---------------------------------------------------------------------------
+// scene_compose_prompts — Phase H2 agentic primitive
+// ---------------------------------------------------------------------------
+
+const sceneComposePromptsSchema = z.object({
+  projectDir: z.string().describe("Project directory containing STORYBOARD.md / DESIGN.md. Required to keep cross-host calls explicit."),
+  beat: z.string().optional().describe("Restrict the plan to a single beat by id (e.g. 'hook', '1'). Omit to emit every beat in the storyboard."),
+});
+
+export const sceneComposePromptsTool = defineTool({
+  name: "scene_compose_prompts",
+  category: "scene",
+  cost: "free",
+  description:
+    "Emit the per-beat compose plan for the host agent to author scene HTML itself. Reads STORYBOARD.md + DESIGN.md and returns each beat's outputPath + userPrompt + cues + body, plus references to the project's SKILL.md (Hyperframes rules) and DESIGN.md (visual identity). The host agent writes each compositions/scene-<id>.html file directly — VibeFrame makes NO LLM call here. Pairs with scene_install_skill (Phase H1). Phase H2 of the agentic-native composer plan; the internal-LLM batch path (scene_build) remains as a fallback for non-agent contexts.",
+  schema: sceneComposePromptsSchema,
+  async execute(args, ctx) {
+    const projectDir = resolve(ctx.workingDirectory, args.projectDir);
+    const result = await getComposePrompts({
+      projectDir,
+      beatId: args.beat,
+    });
+    if (!result.success) {
+      return { success: false, error: result.error ?? "compose-prompts failed" };
+    }
+    return {
+      success: true,
+      data: {
+        projectDir: relative(ctx.workingDirectory, result.projectDir) || ".",
+        designReference: result.designReference,
+        storyboardReference: result.storyboardReference,
+        skillReference: result.skillReference,
+        compositionsDir: result.compositionsDir,
+        beats: result.beats,
+        instructions: result.instructions,
+        bundleVersion: result.bundleVersion,
+        warnings: result.warnings,
+      },
+      humanLines: [
+        `Compose plan ready: ${result.beats.length} beat(s)${result.warnings.length > 0 ? ` (${result.warnings.length} warning(s))` : ""}.`,
+      ],
+    };
+  },
+});
+
 /** All scene-category manifest entries (type-erased for heterogeneous aggregation). */
 export const sceneTools: readonly AnyTool[] = [
   sceneInitTool as unknown as AnyTool,
@@ -497,4 +543,5 @@ export const sceneTools: readonly AnyTool[] = [
   sceneBuildTool as unknown as AnyTool,
   sceneStylesTool as unknown as AnyTool,
   sceneInstallSkillTool as unknown as AnyTool,
+  sceneComposePromptsTool as unknown as AnyTool,
 ];

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -16,8 +16,8 @@ describe("@vibeframe/mcp-server", () => {
       expect(tools.length).toBeGreaterThan(0);
     });
 
-    it("should have 64 tools total", () => {
-      expect(tools.length).toBe(64);
+    it("should have 65 tools total", () => {
+      expect(tools.length).toBe(65);
     });
 
     it("should have correct tool structure", () => {

--- a/packages/mcp-server/src/tools/cli-sync.test.ts
+++ b/packages/mcp-server/src/tools/cli-sync.test.ts
@@ -32,7 +32,7 @@ interface CommanderLike {
 // `<group> <subname>` CLI invocation paired with the canonical manifest
 // tool name (or null if explicitly CLI-only).
 const CLI_TREE: Record<string, string[]> = {
-  scene:    ["init", "styles", "add", "lint", "render", "build", "install-skill"],
+  scene:    ["init", "styles", "add", "lint", "render", "build", "install-skill", "compose-prompts"],
   generate: ["image", "video", "video-status", "video-cancel", "video-extend", "speech", "sound-effect", "music", "music-status", "storyboard", "motion", "thumbnail", "background"],
   edit:     ["silence-cut", "caption", "noise-reduce", "fade", "translate-srt", "jump-cut", "fill-gaps", "grade", "text-overlay", "speed-ramp", "reframe", "image", "interpolate", "upscale-video"],
   audio:    ["transcribe", "voices", "isolate", "voice-clone", "dub", "duck"],
@@ -63,6 +63,7 @@ const CLI_TO_MANIFEST: Record<string, string | null> = {
   "scene render":        "scene_render",
   "scene build":         "scene_build",
   "scene install-skill": "scene_install_skill",
+  "scene compose-prompts": "scene_compose_prompts",
   // generate
   "generate image":         "generate_image",
   "generate video":         "generate_video",

--- a/packages/mcp-server/src/tools/scene.test.ts
+++ b/packages/mcp-server/src/tools/scene.test.ts
@@ -24,11 +24,12 @@ async function callScene(name: string, args: Record<string, unknown>): Promise<s
 }
 
 describe("MCP scene tools — registration", () => {
-  it("exports seven tools with the canonical names", () => {
+  it("exports eight tools with the canonical names", () => {
     const names = sceneMcpTools.map((t) => t.name).sort();
     expect(names).toEqual([
       "scene_add",
       "scene_build",
+      "scene_compose_prompts",
       "scene_init",
       "scene_install_skill",
       "scene_lint",


### PR DESCRIPTION
## Summary

Phase H2 of the agentic-native composer plan. Pairs with H1 (\`scene_install_skill\`, #177): once the host agent has \`SKILL.md\` in context, this command emits the per-beat plan it needs to author HTML files itself — **no LLM call from inside VibeFrame**.

## Why

Plan H closes the architectural smell where \`compose-scenes-with-skills\` made VibeFrame's CLI run its own LLM call internally, hiding the Hyperframes skill bundle from the host agent and splitting reasoning across two contexts. H1 put the skill in the user's project; H2 gives the host agent a structured plan to consume so it can do the composition itself.

## What changed

### New
- **\`commands/_shared/compose-prompts.ts\`** — pure I/O. Reads STORYBOARD.md + DESIGN.md and returns a structured plan: each beat's \`outputPath\`, \`userPrompt\` (same shape \`composeBeatHtml\` builds), \`body\`, \`cues\`, \`duration\`, \`exists\`. Plus references to the project's \`SKILL.md\` / \`DESIGN.md\` and a step-by-step \`instructions\` array for the host agent (read skill → read design → author HTML → lint → render). Surfaces a warning + null \`skillReference\` when SKILL.md is not installed.
- **\`vibe scene compose-prompts [project-dir] [--beat <id>]\`** — CLI subcommand. Human summary by default; \`--json\` emits the full plan with userPrompts.
- **\`scene_compose_prompts\` manifest tool** — same primitive on MCP / Agent surfaces so any host (Claude Code, Cursor, Codex, Aider) can call it and receive the plan as JSON.

### Modified
- Counts: MCP 64 → 65, Agent 80 → 81.
- README + \`apps/web/app/layout.tsx\` fallback updated.
- Test fixtures and SYNC_TABLE entries updated.

## Behaviour

Plan returned to the host agent:

\`\`\`json
{
  "success": true,
  "projectDir": "<abs>",
  "designReference":     "DESIGN.md",
  "storyboardReference": "STORYBOARD.md",
  "skillReference":      "SKILL.md",
  "compositionsDir":     "compositions",
  "beats": [
    {
      "id": "hook",
      "heading": "Beat hook — Hook (0–3s)",
      "outputPath": "compositions/scene-hook.html",
      "duration": 3,
      "body": "...",
      "userPrompt": "Build the Hyperframes sub-composition HTML for this beat...",
      "exists": false
    }
  ],
  "instructions": [
    "1. Read \`SKILL.md\` for the Hyperframes framework rules + house style...",
    "2. Read \`DESIGN.md\` for project-specific palette, typography, motion signature.",
    "3. For each beat in the \`beats\` array below, author HTML at \`outputPath\`...",
    "4. After authoring all 1 beat(s), run \`vibe scene lint --fix\` to validate...",
    "5. Run \`vibe scene render\` to produce the final MP4."
  ],
  "bundleVersion": "970367f-2026-04-25",
  "warnings": []
}
\`\`\`

## Tests

12 new cases in \`compose-prompts.test.ts\`:
- happy path (multi-beat) with userPrompt + outputPath
- "no LLM call" — runs with every API key removed
- \`exists: true\` for pre-existing compositions
- \`--beat <id>\` filter and not-found error
- missing SKILL.md → warning + null \`skillReference\`
- missing DESIGN.md / STORYBOARD.md → structured failure
- empty storyboard → structured failure
- cue-derived duration parsing
- bundleVersion assertion (matches H1 install)

Plus updated registration assertions and SYNC_TABLE rows.

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\`
- [x] \`pnpm lint\` (0 errors, 8 pre-existing warnings)
- [x] \`pnpm -F @vibeframe/cli test\` — 669 passed | 9 skipped
- [x] \`pnpm -F @vibeframe/mcp-server test\` — 48 passed
- [x] \`bash scripts/sync-counts.sh --check\` green
- [x] Built bundle smoke-tested: \`vibe scene init /tmp/h2-test --visual-style "Swiss Pulse"\` (auto-installs skill via H1) then \`vibe scene compose-prompts --beat hook --json\` → emitted SKILL.md/DESIGN.md/STORYBOARD.md references, beat plan with ~5 KB userPrompt, 5-step instructions. Confirmed zero outbound API calls.
- [ ] CI green

## What's next

- **H3** — mode dispatch on \`vibe scene build\`: pick agent vs batch composer based on context (agent host detection / explicit \`--mode\` flag).
- **H4** — multi-host detection in \`vibe doctor\` / setup wizard so users get guided onto the agentic path on first run.