### PR TITLE
feat(scene): mode dispatch on vibe scene build (Plan H — Phase 3)

### DIFF
--- a/packages/cli/src/commands/_shared/scene-build-mode.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build-mode.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Phase H3 — `vibe scene build` mode dispatch tests.
+ *
+ * Covers two layers:
+ *   1. `resolveSceneBuildMode()` — pure function, no I/O. Verifies the
+ *      env-var override + agent-host auto-detect order.
+ *   2. End-to-end agent mode in `executeSceneBuild()` — runs primitives,
+ *      then either returns a `needs-author` plan (compositions missing)
+ *      or proceeds to lint+render (compositions already present).
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { executeSceneBuild, resolveSceneBuildMode } from "./scene-build.js";
+
+vi.mock("./tts-resolve.js", () => ({
+  resolveTtsProvider: vi.fn(),
+  TtsKeyMissingError: class TtsKeyMissingError extends Error {},
+}));
+
+vi.mock("@vibeframe/ai-providers", () => ({
+  OpenAIImageProvider: vi.fn(),
+}));
+
+vi.mock("./compose-scenes-skills.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./compose-scenes-skills.js")>();
+  return {
+    ...actual,
+    executeComposeScenesWithSkills: vi.fn(),
+  };
+});
+
+vi.mock("./scene-render.js", () => ({
+  executeSceneRender: vi.fn(),
+}));
+
+vi.mock("../../utils/agent-host-detect.js", () => ({
+  detectedAgentHosts: vi.fn(),
+}));
+
+import { resolveTtsProvider } from "./tts-resolve.js";
+import { OpenAIImageProvider } from "@vibeframe/ai-providers";
+import { executeComposeScenesWithSkills } from "./compose-scenes-skills.js";
+import { executeSceneRender } from "./scene-render.js";
+import { detectedAgentHosts } from "../../utils/agent-host-detect.js";
+
+const STORYBOARD = `## Beat hook — Hook
+
+\`\`\`yaml
+narration: "Type a YAML."
+duration: 3
+\`\`\`
+
+### Concept
+Cold open.
+
+## Beat outro — Outro
+
+\`\`\`yaml
+narration: "VibeFrame."
+duration: 3
+\`\`\`
+
+### Concept
+End frame.
+`;
+
+let projectDir: string;
+const originalBuildMode = process.env.VIBE_BUILD_MODE;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "scene-build-mode-test-"));
+  mkdirSync(join(projectDir, "compositions"), { recursive: true });
+  writeFileSync(join(projectDir, "STORYBOARD.md"), STORYBOARD);
+  writeFileSync(join(projectDir, "DESIGN.md"), "# Design\n");
+  writeFileSync(join(projectDir, "index.html"), "<!doctype html><body></body>");
+
+  vi.mocked(resolveTtsProvider).mockResolvedValue({
+    provider: "kokoro",
+    audioExtension: "wav",
+    call: vi.fn().mockResolvedValue({ success: true, audioBuffer: Buffer.from([1]) }),
+  });
+
+  vi.mocked(OpenAIImageProvider).mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    generateImage: vi.fn().mockResolvedValue({
+      success: true,
+      images: [{ base64: Buffer.from([5]).toString("base64") }],
+    }),
+  } as unknown as InstanceType<typeof OpenAIImageProvider>));
+
+  vi.mocked(executeComposeScenesWithSkills).mockResolvedValue({
+    success: true,
+    outputPath: projectDir,
+    data: { beats: 2, written: [], totalCostUsd: 0, totalTokensIn: 0, totalTokensOut: 0, cacheHits: 0 },
+  });
+
+  vi.mocked(executeSceneRender).mockResolvedValue({
+    success: true,
+    outputPath: join(projectDir, "renders", "out.mp4"),
+    audioCount: 0,
+    audioMuxApplied: true,
+  });
+
+  vi.mocked(detectedAgentHosts).mockReturnValue([]);
+
+  process.env.OPENAI_API_KEY = "test-key";
+  delete process.env.VIBE_BUILD_MODE;
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+  delete process.env.OPENAI_API_KEY;
+  if (originalBuildMode === undefined) delete process.env.VIBE_BUILD_MODE;
+  else process.env.VIBE_BUILD_MODE = originalBuildMode;
+});
+
+describe("resolveSceneBuildMode", () => {
+  it("explicit batch / agent passes through", () => {
+    expect(resolveSceneBuildMode({ mode: "batch" })).toBe("batch");
+    expect(resolveSceneBuildMode({ mode: "agent" })).toBe("agent");
+  });
+
+  it("auto picks batch when no agent hosts are detected", () => {
+    vi.mocked(detectedAgentHosts).mockReturnValue([]);
+    expect(resolveSceneBuildMode({ mode: "auto" })).toBe("batch");
+    // mode omitted → auto
+    expect(resolveSceneBuildMode({})).toBe("batch");
+  });
+
+  it("auto picks agent when at least one host is detected", () => {
+    vi.mocked(detectedAgentHosts).mockReturnValue([
+      { id: "claude-code", label: "Claude Code", detected: true, signals: [], projectFiles: [] },
+    ]);
+    expect(resolveSceneBuildMode({ mode: "auto" })).toBe("agent");
+  });
+
+  it("VIBE_BUILD_MODE=batch overrides explicit agent (and vice-versa)", () => {
+    process.env.VIBE_BUILD_MODE = "batch";
+    expect(resolveSceneBuildMode({ mode: "agent" })).toBe("batch");
+
+    process.env.VIBE_BUILD_MODE = "agent";
+    expect(resolveSceneBuildMode({ mode: "batch" })).toBe("agent");
+  });
+
+  it("VIBE_BUILD_MODE with garbage value falls through to the requested mode", () => {
+    process.env.VIBE_BUILD_MODE = "nonsense";
+    vi.mocked(detectedAgentHosts).mockReturnValue([]);
+    expect(resolveSceneBuildMode({ mode: "auto" })).toBe("batch");
+    expect(resolveSceneBuildMode({ mode: "agent" })).toBe("agent");
+  });
+});
+
+describe("executeSceneBuild — agent mode dispatch", () => {
+  it("returns a needs-author plan when compositions/scene-*.html are missing", async () => {
+    const r = await executeSceneBuild({ projectDir, mode: "agent" });
+    expect(r.success).toBe(true);
+    expect(r.phase).toBe("needs-author");
+    expect(r.mode).toBe("agent");
+    expect(r.composePrompts).toBeDefined();
+    // Both beats reported with exists:false
+    expect(r.composePrompts!.beats).toHaveLength(2);
+    expect(r.composePrompts!.beats.every((b) => !b.exists)).toBe(true);
+    // Internal LLM compose path NOT invoked
+    expect(executeComposeScenesWithSkills).not.toHaveBeenCalled();
+    // Render NOT invoked yet — agent must author first
+    expect(executeSceneRender).not.toHaveBeenCalled();
+    // Instructions present and reference scene render at the end
+    expect(r.composePrompts!.instructions.some((s) => s.includes("scene render"))).toBe(true);
+  });
+
+  it("proceeds to render when all compositions/scene-*.html already exist", async () => {
+    writeFileSync(join(projectDir, "compositions/scene-hook.html"), "<template/>", "utf-8");
+    writeFileSync(join(projectDir, "compositions/scene-outro.html"), "<template/>", "utf-8");
+
+    const r = await executeSceneBuild({ projectDir, mode: "agent" });
+    expect(r.success).toBe(true);
+    expect(r.phase).toBe("done");
+    expect(r.mode).toBe("agent");
+    // Internal compose still skipped — agent already authored
+    expect(executeComposeScenesWithSkills).not.toHaveBeenCalled();
+    // Render fired
+    expect(executeSceneRender).toHaveBeenCalledOnce();
+    expect(r.outputPath).toBe(join(projectDir, "renders", "out.mp4"));
+  });
+
+  it("auto resolves to agent when host is detected and compositions are missing", async () => {
+    vi.mocked(detectedAgentHosts).mockReturnValue([
+      { id: "claude-code", label: "Claude Code", detected: true, signals: [], projectFiles: [] },
+    ]);
+    const r = await executeSceneBuild({ projectDir }); // no mode flag
+    expect(r.mode).toBe("agent");
+    expect(r.phase).toBe("needs-author");
+  });
+
+  it("VIBE_BUILD_MODE=batch overrides auto-detected agent host", async () => {
+    vi.mocked(detectedAgentHosts).mockReturnValue([
+      { id: "claude-code", label: "Claude Code", detected: true, signals: [], projectFiles: [] },
+    ]);
+    process.env.VIBE_BUILD_MODE = "batch";
+    const r = await executeSceneBuild({ projectDir });
+    expect(r.mode).toBe("batch");
+    // Internal compose called in batch mode
+    expect(executeComposeScenesWithSkills).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -22,9 +22,16 @@ vi.mock("@vibeframe/ai-providers", () => ({
   OpenAIImageProvider: vi.fn(),
 }));
 
-vi.mock("./compose-scenes-skills.js", () => ({
-  executeComposeScenesWithSkills: vi.fn(),
-}));
+vi.mock("./compose-scenes-skills.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./compose-scenes-skills.js")>();
+  // Keep the real `buildUserPrompt` (and other pure helpers) so
+  // `getComposePrompts` works, but stub the LLM-dependent
+  // `executeComposeScenesWithSkills`.
+  return {
+    ...actual,
+    executeComposeScenesWithSkills: vi.fn(),
+  };
+});
 
 vi.mock("./scene-render.js", () => ({
   executeSceneRender: vi.fn(),
@@ -106,12 +113,18 @@ beforeEach(() => {
   });
 
   process.env.OPENAI_API_KEY = "test-key";
+  // Force the batch dispatch path so existing tests keep exercising the
+  // internal-LLM compose call regardless of whether an agent host is
+  // present on the developer's machine. Phase H3 dispatch behaviour is
+  // covered by `scene-build-mode.test.ts`.
+  process.env.VIBE_BUILD_MODE = "batch";
 });
 
 afterEach(() => {
   rmSync(projectDir, { recursive: true, force: true });
   vi.clearAllMocks();
   delete process.env.OPENAI_API_KEY;
+  delete process.env.VIBE_BUILD_MODE;
 });
 
 describe("executeSceneBuild", () => {

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -32,6 +32,8 @@ import {
   type ComposeScenesActionResult,
 } from "./compose-scenes-skills.js";
 import type { ComposerProvider } from "./composer-resolve.js";
+import { getComposePrompts, type ComposePromptsBeat } from "./compose-prompts.js";
+import { detectedAgentHosts } from "../../utils/agent-host-detect.js";
 import { executeSceneRender, type SceneRenderResult } from "./scene-render.js";
 import { parseStoryboard, type Beat } from "./storyboard-parse.js";
 import {
@@ -73,9 +75,32 @@ export interface BeatBuildOutcome {
   backdropError?: string;
 }
 
+/**
+ * Build mode dispatch (Phase H3 / Plan H).
+ *
+ * - `agent` — host agent (Claude Code, Cursor, Codex, Aider …) is the
+ *   sole reasoner. The CLI runs primitives + render, but skips its own
+ *   LLM compose call. If any `compositions/scene-<id>.html` is missing,
+ *   `vibe scene build` returns a structured "needs author" plan from
+ *   `getComposePrompts()` and exits successfully — the host agent is
+ *   expected to fill the missing files and re-invoke. Otherwise lint +
+ *   render proceed.
+ * - `batch` — current internal-LLM path (PR #176, multi-provider). The
+ *   CLI calls Claude / OpenAI / Gemini directly to produce HTML. Right
+ *   choice for CI, headless automation, and "no agent host" contexts.
+ * - `auto` (default) — pick `agent` when (a) `VIBE_BUILD_MODE=agent`
+ *   forces it, OR (b) any agent host is detected via
+ *   `detectedAgentHosts()`. Falls back to `batch`.
+ */
+export type SceneBuildMode = "agent" | "batch" | "auto";
+
 export interface SceneBuildOptions {
   /** Project directory containing STORYBOARD.md, DESIGN.md, index.html. */
   projectDir: string;
+  /**
+   * Build mode dispatch. See {@link SceneBuildMode}. Default: `auto`.
+   */
+  mode?: SceneBuildMode;
   /** Compose effort tier — passed through to `compose-scenes-with-skills`. */
   effort?: ComposeEffort;
   /**
@@ -105,14 +130,46 @@ export interface SceneBuildOptions {
   onProgress?: (e: SceneBuildProgressEvent) => void;
 }
 
+/**
+ * Resulting state after dispatch. `phase` makes the agent contract
+ * explicit:
+ *   - `done` — render succeeded, MP4 at {@link outputPath}.
+ *   - `compose-only` — `--skip-render` was set; compositions written.
+ *   - `needs-author` — agent mode and one or more `compositions/*.html`
+ *     missing. {@link composePrompts} carries the plan the host agent
+ *     needs to author. Re-invoke `vibe scene build` after writing.
+ *   - `failed` — primitives, compose, or render errored. {@link error}
+ *     carries the message; {@link beats} reflects partial state.
+ */
+export type SceneBuildPhase = "done" | "compose-only" | "needs-author" | "failed";
+
 export interface SceneBuildResult {
   success: boolean;
+  /** Final phase reached — see {@link SceneBuildPhase}. */
+  phase: SceneBuildPhase;
+  /** Mode the dispatcher actually ran (after auto-resolve). */
+  mode: "agent" | "batch";
   error?: string;
   beats: BeatBuildOutcome[];
   /** MP4 path when `skipRender` is false and render succeeded. */
   outputPath?: string;
   composeData?: ComposeScenesActionResult["data"];
   renderResult?: SceneRenderResult;
+  /**
+   * Populated only in agent mode when {@link phase} === `"needs-author"`.
+   * The host agent should consume this to write each beat's HTML, then
+   * re-run `vibe scene build`.
+   */
+  composePrompts?: {
+    skillReference: string | null;
+    designReference: string;
+    storyboardReference: string;
+    compositionsDir: string;
+    instructions: string[];
+    beats: ComposePromptsBeat[];
+    bundleVersion: string;
+    warnings: string[];
+  };
   /** Wall-clock total. */
   totalLatencyMs: number;
 }
@@ -123,6 +180,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   const startedAt = Date.now();
   const projectDir = resolve(opts.projectDir);
   const onProgress = opts.onProgress ?? (() => {});
+  const mode = resolveSceneBuildMode(opts);
 
   const storyboardPath = join(projectDir, "STORYBOARD.md");
   if (!existsSync(storyboardPath)) {
@@ -164,34 +222,73 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   );
 
   // ── Phase 2: compose ──────────────────────────────────────────────────
-  onProgress({ type: "phase-start", phase: "compose" });
-  const composeResult = await executeComposeScenesWithSkills(
-    {
-      project: ".",
-      effort: opts.effort,
-      composer: opts.composer,
-      cacheDir: opts.cacheDir,
-      onProgress: (e) => onProgress(e),
-    },
-    projectDir,
-  );
-  if (!composeResult.success) {
-    return {
-      success: false,
-      error: `compose failed: ${composeResult.error ?? "unknown"}`,
-      beats: beatOutcomes,
-      composeData: composeResult.data,
-      totalLatencyMs: Date.now() - startedAt,
-    };
+  // Mode dispatch: agent mode hands authorship to the host agent. We
+  // check whether each beat's compositions/scene-<id>.html exists and,
+  // if any are missing, return a `needs-author` plan from
+  // `getComposePrompts()`. The host agent fills in the files and
+  // re-invokes `vibe scene build`; this branch then sees all files
+  // present and skips straight to lint+render.
+  let composeData: ComposeScenesActionResult["data"] | undefined;
+  if (mode === "agent") {
+    const compositionsDir = join(projectDir, "compositions");
+    const missingBeats = parsed.beats.filter(
+      (b) => !existsSync(join(compositionsDir, `scene-${b.id}.html`)),
+    );
+    if (missingBeats.length > 0) {
+      const plan = await getComposePrompts({ projectDir });
+      return {
+        success: true,
+        phase: "needs-author",
+        mode,
+        beats: beatOutcomes,
+        composePrompts: plan.success
+          ? {
+              skillReference: plan.skillReference,
+              designReference: plan.designReference,
+              storyboardReference: plan.storyboardReference,
+              compositionsDir: plan.compositionsDir,
+              instructions: plan.instructions,
+              beats: plan.beats,
+              bundleVersion: plan.bundleVersion,
+              warnings: plan.warnings,
+            }
+          : undefined,
+        totalLatencyMs: Date.now() - startedAt,
+      };
+    }
+    // All compositions present — fall through to render (no compose call).
+    onProgress({ type: "phase-start", phase: "compose" });
+  } else {
+    // batch — current internal-LLM compose path (PR #176, multi-provider).
+    onProgress({ type: "phase-start", phase: "compose" });
+    const composeResult = await executeComposeScenesWithSkills(
+      {
+        project: ".",
+        effort: opts.effort,
+        composer: opts.composer,
+        cacheDir: opts.cacheDir,
+        onProgress: (e) => onProgress(e),
+      },
+      projectDir,
+    );
+    if (!composeResult.success) {
+      return {
+        success: false,
+        phase: "failed",
+        mode,
+        error: `compose failed: ${composeResult.error ?? "unknown"}`,
+        beats: beatOutcomes,
+        composeData: composeResult.data,
+        totalLatencyMs: Date.now() - startedAt,
+      };
+    }
+    composeData = composeResult.data;
   }
 
   // ── Phase 2.5: wire scene compositions into root index.html ───────────
-  // compose-scenes-with-skills writes per-beat HTML to compositions/, but
-  // doesn't touch the root index.html. Without `<div class="clip"
-  // data-composition-src="compositions/scene-X.html">` references in the
-  // root, the producer renders a black 9-second video. Patch the root
-  // here so users (and agents) get a working render straight from `vibe
-  // scene build` on a fresh `vibe scene init` project.
+  // Both batch and agent modes need this — agents that just authored
+  // composition HTML still need them referenced from the root index for
+  // the producer to find them.
   await syncRootClipReferences(parsed.beats, projectDir, beatOutcomes);
 
   // ── Phase 3: render (optional) ────────────────────────────────────────
@@ -204,9 +301,11 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     if (!renderResult.success) {
       return {
         success: false,
+        phase: "failed",
+        mode,
         error: `render failed: ${renderResult.error ?? "unknown"}`,
         beats: beatOutcomes,
-        composeData: composeResult.data,
+        composeData,
         renderResult,
         totalLatencyMs: Date.now() - startedAt,
       };
@@ -217,9 +316,11 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
 
   return {
     success: true,
+    phase: opts.skipRender ? "compose-only" : "done",
+    mode,
     beats: beatOutcomes,
     outputPath,
-    composeData: composeResult.data,
+    composeData,
     renderResult,
     totalLatencyMs: Date.now() - startedAt,
   };
@@ -369,10 +470,35 @@ async function skipped(
 function failBeforePrimitives(error: string, startedAt: number): SceneBuildResult {
   return {
     success: false,
+    phase: "failed",
+    mode: "batch",
     error,
     beats: [],
     totalLatencyMs: Date.now() - startedAt,
   };
+}
+
+/**
+ * Decide which build mode to actually run. `auto` (default) prefers
+ * `agent` whenever an agent host is detected — assumption: if the user
+ * has Claude Code / Cursor / Codex / Aider installed, they're driving
+ * VibeFrame from there and want the agent to do reasoning. Falls back to
+ * `batch` for headless / CI contexts where no agent host is reachable.
+ *
+ * `VIBE_BUILD_MODE` env var overrides everything (`agent` or `batch`).
+ * Useful for CI that has Claude installed but wants the deterministic
+ * batch path, or for an agent that wants to force batch for benchmarking.
+ */
+export function resolveSceneBuildMode(opts: { mode?: SceneBuildMode }): "agent" | "batch" {
+  const envOverride = process.env.VIBE_BUILD_MODE?.toLowerCase();
+  if (envOverride === "agent" || envOverride === "batch") return envOverride;
+
+  const requested = opts.mode ?? "auto";
+  if (requested === "agent") return "agent";
+  if (requested === "batch") return "batch";
+
+  // auto — pick agent when any host is present, batch otherwise.
+  return detectedAgentHosts().length > 0 ? "agent" : "batch";
 }
 
 // ── Root index.html sync ────────────────────────────────────────────────

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -1205,8 +1205,9 @@ sceneCommand
   .command("build")
   .description("One-shot: read STORYBOARD.md cues, dispatch TTS + image-gen per beat, compose, render to MP4 (v0.60)")
   .argument("[project-dir]", "Project directory containing STORYBOARD.md", ".")
-  .option("--effort <level>", "Compose effort tier: low|medium|high", "medium")
-  .option("--composer <provider>", "LLM that composes scene HTML: claude|openai|gemini (default: auto-resolve from available API keys, claude > gemini > openai)")
+  .option("--mode <mode>", "Build mode: agent (host-agent authors HTML) | batch (CLI's internal LLM authors HTML) | auto (agent if any host detected) [Plan H — Phase 3]", "auto")
+  .option("--effort <level>", "Compose effort tier (batch mode only): low|medium|high", "medium")
+  .option("--composer <provider>", "LLM that composes scene HTML in batch mode: claude|openai|gemini (default: auto-resolve from available API keys, claude > gemini > openai)")
   .option("--skip-narration", "Don't dispatch TTS even when beats declare narration cues")
   .option("--skip-backdrop", "Don't dispatch image-gen even when beats declare backdrop cues")
   .option("--skip-render", "Compose only — don't render to MP4")
@@ -1226,6 +1227,7 @@ sceneCommand
         command: "scene build",
         params: {
           projectDir,
+          mode: options.mode,
           effort: options.effort,
           composer: options.composer,
           skipNarration: options.skipNarration ?? false,
@@ -1252,10 +1254,16 @@ sceneCommand
       exitWithError(usageError(`Invalid --composer: ${options.composer}`, `Must be one of: ${validComposers.join(", ")}`));
     }
 
+    const validModes = ["agent", "batch", "auto"] as const;
+    if (options.mode !== undefined && !validModes.includes(options.mode)) {
+      exitWithError(usageError(`Invalid --mode: ${options.mode}`, `Must be one of: ${validModes.join(", ")}`));
+    }
+
     const spinner = isJsonMode() ? null : ora("Reading STORYBOARD.md...").start();
 
     const result = await executeSceneBuild({
       projectDir,
+      mode: options.mode as "agent" | "batch" | "auto" | undefined,
       effort: options.effort,
       composer: options.composer,
       skipNarration: options.skipNarration,
@@ -1298,6 +1306,36 @@ sceneCommand
 
     if (isJsonMode()) {
       outputResult({ command: "scene build", ...result });
+      return;
+    }
+
+    // Phase H3: agent mode may pause with a "needs-author" plan instead
+    // of producing an MP4. Render this distinctly so the host agent (and
+    // human users) know what to do next.
+    if (result.phase === "needs-author") {
+      spinner?.info(chalk.cyan("Agent mode — host agent must author scene HTML before rendering"));
+      console.log();
+      console.log(chalk.bold.cyan("Beats requiring authorship"));
+      console.log(chalk.dim("─".repeat(60)));
+      const plan = result.composePrompts;
+      if (plan) {
+        for (const b of plan.beats) {
+          const status = b.exists ? chalk.dim("(exists)") : chalk.green("(needs author)");
+          const dur = b.duration !== undefined ? chalk.dim(` ${b.duration}s`) : "";
+          console.log(`  ${chalk.bold(b.id)}${dur} → ${b.outputPath} ${status}`);
+        }
+        console.log();
+        console.log(chalk.bold.cyan("Instructions"));
+        console.log(chalk.dim("─".repeat(60)));
+        for (const line of plan.instructions) console.log(`  ${line}`);
+        if (plan.warnings.length > 0) {
+          console.log();
+          for (const w of plan.warnings) console.log(chalk.yellow(`  ⚠ ${w}`));
+        }
+      }
+      console.log();
+      console.log(chalk.dim("Once you've authored each beat's HTML, re-run `vibe scene build` to lint + render."));
+      console.log(chalk.dim("Or pass `--mode batch` to use the internal LLM compose path instead."));
       return;
     }
 

--- a/packages/cli/src/pipeline/executor.ts
+++ b/packages/cli/src/pipeline/executor.ts
@@ -245,6 +245,7 @@ async function ensureActionsRegistered(): Promise<void> {
     const projectRel = (params.project as string | undefined) ?? ".";
     const r = await executeSceneBuild({
       projectDir: resolve(outputDir, projectRel),
+      mode: params.mode as "agent" | "batch" | "auto" | undefined,
       effort: params.effort as "low" | "medium" | "high" | undefined,
       composer: params.composer as "claude" | "openai" | "gemini" | undefined,
       skipNarration: params.skipNarration as boolean | undefined,

--- a/packages/cli/src/pipeline/scene-actions.test.ts
+++ b/packages/cli/src/pipeline/scene-actions.test.ts
@@ -38,6 +38,8 @@ describe("pipeline action: scene-build", () => {
   it("forwards storyboard cues to executeSceneBuild and surfaces the output path", async () => {
     vi.mocked(executeSceneBuild).mockResolvedValueOnce({
       success: true,
+      phase: "done",
+      mode: "batch",
       beats: [{ beatId: "hook", narrationStatus: "generated", backdropStatus: "generated" }],
       outputPath: "/tmp/render.mp4",
       totalLatencyMs: 1234,
@@ -73,6 +75,8 @@ steps:
   it("surfaces failure from executeSceneBuild as a failed step", async () => {
     vi.mocked(executeSceneBuild).mockResolvedValueOnce({
       success: false,
+      phase: "failed",
+      mode: "batch",
       error: "STORYBOARD.md not found",
       beats: [],
       totalLatencyMs: 0,
@@ -91,6 +95,8 @@ steps: [{ id: b, action: scene-build, project: missing }]
   it("respects --skip-render via params", async () => {
     vi.mocked(executeSceneBuild).mockResolvedValueOnce({
       success: true,
+      phase: "compose-only",
+      mode: "batch",
       beats: [],
       totalLatencyMs: 0,
     });
@@ -166,6 +172,8 @@ describe("pipeline action: scene-build chained with scene-render", () => {
   it("two steps run sequentially, $ref between them resolves", async () => {
     vi.mocked(executeSceneBuild).mockResolvedValueOnce({
       success: true,
+      phase: "done",
+      mode: "batch",
       beats: [],
       outputPath: "/tmp/build-out",
       totalLatencyMs: 0,

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -366,8 +366,9 @@ export const sceneRenderTool = defineTool({
 
 const sceneBuildSchema = z.object({
   projectDir: z.string().optional().describe("Project directory containing STORYBOARD.md, DESIGN.md, index.html. Defaults to the surface's cwd."),
-  effort: z.enum(["low", "medium", "high"]).optional().describe("Compose effort tier passed to compose-scenes-with-skills. Default 'medium'."),
-  composer: z.enum(["claude", "openai", "gemini"]).optional().describe("LLM provider that composes the per-beat scene HTML. Default: auto-resolve from available API keys (ANTHROPIC_API_KEY > GOOGLE_API_KEY > OPENAI_API_KEY). All three pass first-shot lint per the v0.70 spike; Claude is fastest, Gemini cheapest."),
+  mode: z.enum(["agent", "batch", "auto"]).optional().describe("Build mode dispatch [Plan H — Phase 3]. 'agent' = the calling host agent authors per-beat HTML itself (no internal LLM call); on missing compositions/scene-*.html files, returns a needs-author plan with prompts for the agent to consume. 'batch' = current internal-LLM compose path (Claude/OpenAI/Gemini). 'auto' (default) = agent if any agent host is detected, else batch. Override via VIBE_BUILD_MODE env var."),
+  effort: z.enum(["low", "medium", "high"]).optional().describe("Compose effort tier (batch mode only) passed to compose-scenes-with-skills. Default 'medium'."),
+  composer: z.enum(["claude", "openai", "gemini"]).optional().describe("LLM provider that composes the per-beat scene HTML in batch mode. Default: auto-resolve from available API keys (ANTHROPIC_API_KEY > GOOGLE_API_KEY > OPENAI_API_KEY). All three pass first-shot lint per the v0.70 spike; Claude is fastest, Gemini cheapest. Ignored in agent mode."),
   skipNarration: z.boolean().optional().describe("Skip TTS for every beat (use existing audio assets if present)."),
   skipBackdrop: z.boolean().optional().describe("Skip image generation for every beat (use existing PNG assets if present)."),
   skipRender: z.boolean().optional().describe("Stop after compose — produces compositions/*.html but no final MP4."),
@@ -392,6 +393,7 @@ export const sceneBuildTool = defineTool({
       : ctx.workingDirectory;
     const result = await executeSceneBuild({
       projectDir,
+      mode: args.mode,
       effort: args.effort,
       composer: args.composer,
       skipNarration: args.skipNarration,
@@ -410,6 +412,8 @@ export const sceneBuildTool = defineTool({
     return {
       success: true,
       data: {
+        phase: result.phase,
+        mode: result.mode,
         outputPath: result.outputPath,
         beats: result.beats.map((b) => ({
           beatId: b.beatId,
@@ -420,10 +424,13 @@ export const sceneBuildTool = defineTool({
           backdropPath: b.backdropPath,
           backdropError: b.backdropError,
         })),
+        composePrompts: result.composePrompts,
         totalLatencyMs: result.totalLatencyMs,
       },
       humanLines: [
-        `✅ Scene build complete${result.outputPath ? ` — ${result.outputPath}` : " (skipRender)"}`,
+        result.phase === "needs-author"
+          ? `Agent mode — ${result.composePrompts?.beats.filter((b) => !b.exists).length ?? 0} beat(s) need to be authored by the host agent. See data.composePrompts for the plan.`
+          : `Scene build complete${result.outputPath ? ` — ${result.outputPath}` : " (skipRender)"}`,
         `   beats: ${result.beats.length}`,
         `   wall-clock: ${(result.totalLatencyMs / 1000).toFixed(1)}s`,
         ...result.beats.map(


### PR DESCRIPTION
## Summary

Phase H3 of the agentic-native composer plan. Adds explicit \`agent\` vs \`batch\` dispatch on \`vibe scene build\`. With H1 (#177) putting Hyperframes skill in the user's project and H2 (#178) emitting per-beat compose plans, this PR closes the loop — \`vibe scene build --mode agent\` is the one-shot driver that pauses for the host agent to author HTML, then proceeds to lint + render once it's done.

## The contract for agent mode

1. **Run primitives** (TTS, backdrop) — same as today.
2. **Check** \`compositions/scene-<id>.html\` for each beat.
3. **If missing** → return \`phase: "needs-author"\` with a \`composePrompts\` plan (same shape \`scene_compose_prompts\` emits in #178). Host agent authors the HTML files and re-invokes \`vibe scene build\`.
4. **If present** → skip the internal-LLM compose call entirely and run lint+render. Same final MP4 as batch mode, **no second LLM call, no \`ANTHROPIC_API_KEY\` requirement**.

Auto-resolve (default): \`agent\` if any agent host is detected via \`detectedAgentHosts()\`, else \`batch\`. \`VIBE_BUILD_MODE\` env var overrides everything.

## What changed

- **\`commands/_shared/scene-build.ts\`** —
  - New \`SceneBuildMode = "agent" | "batch" | "auto"\` type and \`resolveSceneBuildMode()\` helper.
  - \`SceneBuildResult\` gains \`phase: "done" | "compose-only" | "needs-author" | "failed"\` and \`mode\` so callers branch on actual outcome.
  - \`executeSceneBuild\` dispatches: agent path skips the internal LLM and consults \`getComposePrompts()\` (#178) for the plan.
- **\`commands/scene.ts\`** — \`--mode <agent|batch|auto>\` flag, validated. Human output renders a "Beats requiring authorship" + "Instructions" block on the \`needs-author\` phase.
- **Manifest tool** — \`scene_build\` schema gains the \`mode\` enum; \`data\` surfaces \`phase\` + \`mode\` + \`composePrompts\`.
- **Pipeline executor** — \`scene-build\` YAML action accepts \`mode\` for parity.

## Tests

- 9-case \`scene-build-mode.test.ts\`:
  - \`resolveSceneBuildMode()\` covers explicit / auto / env override
  - End-to-end dispatch: \`needs-author\` emitted when compositions missing; render proceeds when present; \`auto\` picks agent on host detection; \`VIBE_BUILD_MODE=batch\` overrides
- Existing \`scene-build.test.ts\` pinned to batch via \`VIBE_BUILD_MODE=batch\` in \`beforeEach\` so assertions about \`executeComposeScenesWithSkills\` still hold regardless of which agent hosts are installed on the dev machine
- \`pipeline/scene-actions.test.ts\` mocks updated for the new required fields

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\`
- [x] \`pnpm lint\` (0 errors, 8 pre-existing warnings)
- [x] \`pnpm -F @vibeframe/cli test\` — 678 passed | 9 skipped
- [x] \`pnpm -F @vibeframe/mcp-server test\` — 48 passed
- [x] \`bash scripts/sync-counts.sh --check\` green
- [x] E2E with built bundle: \`vibe scene init /tmp/h3-test --visual-style "Swiss Pulse"\` → \`vibe scene build /tmp/h3-test --mode agent --skip-narration --skip-backdrop --json\` returned \`phase: "needs-author"\` with the full \`composePrompts\` plan. After dropping a hand-written \`compositions/scene-hook.html\`, re-running flipped to \`phase: "compose-only"\` with **no internal-LLM call** confirmed. Contract works.
- [ ] CI green

## What's next

H4 (multi-host detection in \`vibe doctor\` / setup wizard) is the only remaining phase. With H1 + H2 + H3 in place a host agent can already drive the full storyboard → MP4 flow without VibeFrame's internal LLM ever firing.