### PR TITLE
feat(doctor): scene composer readiness section (Plan H — Phase 4)

### DIFF
--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -87,3 +87,75 @@ describe("vibe doctor — scope diagnostics", () => {
     expect(json.result.scope.agentHosts.detected).toContain("Claude Code");
   });
 });
+
+describe("vibe doctor — Plan H scene composer readiness", () => {
+  it("reports recommendedMode=batch when no agent host is detected", () => {
+    const { json } = runDoctor();
+    const sc = json.result.scope.sceneComposer;
+    expect(sc.recommendedMode).toBe("batch");
+    expect(sc.sceneProjectInCwd).toBe(false);
+    expect(sc.skillInstalled).toBe(false);
+  });
+
+  it("flips recommendedMode=agent when ~/.claude is present", () => {
+    mkdirSync(join(fakeHome, ".claude"));
+    const { json } = runDoctor();
+    expect(json.result.scope.sceneComposer.recommendedMode).toBe("agent");
+  });
+
+  it("VIBE_BUILD_MODE env override beats host auto-detection", () => {
+    mkdirSync(join(fakeHome, ".claude"));
+    const out = execFileSync(
+      process.execPath,
+      [CLI, "doctor", "--json"],
+      {
+        cwd: projectDir,
+        env: {
+          ...process.env,
+          HOME: fakeHome,
+          PATH: "/usr/bin:/bin",
+          NO_COLOR: "1",
+          VIBE_BUILD_MODE: "batch",
+        },
+        encoding: "utf-8",
+      },
+    );
+    const json = JSON.parse(out);
+    expect(json.result.scope.sceneComposer.recommendedMode).toBe("batch");
+  });
+
+  it("composer=null when no API keys are present", () => {
+    const out = execFileSync(
+      process.execPath,
+      [CLI, "doctor", "--json"],
+      {
+        cwd: projectDir,
+        env: {
+          // Sterilise — drop every composer key so resolveComposer fails cleanly.
+          HOME: fakeHome,
+          PATH: "/usr/bin:/bin",
+          NO_COLOR: "1",
+        },
+        encoding: "utf-8",
+      },
+    );
+    const json = JSON.parse(out);
+    expect(json.result.scope.sceneComposer.composer).toBeNull();
+    expect(json.result.scope.sceneComposer.composerEnvVar).toBeNull();
+  });
+
+  it("flags scene project + missing SKILL.md when STORYBOARD.md is in cwd", () => {
+    writeFileSync(join(projectDir, "STORYBOARD.md"), "## Beat 1 — x\nbody\n");
+    const { json } = runDoctor();
+    expect(json.result.scope.sceneComposer.sceneProjectInCwd).toBe(true);
+    expect(json.result.scope.sceneComposer.skillInstalled).toBe(false);
+  });
+
+  it("flips skillInstalled=true once SKILL.md is in the project", () => {
+    writeFileSync(join(projectDir, "STORYBOARD.md"), "## Beat 1 — x\nbody\n");
+    writeFileSync(join(projectDir, "SKILL.md"), "---\nname: hyperframes\n---\n");
+    const { json } = runDoctor();
+    expect(json.result.scope.sceneComposer.sceneProjectInCwd).toBe(true);
+    expect(json.result.scope.sceneComposer.skillInstalled).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -14,6 +14,14 @@ import { commandExists } from "../utils/exec-safe.js";
 import { execSafe } from "../utils/exec-safe.js";
 import { loadEnv } from "../utils/api-key.js";
 import { detectAgentHosts, summariseAgentHosts } from "../utils/agent-host-detect.js";
+import {
+  composerEnvVar,
+  composerLabel,
+  resolveComposer,
+  ComposerResolveError,
+  type ComposerProvider,
+} from "./_shared/composer-resolve.js";
+import { resolveSceneBuildMode } from "./_shared/scene-build.js";
 import { outputResult } from "./output.js";
 
 /**
@@ -145,6 +153,23 @@ interface DiagnosticResults {
       detected: string[];
       summary: string;
     };
+    /**
+     * Plan H — `vibe scene build` agentic dispatch readiness.
+     *
+     * `recommendedMode` mirrors `resolveSceneBuildMode()` so the user
+     * sees what `vibe scene build` will actually do without flags.
+     * `composer` reports the auto-resolved batch fallback (claude /
+     * gemini / openai) so they know which key powers `--mode batch`.
+     * `sceneProjectInCwd` + `skillInstalled` flag whether the local
+     * cwd is a scene project that already has SKILL.md from H1.
+     */
+    sceneComposer: {
+      recommendedMode: "agent" | "batch";
+      composer: ComposerProvider | null;
+      composerEnvVar: string | null;
+      sceneProjectInCwd: boolean;
+      skillInstalled: boolean;
+    };
   };
   providers: Record<
     string,
@@ -266,6 +291,21 @@ async function runDiagnostics(): Promise<DiagnosticResults> {
   const hosts = detectAgentHosts();
   const detectedNames = hosts.filter((h) => h.detected).map((h) => h.label);
 
+  // Plan H — scene composer readiness ───────────────────────────────────
+  const recommendedMode = resolveSceneBuildMode({});
+  let composerResolved: ComposerProvider | null = null;
+  let composerEnv: string | null = null;
+  try {
+    const r = resolveComposer();
+    composerResolved = r.provider;
+    composerEnv = composerEnvVar(r.provider);
+  } catch (err) {
+    if (!(err instanceof ComposerResolveError)) throw err;
+    // No composer key — composerResolved stays null. Reported in render.
+  }
+  const sceneProjectInCwd = existsSync(resolve(cwd, "STORYBOARD.md"));
+  const skillInstalled = existsSync(resolve(cwd, "SKILL.md"));
+
   return {
     system: {
       node: { version: nodeVersion, ok: true },
@@ -277,6 +317,13 @@ async function runDiagnostics(): Promise<DiagnosticResults> {
       user: { configured: configExists, configPath: CONFIG_PATH },
       project: { cwd, initialized: projectInitialized, files: projectFiles },
       agentHosts: { detected: detectedNames, summary: summariseAgentHosts(hosts) },
+      sceneComposer: {
+        recommendedMode,
+        composer: composerResolved,
+        composerEnvVar: composerEnv,
+        sceneProjectInCwd,
+        skillInstalled,
+      },
     },
     providers,
     readyCount,
@@ -354,6 +401,36 @@ function printReport(results: DiagnosticResults): void {
   // Agent hosts — informational
   console.log(`    Agents     ${chalk.dim(results.scope.agentHosts.summary)}`);
 
+  // Plan H — scene composer ─────────────────────────────────────────────
+  console.log();
+  console.log(chalk.bold("  Scene composer (vibe scene build)"));
+  const sc = results.scope.sceneComposer;
+  const modeBadge = sc.recommendedMode === "agent"
+    ? chalk.cyan("agent")
+    : chalk.dim("batch");
+  const modeNote = sc.recommendedMode === "agent"
+    ? chalk.dim("host agent authors HTML; no internal LLM call")
+    : chalk.dim("CLI's internal LLM authors HTML");
+  console.log(`    Mode (auto)  ${modeBadge}  ${modeNote}`);
+  if (sc.composer) {
+    console.log(
+      `    Batch LLM    ${chalk.green("OK")}     ${chalk.dim(`${composerLabel(sc.composer)} (${sc.composerEnvVar})`)}`,
+    );
+  } else {
+    console.log(
+      `    Batch LLM    ${chalk.yellow("--")}     ${chalk.dim("no ANTHROPIC_API_KEY / GOOGLE_API_KEY / OPENAI_API_KEY — agent-mode only")}`,
+    );
+  }
+  if (sc.sceneProjectInCwd) {
+    if (sc.skillInstalled) {
+      console.log(`    SKILL.md     ${chalk.green("OK")}     ${chalk.dim("installed in this scene project")}`);
+    } else {
+      console.log(`    SKILL.md     ${chalk.yellow("MISSING")} ${chalk.dim("Run: vibe scene install-skill")}`);
+    }
+  } else {
+    console.log(`    SKILL.md     ${chalk.dim("(no STORYBOARD.md in cwd — skill is per-scene-project)")}`);
+  }
+
   console.log();
   console.log(chalk.bold("  API Keys"));
 
@@ -416,6 +493,12 @@ function pickNextStep(results: DiagnosticResults, hasMissingProviders: boolean):
   }
   if (!results.scope.project.initialized) {
     return "Next: run 'vibe init' in your project directory to scaffold AGENTS.md / CLAUDE.md / .env.example.";
+  }
+  // Plan H — nudge a scene project that's missing the skill files.
+  // Without SKILL.md the agentic compose path can't run.
+  const sc = results.scope.sceneComposer;
+  if (sc.sceneProjectInCwd && !sc.skillInstalled) {
+    return "Next: run 'vibe scene install-skill' so your host agent can read the Hyperframes rules from this project.";
   }
   if (hasMissingProviders) {
     return "Run 'vibe setup' to add more provider keys.";

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -425,7 +425,9 @@ function showComplete(
   console.log(chalk.dim("    vibe setup                Re-run user-scope setup anytime"));
 
   // Tailored hint when an agent host is detected — points at the file
-  // `vibe init` will scaffold for that host.
+  // `vibe init` will scaffold for that host, and surfaces the Plan H
+  // agentic compose path so they know `vibe scene build` will dispatch
+  // to their host agent automatically.
   const hosts = detectedAgentHosts();
   const primary = hosts[0];
   if (primary) {
@@ -433,6 +435,19 @@ function showComplete(
     console.log(
       chalk.dim(
         `  Detected ${primary.label} — \`vibe init\` will scaffold ${primary.projectFiles.join(" + ")} in your project.`,
+      ),
+    );
+    console.log(
+      chalk.dim(
+        `  Scene composer will auto-dispatch to ${primary.label} (${chalk.bold("--mode agent")}). ` +
+        `Run \`vibe scene init my-promo\` to scaffold a scene project + install the Hyperframes skill.`,
+      ),
+    );
+  } else {
+    console.log();
+    console.log(
+      chalk.dim(
+        `  No agent host detected — \`vibe scene build\` will use the internal LLM composer (${chalk.bold("--mode batch")}).`,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Phase H4 of the agentic-native composer plan, and the **closer** for Plan H. With H1 (#177), H2 (#178), and H3 (#180) merged, users now have:

- skill files in their projects (H1)
- a compose-prompts primitive that emits the per-beat plan with no LLM call (H2)
- \`vibe scene build --mode <agent|batch|auto>\` dispatch (H3)

H4 makes that machinery **visible**. \`vibe doctor\` now tells you which mode \`vibe scene build\` will pick, what batch fallback is wired up, and whether the current scene project still needs \`vibe scene install-skill\`. The setup wizard's "done" screen surfaces the agentic flow when a host is detected.

## What changed

### \`commands/doctor.ts\`
New \`DiagnosticResults.scope.sceneComposer\` shape:
- \`recommendedMode\` — mirrors \`resolveSceneBuildMode()\`. \`agent\` when any agent host is detected, \`batch\` otherwise. \`VIBE_BUILD_MODE\` overrides.
- \`composer\` + \`composerEnvVar\` — mirror \`resolveComposer()\`. \`null\` when no key.
- \`sceneProjectInCwd\` — STORYBOARD.md present in cwd.
- \`skillInstalled\` — SKILL.md present in cwd.

New "Scene composer (vibe scene build)" section in the human report:
\`\`\`
  Scene composer (vibe scene build)
    Mode (auto)  agent  host agent authors HTML; no internal LLM call
    Batch LLM    OK     Anthropic Claude (ANTHROPIC_API_KEY)
    SKILL.md     MISSING Run: vibe scene install-skill
\`\`\`

\`pickNextStep()\` gains a Plan H rule: when the cwd is a scene project with no SKILL.md, the next-step hint becomes \`vibe scene install-skill\` (ranked above provider-key gaps).

### \`commands/setup.ts\`
Wizard's "Setup complete" screen surfaces the agentic flow:
- With host detected → "Scene composer will auto-dispatch to <Host> (--mode agent). Run \`vibe scene init my-promo\`…"
- Without host → "No agent host detected — \`vibe scene build\` will use the internal LLM composer (--mode batch)."

## Tests

\`doctor.test.ts\` gains 6 Plan H cases (all black-box against the built CLI binary, same pattern as the v0.61 scope tests):
- recommendedMode=batch baseline (sterile env)
- recommendedMode=agent flips when \`~/.claude\` exists
- \`VIBE_BUILD_MODE=batch\` overrides host detection
- composer=null when no API keys are reachable
- sceneProjectInCwd=true when STORYBOARD.md is in cwd
- skillInstalled=true once SKILL.md is dropped in

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\`
- [x] \`pnpm lint\` (0 errors, 8 pre-existing warnings)
- [x] \`pnpm -F @vibeframe/cli test\` — 684 passed | 9 skipped
- [x] \`pnpm -F @vibeframe/mcp-server test\` — 48 passed
- [x] \`bash scripts/sync-counts.sh --check\` green
- [x] E2E with built bundle: \`vibe doctor --json\` returns the new \`sceneComposer\` shape; flips \`sceneProjectInCwd\` true when STORYBOARD.md is present
- [ ] CI green

## Plan H — final scoreboard

| Phase | PR | Outcome |
|-------|-----|---------|
| H1 | #177 | Install Hyperframes skill into user projects (\`SKILL.md\` + per-host layouts) |
| H2 | #178 | \`scene_compose_prompts\` agentic primitive (no LLM call) |
| H3 | #180 | \`vibe scene build --mode <agent\|batch\|auto>\` dispatch |
| H4 | this | Doctor + setup wizard surface the agentic flow |

Score on the agentic-CLI design pattern (skill files principle): **3/10 → 9/10**. The architectural smell where VibeFrame's CLI ran its own LLM behind the host agent's back is closed — host agents (Claude Code, Cursor, Codex, Aider) can now drive the full storyboard → MP4 flow without the internal LLM ever firing.