### PR TITLE
release: v0.70.0 — Plan H (agentic composer) + multi-provider composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.70.0] - 2026-04-28
+
+**Plan H — agentic-native composer.** Closes the architectural smell where `vibe scene build` made VibeFrame's CLI run its own Anthropic / OpenAI / Gemini call hidden behind the host agent. Now the host agent (Claude Code, Cursor, Codex, Aider) is the sole reasoner; VibeFrame ships skill files into the user's project and provides a deterministic toolbelt around them. The internal-LLM batch path is preserved as a fallback for CI / non-agent contexts.
+
+Counts: MCP 63 → 65, Agent 79 → 81.
+
+### Added
+
+- **Multi-provider scene composer (#176)** — `vibe scene build --composer <claude|openai|gemini>` (default: auto-resolve from available API keys, claude > gemini > openai). The Phase 0 spike showed all three providers pass first-shot lint on the vibeframe-promo fixture; the new `composer-resolve.ts` helper picks the right one. Cost / latency table (per beat): Claude $0.060 / 9.4 s, Gemini $0.023 / 20 s, OpenAI gpt-5 $0.056 / 71 s. Backed by a generic `LLMCallFn` injection in `compose-scenes-skills.ts` (replaces the direct Anthropic SDK calls).
+- **Plan H Phase 1 — install Hyperframes skill (#177)** — `vibe scene install-skill [project-dir]` and `scene_install_skill` manifest tool. Writes a universal `SKILL.md` + `references/*.md` at the project root, plus host-specific layouts: `.claude/skills/hyperframes/SKILL.md` (Agent Skills standard, Claude Code) and `.cursor/rules/hyperframes.mdc` (Cursor frontmatter with auto-activate globs on `compositions/**/*.html`). Codex / Aider read the universal `SKILL.md` via AGENTS.md. `vibe scene init` auto-installs for detected hosts. Idempotent (skip-on-exist), `--force` to overwrite, `--dry-run` reports.
+- **Plan H Phase 2 — agentic compose primitive (#178)** — `vibe scene compose-prompts <project-dir> [--beat <id>]` and `scene_compose_prompts` manifest tool. Reads STORYBOARD.md + DESIGN.md and emits a structured plan: each beat's `outputPath`, `userPrompt`, `body`, `cues`, `duration`, `exists`, plus `skillReference` / `designReference` and a 5-step instruction list for the host agent. **No LLM call from inside VibeFrame.** Pairs with the H1 skill files: host agent reads SKILL.md, authors HTML at the indicated paths, runs `vibe scene lint --fix`, then `vibe scene render`.
+- **Plan H Phase 3 — `vibe scene build` mode dispatch (#180)** — `--mode <agent|batch|auto>` with auto-resolve (`agent` if any agent host is detected, `batch` otherwise). `VIBE_BUILD_MODE` env var overrides everything. Agent mode skips the internal-LLM compose call: when any `compositions/scene-*.html` is missing, returns `phase: "needs-author"` with the H2 plan; when all are present, proceeds to lint + render. New `phase: "done" | "compose-only" | "needs-author" | "failed"` discriminator on `SceneBuildResult` so callers branch on actual outcome.
+- **Plan H Phase 4 — doctor + setup readiness (#181)** — `vibe doctor` gains a "Scene composer (vibe scene build)" section reporting the resolved mode, the auto-picked composer (with env var), and SKILL.md status for the cwd. `pickNextStep()` nudges `vibe scene install-skill` when the cwd is a scene project missing the skill. Setup wizard surfaces the agent-mode auto-dispatch on its "Setup complete" screen.
+
+### Changed
+
+- `compose-scenes-skills.ts` refactored from direct Anthropic SDK calls to a generic `LLMCallFn` injection point (#176). `MODEL_SETTINGS` keyed on `(provider, effort)`. `computeCacheKey` folds provider id into the hash so switching composers doesn't serve cached HTML produced by a different model.
+- `vibe init` AGENTS.md template gains a "Scene composer" section pointing at `--composer` and the skill install (#176, #177).
+
+### Removed
+
+Nothing. Plan H is purely additive — the internal-LLM batch path stays as the fallback so CI and non-agent users keep working.
+
+### Maintenance
+
+- v0.70.0 release — bump version + CHANGELOG (this PR)
+
 ## [0.69.0] - 2026-04-28
 
 Plan G Phases 2–5 (OSS-first refactor) + a 3-PR CLI cleanup pass that retired ~6,000 lines of dead/deprecated surface. Counts: MCP 64 → 63, Agent 80 → 79.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bump 0.69.0 → 0.70.0 + CHANGELOG. Releases Plan H (agentic-native composer) + the multi-provider composer that landed since v0.69.0.

## Highlights

- **#176** Multi-provider scene composer — Claude / OpenAI / Gemini selectable via `vibe scene build --composer <name>`. All three pass first-shot lint per the Phase 0 spike.
- **Plan H — agentic composer** (#177, #178, #180, #181) — skill files install, agentic compose primitive, mode dispatch on \`vibe scene build\`, doctor / wizard readiness section.

## Architectural change

Pre-Plan H: \`vibe scene build\` made the CLI run its own LLM call internally with the Hyperframes skill bundle as system prompt. Skill content was a TS string in the bundle — invisible to host agents.

Post-Plan H: \`vibe scene build --mode agent\` returns \`phase: "needs-author"\` with a structured per-beat plan; the host agent (Claude Code / Cursor / Codex / Aider) reads \`SKILL.md\` from the user's project and authors HTML directly. VibeFrame is the deterministic toolbelt around it. Internal-LLM batch path stays as the fallback (\`--mode batch\`).

Counts: MCP 63 → 65, Agent 79 → 81. Non-breaking — \`auto\` mode resolves to \`batch\` when no agent host is present, preserving the v0.69 flow.

## Release flow

1. Merge → \`auto-tag.yml\` creates the \`v0.70.0\` annotated tag from the package.json bump.
2. \`publish.yml\` is dispatched to publish \`@vibeframe/cli\` + \`@vibeframe/mcp-server\` to npm.

## Test plan

- [x] Local typecheck (\`pnpm -r exec tsc --noEmit\`) green
- [x] \`bash scripts/sync-counts.sh --check\` green
- [ ] CI green (typecheck + build-and-test 20/22 + Vercel)
- [ ] auto-tag fires and publish.yml succeeds for both packages