### PR TITLE
feat(agent-detect): recognize Gemini CLI + OpenCode

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -39,7 +39,7 @@ import { exitWithError, isJsonMode, outputResult, usageError } from "./output.js
 
 type AgentSelection = AgentHostId | "all" | "auto";
 
-const VALID_AGENTS: readonly AgentSelection[] = ["claude-code", "codex", "cursor", "aider", "all", "auto"];
+const VALID_AGENTS: readonly AgentSelection[] = ["claude-code", "codex", "cursor", "aider", "gemini-cli", "opencode", "all", "auto"];
 
 interface InitFileAction {
   path: string;
@@ -173,7 +173,7 @@ export const initCommand = new Command("init")
 
 function resolveTargets(agent: AgentSelection): AgentHostId[] {
   if (agent === "all") {
-    return ["claude-code", "codex", "cursor", "aider"];
+    return ["claude-code", "codex", "cursor", "aider", "gemini-cli", "opencode"];
   }
   if (agent === "auto") {
     const detected = detectedAgentHosts().map((h) => h.id);

--- a/packages/cli/src/utils/agent-host-detect.test.ts
+++ b/packages/cli/src/utils/agent-host-detect.test.ts
@@ -40,9 +40,9 @@ function makeConfigDir(rel: string): void {
 }
 
 describe("detectAgentHosts", () => {
-  it("returns all 4 hosts with detected=false in a clean environment", () => {
+  it("returns all 6 hosts with detected=false in a clean environment", () => {
     const hosts = detectAgentHosts({ PATH: PATH_DIR });
-    expect(hosts).toHaveLength(4);
+    expect(hosts).toHaveLength(6);
     for (const h of hosts) {
       expect(h.detected).toBe(false);
       expect(h.signals).toEqual([]);
@@ -52,6 +52,8 @@ describe("detectAgentHosts", () => {
       "codex",
       "cursor",
       "aider",
+      "gemini-cli",
+      "opencode",
     ]);
   });
 
@@ -98,6 +100,49 @@ describe("detectAgentHosts", () => {
     makeBinary("aider");
     const withBinary = detectAgentHosts({ PATH: PATH_DIR });
     expect(withBinary.find((h) => h.id === "aider")!.detected).toBe(true);
+  });
+
+  it("detects Gemini CLI via gemini binary OR ~/.gemini config dir", () => {
+    makeBinary("gemini");
+    const a = detectAgentHosts({ PATH: PATH_DIR });
+    expect(a.find((h) => h.id === "gemini-cli")!.detected).toBe(true);
+    expect(a.find((h) => h.id === "gemini-cli")!.signals).toEqual([{ kind: "binary", name: "gemini" }]);
+  });
+
+  it("detects Gemini CLI via ~/.gemini config dir alone", () => {
+    makeConfigDir(".gemini");
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    const gemini = hosts.find((h) => h.id === "gemini-cli")!;
+    expect(gemini.detected).toBe(true);
+    expect(gemini.signals).toEqual([{ kind: "configDir", path: join(HOME, ".gemini") }]);
+  });
+
+  it("detects OpenCode via opencode binary OR ~/.config/opencode dir", () => {
+    makeBinary("opencode");
+    const a = detectAgentHosts({ PATH: PATH_DIR });
+    expect(a.find((h) => h.id === "opencode")!.detected).toBe(true);
+    expect(a.find((h) => h.id === "opencode")!.signals).toEqual([{ kind: "binary", name: "opencode" }]);
+  });
+
+  it("detects OpenCode via XDG ~/.config/opencode/ even with no binary", () => {
+    makeConfigDir(".config/opencode");
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    const oc = hosts.find((h) => h.id === "opencode")!;
+    expect(oc.detected).toBe(true);
+    expect(oc.signals).toEqual([{ kind: "configDir", path: join(HOME, ".config/opencode") }]);
+  });
+
+  it("Gemini CLI projectFiles include both GEMINI.md (primary) and AGENTS.md (cross-tool)", () => {
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    const gemini = hosts.find((h) => h.id === "gemini-cli")!;
+    expect(gemini.projectFiles).toContain("GEMINI.md");
+    expect(gemini.projectFiles).toContain("AGENTS.md");
+  });
+
+  it("OpenCode projectFiles include AGENTS.md (per agents.md spec)", () => {
+    const hosts = detectAgentHosts({ PATH: PATH_DIR });
+    const oc = hosts.find((h) => h.id === "opencode")!;
+    expect(oc.projectFiles).toContain("AGENTS.md");
   });
 });
 

--- a/packages/cli/src/utils/agent-host-detect.ts
+++ b/packages/cli/src/utils/agent-host-detect.ts
@@ -24,7 +24,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 /** Agent hosts VibeFrame knows how to scaffold for. */
-export type AgentHostId = "claude-code" | "codex" | "cursor" | "aider";
+export type AgentHostId = "claude-code" | "codex" | "cursor" | "aider" | "gemini-cli" | "opencode";
 
 export interface AgentHostInfo {
   id: AgentHostId;
@@ -79,6 +79,26 @@ export function detectAgentHosts(env: NodeJS.ProcessEnv = process.env): AgentHos
       detected: false,
       signals: [],
       projectFiles: ["AGENTS.md", ".aider.conf.yml"],
+    },
+    {
+      id: "gemini-cli",
+      label: "Gemini CLI",
+      detected: false,
+      signals: [],
+      // Per https://geminicli.com/docs/cli/gemini-md/ Gemini CLI's primary
+      // context file is GEMINI.md; AGENTS.md is the cross-tool fallback
+      // VibeFrame writes by default. Both are honoured.
+      projectFiles: ["GEMINI.md", "AGENTS.md", ".gemini/"],
+    },
+    {
+      id: "opencode",
+      label: "OpenCode",
+      detected: false,
+      signals: [],
+      // sst/opencode officially supports the agents.md spec — AGENTS.md at
+      // project root is the standard place. Local config also under
+      // `.opencode/` per https://opencode.ai/docs/config/.
+      projectFiles: ["AGENTS.md", ".opencode/"],
     },
   ].map((host) => {
     const signals: AgentHostSignal[] = [];
@@ -148,6 +168,8 @@ const HOST_BINARIES: Record<AgentHostId, string | null> = {
   codex: "codex",
   cursor: "cursor",
   aider: "aider",
+  "gemini-cli": "gemini",
+  opencode: "opencode",
 };
 
 /**
@@ -159,6 +181,11 @@ const HOST_CONFIG_DIRS: Record<AgentHostId, string | null> = {
   codex: ".codex",
   cursor: ".cursor", // some installs; macOS app stores prefs elsewhere
   aider: null,
+  "gemini-cli": ".gemini",
+  // sst/opencode uses XDG-style `~/.config/opencode/` per
+  // https://opencode.ai/docs/config/. The path is relative to $HOME so
+  // the join in detectAgentHosts() resolves correctly.
+  opencode: ".config/opencode",
 };
 
 /**


### PR DESCRIPTION
## Summary

Pre-work for issue #52 (agent-agnostic positioning). Extends \`agent-host-detect.ts\` and the \`vibe init --agent <id>\` allowlist to cover two more agentic shells:

- **Gemini CLI** (\`google-gemini/gemini-cli\`)
- **OpenCode** (\`sst/opencode\`)

So that the README + landing rewrite (#52 follow-up) can honestly enumerate 6 first-class hosts instead of 4.

## Detection details

Per official docs:

| Host | Binary | Config dir (\$HOME) | Primary project file | Source |
|---|---|---|---|---|
| Gemini CLI | \`gemini\` | \`.gemini/\` | \`GEMINI.md\` (+ \`AGENTS.md\` fallback) | [geminicli.com/docs/cli/gemini-md](https://geminicli.com/docs/cli/gemini-md/) |
| OpenCode | \`opencode\` | \`.config/opencode/\` (XDG) | \`AGENTS.md\` (agents.md spec) | [opencode.ai/docs/rules](https://opencode.ai/docs/rules/), [opencode.ai/docs/config](https://opencode.ai/docs/config/) |

Detection follows the existing pattern — \`detected\` flips when the binary is on PATH OR the config dir exists in \$HOME.

## What this unlocks

- \`vibe init --agent gemini-cli\` / \`--agent opencode\` now scaffold the cross-tool \`AGENTS.md\` (same safe default as Codex / Aider).
- \`vibe init --agent all\` and \`--agent auto\` pick them up automatically.
- \`vibe scene build --mode auto\` now flips to \`agent\` when Gemini CLI or OpenCode is the only host present (Plan H — Phase 3 \`resolveSceneBuildMode\`).
- \`vibe doctor\`'s scene-composer readiness block (Plan H — Phase 4) surfaces them in the \`agentHosts\` line.

## Intentional non-scope

\`vibe scene install-skill\` does **not** add a host-specific layout for these two — they read the universal \`SKILL.md\` via AGENTS.md, matching Codex / Aider. This is the right call: only Claude Code (\`.claude/skills/hyperframes/\`) and Cursor (\`.cursor/rules/hyperframes.mdc\`) have well-known skill formats; Gemini CLI / OpenCode have skill systems but they're newer and the conventions are still settling.

## Tests

6 new cases in \`agent-host-detect.test.ts\`:
- Gemini CLI: binary detection
- Gemini CLI: configDir detection alone
- OpenCode: binary detection
- OpenCode: XDG configDir detection alone
- projectFiles assertions for both hosts (GEMINI.md / AGENTS.md membership)

The existing "all 4 hosts" sanity test bumped to "all 6 hosts" with the new ordering.

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm -F @vibeframe/cli test\` — 690 passed | 9 skipped
- [x] \`bash scripts/sync-counts.sh --check\` green
- [x] E2E with built bundle: \`vibe init /tmp/h --agent gemini-cli --json\` and \`--agent opencode --json\` both wrote AGENTS.md + .env.example + .gitignore + vibe.project.yaml as expected
- [ ] CI green