### PR TITLE
docs(positioning): expand to all 6 detected agent hosts (closes #52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **The video CLI for AI agents.** YAML pipelines. 13 AI providers. 65 MCP tools bundled.
 
+> Works with **Claude Code**, **OpenAI Codex**, **Cursor**, **Aider**, **Gemini CLI**, **OpenCode** — any bash-capable AI coding agent. `vibe doctor` auto-detects all six and `vibe init` scaffolds the right project files.
+
 [![GitHub stars](https://img.shields.io/github/stars/vericontext/vibeframe)](https://github.com/vericontext/vibeframe/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/vericontext/vibeframe/actions/workflows/ci.yml/badge.svg)](https://github.com/vericontext/vibeframe/actions/workflows/ci.yml)
@@ -35,16 +37,18 @@ deterministically by Hyperframes' producer.
 ```bash
 brew install vhs
 vhs assets/demos/cli.tape          # Surface 1 — vibe CLI directly
-vhs assets/demos/agent.tape        # Surface 2 — vibe agent (natural language)
-vhs assets/demos/claude.tape       # Surface 3 — Claude Code → vibe scene build
-vhs assets/demos/claude-i2v.tape   # Surface 4 — Claude Code → t2i + i2v + narration
+vhs assets/demos/agent.tape        # Surface 2 — vibe agent (built-in REPL, BYO LLM)
+vhs assets/demos/claude.tape       # Surface 3 — host agent driving vibe scene build (recorded with Claude Code)
+vhs assets/demos/claude-i2v.tape   # Surface 4 — host agent t2i + i2v + narration (recorded with Claude Code)
 ```
+
+> The Surface 3/4 tapes were recorded with Claude Code, but the same `vibe` commands run identically when driven by Codex / Cursor / Aider / Gemini CLI / OpenCode — the host agent is just translating natural language into the same shell command.
 
 > **New in v0.60:** `vibe scene build` is the one-shot driver — write a `STORYBOARD.md` with per-beat YAML cues (narration / backdrop / duration), and a single command dispatches TTS + GPT Image 2 + composes scene HTML via the `compose-scenes-with-skills` pipeline (v0.59) and renders to MP4. `vibe scene init --visual-style "Swiss Pulse"` (v0.58) still seeds the `DESIGN.md` hard-gate + 8 named visual identities. Hyperframes' `/hyperframes` skill (`npx skills add heygen-com/hyperframes`) is loaded as the LLM system prompt for composition craft.
 
-For the typed MCP route into Claude Code / Cursor, see [`packages/mcp-server/README.md`](packages/mcp-server/README.md).
+For the typed MCP route (Claude Desktop, Cursor, OpenCode, or Claude Code via `claude mcp add`), see [`packages/mcp-server/README.md`](packages/mcp-server/README.md).
 
-**Older long-form videos**: [CLI walkthrough](https://youtu.be/EJUUpPp2d_8) · [Claude Code integration](https://youtu.be/sdf930sZ7co)
+**Older long-form videos**: [CLI walkthrough](https://youtu.be/EJUUpPp2d_8) · [Host-agent walkthrough (recorded with Claude Code)](https://youtu.be/sdf930sZ7co)
 
 ---
 
@@ -89,7 +93,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | **License** | Apache 2.0 | MIT |
 | **OSS provider plugin** | — | `defineProvider({...})` registry — adding an AI provider is a single declaration; resolver / config / setup / doctor / `.env.example` all auto-derive (`pnpm scaffold:provider <name>` for the boilerplate) |
 
-The short version: **if you already write HTML compositions and want them rendered well, use Hyperframes directly. If you want AI to *write* those compositions for you, edit them traditionally, surface them to Claude Code via MCP, or stitch a multi-stage AI pipeline — that's VibeFrame.**
+The short version: **if you already write HTML compositions and want them rendered well, use Hyperframes directly. If you want AI to *write* those compositions for you, edit them traditionally, surface them to your AI coding agent via MCP or shell, or stitch a multi-stage AI pipeline — that's VibeFrame.**
 
 **Design Principles:** CLI-First — AI-Native — Provider Agnostic — MCP Compatible
 
@@ -173,12 +177,12 @@ render:
 
 ---
 
-## Use with Claude Code
+## Use with your AI agent
 
-Already have the CLI installed? Claude Code runs `vibe` commands for you — just describe what you want in natural language.
+VibeFrame is a bash CLI. Any AI coding agent that can shell out to a terminal can drive it — describe what you want in natural language, and the agent invokes the right `vibe` command.
 
-| You say | Claude Code runs |
-|---------|-----------------|
+| You say | Agent runs |
+|---------|-----------|
 | "Remove silence from interview.mp4" | `vibe edit silence-cut interview.mp4 -o clean.mp4` |
 | "Extract 3 best moments from podcast.mp4" | `vibe pipeline highlights podcast.mp4 -c 3` |
 | "Add Korean subtitles to video.mp4" | `vibe edit caption video.mp4 -o captioned.mp4` |
@@ -186,31 +190,48 @@ Already have the CLI installed? Claude Code runs `vibe` commands for you — jus
 | "Remove background noise" | `vibe edit noise-reduce noisy.mp4 -o clean.mp4` |
 | "Make a 60-second highlight reel" | `vibe pipeline highlights long-video.mp4 -d 60` |
 
-No setup needed beyond installing the CLI. Claude Code discovers and runs `vibe` commands directly.
+The example above is host-agnostic — every command works identically across Claude Code, OpenAI Codex, Cursor, Aider, Gemini CLI, OpenCode, or any other agent that runs bash.
 
-### Install as a Claude Code Skill
+### Agent host support
 
-For richer guidance, install the Claude Code Skill pack — it adds three slash commands that walk Claude through common workflows:
+`vibe doctor` auto-detects six host families today and `vibe init` scaffolds the right project guidance file for each. Anyone running another bash-capable agent still gets the universal `AGENTS.md` fallback.
+
+| Host | `vibe init` writes | Plan H skill layout (`vibe scene install-skill`) |
+|---|---|---|
+| **Claude Code** | `CLAUDE.md` (imports `@AGENTS.md`) + `AGENTS.md` | `.claude/skills/hyperframes/` (multi-file, Agent Skills standard) |
+| **OpenAI Codex** | `AGENTS.md` | universal `SKILL.md` (read via `AGENTS.md` ref) |
+| **Cursor** | `AGENTS.md` | `.cursor/rules/hyperframes.mdc` (auto-activates on `compositions/**/*.html`) |
+| **Aider** | `AGENTS.md` | universal `SKILL.md` |
+| **Gemini CLI** | `AGENTS.md` (its primary `GEMINI.md` is on the roadmap) | universal `SKILL.md` |
+| **OpenCode** | `AGENTS.md` | universal `SKILL.md` |
+| Any other bash agent | `AGENTS.md` (with `--agent all`) | universal `SKILL.md` |
+
+`vibe scene build --mode auto` auto-flips to the agentic compose path (no internal LLM call — host agent authors per-beat HTML directly) whenever any of the above hosts is present. Set `VIBE_BUILD_MODE=batch` to force the internal-LLM compose path instead.
+
+### Claude Code deeper integration
+
+Claude Code is the only host today with a slash-command pack on top of the universal CLI surface. After running `vibe scene init`, two slash commands are registered:
 
 ```bash
-# From the repo root (or any project where you want the skill active)
+# From any project where you want the skill pack active
 mkdir -p .claude/skills
 curl -fsSL https://raw.githubusercontent.com/vericontext/vibeframe/main/scripts/install-skills.sh | bash
 ```
 
-This registers:
 - **`/vibe-pipeline`** — YAML pipeline authoring helper (Video as Code)
 - **`/vibe-scene`** — per-scene HTML authoring + `vibe scene build` (Hyperframes-backed)
 
 > The skill pack was consolidated 4 → 2 in v0.62: the older `/vibeframe` overview moved to `AGENTS.md` (scaffolded by `vibe init`), and `/vibe-script-to-video` was retired in v0.63 in favour of `/vibe-scene` driving `vibe scene build`.
 
+Other host families (Codex / Cursor / Aider / Gemini CLI / OpenCode) get their own equivalents on demand — see [`packages/cli/src/utils/agent-host-detect.ts`](packages/cli/src/utils/agent-host-detect.ts) + [`packages/cli/src/commands/_shared/install-skill.ts`](packages/cli/src/commands/_shared/install-skill.ts) for the registration shape, or open an issue / PR if your host needs first-class scaffolds.
+
 Prefer manual install? Copy [`.claude/skills/`](https://github.com/vericontext/vibeframe/tree/main/.claude/skills) from this repo into your project.
 
 ---
 
-## MCP Integration (Claude Desktop / Cursor)
+## MCP Integration (Claude Desktop / Cursor / OpenCode / Claude Code)
 
-The CLI is the primary interface; MCP is the gateway for Claude Desktop & Cursor users (65 MCP tools exposed). No clone needed — add to your config and restart:
+The CLI is the primary interface; MCP is the gateway for hosts that prefer typed JSON-RPC tool calls over shelling out. 65 MCP tools exposed via [`@vibeframe/mcp-server`](https://www.npmjs.com/package/@vibeframe/mcp-server). No clone needed — add to your config and restart:
 
 ```json
 {
@@ -227,6 +248,8 @@ Config file locations:
 - **Claude Desktop (macOS):** `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Claude Desktop (Windows):** `%APPDATA%\Claude\claude_desktop_config.json`
 - **Cursor:** `.cursor/mcp.json` in your workspace
+- **OpenCode:** `.opencode/mcp.json` in your workspace
+- **Claude Code:** add via `claude mcp add @vibeframe/mcp-server -- npx -y @vibeframe/mcp-server` (Claude Code has both shell and MCP routes — pick whichever fits)
 
 See [packages/mcp-server/README.md](packages/mcp-server/README.md) for full tool, resource, and prompt reference.
 
@@ -390,7 +413,7 @@ See [Cookbook](docs/cookbook.md) for 10 practical recipes combining multiple com
 
 ## Agent Mode (Standalone)
 
-For environments without Claude Code, Codex, or MCP — a built-in interactive session:
+For environments with no AI coding agent set up — a built-in interactive session:
 
 ```bash
 vibe agent                     # Start (default: OpenAI)
@@ -398,7 +421,7 @@ vibe agent -p claude           # Use Claude
 vibe agent -p ollama           # Free, local, no API key
 ```
 
-Best used for onboarding and quick experiments. For production workflows, use CLI commands directly or via Claude Code / MCP.
+Best used for onboarding and quick experiments. For production workflows, use CLI commands directly or via your host agent / MCP.
 
 ---
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -17,7 +17,7 @@ const SHARE_DESCRIPTION = `YAML pipelines, ${AI_PROVIDERS} AI providers, ${MCP_T
 export const metadata: Metadata = {
   title: "VibeFrame — The video CLI for AI agents",
   description: `A CLI agents can compose, pipe, and script. ${SHARE_DESCRIPTION}`,
-  keywords: ["video CLI", "AI agent", "agentic CLI", "YAML pipelines", "MCP", "video editor", "Claude Code", "open source"],
+  keywords: ["video CLI", "AI agent", "agentic CLI", "YAML pipelines", "MCP", "video editor", "Claude Code", "OpenAI Codex", "Cursor", "Aider", "Gemini CLI", "OpenCode", "agents.md", "open source"],
   metadataBase: new URL("https://vibeframe.ai"),
   openGraph: {
     title: "VibeFrame — The video CLI for AI agents",

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -79,7 +79,7 @@ export default function LandingPage() {
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto mb-12 animate-fade-in-up delay-100">
             A CLI agents can compose, pipe, and script.
             YAML pipelines, {process.env.NEXT_PUBLIC_AI_PROVIDERS} AI providers, {process.env.NEXT_PUBLIC_MCP_TOOLS} MCP tools bundled.
-            Works with Claude Code, Claude Desktop, Cursor — no GUI required.
+            Works with Claude Code, OpenAI Codex, Cursor, Aider, Gemini CLI, OpenCode — any bash-capable AI coding agent. No GUI required.
           </p>
 
           {/* Install Command */}
@@ -257,23 +257,23 @@ export default function LandingPage() {
         </div>
       </section>
 
-      {/* ② Claude Code Section */}
+      {/* ② Use with your AI agent — host-agnostic showcase + Tier 2 callout */}
       <section className="py-20 px-4 border-t border-border/50 relative">
         <div className="mx-auto max-w-5xl">
           <div className="text-center mb-12">
-            <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/30 bg-orange-500/5 px-4 py-1.5 text-sm text-orange-400 mb-4">
+            <div className="inline-flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-500/5 px-4 py-1.5 text-sm text-cyan-400 mb-4">
               <Code2 className="w-4 h-4" />
-              <span>Claude Code</span>
+              <span>Use with your AI agent</span>
             </div>
             <h2 className="text-3xl sm:text-4xl font-bold mb-4">
               Natural language, real commands
             </h2>
             <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-              Describe what you want — Claude Code runs the right <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">vibe</code> command for you.
+              Describe what you want — your AI coding agent runs the right <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">vibe</code> command. The CLI surface is identical across every host that can shell out to bash.
             </p>
           </div>
 
-          <div className="space-y-4 max-w-3xl mx-auto">
+          <div className="space-y-4 max-w-3xl mx-auto mb-12">
             <ClaudeCodeExample
               input="Remove silence from interview.mp4"
               command="vibe edit silence-cut interview.mp4 -o clean.mp4"
@@ -288,8 +288,71 @@ export default function LandingPage() {
             />
           </div>
 
+          {/* Six-host grid — equal cards, same example, different scaffold target */}
+          <div className="text-center mb-6">
+            <p className="text-sm text-muted-foreground">
+              <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">vibe doctor</code> auto-detects six host families today and <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">vibe init</code> scaffolds the right project file for each.
+            </p>
+          </div>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3 max-w-4xl mx-auto">
+            {[
+              { name: "Claude Code", scaffold: "CLAUDE.md + AGENTS.md", note: "+ /vibe-* slash commands" },
+              { name: "OpenAI Codex", scaffold: "AGENTS.md", note: "agents.md spec" },
+              { name: "Cursor", scaffold: "AGENTS.md + .cursor/rules", note: "MCP-ready" },
+              { name: "Aider", scaffold: "AGENTS.md", note: "binary-detected" },
+              { name: "Gemini CLI", scaffold: "AGENTS.md", note: "GEMINI.md on roadmap" },
+              { name: "OpenCode", scaffold: "AGENTS.md", note: "MCP-ready" },
+            ].map((host) => (
+              <div key={host.name} className="bg-secondary/40 border border-border/50 rounded-xl px-4 py-3">
+                <div className="font-mono text-sm font-semibold text-foreground">{host.name}</div>
+                <div className="text-xs text-muted-foreground mt-1">{host.scaffold}</div>
+                <div className="text-xs text-muted-foreground/70 mt-0.5">{host.note}</div>
+              </div>
+            ))}
+          </div>
+
           <p className="text-center text-muted-foreground text-sm mt-8">
-            No extra setup — install the CLI, and Claude Code discovers all <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">vibe</code> commands automatically.
+            Anyone running another bash-capable agent (Continue, Sourcegraph Cody, your own loop) gets the universal <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">AGENTS.md</code> fallback. Open a PR to <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">agent-host-detect.ts</code> if your host wants first-class detection.
+          </p>
+        </div>
+      </section>
+
+      {/* ②.5 — Claude Code deeper integration (Tier 2) */}
+      <section className="py-20 px-4 border-t border-border/50 relative">
+        <div className="mx-auto max-w-5xl">
+          <div className="text-center mb-10">
+            <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/30 bg-orange-500/5 px-4 py-1.5 text-sm text-orange-400 mb-4">
+              <Sparkles className="w-4 h-4" />
+              <span>Claude Code deeper integration</span>
+            </div>
+            <h2 className="text-3xl sm:text-4xl font-bold mb-4">
+              Slash commands, beyond the CLI
+            </h2>
+            <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
+              Claude Code is the only host today with a slash-command pack on top of the universal CLI. Every other agent host gets the same <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">vibe</code> commands; Claude Code adds two guided flows.
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-4 max-w-4xl mx-auto mb-8">
+            <div className="bg-secondary/40 border border-border/50 rounded-xl p-5">
+              <div className="font-mono text-sm font-semibold text-orange-400 mb-2">/vibe-pipeline</div>
+              <p className="text-sm text-muted-foreground">YAML pipeline authoring helper — Video as Code with cost estimates and step references.</p>
+            </div>
+            <div className="bg-secondary/40 border border-border/50 rounded-xl p-5">
+              <div className="font-mono text-sm font-semibold text-orange-400 mb-2">/vibe-scene</div>
+              <p className="text-sm text-muted-foreground">Per-scene HTML authoring + <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">vibe scene build</code> driver (Hyperframes-backed).</p>
+            </div>
+          </div>
+
+          <div className="bg-background/50 border border-border/50 rounded-xl p-4 max-w-3xl mx-auto">
+            <div className="text-xs text-muted-foreground mb-2">Install (one-shot):</div>
+            <code className="font-mono text-xs text-foreground block break-all">
+              curl -fsSL https://raw.githubusercontent.com/vericontext/vibeframe/main/scripts/install-skills.sh | bash
+            </code>
+          </div>
+
+          <p className="text-center text-muted-foreground text-sm mt-6 max-w-3xl mx-auto">
+            Plan H also auto-installs the Hyperframes skill bundle into <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">.claude/skills/hyperframes/</code> when you run <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">vibe scene init</code> — Claude Code reads it as system context for cinematic scene authoring. Other host families get the same content as a universal <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">SKILL.md</code> at the project root.
           </p>
         </div>
       </section>
@@ -310,7 +373,7 @@ export default function LandingPage() {
                 <div>
                   <h2 className="text-2xl sm:text-3xl font-bold mb-2">MCP Ready</h2>
                   <p className="text-muted-foreground">
-                    {process.env.NEXT_PUBLIC_MCP_TOOLS} tools in Claude Desktop and Cursor — add one JSON config and go
+                    {process.env.NEXT_PUBLIC_MCP_TOOLS} tools for Claude Desktop, Cursor, OpenCode, or Claude Code — add one JSON config and go
                   </p>
                 </div>
               </div>
@@ -350,8 +413,8 @@ export default function LandingPage() {
               Built-in AI Agent
             </h2>
             <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-              No Claude Code or Codex? Run <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">vibe agent</code> for a standalone natural language session.
-              Great for quick onboarding and environments without AI coding tools.
+              No AI coding agent set up? Run <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">vibe agent</code> for a standalone natural-language session.
+              Great for quick onboarding and environments without an installed agent host.
             </p>
           </div>
 
@@ -390,7 +453,7 @@ export default function LandingPage() {
               <FeatureItem
                 icon={<Terminal className="w-5 h-5" />}
                 title="Standalone"
-                description="No Claude Code or Codex needed — built-in fallback for any environment"
+                description="No agent host needed — built-in fallback for any environment"
                 gradient="from-green-500 to-emerald-500"
               />
             </div>


### PR DESCRIPTION
## Summary

Closes #52. The README + landing previously read like a Claude Code companion — the issue called out that VibeFrame is a CLI any bash-capable AI coding agent can drive, and the public surface didn't reflect that. With #183 just landing (Gemini CLI + OpenCode added to \`agent-host-detect.ts\`), the docs can honestly enumerate **six first-class hosts** without overstating support.

## Two-tier framing (per the issue)

**Tier 1 — Universal (new default).** vibe is a bash CLI; any agent that shells out can drive it. Hero subtitle, Section ②, the agent-host matrix, and the README "Use with your AI agent" section all lead with this. Six host cards on the landing show the same \`you-say → vibe-runs\` example with the host-specific scaffold target.

**Tier 2 — Claude Code deeper integration (kept first-class).** Slash-command pack (\`/vibe-pipeline\`, \`/vibe-scene\`) lives in its own labeled section, positioned as the **deepest** integration and not the **only** one. README "### Claude Code deeper integration" parallels page.tsx Section ②.5.

## Six-host honesty matrix (now in README)

| Host | \`vibe init\` writes | Plan H skill layout |
|---|---|---|
| **Claude Code** | \`CLAUDE.md\` (imports \`@AGENTS.md\`) + \`AGENTS.md\` | \`.claude/skills/hyperframes/\` (multi-file Agent Skills) |
| **OpenAI Codex** | \`AGENTS.md\` | universal \`SKILL.md\` |
| **Cursor** | \`AGENTS.md\` | \`.cursor/rules/hyperframes.mdc\` |
| **Aider** | \`AGENTS.md\` | universal \`SKILL.md\` |
| **Gemini CLI** | \`AGENTS.md\` (GEMINI.md on roadmap) | universal \`SKILL.md\` |
| **OpenCode** | \`AGENTS.md\` | universal \`SKILL.md\` |
| Any other bash agent | \`AGENTS.md\` (\`--agent all\`) | universal \`SKILL.md\` |

## Files changed

- \`README.md\` — hero blockquote, Surface 3/4 VHS captions clarification, new "Agent host support" matrix, "Use with Claude Code" → "Use with your AI agent", new "### Claude Code deeper integration" subsection, MCP-integration header + config-locations list expanded (OpenCode + Claude Code), miscellaneous "without Claude Code or Codex" rewording.
- \`apps/web/app/page.tsx\` — hero subtitle, Section ② badge orange→cyan and content rebuilt with six-host grid, new Section ②.5 "Claude Code deeper integration" callout, Section ③ MCP host list, Section ④ "No AI coding agent set up?" generalisation, FeatureItem reword.
- \`apps/web/app/layout.tsx\` — SEO keywords gain OpenAI Codex, Cursor, Aider, Gemini CLI, OpenCode, agents.md (kept Claude Code).

## Non-scope (intentional, deferred to follow-up PRs)

- Renaming \`assets/demos/claude.tape\` / \`claude-i2v.tape\` and recording parallel walkthroughs on other host families.
- Expanding the \`AGENTS.md\` scaffold template (\`init-templates.ts\`) to name all six hosts in its parenthetical.
- Adding a \`GEMINI.md\` scaffold for parity with \`CLAUDE.md\` (Gemini CLI's primary context-file convention).
- \`mcp-server/README.md\` host-section refresh.

These are tracked but kept out of this PR so the diff stays as **pure docs / pure messaging**.

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\`
- [x] \`pnpm lint\` (0 errors, 8 pre-existing warnings)
- [x] \`pnpm -F @vibeframe/cli test\` — 690 passed | 9 skipped
- [x] \`pnpm -F @vibeframe/web build\` — Next.js build green; static prerender for /, /demo, /editor, /opengraph-image, /sitemap, /twitter-image all rebuilt
- [x] \`bash scripts/sync-counts.sh --check\` green
- [ ] CI green (typecheck + build-and-test 20/22 + Vercel preview)

## Audit trail

I had a deeper read pass over \`init-templates.ts\`, \`install-skill.ts\`, every "Claude Code" / "Claude Desktop" mention in README + page.tsx, and \`vibe init\`'s file-write decision tree before drafting. The matrix above is byte-accurate against \`agent-host-detect.ts\` post-#183, \`install-skill.ts\` (claude-code + cursor host-specific layouts only), and \`init.ts\` (CLAUDE.md only on Claude Code; AGENTS.md universal otherwise). No fabricated capability claims.