### PR TITLE
feat: vibe walkthrough — universal slash-command equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VibeFrame
 
-**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 65 MCP tools bundled.
+**The video CLI for AI agents.** YAML pipelines. 13 AI providers. 66 MCP tools bundled.
 
 > Works with **Claude Code**, **OpenAI Codex**, **Cursor**, **Aider**, **Gemini CLI**, **OpenCode** — any bash-capable AI coding agent. `vibe doctor` auto-detects all six and `vibe init` scaffolds the right project files.
 
@@ -79,7 +79,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | Layer | Hyperframes | VibeFrame |
 |---|---|---|
 | **AI generation** | — | OpenAI gpt-image-2 (image default since v0.56), fal.ai Seedance 2.0 (video default since v0.57), Veo, Kling, Runway, Grok, ElevenLabs, Replicate |
-| **Agent integrations** | — | MCP server (65 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
+| **Agent integrations** | — | MCP server (66 tools, `@vibeframe/mcp-server`) · `vibe agent` REPL (BYO LLM × 6) |
 | **Traditional editing** | — | `vibe edit` silence-cut · jump-cut · caption · grade · reframe · speed-ramp · fade · noise-reduce (84+ commands total) |
 | **AI analysis** | — | `vibe analyze` media/video/review/suggest (multimodal LLMs) |
 | **BUILD from text** | composition format only | `vibe scene build` (v0.60 one-shot driver) — STORYBOARD.md → MP4 |
@@ -88,7 +88,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | **Local Kokoro TTS** | ✅ Python `kokoro-onnx` | ✅ Node `kokoro-js` — same Kokoro-82M model, auto-fallback when no `ELEVENLABS_API_KEY` |
 | **Local Whisper transcribe** | ✅ whisper-cpp (offline) | OpenAI Whisper API (cloud, word-level) |
 | **Agent skills** | ✅ `npx skills add heygen-com/hyperframes` (5 skills via vercel-labs/skills) | ✅ ships `/vibe-pipeline`, `/vibe-scene` (overview lives in `AGENTS.md` scaffolded by `vibe init`) |
-| **MCP server** | ❌ | ✅ 65 tools |
+| **MCP server** | ❌ | ✅ 66 tools |
 | **Render** | ✅ native (BeginFrame, parity, HDR, Studio NLE) | uses Hyperframes backend or FFmpeg |
 | **License** | Apache 2.0 | MIT |
 | **OSS provider plugin** | — | `defineProvider({...})` registry — adding an AI provider is a single declaration; resolver / config / setup / doctor / `.env.example` all auto-derive (`pnpm scaffold:provider <name>` for the boilerplate) |
@@ -231,7 +231,7 @@ Prefer manual install? Copy [`.claude/skills/`](https://github.com/vericontext/v
 
 ## MCP Integration (Claude Desktop / Cursor / OpenCode / Claude Code)
 
-The CLI is the primary interface; MCP is the gateway for hosts that prefer typed JSON-RPC tool calls over shelling out. 65 MCP tools exposed via [`@vibeframe/mcp-server`](https://www.npmjs.com/package/@vibeframe/mcp-server). No clone needed — add to your config and restart:
+The CLI is the primary interface; MCP is the gateway for hosts that prefer typed JSON-RPC tool calls over shelling out. 66 MCP tools exposed via [`@vibeframe/mcp-server`](https://www.npmjs.com/package/@vibeframe/mcp-server). No clone needed — add to your config and restart:
 
 ```json
 {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,7 +11,7 @@ const inter = Inter({ subsets: ["latin"] });
 // directory listing + MCP tool name regex), so they stay in sync with the
 // source. Falls back to the post-v0.57 numbers if env var lookup fails.
 const AI_PROVIDERS = process.env.NEXT_PUBLIC_AI_PROVIDERS ?? "13";
-const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "65";
+const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "66";
 const SHARE_DESCRIPTION = `YAML pipelines, ${AI_PROVIDERS} AI providers, ${MCP_TOOLS} MCP tools bundled. Ship videos, not clicks.`;
 
 export const metadata: Metadata = {

--- a/packages/cli/src/agent/tools/integration.test.ts
+++ b/packages/cli/src/agent/tools/integration.test.ts
@@ -162,7 +162,7 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
     it("should register the full manifest", () => {
       // Manifest is the single source of truth post-v0.67 PR2.
       const tools = registry.getAll();
-      expect(tools.length).toBe(81);
+      expect(tools.length).toBe(82);
     });
 
     it("should register all project tools (5)", () => {
@@ -562,6 +562,7 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
       const exportTools = allTools.filter((t) => t.name.startsWith("export_"));
       const batchTools = allTools.filter((t) => t.name.startsWith("batch_"));
       const sceneTools = allTools.filter((t) => t.name.startsWith("scene_"));
+      const walkthroughTools = allTools.filter((t) => t.name === "walkthrough");
 
       expect(projectTools.length).toBe(5);
       expect(timelineTools.length).toBe(11);  // Added timeline_clear
@@ -574,8 +575,9 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
       expect(exportTools.length).toBe(3);
       expect(batchTools.length).toBe(3);
       expect(sceneTools.length).toBe(8);  // v0.70 H1+H2: install-skill + compose-prompts (init/add/lint/render/build/styles/install-skill/compose-prompts)
+      expect(walkthroughTools.length).toBe(1);  // v0.71: universal slash-command equivalent
 
-      // Total: 5+11+4+12+13+15+4+3+3+3+8 = 81
+      // Total: 5+11+4+12+13+15+4+3+3+3+8+1 = 82
       const totalTools = projectTools.length +
           timelineTools.length +
           fsTools.length +
@@ -586,8 +588,9 @@ describe("CLI ↔ Agent Tool Synchronization", () => {
           pipelineTools.length +
           exportTools.length +
           batchTools.length +
-          sceneTools.length;
-      expect(totalTools).toBe(81);
+          sceneTools.length +
+          walkthroughTools.length;
+      expect(totalTools).toBe(82);
     });
   });
 });
@@ -636,12 +639,18 @@ describe("Tool Name Consistency", () => {
       "batch_",
       "scene_",
     ];
+    // Top-level utility tools that don't fit a category prefix. Keep this
+    // list small — every entry is a deliberate naming exception.
+    const exactMatches = new Set([
+      "walkthrough", // v0.71: universal slash-command equivalent (one tool, multi-topic)
+    ]);
 
     for (const tool of tools) {
       const hasValidPrefix = validPrefixes.some((prefix) =>
         tool.name.startsWith(prefix)
       );
-      expect(hasValidPrefix).toBe(true);
+      const isExactMatch = exactMatches.has(tool.name);
+      expect(hasValidPrefix || isExactMatch, `tool "${tool.name}" doesn't follow naming convention`).toBe(true);
     }
   });
 

--- a/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.test.ts
+++ b/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WALKTHROUGH_TOPICS,
+  isWalkthroughTopic,
+  listWalkthroughs,
+  loadWalkthrough,
+} from "./walkthroughs.js";
+
+describe("walkthroughs", () => {
+  describe("WALKTHROUGH_TOPICS", () => {
+    it("includes both scene and pipeline", () => {
+      expect(WALKTHROUGH_TOPICS).toContain("scene");
+      expect(WALKTHROUGH_TOPICS).toContain("pipeline");
+      expect(WALKTHROUGH_TOPICS).toHaveLength(2);
+    });
+  });
+
+  describe("isWalkthroughTopic", () => {
+    it("accepts known topics", () => {
+      expect(isWalkthroughTopic("scene")).toBe(true);
+      expect(isWalkthroughTopic("pipeline")).toBe(true);
+    });
+    it("rejects unknown values", () => {
+      expect(isWalkthroughTopic("agent")).toBe(false);
+      expect(isWalkthroughTopic("")).toBe(false);
+      expect(isWalkthroughTopic(undefined)).toBe(false);
+      expect(isWalkthroughTopic(123)).toBe(false);
+    });
+  });
+
+  describe("loadWalkthrough", () => {
+    it("returns the scene walkthrough with all required fields", () => {
+      const r = loadWalkthrough("scene");
+      expect(r.topic).toBe("scene");
+      expect(r.title).toContain("Scene");
+      expect(r.summary.length).toBeGreaterThan(10);
+      expect(r.steps.length).toBeGreaterThanOrEqual(3);
+      expect(r.relatedCommands).toContain("vibe scene init");
+      expect(r.relatedCommands).toContain("vibe scene build");
+      expect(r.relatedCommands).toContain("vibe scene compose-prompts");
+      expect(r.content.length).toBeGreaterThan(500);
+      expect(r.content).toContain("STORYBOARD.md");
+    });
+
+    it("returns the pipeline walkthrough with all required fields", () => {
+      const r = loadWalkthrough("pipeline");
+      expect(r.topic).toBe("pipeline");
+      expect(r.title).toContain("pipelines");
+      expect(r.steps.length).toBeGreaterThanOrEqual(3);
+      expect(r.relatedCommands).toContain("vibe run");
+      expect(r.content).toContain("steps:");
+      expect(r.content).toContain("$<step-id>");
+    });
+
+    it("scene walkthrough mentions Plan H mode dispatch (--mode agent)", () => {
+      const r = loadWalkthrough("scene");
+      expect(r.content).toMatch(/--mode agent/);
+      expect(r.content).toContain("compose-prompts");
+    });
+
+    it("pipeline walkthrough enumerates the supported actions", () => {
+      const r = loadWalkthrough("pipeline");
+      expect(r.content).toContain("generate-image");
+      expect(r.content).toContain("scene-build");
+      expect(r.content).toContain("compose-scenes-with-skills");
+    });
+
+    it("steps are non-trivial actionable instructions and at least one references a vibe command", () => {
+      for (const topic of WALKTHROUGH_TOPICS) {
+        const r = loadWalkthrough(topic);
+        for (const step of r.steps) {
+          expect(step.length).toBeGreaterThan(20);
+        }
+        // The walkthrough as a whole must drive the user toward a vibe command —
+        // mostly the case anyway, but assert it explicitly so a future edit
+        // doesn't drift into pure prose.
+        const hasVibeCommand = r.steps.some((s) => /\bvibe\s/.test(s));
+        expect(hasVibeCommand, `walkthrough "${topic}" steps mention no vibe command`).toBe(true);
+      }
+    });
+  });
+
+  describe("listWalkthroughs", () => {
+    it("returns a catalog with topic + title + summary for each entry", () => {
+      const list = listWalkthroughs();
+      expect(list).toHaveLength(2);
+      for (const entry of list) {
+        expect(entry.topic).toMatch(/^scene$|^pipeline$/);
+        expect(entry.title.length).toBeGreaterThan(5);
+        expect(entry.summary.length).toBeGreaterThan(10);
+      }
+    });
+
+    it("ordering is stable (scene first, then pipeline) for predictable agent output", () => {
+      const list = listWalkthroughs();
+      expect(list[0].topic).toBe("scene");
+      expect(list[1].topic).toBe("pipeline");
+    });
+  });
+});

--- a/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
+++ b/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
@@ -1,0 +1,352 @@
+/**
+ * @module _shared/walkthroughs
+ *
+ * Universal CLI-equivalents of Claude Code's `/vibe-scene` and
+ * `/vibe-pipeline` slash commands. After Plan H, host agents
+ * (Claude Code, Codex, Cursor, Aider, Gemini CLI, OpenCode) all read
+ * SKILL.md from the user's project and can drive `vibe scene build`
+ * directly — but discoverability of the *workflow* itself was still
+ * Claude-Code-only via the slash menu.
+ *
+ * `vibe walkthrough <topic>` closes that gap: any host (or a human at
+ * a terminal) gets the same step-by-step authoring guide that the
+ * slash commands deliver in Claude Code. The content is vendored as
+ * TS template-literal strings so the CLI binary ships with zero
+ * filesystem dependencies — same approach as `hf-skill-bundle`.
+ *
+ * Source of truth lives here. The Claude Code slash command files
+ * under `.claude/skills/vibe-{scene,pipeline}/SKILL.md` mirror this
+ * content (so the slash command and the CLI command stay in sync) and
+ * add a one-line frontmatter for the slash menu.
+ */
+
+export type WalkthroughTopic = "scene" | "pipeline";
+
+export interface WalkthroughResult {
+  topic: WalkthroughTopic;
+  /** Short title, e.g. "Scene authoring with vibe". */
+  title: string;
+  /** One-line summary suitable for a `--list` output. */
+  summary: string;
+  /** Numbered action items the host agent walks the user through. */
+  steps: string[];
+  /** Related vibe CLI commands referenced by the walkthrough. */
+  relatedCommands: string[];
+  /** Full markdown body — same content the Claude Code slash command loads. */
+  content: string;
+}
+
+const SCENE_WALKTHROUGH = `# Scene authoring with vibe
+
+A scene project is a directory that is **bilingual**: it works with both
+\`vibe\` and \`npx hyperframes\`. Each scene is one HTML file with scoped CSS
+and a paused GSAP timeline. Cheap to edit, cheap to lint, expensive only
+at render.
+
+\`vibe scene build\` (v0.60+) is the supported one-shot driver from a
+written storyboard to an MP4. Plan H (v0.70) added \`--mode agent\` so the
+host agent itself authors the per-beat HTML — no internal LLM call.
+
+## Three authoring paths
+
+| Path | Command | When to use |
+|---|---|---|
+| **One-shot (default, v0.60+)** | \`vibe scene build [project-dir]\` | STORYBOARD.md has YAML frontmatter + per-beat cues |
+| **High-craft (manual)** | \`DESIGN.md\` + Hyperframes skill in your agent | Maximum control: hand-author each scene |
+| **Quick draft** | \`vibe scene add --style <preset>\` | No agent or no API keys; fast iteration |
+
+Recommend \`vibe scene build\` whenever the user has a STORYBOARD with
+narration / backdrop intent.
+
+## High-craft path
+
+1. \`vibe scene init my-promo --visual-style "Swiss Pulse"\` — seeds
+   \`DESIGN.md\` (palette, typography, motion, transitions) plus the
+   \`vibe.project.yaml\` / \`hyperframes.json\` / \`index.html\` scaffold.
+   In Plan H this **also installs the Hyperframes skill** at the
+   right place for your host (\`.claude/skills/hyperframes/\` for Claude
+   Code, \`.cursor/rules/hyperframes.mdc\` for Cursor, universal
+   \`SKILL.md\` for everyone else).
+2. Read \`SKILL.md\` (or the host-specific copy) — Hyperframes
+   framework rules, motion principles, type system, transition recipes.
+3. Read \`DESIGN.md\` — project-specific palette / typography / motion
+   signature (visual identity hard-gate).
+4. Author each scene HTML directly under \`compositions/scene-<id>.html\`
+   using the rules from steps 2 and 3. The skill enforces the visual
+   identity contract — scenes that contradict DESIGN.md fail lint.
+5. \`vibe scene lint --fix\` for mechanical issues, \`vibe scene render\`
+   to MP4.
+
+## Quick-draft path
+
+\`\`\`bash
+vibe scene init my-promo -r 16:9 -d 30
+vibe scene add intro --style announcement \\
+    --headline "Ship videos, not clicks"
+vibe scene lint
+vibe scene render
+\`\`\`
+
+\`vibe scene init\` is **idempotent** — running it on an existing
+Hyperframes directory merges \`hyperframes.json\` instead of clobbering it.
+Safe to invoke on user-provided projects.
+
+## Subcommands
+
+\`\`\`bash
+vibe scene init <dir> [-r 16:9|9:16|1:1|4:5] [-d <sec>] [--visual-style "<name>"]
+vibe scene styles [<name>]                   # list / show vendored visual identities
+vibe scene install-skill [<dir>] [--host all]  # retroactive Hyperframes-skill install
+vibe scene add <name> --style <preset> [...]
+vibe scene compose-prompts [<dir>] [--beat <id>]   # H2: emit plan, no LLM call
+vibe scene lint [<root>] [--json] [--fix]
+vibe scene render [<root>] [--fps 30] [--quality standard] [--format mp4]
+vibe scene build [<dir>] [--mode agent|batch|auto]   # H3 dispatch
+\`\`\`
+
+## Style presets (for \`vibe scene add --style\`)
+
+- **simple** — backdrop + bottom caption (default)
+- **announcement** — single huge headline, gradient text
+- **explainer** — kicker + title + subtitle stack
+- **kinetic-type** — words animate in word-by-word
+- **product-shot** — corner label + bottom headline + slow zoom
+
+All presets accept \`--narration <text|file>\`, \`--visuals <prompt>\`,
+\`--headline\`, \`--kicker\`. With \`--narration\`, scene duration auto-derives
+from the generated TTS audio.
+
+## STORYBOARD-to-MP4 (one command, v0.60+)
+
+\`\`\`bash
+vibe scene init my-promo --visual-style "Swiss Pulse" -d 12
+# (edit STORYBOARD.md with per-beat YAML cues — narration, backdrop, duration)
+vibe scene build my-promo
+\`\`\`
+
+\`vibe scene build\` reads the STORYBOARD frontmatter + per-beat cues,
+dispatches TTS + image-gen per beat, then either:
+
+- **\`--mode agent\`** (default when an agent host is detected) — emits a
+  \`needs-author\` plan via \`vibe scene compose-prompts\`. The host agent
+  authors each \`compositions/scene-<id>.html\` itself, then re-invoking
+  \`vibe scene build\` proceeds to lint + render.
+- **\`--mode batch\`** — VibeFrame runs an internal LLM (Claude / OpenAI /
+  Gemini) to compose the HTML, then renders.
+
+\`VIBE_BUILD_MODE\` env var overrides the auto-resolve.
+
+## Lint feedback loop
+
+\`\`\`bash
+vibe scene lint --json --fix
+\`\`\`
+
+Returns structured findings. The recommended loop: 1) run lint with
+\`--fix\` (mechanical fixes applied), 2) if \`errorCount > 0\`, edit the
+scene HTML, 3) re-lint. Cap retries at 3 — if errors persist, fall back
+to a template preset (\`vibe scene add <id> --style simple --force\`)
+and surface the error to the user.
+
+## When to use VibeFrame vs raw Hyperframes
+
+| Task | Tool |
+|------|------|
+| Generate narration + image, then author scene | \`vibe scene add\` |
+| Generate a full scenes project from a STORYBOARD | \`vibe scene build\` |
+| Hand-tweak a single scene's animation | edit \`compositions/<file>.html\` directly |
+| Render the project | \`vibe scene render\` *or* \`npx hyperframes render\` (equivalent) |
+| Lint | \`vibe scene lint\` *or* \`npx hyperframes lint\` (equivalent) |
+
+The \`vibe\` CLI adds asset generation, AI orchestration, and pipeline
+integration on top of Hyperframes' rendering primitives.
+
+## Quality checklist before render
+
+- [ ] \`vibe scene lint\` exits 0 (or only warnings)
+- [ ] \`vibe doctor\` confirms a usable Chrome (required for render)
+- [ ] Root \`data-duration\` matches the sum of clip durations
+- [ ] Aspect ratio in \`vibe.project.yaml\` matches the destination platform
+`;
+
+const PIPELINE_WALKTHROUGH = `# YAML pipelines (Video as Code)
+
+A pipeline is a YAML manifest with steps that reference each other's
+outputs. \`vibe run pipeline.yaml\` executes them with checkpointing and
+cost estimation.
+
+## Minimal skeleton
+
+\`\`\`yaml
+name: promo-video
+description: 15s product teaser
+steps:
+  - id: backdrop
+    action: generate-image
+    prompt: "sleek product shot on white background"
+    output: backdrop.png
+  - id: scene
+    action: generate-video
+    image: $backdrop.output        # reference previous step output
+    prompt: "slow camera pan"
+    duration: 5
+    output: scene.mp4
+  - id: voice
+    action: generate-tts
+    text: "Meet the new standard."
+    output: voice.mp3
+  - id: final
+    action: compose
+    video: $scene.output
+    audio: $voice.output
+    output: final.mp4
+\`\`\`
+
+## Supported actions
+
+- \`generate-image\`, \`generate-video\`, \`generate-tts\`, \`generate-music\`,
+  \`generate-sound-effect\`, \`generate-storyboard\`, \`generate-motion\`
+- \`edit-silence-cut\`, \`edit-jump-cut\`, \`edit-caption\`, \`edit-grade\`,
+  \`edit-reframe\`, \`edit-speed-ramp\`, \`edit-fade\`, \`edit-noise-reduce\`,
+  \`edit-text-overlay\`, \`edit-fill-gaps\`
+- \`analyze-media\`, \`analyze-video\`, \`analyze-review\`, \`analyze-suggest\`
+- \`audio-transcribe\`, \`audio-isolate\`, \`audio-voice-clone\`, \`audio-dub\`,
+  \`audio-duck\`
+- \`detect-scenes\`, \`detect-silence\`, \`detect-beats\`
+- \`compose\`, \`export\`
+- \`scene-build\` (Plan H one-shot driver) and \`scene-render\`
+- \`compose-scenes-with-skills\` (internal-LLM compose pass)
+
+The full set lives in \`packages/cli/src/pipeline/executor.ts\`.
+
+## Variable references
+
+- \`$<step-id>.output\` — previous step's output path
+- \`$<step-id>.result.<field>\` — structured field from JSON result
+- \`\${ENV_VAR}\` — environment variable
+- Values can be templated: \`"\${SCRIPT_TITLE} - Episode \${EPISODE}"\`
+
+## Running
+
+\`\`\`bash
+vibe run pipeline.yaml --dry-run           # plan + cost estimate, no execution
+vibe run pipeline.yaml                     # execute
+vibe run pipeline.yaml --resume            # retry from last successful step
+vibe run pipeline.yaml --from scene        # start at specific step
+vibe run pipeline.yaml --provider-video kling   # override provider
+\`\`\`
+
+Checkpoints land next to the YAML: \`pipeline.yaml.checkpoint.json\`.
+
+## Authoring tips
+
+1. **Start from examples** — \`examples/demo-pipeline.yaml\` (FFmpeg-only,
+   no keys), \`examples/promo-video.yaml\` (AI providers).
+2. **Dry-run first** — you see estimated cost and resolved variable
+   graph before spending API credits.
+3. **Keep step ids short and descriptive** (\`intro\`, \`scene1\`, \`voice\`,
+   \`bgm\`) — they appear in logs and variable refs.
+4. **Name outputs** with extensions matching the action (\`.mp4\`, \`.mp3\`,
+   \`.png\`, \`.json\`).
+5. **Declare \`budget:\`** on expensive pipelines:
+   \`\`\`yaml
+   budget:
+     tokens: 500_000
+     max_tool_errors: 3
+     cost_usd: 5.00
+   \`\`\`
+6. **Split large pipelines** into smaller YAML files and compose via
+   \`action: run-pipeline\` (nested).
+
+## Converting ad-hoc shell sessions to pipelines
+
+When the user has a working shell sequence, extract steps:
+
+- Each \`vibe ...\` command becomes one step
+- File outputs become step outputs; downstream \`-i <file>\` references
+  become \`$<id>.output\`
+- Shared parameters move to a top-level \`defaults:\` section
+- Wrap the entire chain in a \`name:\` + \`steps:\` skeleton
+
+The \`compose\` action is the catch-all assembly step (audio mux, video
+overlay, etc.) — useful at the tail of a pipeline.
+`;
+
+const META: Record<WalkthroughTopic, Pick<WalkthroughResult, "title" | "summary" | "steps" | "relatedCommands">> = {
+  scene: {
+    title: "Scene authoring with vibe",
+    summary: "Author per-scene HTML compositions and render to MP4 (BUILD flow)",
+    steps: [
+      'Run `vibe scene init <dir> --visual-style "<style name>"` to scaffold the project + install the Hyperframes skill (Plan H).',
+      "Edit `STORYBOARD.md` with per-beat YAML cues (narration / backdrop / duration).",
+      "Read `SKILL.md` for the framework rules and `DESIGN.md` for the visual-identity hard-gate.",
+      "Run `vibe scene build <dir>`. With an agent host detected, the CLI emits a `needs-author` plan; the host agent authors each `compositions/scene-<id>.html` and re-invokes to render.",
+      "Run `vibe scene lint --fix` to validate, then `vibe scene render` to produce the MP4.",
+    ],
+    relatedCommands: [
+      "vibe scene init",
+      "vibe scene styles",
+      "vibe scene install-skill",
+      "vibe scene compose-prompts",
+      "vibe scene build",
+      "vibe scene lint",
+      "vibe scene render",
+      "vibe scene add",
+    ],
+  },
+  pipeline: {
+    title: "YAML pipelines (Video as Code)",
+    summary: "Author and run reproducible multi-step video workflows",
+    steps: [
+      "Sketch the workflow as YAML — `name`, `description`, then `steps:` with `id` + `action` + inputs/outputs.",
+      "Reference previous step outputs via `$<step-id>.output` (or `$<step-id>.result.<field>` for structured returns).",
+      "Run `vibe run pipeline.yaml --dry-run` to see the resolved graph + cost estimate before spending API budget.",
+      "Add a `budget:` block (tokens / cost_usd / max_tool_errors) to cap expensive runs.",
+      "Run `vibe run pipeline.yaml` to execute. Failed steps checkpoint to `pipeline.yaml.checkpoint.json`; resume with `--resume`.",
+    ],
+    relatedCommands: [
+      "vibe run",
+      "vibe schema --list",
+      "vibe doctor",
+    ],
+  },
+};
+
+const CONTENT: Record<WalkthroughTopic, string> = {
+  scene: SCENE_WALKTHROUGH,
+  pipeline: PIPELINE_WALKTHROUGH,
+};
+
+/** All walkthrough topics this CLI knows. */
+export const WALKTHROUGH_TOPICS: readonly WalkthroughTopic[] = ["scene", "pipeline"] as const;
+
+/** Pure data accessor — no I/O. Throws on unknown topic. */
+export function loadWalkthrough(topic: WalkthroughTopic): WalkthroughResult {
+  const meta = META[topic];
+  const content = CONTENT[topic];
+  if (!meta || !content) {
+    throw new Error(`Unknown walkthrough topic: ${topic}`);
+  }
+  return {
+    topic,
+    title: meta.title,
+    summary: meta.summary,
+    steps: meta.steps,
+    relatedCommands: meta.relatedCommands,
+    content,
+  };
+}
+
+/** List all walkthroughs (for `vibe walkthrough --list` / no-arg invocation). */
+export function listWalkthroughs(): Array<{ topic: WalkthroughTopic; title: string; summary: string }> {
+  return WALKTHROUGH_TOPICS.map((topic) => ({
+    topic,
+    title: META[topic].title,
+    summary: META[topic].summary,
+  }));
+}
+
+/** Type guard for runtime topic validation. */
+export function isWalkthroughTopic(value: unknown): value is WalkthroughTopic {
+  return typeof value === "string" && (WALKTHROUGH_TOPICS as readonly string[]).includes(value);
+}

--- a/packages/cli/src/commands/walkthrough.ts
+++ b/packages/cli/src/commands/walkthrough.ts
@@ -1,0 +1,103 @@
+/**
+ * @module commands/walkthrough
+ *
+ * `vibe walkthrough [topic]` — universal CLI equivalent of Claude Code's
+ * `/vibe-scene` and `/vibe-pipeline` slash commands. Any host agent
+ * (Claude Code, Codex, Cursor, Aider, Gemini CLI, OpenCode) can invoke
+ * this to load the same step-by-step authoring guide the slash commands
+ * deliver in Claude Code — closes the last Claude-Code-only gap on top
+ * of Plan H's universal skill / compose primitives.
+ *
+ * Without arguments, lists available topics. With a topic, emits the
+ * full markdown body + structured metadata. `--json` returns the
+ * structured shape from `loadWalkthrough()` directly.
+ */
+
+import { Command } from "commander";
+import chalk from "chalk";
+
+import {
+  WALKTHROUGH_TOPICS,
+  isWalkthroughTopic,
+  listWalkthroughs,
+  loadWalkthrough,
+  type WalkthroughTopic,
+} from "./_shared/walkthroughs/walkthroughs.js";
+import { exitWithError, isJsonMode, outputResult, usageError } from "./output.js";
+
+export const walkthroughCommand = new Command("walkthrough")
+  .description("Step-by-step authoring guide for a vibe workflow (universal /vibe-* slash-command equivalent)")
+  .argument("[topic]", `Walkthrough topic: ${WALKTHROUGH_TOPICS.join(" | ")}. Omit to list all.`)
+  .option("--list", "List available walkthroughs and exit")
+  .action(async (topicArg: string | undefined, options) => {
+    if (!topicArg || options.list) {
+      const topics = listWalkthroughs();
+
+      if (isJsonMode()) {
+        outputResult({
+          command: "walkthrough",
+          action: "list",
+          topics,
+        });
+        return;
+      }
+
+      console.log();
+      console.log(chalk.bold.cyan("Available walkthroughs"));
+      console.log(chalk.dim("─".repeat(60)));
+      for (const t of topics) {
+        console.log(`  ${chalk.bold(t.topic.padEnd(10))} ${chalk.dim(t.summary)}`);
+      }
+      console.log();
+      console.log(chalk.dim("Run `vibe walkthrough <topic>` for the full guide."));
+      console.log(chalk.dim("Add `--json` to get structured output for an agent host."));
+      console.log();
+      return;
+    }
+
+    if (!isWalkthroughTopic(topicArg)) {
+      exitWithError(usageError(
+        `Unknown walkthrough topic: ${topicArg}`,
+        `Valid topics: ${WALKTHROUGH_TOPICS.join(", ")}`,
+      ));
+    }
+
+    const topic = topicArg as WalkthroughTopic;
+    const result = loadWalkthrough(topic);
+
+    if (isJsonMode()) {
+      outputResult({
+        command: "walkthrough",
+        action: "show",
+        ...result,
+      });
+      return;
+    }
+
+    // Human render: title + steps + content.
+    console.log();
+    console.log(chalk.bold.cyan(result.title));
+    console.log(chalk.dim("─".repeat(60)));
+    console.log(chalk.dim(result.summary));
+    console.log();
+
+    console.log(chalk.bold("Quick steps"));
+    console.log(chalk.dim("─".repeat(60)));
+    for (let i = 0; i < result.steps.length; i++) {
+      console.log(`  ${chalk.cyan(`${i + 1}.`)} ${result.steps[i]}`);
+    }
+    console.log();
+
+    console.log(chalk.bold("Related commands"));
+    console.log(chalk.dim("─".repeat(60)));
+    for (const cmd of result.relatedCommands) {
+      console.log(`  ${chalk.cyan(cmd)}`);
+    }
+    console.log();
+
+    console.log(chalk.bold("Full guide"));
+    console.log(chalk.dim("─".repeat(60)));
+    console.log();
+    console.log(result.content);
+    console.log();
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,6 +35,7 @@ import { demoCommand } from "./commands/demo.js";
 import { contextCommand } from "./commands/context.js";
 import { runCommand } from "./commands/run.js";
 import { agentCommand } from "./commands/agent.js";
+import { walkthroughCommand } from "./commands/walkthrough.js";
 import { ApiKeyError } from "./utils/api-key.js";
 import { isFirstRun, showFirstRunBanner, markBannerShown } from "./utils/first-run.js";
 import { exitWithError, usageError } from "./commands/output.js";
@@ -210,6 +211,7 @@ program.addCommand(batchCommand);
 // Agent integration commands
 program.addCommand(schemaCommand);
 program.addCommand(contextCommand);
+program.addCommand(walkthroughCommand);
 
 // Utility commands (less commonly used directly)
 program.addCommand(mediaCommand, { hidden: true });

--- a/packages/cli/src/tools/manifest/index.ts
+++ b/packages/cli/src/tools/manifest/index.ts
@@ -16,6 +16,7 @@ import { timelineTools } from "./timeline.js";
 import { projectTools } from "./project.js";
 import { exportTools } from "./export.js";
 import { agentOnlyTools } from "./agent-only.js";
+import { walkthroughTools } from "./walkthrough.js";
 
 export const manifest: readonly AnyTool[] = [
   ...sceneTools,
@@ -29,6 +30,7 @@ export const manifest: readonly AnyTool[] = [
   ...projectTools,
   ...exportTools,
   ...agentOnlyTools,
+  ...walkthroughTools,
 ];
 
 export {
@@ -43,4 +45,5 @@ export {
   projectTools,
   exportTools,
   agentOnlyTools,
+  walkthroughTools,
 };

--- a/packages/cli/src/tools/manifest/walkthrough.ts
+++ b/packages/cli/src/tools/manifest/walkthrough.ts
@@ -1,0 +1,63 @@
+/**
+ * @module manifest/walkthrough
+ * @description Universal walkthrough primitive — host-agnostic equivalent of
+ * Claude Code's `/vibe-scene` and `/vibe-pipeline` slash commands.
+ *
+ * Any agent host (Claude Code, Codex, Cursor, Aider, Gemini CLI, OpenCode)
+ * can invoke `walkthrough` to load the same step-by-step authoring guide
+ * the slash commands deliver. Source content is vendored as TS template
+ * literals (see `commands/_shared/walkthroughs/`) so the bundle has zero
+ * filesystem dependencies.
+ */
+
+import { z } from "zod";
+import { defineTool, type AnyTool } from "../define-tool.js";
+import {
+  WALKTHROUGH_TOPICS,
+  listWalkthroughs,
+  loadWalkthrough,
+  type WalkthroughTopic,
+} from "../../commands/_shared/walkthroughs/walkthroughs.js";
+
+const walkthroughSchema = z.object({
+  topic: z
+    .enum(WALKTHROUGH_TOPICS as unknown as [WalkthroughTopic, ...WalkthroughTopic[]])
+    .optional()
+    .describe(
+      "Walkthrough topic to load. Omit to list every available walkthrough — useful for discovery on first contact.",
+    ),
+});
+
+export const walkthroughTool = defineTool({
+  name: "walkthrough",
+  category: "agent",
+  cost: "free",
+  description:
+    "Load the step-by-step authoring guide for a vibe workflow (BUILD scene authoring, YAML pipeline authoring). Universal CLI-equivalent of Claude Code's /vibe-* slash commands — any host agent that calls this tool gets the same content the slash menu delivers in Claude Code, with no Claude Code dependency. Without a topic, returns the catalog of walkthroughs for discovery.",
+  schema: walkthroughSchema,
+  async execute(args) {
+    if (!args.topic) {
+      const topics = listWalkthroughs();
+      return {
+        success: true,
+        data: { action: "list", topics },
+        humanLines: [
+          `Available walkthroughs: ${topics.map((t) => t.topic).join(", ")}.`,
+          `Call again with topic to load full content.`,
+        ],
+      };
+    }
+
+    const result = loadWalkthrough(args.topic);
+    return {
+      success: true,
+      data: { action: "show", ...result },
+      humanLines: [
+        `Loaded walkthrough: ${result.title}.`,
+        `${result.steps.length} steps, ${result.relatedCommands.length} related commands, ${result.content.length} chars of guide content.`,
+      ],
+    };
+  },
+});
+
+export const walkthroughTools: readonly AnyTool[] = [walkthroughTool as unknown as AnyTool];

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -16,8 +16,8 @@ describe("@vibeframe/mcp-server", () => {
       expect(tools.length).toBeGreaterThan(0);
     });
 
-    it("should have 65 tools total", () => {
-      expect(tools.length).toBe(65);
+    it("should have 66 tools total", () => {
+      expect(tools.length).toBe(66);
     });
 
     it("should have correct tool structure", () => {

--- a/packages/mcp-server/src/tools/cli-sync.test.ts
+++ b/packages/mcp-server/src/tools/cli-sync.test.ts
@@ -41,6 +41,11 @@ const CLI_TREE: Record<string, string[]> = {
   timeline: ["add-source", "add-clip", "add-track", "add-effect", "trim", "list", "split", "duplicate", "delete", "move"],
   project:  ["create", "info", "set"],
   analyze:  ["media", "video", "review", "suggest"],
+  // `vibe walkthrough <topic>` is a top-level command with a positional
+  // arg, not a real subcommand group. We model the topics as "subs" here
+  // so each one ↔ manifest mapping is verifiable; the single backing
+  // manifest tool (`walkthrough`) handles them all by routing on `topic`.
+  walkthrough: ["scene", "pipeline"],
 };
 
 // Top-level CLI commands with no manifest equivalent — pure ergonomics
@@ -129,6 +134,10 @@ const CLI_TO_MANIFEST: Record<string, string | null> = {
   "analyze video":   "analyze_video",
   "analyze review":  "analyze_review",
   "analyze suggest": "analyze_suggest",
+  // walkthrough — both topics route through the single `walkthrough`
+  // manifest tool (the topic is a tool arg, not a separate tool)
+  "walkthrough scene":    "walkthrough",
+  "walkthrough pipeline": "walkthrough",
 };
 
 describe("CLI ↔ manifest sync", () => {


### PR DESCRIPTION
## Summary

Closes the last Claude-Code-only gap on top of Plan H. Before this PR, \`/vibe-pipeline\` and \`/vibe-scene\` slash commands were the only way to discover + load step-by-step authoring guides — Codex / Cursor / Aider / Gemini CLI / OpenCode users had to read \`SKILL.md\` manually and stitch the workflow themselves. Now any host (or a human at a terminal) gets the same content with one CLI command.

This is the answer to the user's review question on #52: *"slash command이 Claude Code만 되는 부분인데 vibe CLI만 가지고 할 수는 없는거야?"* — yes, with this command.

## What ships

| Surface | Effect |
|---|---|
| \`vibe walkthrough\` | Lists available topics (\`scene\`, \`pipeline\`) with one-line summaries |
| \`vibe walkthrough <topic>\` | Emits full guide: numbered steps + related commands + markdown body |
| \`--json\` flag | Structured \`{topic, title, summary, steps[], relatedCommands[], content}\` for agents |
| Manifest tool \`walkthrough\` | Same primitive on MCP / Agent surfaces; optional \`topic\` arg returns catalog when omitted |

## Architecture

- Source content lives in \`packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts\` as TS template literals — same vendoring pattern as \`hf-skill-bundle\`. Zero filesystem dependencies in the bundle.
- The Claude Code slash command files at \`.claude/skills/vibe-{scene,pipeline}/SKILL.md\` remain as-is (they ship the same content with frontmatter for the slash menu). Future drift is acceptable — the walkthrough module is the source of truth for cross-host parity; the slash-command files can layer Claude Code-specific niceties on top.

## Tests

- **10-case \`walkthroughs.test.ts\`** — topic catalog, type-guard, field shape, Plan H references in scene content (\`--mode agent\` + \`compose-prompts\`), action enumeration in pipeline content, step quality.
- **\`cli-sync.test.ts\`** extended with \`walkthrough\` group — topics modelled as "subs" so the CLI ↔ manifest mapping stays verifiable; both topics route to the single \`walkthrough\` manifest tool. Comment explains the modelling.
- **\`integration.test.ts\`** agent-tool count: 81 → 82, with \`walkthroughTools.length === 1\` assertion. Naming convention test gains an \`exactMatches\` set for rare cross-category top-level utilities (currently just \`walkthrough\` — comment says "keep this small").
- Counts: MCP 65 → 66, Agent 81 → 82. README + landing fallback bumped.

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm -F @vibeframe/cli test\` — 700 passed | 9 skipped
- [x] \`pnpm -F @vibeframe/mcp-server test\` — 48 passed
- [x] \`bash scripts/sync-counts.sh --check\` green
- [x] E2E with built bundle: \`vibe walkthrough --json\` → 2-topic catalog; \`vibe walkthrough scene --json\` → full structured shape with 5 steps + 8 related commands + ~3 KB content; \`vibe walkthrough invalid\` → USAGE_ERROR (exit 2).
- [ ] CI green

## Side-effect

The "Tier 2 — Claude Code deeper integration" framing in #52 (PR #184) becomes weaker — every host can reach the same walkthroughs now. README / landing don't change in this PR (defer to a follow-up so the diff stays focused), but the next docs touch can tone down the Tier 2 callout to "Claude Code adds a slash menu over the universal \`vibe walkthrough\` content."