### PR TITLE
docs: fold "Claude Code deeper integration" into universal walkthroughs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ See [`docs/comparison.md`](docs/comparison.md) for a measured side-by-side of `v
 | **Video as Code** | composition is somewhat declarative | `vibe run pipeline.yaml` · `--dry-run` cost preview · `--resume` checkpoints · step references (`$step.output`) |
 | **Local Kokoro TTS** | ✅ Python `kokoro-onnx` | ✅ Node `kokoro-js` — same Kokoro-82M model, auto-fallback when no `ELEVENLABS_API_KEY` |
 | **Local Whisper transcribe** | ✅ whisper-cpp (offline) | OpenAI Whisper API (cloud, word-level) |
-| **Agent skills** | ✅ `npx skills add heygen-com/hyperframes` (5 skills via vercel-labs/skills) | ✅ ships `/vibe-pipeline`, `/vibe-scene` (overview lives in `AGENTS.md` scaffolded by `vibe init`) |
+| **Agent skills** | ✅ `npx skills add heygen-com/hyperframes` (5 skills via vercel-labs/skills) | ✅ universal `vibe walkthrough <topic>` (scene / pipeline) — same content as Claude Code's `/vibe-scene` and `/vibe-pipeline` slash commands, callable from any host. Project guidance in `AGENTS.md` (`vibe init`). |
 | **MCP server** | ❌ | ✅ 66 tools |
 | **Render** | ✅ native (BeginFrame, parity, HDR, Studio NLE) | uses Hyperframes backend or FFmpeg |
 | **License** | Apache 2.0 | MIT |
@@ -208,24 +208,18 @@ The example above is host-agnostic — every command works identically across Cl
 
 `vibe scene build --mode auto` auto-flips to the agentic compose path (no internal LLM call — host agent authors per-beat HTML directly) whenever any of the above hosts is present. Set `VIBE_BUILD_MODE=batch` to force the internal-LLM compose path instead.
 
-### Claude Code deeper integration
+### Step-by-step authoring guides
 
-Claude Code is the only host today with a slash-command pack on top of the universal CLI surface. After running `vibe scene init`, two slash commands are registered:
+`vibe walkthrough` ships a built-in catalog of authoring guides — universal across every host, no slash menu required:
 
 ```bash
-# From any project where you want the skill pack active
-mkdir -p .claude/skills
-curl -fsSL https://raw.githubusercontent.com/vericontext/vibeframe/main/scripts/install-skills.sh | bash
+vibe walkthrough              # list available topics
+vibe walkthrough scene        # full scene-authoring guide (BUILD flow)
+vibe walkthrough pipeline     # full YAML-pipeline authoring guide (Video as Code)
+vibe walkthrough scene --json # structured shape for an agent host to consume
 ```
 
-- **`/vibe-pipeline`** — YAML pipeline authoring helper (Video as Code)
-- **`/vibe-scene`** — per-scene HTML authoring + `vibe scene build` (Hyperframes-backed)
-
-> The skill pack was consolidated 4 → 2 in v0.62: the older `/vibeframe` overview moved to `AGENTS.md` (scaffolded by `vibe init`), and `/vibe-script-to-video` was retired in v0.63 in favour of `/vibe-scene` driving `vibe scene build`.
-
-Other host families (Codex / Cursor / Aider / Gemini CLI / OpenCode) get their own equivalents on demand — see [`packages/cli/src/utils/agent-host-detect.ts`](packages/cli/src/utils/agent-host-detect.ts) + [`packages/cli/src/commands/_shared/install-skill.ts`](packages/cli/src/commands/_shared/install-skill.ts) for the registration shape, or open an issue / PR if your host needs first-class scaffolds.
-
-Prefer manual install? Copy [`.claude/skills/`](https://github.com/vericontext/vibeframe/tree/main/.claude/skills) from this repo into your project.
+Same content the `/vibe-scene` and `/vibe-pipeline` slash commands deliver in Claude Code — works identically when called from any other host. Claude Code users can keep the slash menu as a one-keystroke shortcut (install via `curl -fsSL https://raw.githubusercontent.com/vericontext/vibeframe/main/scripts/install-skills.sh | bash`); the underlying guide is the same.
 
 ---
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -296,7 +296,7 @@ export default function LandingPage() {
           </div>
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3 max-w-4xl mx-auto">
             {[
-              { name: "Claude Code", scaffold: "CLAUDE.md + AGENTS.md", note: "+ /vibe-* slash commands" },
+              { name: "Claude Code", scaffold: "CLAUDE.md + AGENTS.md", note: "slash menu shortcut to walkthroughs" },
               { name: "OpenAI Codex", scaffold: "AGENTS.md", note: "agents.md spec" },
               { name: "Cursor", scaffold: "AGENTS.md + .cursor/rules", note: "MCP-ready" },
               { name: "Aider", scaffold: "AGENTS.md", note: "binary-detected" },
@@ -317,42 +317,45 @@ export default function LandingPage() {
         </div>
       </section>
 
-      {/* ②.5 — Claude Code deeper integration (Tier 2) */}
+      {/* ②.5 — Step-by-step authoring guides (universal walkthroughs) */}
       <section className="py-20 px-4 border-t border-border/50 relative">
         <div className="mx-auto max-w-5xl">
           <div className="text-center mb-10">
-            <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/30 bg-orange-500/5 px-4 py-1.5 text-sm text-orange-400 mb-4">
+            <div className="inline-flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-500/5 px-4 py-1.5 text-sm text-cyan-400 mb-4">
               <Sparkles className="w-4 h-4" />
-              <span>Claude Code deeper integration</span>
+              <span>Universal walkthroughs</span>
             </div>
             <h2 className="text-3xl sm:text-4xl font-bold mb-4">
-              Slash commands, beyond the CLI
+              <code className="text-primary bg-primary/10 px-3 py-1 rounded">vibe walkthrough</code>
             </h2>
             <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-              Claude Code is the only host today with a slash-command pack on top of the universal CLI. Every other agent host gets the same <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">vibe</code> commands; Claude Code adds two guided flows.
+              Step-by-step authoring guides built into the CLI — discoverable by every host, not just Claude Code's slash menu.
             </p>
           </div>
 
           <div className="grid md:grid-cols-2 gap-4 max-w-4xl mx-auto mb-8">
             <div className="bg-secondary/40 border border-border/50 rounded-xl p-5">
-              <div className="font-mono text-sm font-semibold text-orange-400 mb-2">/vibe-pipeline</div>
-              <p className="text-sm text-muted-foreground">YAML pipeline authoring helper — Video as Code with cost estimates and step references.</p>
+              <div className="font-mono text-sm font-semibold text-cyan-400 mb-2">vibe walkthrough scene</div>
+              <p className="text-sm text-muted-foreground">Scene authoring — STORYBOARD.md → MP4 via <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">vibe scene build</code> (Hyperframes-backed, Plan H agentic compose).</p>
             </div>
             <div className="bg-secondary/40 border border-border/50 rounded-xl p-5">
-              <div className="font-mono text-sm font-semibold text-orange-400 mb-2">/vibe-scene</div>
-              <p className="text-sm text-muted-foreground">Per-scene HTML authoring + <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">vibe scene build</code> driver (Hyperframes-backed).</p>
+              <div className="font-mono text-sm font-semibold text-cyan-400 mb-2">vibe walkthrough pipeline</div>
+              <p className="text-sm text-muted-foreground">YAML pipeline authoring — Video as Code with cost estimates, checkpoints, and step references.</p>
             </div>
           </div>
 
           <div className="bg-background/50 border border-border/50 rounded-xl p-4 max-w-3xl mx-auto">
-            <div className="text-xs text-muted-foreground mb-2">Install (one-shot):</div>
-            <code className="font-mono text-xs text-foreground block break-all">
-              curl -fsSL https://raw.githubusercontent.com/vericontext/vibeframe/main/scripts/install-skills.sh | bash
+            <div className="text-xs text-muted-foreground mb-2">List + load:</div>
+            <code className="font-mono text-xs text-foreground block">
+              vibe walkthrough              <span className="text-muted-foreground"># list available topics</span>
+            </code>
+            <code className="font-mono text-xs text-foreground block mt-1">
+              vibe walkthrough scene --json <span className="text-muted-foreground"># structured shape for an agent host</span>
             </code>
           </div>
 
           <p className="text-center text-muted-foreground text-sm mt-6 max-w-3xl mx-auto">
-            Plan H also auto-installs the Hyperframes skill bundle into <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">.claude/skills/hyperframes/</code> when you run <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">vibe scene init</code> — Claude Code reads it as system context for cinematic scene authoring. Other host families get the same content as a universal <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">SKILL.md</code> at the project root.
+            Same content the <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">/vibe-scene</code> and <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">/vibe-pipeline</code> slash commands deliver in Claude Code. Claude Code users can keep the slash menu as a one-keystroke shortcut — the underlying guide is identical.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary

#185 just shipped \`vibe walkthrough\`, which delivers identical content to Claude Code's \`/vibe-scene\` and \`/vibe-pipeline\` slash commands — callable from any host. The Tier 2 "Claude Code-specific" framing in the README + landing (added in #184) was honest when written, but walkthrough now obsoletes that distinction: the content is universal, and Claude Code's slash menu is just a one-keystroke shortcut on top of the same primitive.

User feedback after #185: *"claude code 고유 메뉴 부분은 없애도 될듯. walkthrough로 대체되는거 아님?"* — yes, folding.

## What changed

### README.md
- Drop the **"### Claude Code deeper integration"** subsection.
- Replace with a tighter **"### Step-by-step authoring guides"** block that leads with \`vibe walkthrough <topic>\` and notes Claude Code's slash menu as a shortcut to the same content.
- Hyperframes-vs-VibeFrame "Agent skills" matrix row: was *"ships /vibe-pipeline, /vibe-scene"*, now leads with the universal \`vibe walkthrough\` and mentions the slash commands parenthetically.

### apps/web/app/page.tsx
- **Section ②.5** reframed: orange "Claude Code deeper integration" badge → cyan **"Universal walkthroughs"** badge. Heading is the command itself (\`vibe walkthrough\`); cards advertise \`vibe walkthrough scene\` / \`vibe walkthrough pipeline\` instead of slash commands.
- **Six-host grid** card for Claude Code: *"+ /vibe-* slash commands"* → *"slash menu shortcut to walkthroughs"*.
- Slash-command install snippet retained as a footnote (*"Claude Code users can keep the slash menu as a one-keystroke shortcut — the underlying guide is identical"*).

## What's NOT changed (deliberate)

- \`.claude/skills/vibe-{scene,pipeline}/SKILL.md\` files still exist.
- \`scripts/install-skills.sh\` still works.
- The slash menu still functions in Claude Code.

This is **purely a positioning correction** — walkthrough becomes the first-class universal primitive, slash commands become the shortcut layer specific to Claude Code (not the other way around).

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm -F @vibeframe/web build\` — Next.js prerender green
- [x] \`bash scripts/sync-counts.sh --check\` green
- [ ] CI green