### PR TITLE
release: v0.71.0 — agent-host coverage + universal walkthroughs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.71.0] - 2026-04-28
+
+Agent-host coverage + CLI-only walkthroughs. Closes the last Claude-Code-only positioning gap on top of Plan H. All changes are additive — no breaking changes. Counts: MCP 65 → 66, Agent 81 → 82.
+
+### Added
+
+- **Gemini CLI + OpenCode host detection (#183)** — \`agent-host-detect.ts\` now recognises six hosts (Claude Code, OpenAI Codex, Cursor, Aider, Gemini CLI, OpenCode). \`vibe doctor\` auto-detects, \`vibe init --agent gemini-cli|opencode\` scaffolds AGENTS.md, \`--agent all\` covers everyone. Detection follows the existing pattern (binary on PATH OR config dir in \$HOME).
+- **\`vibe walkthrough <topic>\` command (#185)** — universal CLI equivalent of Claude Code's \`/vibe-scene\` and \`/vibe-pipeline\` slash commands. Topics: \`scene\`, \`pipeline\`. Without a topic, lists the catalog. \`--json\` returns a structured \`{topic, title, summary, steps, relatedCommands, content}\` shape for agent hosts. Source content vendored as TS template literals (zero filesystem dependencies). Manifest tool \`walkthrough\` exposes the same primitive on MCP / Agent surfaces.
+
+### Changed
+
+- **README + landing rewritten for agent-agnostic positioning (#184)** — closes issue #52. New "Agent host support" matrix in the README enumerates all six detected hosts with their \`vibe init\` scaffold + Plan H skill layout. Hero / Section ② / SEO keywords updated to lead with "any bash-capable AI coding agent" instead of Claude Code only. Honest matrix — only host-specific signals the codebase actually emits, no fabricated capability claims.
+- **"Claude Code deeper integration" → "Universal walkthroughs" (#186)** — once \`vibe walkthrough\` shipped, the slash-command-as-Tier-2 framing became misleading. Slash commands are now positioned as a one-keystroke shortcut to the same universal walkthrough content, not a Claude-Code-exclusive feature. \`.claude/skills/vibe-{scene,pipeline}/\` files unchanged — same install path still works.
+
+### Maintenance
+
+- v0.71.0 release — bump version + CHANGELOG (this PR)
+
 ## [0.70.0] - 2026-04-28
 
 **Plan H — agentic-native composer.** Closes the architectural smell where `vibe scene build` made VibeFrame's CLI run its own Anthropic / OpenAI / Gemini call hidden behind the host agent. Now the host agent (Claude Code, Cursor, Codex, Aider) is the sole reasoner; VibeFrame ships skill files into the user's project and provides a deterministic toolbelt around them. The internal-LLM batch path is preserved as a fallback for CI / non-agent contexts.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bump 0.70.0 → 0.71.0 + CHANGELOG. Releases the agent-host coverage + walkthrough work that landed since v0.70.0.

## Highlights

- **#183** — Gemini CLI + OpenCode host detection (\`agent-host-detect.ts\` now recognises six host families)
- **#184** — README + landing rewritten for agent-agnostic positioning (closes issue #52)
- **#185** — \`vibe walkthrough <topic>\` universal slash-command equivalent
- **#186** — "Claude Code deeper integration" folded into universal walkthroughs

All additive. No breaking changes. \`auto-tag.yml\` will detect the version bump and dispatch \`publish.yml\` for \`@vibeframe/cli\` + \`@vibeframe/mcp-server\`.

## Test plan

- [x] Local typecheck (\`pnpm -r exec tsc --noEmit\`) green
- [x] \`bash scripts/sync-counts.sh --check\` green
- [ ] CI green
- [ ] auto-tag fires + publish.yml succeeds for both packages