### PR TITLE
chore(demos): rename claude.tape → host-agent.tape (4a, deferred from #184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ deterministically by Hyperframes' producer.
 
 ```bash
 brew install vhs
-vhs assets/demos/cli.tape          # Surface 1 — vibe CLI directly
-vhs assets/demos/agent.tape        # Surface 2 — vibe agent (built-in REPL, BYO LLM)
-vhs assets/demos/claude.tape       # Surface 3 — host agent driving vibe scene build (recorded with Claude Code)
-vhs assets/demos/claude-i2v.tape   # Surface 4 — host agent t2i + i2v + narration (recorded with Claude Code)
+vhs assets/demos/cli.tape              # Surface 1 — vibe CLI directly
+vhs assets/demos/agent.tape            # Surface 2 — vibe agent (built-in REPL, BYO LLM)
+vhs assets/demos/host-agent.tape       # Surface 3 — host agent driving vibe scene build
+vhs assets/demos/host-agent-i2v.tape   # Surface 4 — host agent t2i + i2v + narration
 ```
 
-> The Surface 3/4 tapes were recorded with Claude Code, but the same `vibe` commands run identically when driven by Codex / Cursor / Aider / Gemini CLI / OpenCode — the host agent is just translating natural language into the same shell command.
+> The Surface 3/4 tapes were recorded with Claude Code (it's the agent we use day-to-day), but the same `vibe` commands run identically when driven by Codex / Cursor / Aider / Gemini CLI / OpenCode — the host agent is just translating natural language into the same shell command. Re-record on your favourite host with `vhs <tape>` after exporting that host's API key.
 
 > **New in v0.60:** `vibe scene build` is the one-shot driver — write a `STORYBOARD.md` with per-beat YAML cues (narration / backdrop / duration), and a single command dispatches TTS + GPT Image 2 + composes scene HTML via the `compose-scenes-with-skills` pipeline (v0.59) and renders to MP4. `vibe scene init --visual-style "Swiss Pulse"` (v0.58) still seeds the `DESIGN.md` hard-gate + 8 named visual identities. Hyperframes' `/hyperframes` skill (`npx skills add heygen-com/hyperframes`) is loaded as the LLM system prompt for composition craft.
 

--- a/apps/web/app/demo/page.tsx
+++ b/apps/web/app/demo/page.tsx
@@ -128,16 +128,16 @@ export default function DemoPage() {
               command="vhs assets/demos/agent.tape"
             />
             <TapeCard
-              badge="3 · Claude Code"
+              badge="3 · Host agent"
               title="scene build"
-              note="Claude Code drives storyboard → multi-beat MP4"
-              command="vhs assets/demos/claude.tape"
+              note="Host agent drives storyboard → multi-beat MP4 (recorded with Claude Code)"
+              command="vhs assets/demos/host-agent.tape"
             />
             <TapeCard
-              badge="4 · Claude Code"
+              badge="4 · Host agent"
               title="primitive chain"
-              note="t2i (gpt-image-2) → i2v (Seedance 2.0) → narration → mux"
-              command="vhs assets/demos/claude-i2v.tape"
+              note="t2i (gpt-image-2) → i2v (Seedance 2.0) → narration → mux (recorded with Claude Code)"
+              command="vhs assets/demos/host-agent-i2v.tape"
             />
           </div>
 

--- a/assets/demos/host-agent-i2v.tape
+++ b/assets/demos/host-agent-i2v.tape
@@ -1,13 +1,15 @@
-# assets/demos/claude-i2v.tape — Surface 4: Claude Code drives the
-# primitive pipeline (t2i → i2v → narration → mux), no scene authoring.
+# assets/demos/host-agent-i2v.tape — Surface 4: a host agent drives
+# the primitive pipeline (t2i → i2v → narration → mux), no scene
+# authoring. Recorded with Claude Code; the same flow works on any
+# host that reads AGENTS.md.
 #
-# Renders → assets/demos/claude-i2v.mp4
+# Renders → assets/demos/host-agent-i2v.mp4
 #
-# Where claude.tape demonstrates skills + scene build (a STORYBOARD
+# Where host-agent.tape demonstrates skills + scene build (a STORYBOARD
 # becomes a multi-beat cinematic), this one demonstrates the OTHER
 # canonical VibeFrame flow: chain individual generation primitives to
-# produce a single short clip. Same surface (Claude Code), different
-# CLI subcommands.
+# produce a single short clip. Same surface (any host agent),
+# different CLI subcommands.
 #
 # Primitive chain:
 #   1. gpt-image-2 (text-to-image, HD)              — $0.04
@@ -24,9 +26,9 @@
 #   export OPENAI_API_KEY=...       # gpt-image-2
 #   export FAL_KEY=...              # Seedance 2.0
 #   export ELEVENLABS_API_KEY=...   # TTS
-#   vhs assets/demos/claude-i2v.tape
+#   vhs assets/demos/host-agent-i2v.tape
 
-Output assets/demos/claude-i2v.mp4
+Output assets/demos/host-agent-i2v.mp4
 
 Set FontSize 12
 Set Width 1400

--- a/assets/demos/host-agent.tape
+++ b/assets/demos/host-agent.tape
@@ -1,12 +1,15 @@
-# assets/demos/claude.tape — Surface 3: end-to-end via Claude Code
+# assets/demos/host-agent.tape — Surface 3: end-to-end via a host agent
+# (recorded with Claude Code; the same flow works on any host that
+# reads AGENTS.md — Codex / Cursor / Aider / Gemini CLI / OpenCode).
 #
-# Renders → assets/demos/claude.mp4
+# Renders → assets/demos/host-agent.mp4
 #
-# Captures: curl install → vibe init → claude --dangerously-skip-permissions
-# → natural-language prompt → Claude reads AGENTS.md → drives full
-# scene build flow → cinematic 12-second MP4.
+# Captures: curl install → vibe init → host agent (Claude Code in the
+# recording) reads AGENTS.md → user describes the video in natural
+# language → agent drives the full scene build flow → cinematic
+# 12-second MP4.
 
-Output assets/demos/claude.mp4
+Output assets/demos/host-agent.mp4
 
 Set FontSize 12
 Set Width 1400


### PR DESCRIPTION
Renames the Surface 3/4 VHS tapes from `claude.tape` / `claude-i2v.tape` to `host-agent.tape` / `host-agent-i2v.tape`. Tapes were named after the recording host (Claude Code), but the same flow runs on any host that reads AGENTS.md.

Internal updates: tape header comments reframed, output paths updated (`host-agent.mp4` / `host-agent-i2v.mp4`), README + apps/web/app/demo/page.tsx TapeCards adjusted.

No external URL impact — tape output `.mp4`s are gitignored, only `cinematic-v060.mp4` is committed under assets/demos/ and stays put.

Verification: `pnpm -r exec tsc --noEmit`, `pnpm lint`, `pnpm -F @vibeframe/web build` green.

Part 1/4 of the deferred follow-ups from #184 (Issue #52).