### PR TITLE
feat(init): GEMINI.md scaffold for Gemini CLI parity (4c, deferred from #184)

### DIFF
--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -192,6 +192,31 @@ curl -fsSL https://raw.githubusercontent.com/vericontext/vibeframe/main/scripts/
      slash commands you've added, conversational style preferences, etc. -->
 `;
 
+/**
+ * Gemini CLI project file. Gemini CLI's primary context file is
+ * `GEMINI.md` (per https://geminicli.com/docs/cli/gemini-md/), so this
+ * scaffold gives Gemini CLI users a top-level entry point that points
+ * at the canonical `AGENTS.md`. The leading `@AGENTS.md` follows the
+ * same import convention Claude Code's `CLAUDE.md` uses; Gemini CLI
+ * also honours sibling-file references in context, and the
+ * human-readable note below ensures the agent picks up `AGENTS.md`
+ * either way.
+ */
+export const GEMINI_MD = `@AGENTS.md
+
+# Gemini CLI overrides
+
+This project's canonical agent guidance lives in \`AGENTS.md\` — read
+it first. The \`@AGENTS.md\` line above is the import marker; if
+Gemini CLI doesn't inline imported files in your version, open
+\`AGENTS.md\` directly. Both files are kept in sync by \`vibe init\`.
+
+## Project-specific guidance
+
+<!-- Add Gemini-CLI-specific notes here: any conventions specific to
+     how you drive vibe from Gemini CLI (preferred models, tone, etc.). -->
+`;
+
 /** Shape the init renderer can fill in for the .env.example body. */
 export interface EnvExampleOptions {
   /** When true, surfaces a "tier: free local fallbacks" section at the top. */

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -31,6 +31,7 @@ import { detectedAgentHosts, type AgentHostId } from "../utils/agent-host-detect
 import {
   AGENTS_MD,
   CLAUDE_MD,
+  GEMINI_MD,
   GITIGNORE_ADDITIONS,
   renderEnvExample,
   renderProjectYaml,
@@ -66,6 +67,7 @@ export const initCommand = new Command("init")
     // "all" = every host we know about; otherwise the explicit set.
     const targetHosts = resolveTargets(agent);
     const wantsClaude = targetHosts.includes("claude-code");
+    const wantsGemini = targetHosts.includes("gemini-cli");
     const wantsCrossTool = targetHosts.some((h) => h !== "claude-code");
 
     const actions: InitFileAction[] = [];
@@ -96,6 +98,20 @@ export const initCommand = new Command("init")
       actions.push(await writeIfMissing(
         resolve(projectDir, "CLAUDE.md"),
         CLAUDE_MD,
+        options.force,
+        options.dryRun,
+      ));
+    }
+
+    // ── GEMINI.md (Gemini CLI, parallels CLAUDE.md) ────────────────────
+    // Gemini CLI's primary context file is GEMINI.md (per
+    // https://geminicli.com/docs/cli/gemini-md/). Same import-from-
+    // AGENTS.md pattern as CLAUDE.md so the canonical guidance lives
+    // in one place and host-specific overrides go in the wrapper.
+    if (wantsGemini) {
+      actions.push(await writeIfMissing(
+        resolve(projectDir, "GEMINI.md"),
+        GEMINI_MD,
         options.force,
         options.dryRun,
       ));


### PR DESCRIPTION
Part 3/4 of #184 deferred follow-ups.

Gemini CLI's primary context file is `GEMINI.md` (per https://geminicli.com/docs/cli/gemini-md/). Pre-this-PR, `vibe init --agent gemini-cli` only wrote `AGENTS.md`, leaving Gemini CLI users without a host-specific entry point that paralleled what Claude Code got via `CLAUDE.md`.

New `GEMINI_MD` template mirrors `CLAUDE_MD`'s shape: leading `@AGENTS.md` import marker + "Gemini CLI overrides" header. Body explicitly notes that if Gemini CLI doesn't inline imported files in the user's version, they should read AGENTS.md directly — defensive framing that works either way.

`vibe init` writes GEMINI.md whenever `gemini-cli` is in the resolved target host set (`--agent gemini-cli`, `--agent all`, or `--agent auto` with Gemini CLI detected).

E2E with built bundle:
```
vibe init /tmp/g --agent gemini-cli --json
→ wrote AGENTS.md + GEMINI.md + .env.example + .gitignore + vibe.project.yaml
```

Verification: `pnpm -r exec tsc --noEmit`, `pnpm lint`, init-templates tests (15 passed).