### PR TITLE
feat(cli)!: new --json envelope on generate image (Issue #33 — 2c-canary)

### DIFF
--- a/packages/cli/src/commands/generate/image.ts
+++ b/packages/cli/src/commands/generate/image.ts
@@ -20,7 +20,7 @@ import { requireApiKey, hasApiKey } from "../../utils/api-key.js";
 import { hasTTY, prompt as promptText } from "../../utils/tty.js";
 import {
   isJsonMode,
-  outputResult,
+  outputSuccess,
   log,
   exitWithError,
   apiError,
@@ -56,6 +56,7 @@ Examples:
   $ vibe gen img "portrait" -o portrait.png -p gemini -m pro
   $ vibe gen img "product shot" --dry-run --json`)
     .action(async (prompt: string | undefined, options) => {
+      const startedAt = Date.now();
       try {
         // Interactive prompt if no argument provided
         if (!prompt) {
@@ -135,18 +136,21 @@ Examples:
 
         // Dry-run check
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "generate image",
-            params: {
-              prompt,
-              provider,
-              model: options.model,
-              ratio: options.ratio,
-              size: options.size,
-              quality: options.quality,
-              count: options.count,
-              output: options.output,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                prompt,
+                provider,
+                model: options.model,
+                ratio: options.ratio,
+                size: options.size,
+                quality: options.quality,
+                count: options.count,
+                output: options.output,
+              },
             },
           });
           return;
@@ -193,14 +197,17 @@ Examples:
               await mkdir(dirname(outputPath), { recursive: true });
               await writeFile(outputPath, buffer);
             }
-            outputResult({
-              success: true,
-              provider: "openai",
-              images: result.images.map((img) => ({
-                url: img.url,
-                revisedPrompt: img.revisedPrompt,
-              })),
-              outputPath,
+            outputSuccess({
+              command: "generate image",
+              startedAt,
+              data: {
+                provider: "openai",
+                images: result.images.map((img) => ({
+                  url: img.url,
+                  revisedPrompt: img.revisedPrompt,
+                })),
+                outputPath,
+              },
             });
             return;
           }
@@ -321,13 +328,18 @@ Examples:
               await mkdir(dirname(outputPath), { recursive: true });
               await writeFile(outputPath, buffer);
             }
-            outputResult({
-              success: true,
-              provider: "gemini",
-              images: result.images.map((img: { mimeType?: string }) => ({
-                mimeType: img.mimeType,
-              })),
-              outputPath,
+            outputSuccess({
+              command: "generate image",
+              startedAt,
+              warnings: usedLabel.includes("fallback") ? [`Model "${options.model}" failed; fell back to flash`] : [],
+              data: {
+                provider: "gemini",
+                model: usedLabel,
+                images: result.images.map((img: { mimeType?: string }) => ({
+                  mimeType: img.mimeType,
+                })),
+                outputPath,
+              },
             });
             return;
           }
@@ -411,11 +423,14 @@ Examples:
               await mkdir(dirname(outputPath), { recursive: true });
               await writeFile(outputPath, buffer);
             }
-            outputResult({
-              success: true,
-              provider: "grok",
-              images: result.images.map((img) => ({ url: img.url })),
-              outputPath,
+            outputSuccess({
+              command: "generate image",
+              startedAt,
+              data: {
+                provider: "grok",
+                images: result.images.map((img) => ({ url: img.url })),
+                outputPath,
+              },
             });
             return;
           }
@@ -498,11 +513,14 @@ Examples:
             proc.on("close", (code) => {
               if (code === 0) {
                 if (isJsonMode()) {
-                  outputResult({
-                    success: true,
-                    provider: "runway",
-                    images: [{ format: "file" }],
-                    outputPath,
+                  outputSuccess({
+                    command: "generate image",
+                    startedAt,
+                    data: {
+                      provider: "runway",
+                      images: [{ format: "file" }],
+                      outputPath,
+                    },
                   });
                 } else {
                   spinner.succeed(chalk.green("Generated image with Runway"));

--- a/packages/cli/src/commands/output.ts
+++ b/packages/cli/src/commands/output.ts
@@ -180,6 +180,85 @@ function formatCost(min: number, max: number, unit: string): string {
   return `~$${min.toFixed(2)}-$${max.toFixed(2)} ${unit}`;
 }
 
+// ── New envelope (Issue #33 — 2c) ────────────────────────────────────────
+// {
+//   "command": "generate image",
+//   "dryRun"?: true,
+//   "elapsedMs": 1234,
+//   "costUsd": 0.04,
+//   "warnings": [],
+//   "data": { ...domain shape... }
+// }
+//
+// Errors still go to stderr via exitWithError(StructuredError) — unchanged.
+// `success` / `ok` keys are intentionally omitted: exit code 0 is the UNIX
+// success signal. Duplicating it on stdout invites buggy agents that check
+// both. See docs/CLI_UX_AUDIT.md "Decisions" section for the rationale.
+
+export interface SuccessEnvelopeOptions {
+  /** Canonical command name, e.g. "generate image". Matches `vibe schema --list`. */
+  command: string;
+  /** Domain payload — provider-specific success keys (`provider`, `images`, `outputPath`, etc.). */
+  data: Record<string, unknown>;
+  /** Wallclock start. Use `Date.now()` at the top of the action handler. */
+  startedAt: number;
+  /** Actual cost. Omit for free ops (defaults to 0). For dry-run, defaults to COST_ESTIMATES upper bound. */
+  costUsd?: number;
+  /** Non-fatal signals (provider fallback, deprecated flag, partial cache miss). */
+  warnings?: string[];
+  /** Pass-through of `--dry-run` flag — surfaces as a top-level `dryRun: true` in the envelope. */
+  dryRun?: boolean;
+}
+
+/** Look up the upper-bound cost estimate for a command (used by dry-run). */
+function lookupCostEstimateUpperBound(command: string): number {
+  return COST_ESTIMATES[command]?.max ?? 0;
+}
+
+/**
+ * Emit a canonical success envelope (#33 — 2c). JSON mode prints the
+ * envelope; quiet mode prints a single primary value extracted from
+ * `data.outputPath ?? data.output ?? data.path ?? data.url ?? data.id`;
+ * human mode prints nothing — the caller renders human output itself.
+ *
+ * Canary scope: `generate image` only in 2c-canary. 2c-sweep migrates
+ * the rest. Old `outputResult()` remains for the sweep transition.
+ */
+export function outputSuccess(opts: SuccessEnvelopeOptions): void {
+  const elapsedMs = Math.max(0, Date.now() - opts.startedAt);
+  const costUsd = opts.costUsd ?? (opts.dryRun ? lookupCostEstimateUpperBound(opts.command) : 0);
+  const envelope: Record<string, unknown> = {
+    command: opts.command,
+    ...(opts.dryRun ? { dryRun: true } : {}),
+    elapsedMs,
+    costUsd,
+    warnings: opts.warnings ?? [],
+    data: opts.data,
+  };
+
+  if (isJsonMode()) {
+    const fields = process.env.VIBE_OUTPUT_FIELDS;
+    if (fields) {
+      const keys = fields.split(",").map((k) => k.trim());
+      const filtered: Record<string, unknown> = {};
+      for (const key of keys) {
+        if (key in envelope) filtered[key] = envelope[key];
+      }
+      console.log(JSON.stringify(filtered, null, 2));
+    } else {
+      console.log(JSON.stringify(envelope, null, 2));
+    }
+    return;
+  }
+
+  if (isQuietMode()) {
+    const data = opts.data;
+    const primary =
+      data.outputPath ?? data.output ?? data.path ?? data.url ?? data.id;
+    if (primary !== undefined) console.log(String(primary));
+  }
+}
+
 /** Output result - JSON mode outputs JSON, quiet mode outputs primary value only */
 export function outputResult(result: Record<string, unknown>): void {
   // Inject cost estimate for dry-run results


### PR DESCRIPTION
## Summary

**Canary PR** for the new \`--json\` envelope. Migrates only \`vibe generate image\` to the shape decided in #192 / #193. The remaining 79 commands move in **2c-sweep** (next PR), once you've confirmed this canary feels right.

## The new envelope

\`\`\`json
{
  \"command\": \"generate image\",
  \"dryRun\"?: true,
  \"elapsedMs\": 1234,
  \"costUsd\": 0.04,
  \"warnings\": [],
  \"data\": { \"provider\": \"openai\", \"images\": [...], \"outputPath\": \"...\" }
}
\`\`\`

Smoke test (verified locally):

\`\`\`
$ vibe generate image \"test prompt\" --dry-run --json
{
  \"command\": \"generate image\",
  \"dryRun\": true,
  \"elapsedMs\": 1,
  \"costUsd\": 0.07,
  \"warnings\": [],
  \"data\": { \"params\": { ... } }
}
\`\`\`

## Migration for agents

| Old | New |
|---|---|
| \`jq .images\` | \`jq .data.images\` |
| \`jq .outputPath\` | \`jq .data.outputPath\` |
| \`jq .estimatedCost\` | \`jq .costUsd\` (numeric, no string parsing) |
| \`jq .success\` | drop — exit code 0 is the signal |

## Why each design choice

- **No \`success\` / \`ok\` key**: exit code 0 is the UNIX success signal. Duplicating it on stdout invites buggy agents that check both. Matches \`gh\` / \`kubectl\` / \`aws\`.
- **\`data\` namespace**: future top-level meta fields (\`traceId\`, \`requestId\`) won't collide with domain keys.
- **\`warnings\` first-class**: the Gemini path now surfaces \`latest → flash\` auto-fallback as a structured warning instead of a stderr-mixed log line. First real demo case for why the channel exists.
- **Numeric \`costUsd\`**: old \`estimatedCost: \"~\$0.01-\$0.07 per image\"\` needed regex parsing. New is parseable as-is.
- **Pre-1.0 breaking**: 0.71.0 → no transition shim. One CHANGELOG note + one-version migration is cheaper than dual emission.

## New helper

\`outputSuccess(opts)\` in \`packages/cli/src/commands/output.ts\`:
\`\`\`ts
export function outputSuccess(opts: {
  command: string;
  data: Record<string, unknown>;
  startedAt: number;     // Date.now() at action handler entry
  costUsd?: number;      // omit → 0 (or COST_ESTIMATES upper bound on dry-run)
  warnings?: string[];   // omit → []
  dryRun?: boolean;
}): void
\`\`\`

\`--fields\` filtering and \`--quiet\` mode preserved (quiet extracts primary value from \`data.outputPath ?? data.output ?? data.path ?? data.url ?? data.id\`).

## Old helper retained

\`outputResult()\` is unchanged and still used by all 79 other commands. 2c-sweep migrates them; 2c-cleanup retires \`outputResult\` once everyone's on the new shape.

## Test plan
- [x] \`pnpm -F @vibeframe/cli exec tsc --noEmit\` clean
- [x] \`pnpm lint\` 0 errors (10/10 tasks)
- [x] \`pnpm -F @vibeframe/cli exec vitest run\` 700 passed, 9 skipped, 0 failed
- [x] \`bash scripts/sync-counts.sh --check\` green
- [x] Manual smoke: \`vibe generate image \"test\" --dry-run --json\` produces expected envelope (sample in commit message)

## Reviewer focus

Does the envelope shape feel right when you imagine yourself parsing it as an agent? If so, 2c-sweep can apply the same shape to the other 79 commands without surprises. If anything feels off (key naming, nesting depth, missing field), now is the cheap time to fix it.