### PR TITLE
feat(cli)!: migrate generate.* to outputSuccess envelope (Issue #33 — 2c-sweep-1)

### DIFF
--- a/packages/cli/src/commands/generate/background.ts
+++ b/packages/cli/src/commands/generate/background.ts
@@ -12,7 +12,7 @@ import ora from "ora";
 import { OpenAIImageProvider } from "@vibeframe/ai-providers";
 import { requireApiKey, hasApiKey } from "../../utils/api-key.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
-import { isJsonMode, outputResult, exitWithError, apiError } from "../output.js";
+import { isJsonMode, outputSuccess, exitWithError, apiError } from "../output.js";
 import { rejectControlChars, validateOutputPath } from "../validate.js";
 
 // ── Library: executeBackground ──────────────────────────────────────────
@@ -98,6 +98,7 @@ export function registerBackgroundCommand(parent: Command): void {
     .option("-a, --aspect <ratio>", "Aspect ratio: 16:9, 9:16, 1:1", "16:9")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (description: string, options) => {
+      const startedAt = Date.now();
       try {
         rejectControlChars(description);
         if (options.output) {
@@ -105,10 +106,11 @@ export function registerBackgroundCommand(parent: Command): void {
         }
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "generate background",
-            params: { description, aspect: options.aspect, output: options.output },
+            startedAt,
+            dryRun: true,
+            data: { params: { description, aspect: options.aspect, output: options.output } },
           });
           return;
         }
@@ -151,7 +153,11 @@ export function registerBackgroundCommand(parent: Command): void {
             await mkdir(dirname(outputPath), { recursive: true });
             await writeFile(outputPath, buffer);
           }
-          outputResult({ success: true, imageUrl: img.url, outputPath });
+          outputSuccess({
+            command: "generate background",
+            startedAt,
+            data: { imageUrl: img.url, outputPath },
+          });
           return;
         }
 

--- a/packages/cli/src/commands/generate/music-status.ts
+++ b/packages/cli/src/commands/generate/music-status.ts
@@ -10,7 +10,7 @@ import chalk from "chalk";
 import { ReplicateProvider } from "@vibeframe/ai-providers";
 import { requireApiKey, hasApiKey } from "../../utils/api-key.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
-import { isJsonMode, outputResult, exitWithError, apiError } from "../output.js";
+import { isJsonMode, outputSuccess, exitWithError, apiError } from "../output.js";
 
 // ── Library: executeMusicStatus ─────────────────────────────────────────
 
@@ -73,6 +73,7 @@ export function registerMusicStatusCommand(parent: Command): void {
     .argument("<task-id>", "Task ID from music generation")
     .option("-k, --api-key <key>", "Replicate API token (or set REPLICATE_API_TOKEN env)")
     .action(async (taskId: string, options) => {
+      const startedAt = Date.now();
       try {
         const apiKey = await requireApiKey(
           "REPLICATE_API_TOKEN",
@@ -91,12 +92,15 @@ export function registerMusicStatusCommand(parent: Command): void {
             : result.error
               ? "failed"
               : "processing";
-          outputResult({
-            success: true,
-            taskId,
-            status,
-            audioUrl: result.audioUrl,
-            error: result.error,
+          outputSuccess({
+            command: "generate music-status",
+            startedAt,
+            data: {
+              taskId,
+              status,
+              audioUrl: result.audioUrl,
+              error: result.error,
+            },
           });
           return;
         }

--- a/packages/cli/src/commands/generate/music.ts
+++ b/packages/cli/src/commands/generate/music.ts
@@ -19,7 +19,7 @@ import { requireApiKey, hasApiKey } from "../../utils/api-key.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
 import {
   isJsonMode,
-  outputResult,
+  outputSuccess,
   exitWithError,
   apiError,
   notFoundError,
@@ -138,6 +138,7 @@ export function registerMusicCommand(parent: Command): void {
     .option("--no-wait", "Don't wait for generation to complete (Replicate async mode)")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (prompt: string, options) => {
+      const startedAt = Date.now();
       try {
         rejectControlChars(prompt);
         if (options.output) {
@@ -147,16 +148,19 @@ export function registerMusicCommand(parent: Command): void {
         const provider = (options.provider || "elevenlabs").toLowerCase();
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "generate music",
-            params: {
-              prompt,
-              provider,
-              duration: options.duration,
-              model: options.model,
-              output: options.output,
-              instrumental: options.instrumental,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                prompt,
+                provider,
+                duration: options.duration,
+                model: options.model,
+                output: options.output,
+                instrumental: options.instrumental,
+              },
             },
           });
           return;
@@ -192,11 +196,14 @@ export function registerMusicCommand(parent: Command): void {
           spinner.succeed(chalk.green("Music generated successfully"));
 
           if (isJsonMode()) {
-            outputResult({
-              success: true,
-              provider: "elevenlabs",
-              outputPath,
-              duration,
+            outputSuccess({
+              command: "generate music",
+              startedAt,
+              data: {
+                provider: "elevenlabs",
+                outputPath,
+                duration,
+              },
             });
             return;
           }
@@ -286,12 +293,15 @@ export function registerMusicCommand(parent: Command): void {
           spinner.succeed(chalk.green("Music generated successfully"));
 
           if (isJsonMode()) {
-            outputResult({
-              success: true,
-              provider: "replicate",
-              taskId: result.taskId,
-              audioUrl: finalResult.audioUrl,
-              outputPath,
+            outputSuccess({
+              command: "generate music",
+              startedAt,
+              data: {
+                provider: "replicate",
+                taskId: result.taskId,
+                audioUrl: finalResult.audioUrl,
+                outputPath,
+              },
             });
             return;
           }

--- a/packages/cli/src/commands/generate/sound-effect.ts
+++ b/packages/cli/src/commands/generate/sound-effect.ts
@@ -12,7 +12,7 @@ import ora from "ora";
 import { ElevenLabsProvider } from "@vibeframe/ai-providers";
 import { requireApiKey, hasApiKey } from "../../utils/api-key.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
-import { isJsonMode, outputResult, exitWithError, apiError } from "../output.js";
+import { isJsonMode, outputSuccess, exitWithError, apiError } from "../output.js";
 import { rejectControlChars, validateOutputPath } from "../validate.js";
 
 // ── Library: executeSoundEffect (used by pipeline executor + manifest) ──
@@ -86,6 +86,7 @@ export function registerSoundEffectCommand(parent: Command): void {
     .option("--prompt-influence <value>", "Prompt influence (0-1, default: 0.3)")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (prompt: string, options) => {
+      const startedAt = Date.now();
       try {
         rejectControlChars(prompt);
         if (options.output) {
@@ -93,14 +94,17 @@ export function registerSoundEffectCommand(parent: Command): void {
         }
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "generate sound-effect",
-            params: {
-              prompt,
-              duration: options.duration,
-              promptInfluence: options.promptInfluence,
-              output: options.output,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                prompt,
+                duration: options.duration,
+                promptInfluence: options.promptInfluence,
+                output: options.output,
+              },
             },
           });
           return;
@@ -137,7 +141,11 @@ export function registerSoundEffectCommand(parent: Command): void {
         spinner.succeed(chalk.green("Sound effect generated"));
 
         if (isJsonMode()) {
-          outputResult({ success: true, outputPath });
+          outputSuccess({
+            command: "generate sound-effect",
+            startedAt,
+            data: { outputPath },
+          });
           return;
         }
 

--- a/packages/cli/src/commands/generate/speech.ts
+++ b/packages/cli/src/commands/generate/speech.ts
@@ -16,7 +16,7 @@ import { hasTTY, prompt as promptText } from "../../utils/tty.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
 import {
   isJsonMode,
-  outputResult,
+  outputSuccess,
   log,
   exitWithError,
   apiError,
@@ -89,6 +89,7 @@ export function registerSpeechCommand(parent: Command): void {
     .option("--fit-duration <seconds>", "Speed up audio to fit target duration (via FFmpeg atempo)", parseFloat)
     .option("--dry-run", "Preview parameters without executing")
     .action(async (text: string | undefined, options) => {
+      const startedAt = Date.now();
       try {
         // Interactive prompt if no argument provided
         if (!text) {
@@ -112,10 +113,11 @@ export function registerSpeechCommand(parent: Command): void {
         }
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "generate speech",
-            params: { text, voice: options.voice, output: options.output },
+            startedAt,
+            dryRun: true,
+            data: { params: { text, voice: options.voice, output: options.output } },
           });
           return;
         }
@@ -217,10 +219,13 @@ export function registerSpeechCommand(parent: Command): void {
         }
 
         if (isJsonMode()) {
-          outputResult({
-            success: true,
-            characterCount: result.characterCount,
-            outputPath,
+          outputSuccess({
+            command: "generate speech",
+            startedAt,
+            data: {
+              characterCount: result.characterCount,
+              outputPath,
+            },
           });
           return;
         }

--- a/packages/cli/src/commands/generate/storyboard.ts
+++ b/packages/cli/src/commands/generate/storyboard.ts
@@ -14,7 +14,7 @@ import { requireApiKey } from "../../utils/api-key.js";
 import { sanitizeLLMResponse } from "../sanitize.js";
 import {
   isJsonMode,
-  outputResult,
+  outputSuccess,
   exitWithError,
   apiError,
   usageError,
@@ -98,6 +98,7 @@ export function registerStoryboardCommand(parent: Command): void {
     .option("-c, --creativity <level>", "Creativity level: low (default, consistent) or high (varied, unexpected)", "low")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (content: string, options) => {
+      const startedAt = Date.now();
       try {
         rejectControlChars(content);
         if (options.output) {
@@ -117,13 +118,16 @@ export function registerStoryboardCommand(parent: Command): void {
         }
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "generate storyboard",
-            params: {
-              content: textContent.substring(0, 200),
-              duration: options.duration,
-              creativity,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                content: textContent.substring(0, 200),
+                duration: options.duration,
+                creativity,
+              },
             },
           });
           return;
@@ -165,16 +169,23 @@ export function registerStoryboardCommand(parent: Command): void {
           const outputPath = resolve(process.cwd(), options.output);
           await writeFile(outputPath, JSON.stringify(segments, null, 2), "utf-8");
           if (isJsonMode()) {
-            outputResult({
-              success: true,
-              segmentCount: segments.length,
-              segments,
-              outputPath,
+            outputSuccess({
+              command: "generate storyboard",
+              startedAt,
+              data: {
+                segmentCount: segments.length,
+                segments,
+                outputPath,
+              },
             });
             return;
           }
         } else if (isJsonMode()) {
-          outputResult({ success: true, segmentCount: segments.length, segments });
+          outputSuccess({
+            command: "generate storyboard",
+            startedAt,
+            data: { segmentCount: segments.length, segments },
+          });
           return;
         }
 

--- a/packages/cli/src/commands/generate/thumbnail.ts
+++ b/packages/cli/src/commands/generate/thumbnail.ts
@@ -16,7 +16,7 @@ import { requireApiKey } from "../../utils/api-key.js";
 import { commandExists } from "../../utils/exec-safe.js";
 import {
   isJsonMode,
-  outputResult,
+  outputSuccess,
   exitWithError,
   apiError,
   notFoundError,
@@ -42,6 +42,7 @@ export function registerThumbnailCommand(parent: Command): void {
     .option("--prompt <prompt>", "Custom prompt for best-frame analysis")
     .option("--model <model>", "Gemini model: flash, latest, pro (default: flash)", "flash")
     .action(async (description: string | undefined, options) => {
+      const startedAt = Date.now();
       try {
         if (description) rejectControlChars(description);
         if (options.output) {
@@ -87,11 +88,14 @@ export function registerThumbnailCommand(parent: Command): void {
           spinner.succeed(chalk.green("Best frame extracted"));
 
           if (isJsonMode()) {
-            outputResult({
-              success: true,
-              timestamp: result.timestamp,
-              reason: result.reason,
-              outputPath: result.outputPath,
+            outputSuccess({
+              command: "generate thumbnail",
+              startedAt,
+              data: {
+                timestamp: result.timestamp,
+                reason: result.reason,
+                outputPath: result.outputPath,
+              },
             });
             return;
           }
@@ -150,7 +154,11 @@ export function registerThumbnailCommand(parent: Command): void {
             await mkdir(dirname(outputPath), { recursive: true });
             await writeFile(outputPath, buffer);
           }
-          outputResult({ success: true, imageUrl: img.url, outputPath });
+          outputSuccess({
+            command: "generate thumbnail",
+            startedAt,
+            data: { imageUrl: img.url, outputPath },
+          });
           return;
         }
 

--- a/packages/cli/src/commands/generate/video-cancel.ts
+++ b/packages/cli/src/commands/generate/video-cancel.ts
@@ -12,7 +12,7 @@ import { GrokProvider, RunwayProvider } from "@vibeframe/ai-providers";
 import { requireApiKey } from "../../utils/api-key.js";
 import {
   isJsonMode,
-  outputResult,
+  outputSuccess,
   exitWithError,
   apiError,
   usageError,
@@ -26,6 +26,7 @@ export function registerVideoCancelCommand(parent: Command): void {
     .option("-p, --provider <provider>", "Provider: grok, runway", "grok")
     .option("-k, --api-key <key>", "API key (or set XAI_API_KEY / RUNWAY_API_SECRET env)")
     .action(async (taskId: string, options) => {
+      const startedAt = Date.now();
       try {
         const provider = (options.provider || "grok").toLowerCase();
 
@@ -42,7 +43,11 @@ export function registerVideoCancelCommand(parent: Command): void {
           if (success) {
             spinner.succeed(chalk.green("Generation cancelled"));
             if (isJsonMode()) {
-              outputResult({ success: true, taskId, provider: "grok", cancelled: true });
+              outputSuccess({
+                command: "generate video-cancel",
+                startedAt,
+                data: { taskId, provider: "grok", cancelled: true },
+              });
               return;
             }
           } else {
@@ -64,7 +69,11 @@ export function registerVideoCancelCommand(parent: Command): void {
           if (success) {
             spinner.succeed(chalk.green("Generation cancelled"));
             if (isJsonMode()) {
-              outputResult({ success: true, taskId, provider: "runway", cancelled: true });
+              outputSuccess({
+                command: "generate video-cancel",
+                startedAt,
+                data: { taskId, provider: "runway", cancelled: true },
+              });
               return;
             }
           } else {

--- a/packages/cli/src/commands/generate/video-extend.ts
+++ b/packages/cli/src/commands/generate/video-extend.ts
@@ -17,7 +17,7 @@ import {
 import { requireApiKey } from "../../utils/api-key.js";
 import {
   isJsonMode,
-  outputResult,
+  outputSuccess,
   exitWithError,
   apiError,
   authError,
@@ -41,6 +41,7 @@ export function registerVideoExtendCommand(parent: Command): void {
     .option("--no-wait", "Start extension and return task ID without waiting")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (id: string, options) => {
+      const startedAt = Date.now();
       try {
         const provider = (options.provider || "kling").toLowerCase();
         if (options.output) {
@@ -48,16 +49,19 @@ export function registerVideoExtendCommand(parent: Command): void {
         }
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "generate video-extend",
-            params: {
-              id,
-              provider,
-              prompt: options.prompt,
-              duration: options.duration,
-              negative: options.negative,
-              veoModel: options.veoModel,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                id,
+                provider,
+                prompt: options.prompt,
+                duration: options.duration,
+                negative: options.negative,
+                veoModel: options.veoModel,
+              },
             },
           });
           return;
@@ -128,13 +132,16 @@ export function registerVideoExtendCommand(parent: Command): void {
               outputPath = resolve(process.cwd(), options.output);
               await writeFile(outputPath, buffer);
             }
-            outputResult({
-              success: true,
-              provider: "kling",
-              taskId: result.id,
-              videoUrl: finalResult.videoUrl,
-              duration: finalResult.duration,
-              outputPath,
+            outputSuccess({
+              command: "generate video-extend",
+              startedAt,
+              data: {
+                provider: "kling",
+                taskId: result.id,
+                videoUrl: finalResult.videoUrl,
+                duration: finalResult.duration,
+                outputPath,
+              },
             });
             return;
           }
@@ -231,13 +238,16 @@ export function registerVideoExtendCommand(parent: Command): void {
               outputPath = resolve(process.cwd(), options.output);
               await writeFile(outputPath, buffer);
             }
-            outputResult({
-              success: true,
-              provider: "veo",
-              taskId: result.id,
-              videoUrl: finalResult.videoUrl,
-              duration: finalResult.duration,
-              outputPath,
+            outputSuccess({
+              command: "generate video-extend",
+              startedAt,
+              data: {
+                provider: "veo",
+                taskId: result.id,
+                videoUrl: finalResult.videoUrl,
+                duration: finalResult.duration,
+                outputPath,
+              },
             });
             return;
           }

--- a/packages/cli/src/commands/generate/video-status.ts
+++ b/packages/cli/src/commands/generate/video-status.ts
@@ -18,7 +18,7 @@ import {
 import { requireApiKey } from "../../utils/api-key.js";
 import {
   isJsonMode,
-  outputResult,
+  outputSuccess,
   exitWithError,
   apiError,
   usageError,
@@ -52,6 +52,7 @@ export function registerVideoStatusCommand(parent: Command): void {
     .option("-w, --wait", "Wait for completion")
     .option("-o, --output <path>", "Download video when complete")
     .action(async (taskId: string, options) => {
+      const startedAt = Date.now();
       try {
         const provider = (options.provider || "grok").toLowerCase();
 
@@ -81,14 +82,17 @@ export function registerVideoStatusCommand(parent: Command): void {
               outputPath = resolve(process.cwd(), options.output);
               await writeFile(outputPath, buffer);
             }
-            outputResult({
-              success: true,
-              taskId,
-              provider: "grok",
-              status: result.status,
-              videoUrl: result.videoUrl,
-              error: result.error,
-              outputPath,
+            outputSuccess({
+              command: "generate video-status",
+              startedAt,
+              data: {
+                taskId,
+                provider: "grok",
+                status: result.status,
+                videoUrl: result.videoUrl,
+                error: result.error,
+                outputPath,
+              },
             });
             return;
           }
@@ -159,15 +163,18 @@ export function registerVideoStatusCommand(parent: Command): void {
               outputPath = resolve(process.cwd(), options.output);
               await writeFile(outputPath, buffer);
             }
-            outputResult({
-              success: true,
-              taskId,
-              provider: "runway",
-              status: result.status,
-              videoUrl: result.videoUrl,
-              progress: result.progress,
-              error: result.error,
-              outputPath,
+            outputSuccess({
+              command: "generate video-status",
+              startedAt,
+              data: {
+                taskId,
+                provider: "runway",
+                status: result.status,
+                videoUrl: result.videoUrl,
+                progress: result.progress,
+                error: result.error,
+                outputPath,
+              },
             });
             return;
           }
@@ -236,15 +243,18 @@ export function registerVideoStatusCommand(parent: Command): void {
               outputPath = resolve(process.cwd(), options.output);
               await writeFile(outputPath, buffer);
             }
-            outputResult({
-              success: true,
-              taskId,
-              provider: "kling",
-              status: result.status,
-              videoUrl: result.videoUrl,
-              duration: result.duration,
-              error: result.error,
-              outputPath,
+            outputSuccess({
+              command: "generate video-status",
+              startedAt,
+              data: {
+                taskId,
+                provider: "kling",
+                status: result.status,
+                videoUrl: result.videoUrl,
+                duration: result.duration,
+                error: result.error,
+                outputPath,
+              },
             });
             return;
           }

--- a/packages/cli/src/commands/generate/video.ts
+++ b/packages/cli/src/commands/generate/video.ts
@@ -23,7 +23,7 @@ import { hasTTY, prompt as promptText } from "../../utils/tty.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
 import {
   isJsonMode,
-  outputResult,
+  outputSuccess,
   log,
   exitWithError,
   apiError,
@@ -66,6 +66,7 @@ Examples:
   $ vibe gen vid "ocean waves" -o waves.mp4 -p veo --resolution 1080p # Veo
   $ vibe gen vid "sunset" -o sun.mp4 -d 10 --dry-run --json`)
     .action(async (prompt: string | undefined, options) => {
+      const startedAt = Date.now();
       try {
         // Interactive prompt if no argument provided
         if (!prompt) {
@@ -177,19 +178,22 @@ Examples:
         }
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "generate video",
-            params: {
-              prompt,
-              provider,
-              duration: options.duration,
-              ratio: options.ratio,
-              image: options.image,
-              mode: options.mode,
-              negative: options.negative,
-              resolution: options.resolution,
-              veoModel: options.veoModel,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                prompt,
+                provider,
+                duration: options.duration,
+                ratio: options.ratio,
+                image: options.image,
+                mode: options.mode,
+                negative: options.negative,
+                resolution: options.resolution,
+                veoModel: options.veoModel,
+              },
             },
           });
           return;
@@ -527,13 +531,16 @@ Examples:
             outputPath = resolve(process.cwd(), options.output);
             await writeFile(outputPath, buffer);
           }
-          outputResult({
-            success: true,
-            provider,
-            taskId: result?.id,
-            videoUrl: finalResult.videoUrl,
-            duration: finalResult.duration,
-            outputPath,
+          outputSuccess({
+            command: "generate video",
+            startedAt,
+            data: {
+              provider,
+              taskId: result?.id,
+              videoUrl: finalResult.videoUrl,
+              duration: finalResult.duration,
+              outputPath,
+            },
           });
           return;
         }


### PR DESCRIPTION
## Summary

Sweep 1 of 3. Migrates the 11 remaining \`generate.*\` commands to the new \`outputSuccess()\` envelope established in #194 (canary on \`generate image\`). The full \`generate.*\` family — 12 commands — now emits the same shape.

## Smoke tests (local)

\`\`\`
$ vibe generate speech \"hi\" --dry-run --json
{
  \"command\": \"generate speech\",
  \"dryRun\": true,
  \"elapsedMs\": 0,
  \"costUsd\": 0.3,
  \"warnings\": [],
  \"data\": { \"params\": { \"text\": \"hi\", \"voice\": \"21m00...\", \"output\": \"output.mp3\" } }
}

$ vibe generate video \"test\" --dry-run --json
{
  \"command\": \"generate video\",
  \"dryRun\": true,
  \"elapsedMs\": 0,
  \"costUsd\": 5,
  \"warnings\": [],
  \"data\": { \"params\": { \"prompt\": \"test\", \"provider\": \"fal\", \"duration\": \"5\", ... } }
}
\`\`\`

## Files (11)

| File | Sites |
|---|---|
| \`generate/speech.ts\` | 1 dry-run + 1 success |
| \`generate/background.ts\` | 1 dry-run + 1 success |
| \`generate/music.ts\` | 1 dry-run + 2 success (Suno + ElevenLabs) |
| \`generate/music-status.ts\` | 1 success (read-only) |
| \`generate/sound-effect.ts\` | 1 dry-run + 1 success |
| \`generate/storyboard.ts\` | 1 dry-run + 2 success |
| \`generate/thumbnail.ts\` | 2 success (no \`--dry-run\`) |
| \`generate/video.ts\` | 1 dry-run + 1 success |
| \`generate/video-status.ts\` | 3 success (read-only, per-provider) |
| \`generate/video-cancel.ts\` | 2 success (per-provider) |
| \`generate/video-extend.ts\` | 1 dry-run + 2 success |

27 mechanical edits total (1 import + 1 \`startedAt\` const + N call sites per file).

## Transformation pattern (uniform)

\`\`\`ts
// Before
outputResult({ success: true, ...domain })

// After
outputSuccess({
  command: \"generate <name>\",
  startedAt,
  data: { ...domain },   // 'success: true' dropped — exit code is the signal
})
\`\`\`

## Migration for agents (extends canary's table)

| Old | New |
|---|---|
| \`jq .audio\` / \`.video\` / \`.image\` / \`.audioBuffer\` | \`jq .data.<same>\` |
| \`jq .characterCount\` / \`.duration\` / \`.taskId\` | \`jq .data.<same>\` |
| \`jq .estimatedCost\` (string) | \`jq .costUsd\` (number) |
| \`jq .success\` | drop — exit code 0 is success |

## What's next

- \`generate.*\` family is **complete** on new envelope
- **2c-sweep-2** (next PR): edit + audio + detect + project + batch + export + run + init
- **2c-sweep-3** (after sweep-2): scene + pipeline + analyze (quirks: composite outputs, \`--fields\` filtering)
- **2c-coverage** (separate): add \`--json\` to commands that lack it (timeline success path, scene render/build/styles, doctor, export)

## Verification

- [x] \`pnpm -F @vibeframe/cli exec tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors (8 pre-existing warnings in timeline.ts, unrelated)
- [x] \`pnpm -F @vibeframe/cli exec vitest run\` — 700 passed, 9 skipped, 0 failed
- [x] \`bash scripts/sync-counts.sh --check\` — green
- [x] \`grep -rn \"outputResult\" packages/cli/src/commands/generate/\` — 0 hits
- [x] Manual smoke tests above