### PR TITLE
feat(cli)!: migrate edit/audio/detect/batch/project/export/init to outputSuccess (Issue #33 — 2c-sweep-2)

### DIFF
--- a/packages/cli/src/commands/ai-edit-cli.ts
+++ b/packages/cli/src/commands/ai-edit-cli.ts
@@ -26,7 +26,7 @@ import {
   executeJumpCut,
   type CaptionStyle,
 } from './ai-edit.js';
-import { isJsonMode, outputResult, exitWithError, authError, notFoundError, apiError, usageError, generalError } from "./output.js";
+import { isJsonMode, outputSuccess, exitWithError, authError, notFoundError, apiError, usageError, generalError } from "./output.js";
 import { rejectControlChars, validateOutputPath } from "./validate.js";
 
 // ── Command registrations ───────────────────────────────────────────────────
@@ -59,6 +59,7 @@ Examples:
 
 No API key needed (FFmpeg only). Use --use-gemini for smart detection (requires GOOGLE_API_KEY).`)
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -81,16 +82,19 @@ No API key needed (FFmpeg only). Use --use-gemini for smart detection (requires 
       const useGemini = options.useGemini || false;
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit silence-cut",
-          params: {
-            videoPath: absVideoPath,
-            noiseThreshold: parseFloat(options.noise),
-            minDuration: parseFloat(options.minDuration),
-            padding: parseFloat(options.padding),
-            useGemini,
-            analyzeOnly: options.analyzeOnly || false,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: absVideoPath,
+              noiseThreshold: parseFloat(options.noise),
+              minDuration: parseFloat(options.minDuration),
+              padding: parseFloat(options.padding),
+              useGemini,
+              analyzeOnly: options.analyzeOnly || false,
+            },
           },
         });
         return;
@@ -122,13 +126,16 @@ No API key needed (FFmpeg only). Use --use-gemini for smart detection (requires 
       spinner.succeed(chalk.green("Silence detection complete"));
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
-          method: result.method,
-          totalDuration: result.totalDuration,
-          silentPeriods: result.silentPeriods,
-          silentDuration: result.silentDuration,
-          outputPath: result.outputPath,
+        outputSuccess({
+          command: "edit silence-cut",
+          startedAt,
+          data: {
+            method: result.method,
+            totalDuration: result.totalDuration,
+            silentPeriods: result.silentPeriods,
+            silentDuration: result.silentDuration,
+            outputPath: result.outputPath,
+          },
         });
         return;
       }
@@ -188,6 +195,7 @@ Examples:
 
 Requires: OPENAI_API_KEY (Whisper transcription) + FFmpeg`)
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -204,16 +212,19 @@ Requires: OPENAI_API_KEY (Whisper transcription) + FFmpeg`)
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit caption",
-          params: {
-            videoPath: absVideoPath,
-            style: options.style,
-            fontSize: options.fontSize ? parseInt(options.fontSize) : undefined,
-            fontColor: options.color,
-            language: options.language,
-            position: options.position,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: absVideoPath,
+              style: options.style,
+              fontSize: options.fontSize ? parseInt(options.fontSize) : undefined,
+              fontColor: options.color,
+              language: options.language,
+              position: options.position,
+            },
           },
         });
         return;
@@ -249,12 +260,15 @@ Requires: OPENAI_API_KEY (Whisper transcription) + FFmpeg`)
       spinner.succeed(chalk.green("Captions applied"));
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
-          segmentCount: result.segmentCount,
-          style: options.style || "bold",
-          outputPath: result.outputPath,
-          srtPath: result.srtPath,
+        outputSuccess({
+          command: "edit caption",
+          startedAt,
+          data: {
+            segmentCount: result.segmentCount,
+            style: options.style || "bold",
+            outputPath: result.outputPath,
+            srtPath: result.srtPath,
+          },
         });
         return;
       }
@@ -287,6 +301,7 @@ aiCommand
   .option("-n, --noise-floor <dB>", "Custom noise floor in dB (overrides strength preset)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (inputPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -302,13 +317,16 @@ aiCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit noise-reduce",
-          params: {
-            inputPath: absInputPath,
-            strength: options.strength,
-            noiseFloor: options.noiseFloor ? parseFloat(options.noiseFloor) : undefined,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              inputPath: absInputPath,
+              strength: options.strength,
+              noiseFloor: options.noiseFloor ? parseFloat(options.noiseFloor) : undefined,
+            },
           },
         });
         return;
@@ -335,11 +353,14 @@ aiCommand
       spinner.succeed(chalk.green("Noise reduction complete"));
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
-          inputDuration: result.inputDuration,
-          strength: options.strength || "medium",
-          outputPath: result.outputPath,
+        outputSuccess({
+          command: "edit noise-reduce",
+          startedAt,
+          data: {
+            inputDuration: result.inputDuration,
+            strength: options.strength || "medium",
+            outputPath: result.outputPath,
+          },
         });
         return;
       }
@@ -371,6 +392,7 @@ aiCommand
   .option("--video-only", "Apply fade to video only (audio stream copied)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -386,15 +408,18 @@ aiCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit fade",
-          params: {
-            videoPath: absVideoPath,
-            fadeIn: parseFloat(options.fadeIn),
-            fadeOut: parseFloat(options.fadeOut),
-            audioOnly: options.audioOnly || false,
-            videoOnly: options.videoOnly || false,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: absVideoPath,
+              fadeIn: parseFloat(options.fadeIn),
+              fadeOut: parseFloat(options.fadeOut),
+              audioOnly: options.audioOnly || false,
+              videoOnly: options.videoOnly || false,
+            },
           },
         });
         return;
@@ -423,12 +448,15 @@ aiCommand
       spinner.succeed(chalk.green("Fade effects applied"));
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
-          totalDuration: result.totalDuration,
-          fadeInApplied: result.fadeInApplied,
-          fadeOutApplied: result.fadeOutApplied,
-          outputPath: result.outputPath,
+        outputSuccess({
+          command: "edit fade",
+          startedAt,
+          data: {
+            totalDuration: result.totalDuration,
+            fadeInApplied: result.fadeInApplied,
+            fadeOutApplied: result.fadeOutApplied,
+            outputPath: result.outputPath,
+          },
         });
         return;
       }
@@ -461,6 +489,7 @@ aiCommand
   .option("-k, --api-key <key>", "API key (or set ANTHROPIC_API_KEY / OPENAI_API_KEY env)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (srtPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -476,14 +505,17 @@ aiCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit translate-srt",
-          params: {
-            srtPath: absSrtPath,
-            targetLanguage: options.target,
-            provider: options.provider || "claude",
-            sourceLanguage: options.source,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              srtPath: absSrtPath,
+              targetLanguage: options.target,
+              provider: options.provider || "claude",
+              sourceLanguage: options.source,
+            },
           },
         });
         return;
@@ -521,12 +553,15 @@ aiCommand
       spinner.succeed(chalk.green("Translation complete"));
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
-          segmentCount: result.segmentCount,
-          sourceLanguage: result.sourceLanguage,
-          targetLanguage: result.targetLanguage,
-          outputPath: result.outputPath,
+        outputSuccess({
+          command: "edit translate-srt",
+          startedAt,
+          data: {
+            segmentCount: result.segmentCount,
+            sourceLanguage: result.sourceLanguage,
+            targetLanguage: result.targetLanguage,
+            outputPath: result.outputPath,
+          },
         });
         return;
       }
@@ -560,6 +595,7 @@ aiCommand
   .option("-k, --api-key <key>", "OpenAI API key (or set OPENAI_API_KEY env)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -580,15 +616,18 @@ aiCommand
         const fillers = options.fillers
           ? options.fillers.split(",").map((f: string) => f.trim())
           : undefined;
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit jump-cut",
-          params: {
-            videoPath: absVideoPath,
-            fillers,
-            padding: parseFloat(options.padding),
-            language: options.language,
-            analyzeOnly: options.analyzeOnly || false,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: absVideoPath,
+              fillers,
+              padding: parseFloat(options.padding),
+              language: options.language,
+              analyzeOnly: options.analyzeOnly || false,
+            },
           },
         });
         return;
@@ -627,13 +666,16 @@ aiCommand
       spinner.succeed(chalk.green("Filler detection complete"));
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
-          totalDuration: result.totalDuration,
-          fillerCount: result.fillerCount,
-          fillerDuration: result.fillerDuration,
-          fillers: result.fillers,
-          outputPath: result.outputPath,
+        outputSuccess({
+          command: "edit jump-cut",
+          startedAt,
+          data: {
+            totalDuration: result.totalDuration,
+            fillerCount: result.fillerCount,
+            fillerDuration: result.fillerDuration,
+            fillers: result.fillers,
+            outputPath: result.outputPath,
+          },
         });
         return;
       }

--- a/packages/cli/src/commands/ai-motion.ts
+++ b/packages/cli/src/commands/ai-motion.ts
@@ -18,7 +18,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { ClaudeProvider, GeminiProvider } from '@vibeframe/ai-providers';
 import { getApiKey } from '../utils/api-key.js';
-import { exitWithError, outputResult, apiError, generalError } from './output.js';
+import { exitWithError, outputSuccess, apiError, generalError } from './output.js';
 import { validateOutputPath } from "./validate.js";
 
 // ── Motion: exported function for Agent tool ────────────────────────────────
@@ -287,28 +287,32 @@ export function registerMotionCommand(aiCommand: Command): void {
     .option("-m, --model <alias>", "LLM model: sonnet (default), opus, gemini, gemini-3.1-pro", "sonnet")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (description: string, options) => {
+      const startedAt = Date.now();
       try {
         if (options.output) {
           validateOutputPath(options.output);
         }
 
         if (options.dryRun) {
-          outputResult({
+          outputSuccess({
+            command: "generate motion",
+            startedAt,
             dryRun: true,
-            command: "ai motion",
-            params: {
-              description: description.slice(0, 200),
-              duration: options.duration,
-              width: options.width,
-              height: options.height,
-              fps: options.fps,
-              style: options.style,
-              render: options.render ?? false,
-              video: options.video,
-              image: options.image,
-              fromTsx: options.fromTsx,
-              model: options.model,
-              output: options.output,
+            data: {
+              params: {
+                description: description.slice(0, 200),
+                duration: options.duration,
+                width: options.width,
+                height: options.height,
+                fps: options.fps,
+                style: options.style,
+                render: options.render ?? false,
+                video: options.video,
+                image: options.image,
+                fromTsx: options.fromTsx,
+                model: options.model,
+                output: options.output,
+              },
             },
           });
           return;

--- a/packages/cli/src/commands/audio.ts
+++ b/packages/cli/src/commands/audio.ts
@@ -29,7 +29,7 @@ import { getApiKey, requireApiKey } from "../utils/api-key.js";
 import { execSafe, commandExists, execSafeSync } from "../utils/exec-safe.js";
 import { detectFormat, formatTranscript } from "../utils/subtitle.js";
 import { formatTime } from "./ai-helpers.js";
-import { isJsonMode, outputResult, exitWithError, notFoundError, usageError, apiError, generalError } from "./output.js";
+import { isJsonMode, outputSuccess, exitWithError, notFoundError, usageError, apiError, generalError } from "./output.js";
 import { rejectControlChars, validateOutputPath } from "./validate.js";
 
 export const audioCommand = new Command("audio")
@@ -68,6 +68,7 @@ audioCommand
   .option("-o, --output <path>", "Output file path")
   .option("-f, --format <format>", "Output format: json, srt, vtt (auto-detected from extension)")
   .action(async (audioPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -96,7 +97,16 @@ audioCommand
       spinner.succeed(chalk.green("Transcription complete"));
 
       if (isJsonMode()) {
-        outputResult({ success: true, fullText: result.fullText, segments: result.segments, language: result.detectedLanguage, outputPath: options.output ? resolve(process.cwd(), options.output) : undefined });
+        outputSuccess({
+          command: "audio transcribe",
+          startedAt,
+          data: {
+            fullText: result.fullText,
+            segments: result.segments,
+            language: result.detectedLanguage,
+            outputPath: options.output ? resolve(process.cwd(), options.output) : undefined,
+          },
+        });
         return;
       }
 
@@ -136,6 +146,7 @@ audioCommand
   .description("List available ElevenLabs voices")
   .option("-k, --api-key <key>", "ElevenLabs API key (or set ELEVENLABS_API_KEY env)")
   .action(async (options) => {
+    const startedAt = Date.now();
     try {
       const apiKey = await requireApiKey("ELEVENLABS_API_KEY", "ElevenLabs", options.apiKey);
 
@@ -147,7 +158,13 @@ audioCommand
       spinner.succeed(chalk.green(`Found ${voices.length} voices`));
 
       if (isJsonMode()) {
-        outputResult({ success: true, voices: voices.map(v => ({ name: v.name, voiceId: v.voice_id, category: v.category, labels: v.labels })) });
+        outputSuccess({
+          command: "audio voices",
+          startedAt,
+          data: {
+            voices: voices.map(v => ({ name: v.name, voiceId: v.voice_id, category: v.category, labels: v.labels })),
+          },
+        });
         return;
       }
 
@@ -177,9 +194,15 @@ audioCommand
   .option("-o, --output <path>", "Output audio file path", "vocals.mp3")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (audioPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.dryRun) {
-        outputResult({ dryRun: true, command: "audio isolate", audioPath });
+        outputSuccess({
+          command: "audio isolate",
+          startedAt,
+          dryRun: true,
+          data: { params: { audioPath } },
+        });
         return;
       }
 
@@ -212,7 +235,11 @@ audioCommand
       spinner.succeed(chalk.green("Vocals isolated"));
 
       if (isJsonMode()) {
-        outputResult({ success: true, outputPath });
+        outputSuccess({
+          command: "audio isolate",
+          startedAt,
+          data: { outputPath },
+        });
         return;
       }
 
@@ -238,9 +265,15 @@ audioCommand
   .option("--list", "List all available voices")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (samples: string[], options) => {
+    const startedAt = Date.now();
     try {
       if (options.dryRun) {
-        outputResult({ dryRun: true, command: "audio voice-clone", samples: samples?.length, name: options.name });
+        outputSuccess({
+          command: "audio voice-clone",
+          startedAt,
+          dryRun: true,
+          data: { params: { samples: samples?.length, name: options.name } },
+        });
         return;
       }
 
@@ -314,7 +347,11 @@ audioCommand
       spinner.succeed(chalk.green("Voice cloned successfully"));
 
       if (isJsonMode()) {
-        outputResult({ success: true, name: options.name, voiceId: result.voiceId });
+        outputSuccess({
+          command: "audio voice-clone",
+          startedAt,
+          data: { name: options.name, voiceId: result.voiceId },
+        });
         return;
       }
 
@@ -346,9 +383,15 @@ audioCommand
   .option("-o, --output <path>", "Output file path")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (mediaPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.dryRun) {
-        outputResult({ dryRun: true, command: "audio dub", mediaPath, targetLanguage: options.language, sourceLanguage: options.source, voice: options.voice });
+        outputSuccess({
+          command: "audio dub",
+          startedAt,
+          dryRun: true,
+          data: { params: { mediaPath, targetLanguage: options.language, sourceLanguage: options.source, voice: options.voice } },
+        });
         return;
       }
 
@@ -543,7 +586,16 @@ audioCommand
       spinner.succeed(chalk.green("Dubbing complete"));
 
       if (isJsonMode()) {
-        outputResult({ success: true, sourceLanguage: transcriptResult.detectedLanguage || options.source || "auto", targetLanguage: options.language, segmentCount: translatedSegments.length, outputPath: finalOutputPath });
+        outputSuccess({
+          command: "audio dub",
+          startedAt,
+          data: {
+            sourceLanguage: transcriptResult.detectedLanguage || options.source || "auto",
+            targetLanguage: options.language,
+            segmentCount: translatedSegments.length,
+            outputPath: finalOutputPath,
+          },
+        });
         return;
       }
 
@@ -580,13 +632,19 @@ audioCommand
   .option("-l, --release <ms>", "Release time in ms", "200")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (musicPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.dryRun) {
         const threshold = parseFloat(options.threshold);
         const ratio = parseFloat(options.ratio);
         const attack = parseFloat(options.attack);
         const release = parseFloat(options.release);
-        outputResult({ dryRun: true, command: "audio duck", musicPath, voicePath: options.voice, threshold, ratio, attack, release });
+        outputSuccess({
+          command: "audio duck",
+          startedAt,
+          dryRun: true,
+          data: { params: { musicPath, voicePath: options.voice, threshold, ratio, attack, release } },
+        });
         return;
       }
 
@@ -627,7 +685,11 @@ audioCommand
       spinner.succeed(chalk.green("Audio ducking complete"));
 
       if (isJsonMode()) {
-        outputResult({ success: true, musicPath: absMusic, voicePath: options.voice, threshold: thresholdDb, ratio, outputPath });
+        outputSuccess({
+          command: "audio duck",
+          startedAt,
+          data: { musicPath: absMusic, voicePath: options.voice, threshold: thresholdDb, ratio, outputPath },
+        });
         return;
       }
 

--- a/packages/cli/src/commands/batch.ts
+++ b/packages/cli/src/commands/batch.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { Project, type ProjectFile } from "../engine/index.js";
 import type { MediaType, EffectType } from "@vibeframe/core/timeline";
-import { exitWithError, generalError, outputResult, usageError } from "./output.js";
+import { exitWithError, generalError, outputSuccess, usageError } from "./output.js";
 
 export const batchCommand = new Command("batch")
   .description("Batch operations for processing multiple items");
@@ -50,19 +50,23 @@ batchCommand
   .option("--filter <pattern>", "Filter files by extension (e.g., '.mp4,.mov')")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, directory: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Scanning directory...").start();
 
     try {
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "batch import",
-          params: {
-            project: projectPath,
-            directory,
-            recursive: options.recursive,
-            duration: options.duration,
-            filter: options.filter || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              directory,
+              recursive: options.recursive,
+              duration: options.duration,
+              filter: options.filter || null,
+            },
           },
         });
         return;
@@ -160,20 +164,24 @@ batchCommand
   .option("--gap <seconds>", "Gap between clips", "0")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, sourceIds: string[], options) => {
+    const startedAt = Date.now();
     const spinner = ora("Creating clips...").start();
 
     try {
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "batch concat",
-          params: {
-            project: projectPath,
-            sourceIds,
-            all: options.all,
-            track: options.track || null,
-            start: options.start,
-            gap: options.gap,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              sourceIds,
+              all: options.all,
+              track: options.track || null,
+              start: options.start,
+              gap: options.gap,
+            },
           },
         });
         return;
@@ -273,21 +281,25 @@ batchCommand
       clipIds: string[],
       options
     ) => {
+      const startedAt = Date.now();
       const spinner = ora("Applying effects...").start();
 
       try {
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "batch apply-effect",
-            params: {
-              project: projectPath,
-              effectType,
-              clipIds,
-              all: options.all,
-              duration: options.duration,
-              start: options.start,
-              intensity: options.intensity,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                project: projectPath,
+                effectType,
+                clipIds,
+                all: options.all,
+                duration: options.duration,
+                start: options.start,
+                intensity: options.intensity,
+              },
             },
           });
           return;
@@ -365,18 +377,22 @@ batchCommand
   .option("--track <track-id>", "Remove clips from specific track only")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, clipIds: string[], options) => {
+    const startedAt = Date.now();
     const spinner = ora("Removing clips...").start();
 
     try {
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "batch remove-clips",
-          params: {
-            project: projectPath,
-            clipIds,
-            all: options.all,
-            track: options.track || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              clipIds,
+              all: options.all,
+              track: options.track || null,
+            },
           },
         });
         return;

--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -12,7 +12,7 @@ import ora from "ora";
 import { commandExists, execSafe } from "../utils/exec-safe.js";
 import { executeDetectScenes, executeDetectSilence } from "./detect.js";
 import { executeSilenceCut, executeFade, executeNoiseReduce } from "./ai-edit.js";
-import { outputResult, exitWithError, generalError, isJsonMode } from "./output.js";
+import { outputSuccess, exitWithError, generalError, isJsonMode } from "./output.js";
 
 const DEMO_DIR = resolve(process.cwd(), ".vibeframe-demo");
 
@@ -66,6 +66,7 @@ export const demoCommand = new Command("demo")
   .option("--keep", "Keep demo output files after completion")
   .option("--json", "Output results as JSON")
   .action(async (options) => {
+    const startedAt = Date.now();
     if (options.json) process.env.VIBE_JSON_OUTPUT = "1";
     const isJson = isJsonMode() || !process.stdin.isTTY;
 
@@ -181,11 +182,16 @@ export const demoCommand = new Command("demo")
     const total = results.length;
 
     if (isJson) {
-      outputResult({
-        success: passed === total,
+      outputSuccess({
         command: "demo",
-        result: { passed, total, steps: results },
-        demoDir: DEMO_DIR,
+        startedAt,
+        data: {
+          allPassed: passed === total,
+          passed,
+          total,
+          steps: results,
+          demoDir: DEMO_DIR,
+        },
       });
     } else {
       console.log();

--- a/packages/cli/src/commands/detect.ts
+++ b/packages/cli/src/commands/detect.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { Project, type ProjectFile } from "../engine/index.js";
 import { execSafe, commandExists, ffprobeDuration } from "../utils/exec-safe.js";
-import { exitWithError, generalError, outputResult } from "./output.js";
+import { exitWithError, generalError, outputSuccess } from "./output.js";
 import { validateOutputPath } from "./validate.js";
 
 // ── Execute function interfaces ──────────────────────────────────────
@@ -223,6 +223,7 @@ detectCommand
   .option("-p, --project <path>", "Add scenes as clips to project")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Detecting scenes...").start();
 
     try {
@@ -231,14 +232,17 @@ detectCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "detect scenes",
-          params: {
-            video: videoPath,
-            threshold: options.threshold,
-            output: options.output || null,
-            project: options.project || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              video: videoPath,
+              threshold: options.threshold,
+              output: options.output || null,
+              project: options.project || null,
+            },
           },
         });
         return;
@@ -376,6 +380,7 @@ detectCommand
   .option("-o, --output <path>", "Output JSON file with timestamps")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (mediaPath: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Detecting silence...").start();
 
     try {
@@ -384,14 +389,17 @@ detectCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "detect silence",
-          params: {
-            media: mediaPath,
-            noise: options.noise,
-            duration: options.duration,
-            output: options.output || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              media: mediaPath,
+              noise: options.noise,
+              duration: options.duration,
+              output: options.output || null,
+            },
           },
         });
         return;
@@ -477,6 +485,7 @@ detectCommand
   .option("-o, --output <path>", "Output JSON file with timestamps")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (audioPath: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Detecting beats...").start();
 
     try {
@@ -485,12 +494,15 @@ detectCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "detect beats",
-          params: {
-            audio: audioPath,
-            output: options.output || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              audio: audioPath,
+              output: options.output || null,
+            },
           },
         });
         return;

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -45,7 +45,7 @@ function runDoctor(): { json: ReturnType<typeof JSON.parse>; stderr: string } {
 describe("vibe doctor — scope diagnostics", () => {
   it("reports user scope unconfigured + project uninitialized in a fresh environment", () => {
     const { json } = runDoctor();
-    const scope = json.result.scope;
+    const scope = json.data.scope;
 
     expect(scope.user.configured).toBe(false);
     expect(scope.project.initialized).toBe(false);
@@ -61,9 +61,9 @@ describe("vibe doctor — scope diagnostics", () => {
   it("flips project.initialized=true when AGENTS.md is present", () => {
     writeFileSync(join(projectDir, "AGENTS.md"), "# AGENTS\n");
     const { json } = runDoctor();
-    expect(json.result.scope.project.initialized).toBe(true);
+    expect(json.data.scope.project.initialized).toBe(true);
 
-    const agents = json.result.scope.project.files.find((f: { path: string }) => f.path === "AGENTS.md");
+    const agents = json.data.scope.project.files.find((f: { path: string }) => f.path === "AGENTS.md");
     expect(agents.exists).toBe(true);
   });
 
@@ -71,27 +71,27 @@ describe("vibe doctor — scope diagnostics", () => {
     mkdirSync(join(fakeHome, ".vibeframe"));
     writeFileSync(join(fakeHome, ".vibeframe", "config.yaml"), "providers: {}\n");
     const { json } = runDoctor();
-    expect(json.result.scope.user.configured).toBe(true);
-    expect(json.result.scope.user.configPath).toContain(".vibeframe");
+    expect(json.data.scope.user.configured).toBe(true);
+    expect(json.data.scope.user.configPath).toContain(".vibeframe");
   });
 
   it("agentHosts.detected is empty in a sterilised environment", () => {
     const { json } = runDoctor();
-    expect(json.result.scope.agentHosts.detected).toEqual([]);
-    expect(json.result.scope.agentHosts.summary).toBe("(none detected)");
+    expect(json.data.scope.agentHosts.detected).toEqual([]);
+    expect(json.data.scope.agentHosts.summary).toBe("(none detected)");
   });
 
   it("agentHosts.detected picks up Claude Code via ~/.claude config dir", () => {
     mkdirSync(join(fakeHome, ".claude"));
     const { json } = runDoctor();
-    expect(json.result.scope.agentHosts.detected).toContain("Claude Code");
+    expect(json.data.scope.agentHosts.detected).toContain("Claude Code");
   });
 });
 
 describe("vibe doctor — Plan H scene composer readiness", () => {
   it("reports recommendedMode=batch when no agent host is detected", () => {
     const { json } = runDoctor();
-    const sc = json.result.scope.sceneComposer;
+    const sc = json.data.scope.sceneComposer;
     expect(sc.recommendedMode).toBe("batch");
     expect(sc.sceneProjectInCwd).toBe(false);
     expect(sc.skillInstalled).toBe(false);
@@ -100,7 +100,7 @@ describe("vibe doctor — Plan H scene composer readiness", () => {
   it("flips recommendedMode=agent when ~/.claude is present", () => {
     mkdirSync(join(fakeHome, ".claude"));
     const { json } = runDoctor();
-    expect(json.result.scope.sceneComposer.recommendedMode).toBe("agent");
+    expect(json.data.scope.sceneComposer.recommendedMode).toBe("agent");
   });
 
   it("VIBE_BUILD_MODE env override beats host auto-detection", () => {
@@ -121,7 +121,7 @@ describe("vibe doctor — Plan H scene composer readiness", () => {
       },
     );
     const json = JSON.parse(out);
-    expect(json.result.scope.sceneComposer.recommendedMode).toBe("batch");
+    expect(json.data.scope.sceneComposer.recommendedMode).toBe("batch");
   });
 
   it("composer=null when no API keys are present", () => {
@@ -140,22 +140,22 @@ describe("vibe doctor — Plan H scene composer readiness", () => {
       },
     );
     const json = JSON.parse(out);
-    expect(json.result.scope.sceneComposer.composer).toBeNull();
-    expect(json.result.scope.sceneComposer.composerEnvVar).toBeNull();
+    expect(json.data.scope.sceneComposer.composer).toBeNull();
+    expect(json.data.scope.sceneComposer.composerEnvVar).toBeNull();
   });
 
   it("flags scene project + missing SKILL.md when STORYBOARD.md is in cwd", () => {
     writeFileSync(join(projectDir, "STORYBOARD.md"), "## Beat 1 — x\nbody\n");
     const { json } = runDoctor();
-    expect(json.result.scope.sceneComposer.sceneProjectInCwd).toBe(true);
-    expect(json.result.scope.sceneComposer.skillInstalled).toBe(false);
+    expect(json.data.scope.sceneComposer.sceneProjectInCwd).toBe(true);
+    expect(json.data.scope.sceneComposer.skillInstalled).toBe(false);
   });
 
   it("flips skillInstalled=true once SKILL.md is in the project", () => {
     writeFileSync(join(projectDir, "STORYBOARD.md"), "## Beat 1 — x\nbody\n");
     writeFileSync(join(projectDir, "SKILL.md"), "---\nname: hyperframes\n---\n");
     const { json } = runDoctor();
-    expect(json.result.scope.sceneComposer.sceneProjectInCwd).toBe(true);
-    expect(json.result.scope.sceneComposer.skillInstalled).toBe(true);
+    expect(json.data.scope.sceneComposer.sceneProjectInCwd).toBe(true);
+    expect(json.data.scope.sceneComposer.skillInstalled).toBe(true);
   });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -22,7 +22,7 @@ import {
   type ComposerProvider,
 } from "./_shared/composer-resolve.js";
 import { resolveSceneBuildMode } from "./_shared/scene-build.js";
-import { outputResult } from "./output.js";
+import { outputSuccess } from "./output.js";
 
 /**
  * Mapping of env vars to the commands they unlock. Derived from the
@@ -59,15 +59,16 @@ Examples:
 `
   )
   .action(async (options) => {
+    const startedAt = Date.now();
     if (options.json) process.env.VIBE_JSON_OUTPUT = "1";
     const isJson = process.env.VIBE_JSON_OUTPUT === "1";
     const results = await runDiagnostics();
 
     if (isJson) {
-      outputResult({
-        success: true,
+      outputSuccess({
         command: "doctor",
-        result: results,
+        startedAt,
+        data: results,
       });
       return;
     }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -68,7 +68,7 @@ Examples:
       outputSuccess({
         command: "doctor",
         startedAt,
-        data: results,
+        data: { ...results },
       });
       return;
     }

--- a/packages/cli/src/commands/edit-cmd.ts
+++ b/packages/cli/src/commands/edit-cmd.ts
@@ -40,7 +40,7 @@ import { formatTime } from "./ai-helpers.js";
 import { applyTextOverlays, type TextOverlayStyle } from "./ai-edit.js";
 import { registerEditCommands } from "./ai-edit-cli.js";
 import { registerFillGapsCommand } from "./ai-fill-gaps.js";
-import { isJsonMode, outputResult, exitWithError, usageError, notFoundError, apiError, generalError } from "./output.js";
+import { isJsonMode, outputSuccess, exitWithError, usageError, notFoundError, apiError, generalError } from "./output.js";
 import { rejectControlChars, validateOutputPath } from "./validate.js";
 
 export const editCommand = new Command("edit")
@@ -92,6 +92,7 @@ editCommand
   .option("-k, --api-key <key>", "Anthropic API key (or set ANTHROPIC_API_KEY env)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.style) rejectControlChars(options.style);
       if (options.output) {
@@ -111,13 +112,16 @@ editCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit grade",
-          params: {
-            videoPath: resolve(process.cwd(), videoPath),
-            style: options.style || options.preset,
-            analyzeOnly: options.analyzeOnly || false,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: resolve(process.cwd(), videoPath),
+              style: options.style || options.preset,
+              analyzeOnly: options.analyzeOnly || false,
+            },
           },
         });
         return;
@@ -151,12 +155,15 @@ editCommand
         const gradeOutputPath = options.output
           ? resolve(process.cwd(), options.output)
           : absPath.replace(/(\.[^.]+)$/, "-graded$1");
-        outputResult({
-          success: true,
-          style: options.preset || options.style,
-          description: gradeResult.description,
-          ffmpegFilter: gradeResult.ffmpegFilter,
-          outputPath: options.analyzeOnly ? undefined : gradeOutputPath,
+        outputSuccess({
+          command: "edit grade",
+          startedAt,
+          data: {
+            style: options.preset || options.style,
+            description: gradeResult.description,
+            ffmpegFilter: gradeResult.ffmpegFilter,
+            outputPath: options.analyzeOnly ? undefined : gradeOutputPath,
+          },
         });
         return;
       }
@@ -209,6 +216,7 @@ editCommand
   .option("-o, --output <path>", "Output video file path")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (!options.text || options.text.length === 0) {
         exitWithError(usageError("At least one --text option is required", 'Example: vibe edit text-overlay video.mp4 -t "NEXUS AI" --style center-bold'));
@@ -225,18 +233,21 @@ editCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit text-overlay",
-          params: {
-            videoPath: resolve(process.cwd(), videoPath),
-            texts: options.text,
-            style: options.style,
-            fontSize: options.fontSize ? parseInt(options.fontSize) : undefined,
-            fontColor: options.fontColor,
-            fade: parseFloat(options.fade),
-            start: parseFloat(options.start),
-            end: options.end ? parseFloat(options.end) : undefined,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: resolve(process.cwd(), videoPath),
+              texts: options.text,
+              style: options.style,
+              fontSize: options.fontSize ? parseInt(options.fontSize) : undefined,
+              fontColor: options.fontColor,
+              fade: parseFloat(options.fade),
+              start: parseFloat(options.start),
+              end: options.end ? parseFloat(options.end) : undefined,
+            },
           },
         });
         return;
@@ -269,11 +280,14 @@ editCommand
       spinner.succeed(chalk.green("Text overlays applied"));
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
-          style: options.style,
-          texts: options.text,
-          outputPath: result.outputPath,
+        outputSuccess({
+          command: "edit text-overlay",
+          startedAt,
+          data: {
+            style: options.style,
+            texts: options.text,
+            outputPath: result.outputPath,
+          },
         });
         return;
       }
@@ -306,6 +320,7 @@ editCommand
   .option("-k, --api-key <key>", "Anthropic API key (or set ANTHROPIC_API_KEY env)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -317,15 +332,18 @@ editCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit speed-ramp",
-          params: {
-            videoPath: resolve(process.cwd(), videoPath),
-            style: options.style,
-            minSpeed: parseFloat(options.minSpeed),
-            maxSpeed: parseFloat(options.maxSpeed),
-            analyzeOnly: options.analyzeOnly || false,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: resolve(process.cwd(), videoPath),
+              style: options.style,
+              minSpeed: parseFloat(options.minSpeed),
+              maxSpeed: parseFloat(options.maxSpeed),
+              analyzeOnly: options.analyzeOnly || false,
+            },
           },
         });
         return;
@@ -391,11 +409,14 @@ editCommand
         const speedRampOutputPath = options.output
           ? resolve(process.cwd(), options.output)
           : absPath.replace(/(\.[^.]+)$/, "-ramped$1");
-        outputResult({
-          success: true,
-          keyframes: speedResult.keyframes,
-          avgSpeed,
-          outputPath: options.analyzeOnly ? undefined : speedRampOutputPath,
+        outputSuccess({
+          command: "edit speed-ramp",
+          startedAt,
+          data: {
+            keyframes: speedResult.keyframes,
+            avgSpeed,
+            outputPath: options.analyzeOnly ? undefined : speedRampOutputPath,
+          },
         });
         return;
       }
@@ -468,6 +489,7 @@ editCommand
   .option("-k, --api-key <key>", "Anthropic API key (or set ANTHROPIC_API_KEY env)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -479,14 +501,17 @@ editCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit reframe",
-          params: {
-            videoPath: resolve(process.cwd(), videoPath),
-            aspect: options.aspect,
-            focus: options.focus,
-            analyzeOnly: options.analyzeOnly || false,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: resolve(process.cwd(), videoPath),
+              aspect: options.aspect,
+              focus: options.focus,
+              analyzeOnly: options.analyzeOnly || false,
+            },
           },
         });
         return;
@@ -581,13 +606,16 @@ editCommand
         const reframeOutputPath = options.output
           ? resolve(process.cwd(), options.output)
           : absPath.replace(/(\.[^.]+)$/, `-${options.aspect.replace(":", "x")}$1`);
-        outputResult({
-          success: true,
-          sourceWidth,
-          sourceHeight,
-          aspect: options.aspect,
-          cropKeyframes,
-          outputPath: options.analyzeOnly ? undefined : reframeOutputPath,
+        outputSuccess({
+          command: "edit reframe",
+          startedAt,
+          data: {
+            sourceWidth,
+            sourceHeight,
+            aspect: options.aspect,
+            cropKeyframes,
+            outputPath: options.analyzeOnly ? undefined : reframeOutputPath,
+          },
         });
         return;
       }
@@ -665,6 +693,7 @@ editCommand
   .option("-s, --size <resolution>", "Resolution: 1K, 2K, 4K (Gemini Pro only)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (args: string[], options) => {
+    const startedAt = Date.now();
     try {
       // Last argument is the prompt, rest are image paths
       if (args.length < 2) {
@@ -685,16 +714,19 @@ editCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit image",
-          params: {
-            imagePaths: imagePaths.map((p: string) => resolve(process.cwd(), p)),
-            prompt,
-            provider,
-            model: options.model,
-            ratio: options.ratio,
-            size: options.size,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              imagePaths: imagePaths.map((p: string) => resolve(process.cwd(), p)),
+              prompt,
+              provider,
+              model: options.model,
+              ratio: options.ratio,
+              size: options.size,
+            },
           },
         });
         return;
@@ -792,11 +824,14 @@ editCommand
       const resultModel = (result as { model?: string }).model;
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
-          provider,
-          model: resultModel || options.model,
-          outputPath,
+        outputSuccess({
+          command: "edit image",
+          startedAt,
+          data: {
+            provider,
+            model: resultModel || options.model,
+            outputPath,
+          },
         });
         await saveImage();
         return;
@@ -827,6 +862,7 @@ editCommand
   .option("--quality <mode>", "Quality: fast or quality", "quality")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -840,14 +876,17 @@ editCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit interpolate",
-          params: {
-            videoPath: absPath,
-            factor,
-            fps: options.fps ? parseInt(options.fps) : undefined,
-            quality: options.quality,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: absPath,
+              factor,
+              fps: options.fps ? parseInt(options.fps) : undefined,
+              quality: options.quality,
+            },
           },
         });
         return;
@@ -881,12 +920,15 @@ editCommand
         spinner.succeed(chalk.green(`Created ${factor}x slow motion`));
 
         if (isJsonMode()) {
-          outputResult({
-            success: true,
-            originalFps,
-            targetFps,
-            factor,
-            outputPath,
+          outputSuccess({
+            command: "edit interpolate",
+            startedAt,
+            data: {
+              originalFps,
+              targetFps,
+              factor,
+              outputPath,
+            },
           });
           return;
         }
@@ -927,6 +969,7 @@ editCommand
   .option("--no-wait", "Start processing and return task ID without waiting")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       if (options.output) {
         validateOutputPath(options.output);
@@ -940,14 +983,17 @@ editCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "edit upscale-video",
-          params: {
-            videoPath: absPath,
-            scale,
-            model: options.model,
-            ffmpeg: options.ffmpeg || false,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: absPath,
+              scale,
+              model: options.model,
+              ffmpeg: options.ffmpeg || false,
+            },
           },
         });
         return;
@@ -976,10 +1022,13 @@ editCommand
           spinner.succeed(chalk.green(`Upscaled to ${newWidth}x${newHeight}`));
 
           if (isJsonMode()) {
-            outputResult({
-              success: true,
-              dimensions: `${newWidth}x${newHeight}`,
-              outputPath,
+            outputSuccess({
+              command: "edit upscale-video",
+              startedAt,
+              data: {
+                dimensions: `${newWidth}x${newHeight}`,
+                outputPath,
+              },
             });
             return;
           }

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { Project, type ProjectFile } from "../engine/index.js";
 import { execSafe, ffprobeDuration } from "../utils/exec-safe.js";
-import { exitWithError, generalError, notFoundError, outputResult, usageError } from "./output.js";
+import { exitWithError, generalError, notFoundError, outputSuccess, usageError } from "./output.js";
 import { validateOutputPath } from "./validate.js";
 
 /**
@@ -258,6 +258,7 @@ GIF format: 15fps, no audio, looping. Good for previews and sharing.
 Custom flags (--bitrate, --fps, --resolution, --codec) override preset values.
 Run 'vibe schema export' for structured parameter info.`)
   .action(async (projectPath: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Checking FFmpeg...").start();
 
     try {
@@ -278,21 +279,24 @@ Run 'vibe schema export' for structured parameter info.`)
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "export",
-          params: {
-            project: projectPath,
-            output: options.output || null,
-            format: options.format,
-            preset: options.preset,
-            overwrite: options.overwrite,
-            gapFill: options.gapFill,
-            backend: options.backend,
-            bitrate: options.bitrate ?? null,
-            fps: customOverrides.fps ?? null,
-            resolution: options.resolution ?? null,
-            codec: options.codec ?? null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              output: options.output || null,
+              format: options.format,
+              preset: options.preset,
+              overwrite: options.overwrite,
+              gapFill: options.gapFill,
+              backend: options.backend,
+              bitrate: options.bitrate ?? null,
+              fps: customOverrides.fps ?? null,
+              resolution: options.resolution ?? null,
+              codec: options.codec ?? null,
+            },
           },
         });
         return;
@@ -300,7 +304,7 @@ Run 'vibe schema export' for structured parameter info.`)
 
       // Hyperframes backend path
       if (options.backend === "hyperframes") {
-        await runHyperframesExport(projectPath, options, spinner);
+        await runHyperframesExport(projectPath, options, spinner, startedAt);
         return;
       }
 
@@ -1146,14 +1150,15 @@ function getPresetSettings(
 async function runHyperframesExport(
   projectPath: string,
   options: { output?: string; format?: string; preset?: string },
-  spinner: ReturnType<typeof ora>
+  spinner: ReturnType<typeof ora>,
+  startedAt: number
 ): Promise<void> {
   spinner.text = "Loading project...";
   const { readFile } = await import("node:fs/promises");
   const { resolve, basename } = await import("node:path");
   const { Project } = await import("../engine/index.js");
   const { createHyperframesBackend } = await import("../pipeline/renderers/hyperframes.js");
-  const { exitWithError, generalError, outputResult } = await import("./output.js");
+  const { exitWithError, generalError, outputSuccess } = await import("./output.js");
   const chalk = (await import("chalk")).default;
 
   const filePath = resolve(process.cwd(), projectPath);
@@ -1188,10 +1193,10 @@ async function runHyperframesExport(
   }
 
   spinner.succeed(chalk.green(`Exported: ${result.outputPath}`));
-  outputResult({
-    success: true,
+  outputSuccess({
     command: "export",
-    result: {
+    startedAt,
+    data: {
       outputPath: result.outputPath,
       backend: "hyperframes",
       durationMs: result.durationMs,

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -57,7 +57,7 @@ describe("vibe init (black-box)", () => {
     const result = JSON.parse(stdout);
 
     expect(result.command).toBe("init");
-    expect(result.actions.every((a: { status: string }) => a.status === "wrote")).toBe(true);
+    expect(result.data.actions.every((a: { status: string }) => a.status === "wrote")).toBe(true);
 
     expect(existsSync(join(projectDir, "AGENTS.md"))).toBe(true);
     expect(existsSync(join(projectDir, "CLAUDE.md"))).toBe(true);
@@ -78,16 +78,16 @@ describe("vibe init (black-box)", () => {
     const { stdout } = runInit(["--agent", "all"]);
     const result = JSON.parse(stdout);
 
-    const skipped = result.actions.filter((a: { status: string }) => a.status === "skipped-exists");
+    const skipped = result.data.actions.filter((a: { status: string }) => a.status === "skipped-exists");
     expect(skipped.length).toBeGreaterThan(0);
-    expect(result.actions.every((a: { status: string }) => a.status !== "wrote")).toBe(true);
+    expect(result.data.actions.every((a: { status: string }) => a.status !== "wrote")).toBe(true);
   });
 
   it("with --agent claude-code writes CLAUDE.md but skips AGENTS.md (Claude-only mode)", () => {
     const { stdout } = runInit(["--agent", "claude-code"]);
     const result = JSON.parse(stdout);
 
-    const paths = result.actions.map((a: { path: string }) => a.path);
+    const paths = result.data.actions.map((a: { path: string }) => a.path);
     expect(paths.some((p: string) => p.endsWith("CLAUDE.md"))).toBe(true);
     expect(paths.some((p: string) => p.endsWith("AGENTS.md"))).toBe(false);
   });
@@ -96,7 +96,7 @@ describe("vibe init (black-box)", () => {
     const { stdout } = runInit(["--agent", "codex"]);
     const result = JSON.parse(stdout);
 
-    const paths = result.actions.map((a: { path: string }) => a.path);
+    const paths = result.data.actions.map((a: { path: string }) => a.path);
     expect(paths.some((p: string) => p.endsWith("AGENTS.md"))).toBe(true);
     expect(paths.some((p: string) => p.endsWith("CLAUDE.md"))).toBe(false);
   });
@@ -106,9 +106,9 @@ describe("vibe init (black-box)", () => {
     const { stdout } = runInit(["--agent", "auto"]);
     const result = JSON.parse(stdout);
 
-    const paths = result.actions.map((a: { path: string }) => a.path);
+    const paths = result.data.actions.map((a: { path: string }) => a.path);
     expect(paths.some((p: string) => p.endsWith("AGENTS.md"))).toBe(true);
-    expect(result.targetHosts).toEqual([]);
+    expect(result.data.targetHosts).toEqual([]);
   });
 
   it("merges .gitignore additions instead of overwriting an existing file", () => {
@@ -127,7 +127,7 @@ describe("vibe init (black-box)", () => {
     const result = JSON.parse(stdout);
 
     expect(result.dryRun).toBe(true);
-    expect(result.actions.every((a: { status: string }) => a.status === "would-write")).toBe(true);
+    expect(result.data.actions.every((a: { status: string }) => a.status === "would-write")).toBe(true);
     expect(existsSync(join(projectDir, "AGENTS.md"))).toBe(false);
   });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -36,7 +36,7 @@ import {
   renderEnvExample,
   renderProjectYaml,
 } from "./_shared/init-templates.js";
-import { exitWithError, isJsonMode, outputResult, usageError } from "./output.js";
+import { exitWithError, isJsonMode, outputSuccess, usageError } from "./output.js";
 
 type AgentSelection = AgentHostId | "all" | "auto";
 
@@ -55,6 +55,7 @@ export const initCommand = new Command("init")
   .option("--force", "Overwrite existing files instead of skipping")
   .option("--dry-run", "Print the file list without writing anything")
   .action(async (projectDirArg: string, options) => {
+    const startedAt = Date.now();
     const agent = options.agent as AgentSelection;
     if (!VALID_AGENTS.includes(agent)) {
       exitWithError(usageError(`Invalid --agent: ${agent}`, `Must be one of: ${VALID_AGENTS.join(", ")}`));
@@ -142,13 +143,16 @@ export const initCommand = new Command("init")
 
     // ── Output ─────────────────────────────────────────────────────────
     if (isJsonMode()) {
-      outputResult({
+      outputSuccess({
         command: "init",
-        projectDir,
-        agent,
-        targetHosts,
-        actions,
-        dryRun: options.dryRun ?? false,
+        startedAt,
+        ...(options.dryRun ? { dryRun: true } : {}),
+        data: {
+          projectDir,
+          agent,
+          targetHosts,
+          actions,
+        },
       });
       return;
     }

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import chalk from "chalk";
 import ora from "ora";
 import { Project, type ProjectFile } from "../engine/index.js";
-import { exitWithError, generalError, outputResult } from "./output.js";
+import { exitWithError, generalError, outputSuccess } from "./output.js";
 import { validateOutputPath } from "./validate.js";
 
 /**
@@ -47,6 +47,7 @@ projectCommand
   .option("-f, --fps <fps>", "Frame rate", "30")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (name: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Creating project...").start();
 
     try {
@@ -55,14 +56,17 @@ projectCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "project create",
-          params: {
-            name,
-            output: options.output || null,
-            aspectRatio: options.ratio,
-            frameRate: options.fps,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              name,
+              output: options.output || null,
+              aspectRatio: options.ratio,
+              frameRate: options.fps,
+            },
           },
         });
         return;
@@ -151,18 +155,22 @@ projectCommand
   .option("-f, --fps <fps>", "Frame rate")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (file: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Updating project...").start();
 
     try {
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "project set",
-          params: {
-            file,
-            name: options.name || null,
-            ratio: options.ratio || null,
-            fps: options.fps || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              file,
+              name: options.name || null,
+              ratio: options.ratio || null,
+              fps: options.fps || null,
+            },
           },
         });
         return;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -16,7 +16,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { loadPipeline, executePipeline } from "../pipeline/index.js";
 import type { PipelineBudget } from "../pipeline/types.js";
-import { outputResult, exitWithError, generalError, usageError } from "./output.js";
+import { outputSuccess, exitWithError, generalError, usageError } from "./output.js";
 import { loadEnv } from "../utils/api-key.js";
 
 export const runCommand = new Command("run")
@@ -64,6 +64,7 @@ Cost: Depends on steps. Use --dry-run to preview before executing.
 Run 'vibe schema run' for structured parameter info.
 `)
   .action(async (pipelinePath: string, options) => {
+    const startedAt = Date.now();
     // Pipeline steps call execute*() functions directly (not CLI actions),
     // so we must ensure .env is loaded before executor dispatches steps.
     loadEnv();
@@ -107,13 +108,16 @@ Run 'vibe schema run' for structured parameter info.
         });
 
         if (isJson) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "run",
-            name: manifest.name,
-            steps: result.steps.map(s => ({ id: s.id, action: s.action, estimatedCost: (s.data as Record<string, unknown>)?.estimatedCost })),
-            totalSteps: result.totalSteps,
-            budget: result.budget,
+            startedAt,
+            dryRun: true,
+            data: {
+              name: manifest.name,
+              steps: result.steps.map(s => ({ id: s.id, action: s.action, estimatedCost: (s.data as Record<string, unknown>)?.estimatedCost })),
+              totalSteps: result.totalSteps,
+              budget: result.budget,
+            },
           });
         } else {
           console.log(chalk.bold("  Execution Plan:"));
@@ -150,24 +154,27 @@ Run 'vibe schema run' for structured parameter info.
       spinner?.stop();
 
       if (isJson) {
-        outputResult({
-          success: result.success,
-          name: result.name,
-          error: result.error,
-          completedSteps: result.completedSteps,
-          totalSteps: result.totalSteps,
-          totalDuration: result.totalDuration,
-          outputDir: result.outputDir,
-          budget: result.budget,
-          steps: result.steps.map(s => ({
-            id: s.id,
-            action: s.action,
-            success: s.success,
-            output: s.output,
-            duration: s.duration,
-            error: s.error,
-            data: s.data,
-          })),
+        outputSuccess({
+          command: "run",
+          startedAt,
+          data: {
+            name: result.name,
+            error: result.error,
+            completedSteps: result.completedSteps,
+            totalSteps: result.totalSteps,
+            totalDuration: result.totalDuration,
+            outputDir: result.outputDir,
+            budget: result.budget,
+            steps: result.steps.map(s => ({
+              id: s.id,
+              action: s.action,
+              success: s.success,
+              output: s.output,
+              duration: s.duration,
+              error: s.error,
+              data: s.data,
+            })),
+          },
         });
       } else {
         console.log();

--- a/packages/cli/src/commands/walkthrough.ts
+++ b/packages/cli/src/commands/walkthrough.ts
@@ -23,21 +23,25 @@ import {
   loadWalkthrough,
   type WalkthroughTopic,
 } from "./_shared/walkthroughs/walkthroughs.js";
-import { exitWithError, isJsonMode, outputResult, usageError } from "./output.js";
+import { exitWithError, isJsonMode, outputSuccess, usageError } from "./output.js";
 
 export const walkthroughCommand = new Command("walkthrough")
   .description("Step-by-step authoring guide for a vibe workflow (universal /vibe-* slash-command equivalent)")
   .argument("[topic]", `Walkthrough topic: ${WALKTHROUGH_TOPICS.join(" | ")}. Omit to list all.`)
   .option("--list", "List available walkthroughs and exit")
   .action(async (topicArg: string | undefined, options) => {
+    const startedAt = Date.now();
     if (!topicArg || options.list) {
       const topics = listWalkthroughs();
 
       if (isJsonMode()) {
-        outputResult({
+        outputSuccess({
           command: "walkthrough",
-          action: "list",
-          topics,
+          startedAt,
+          data: {
+            action: "list",
+            topics,
+          },
         });
         return;
       }
@@ -66,10 +70,13 @@ export const walkthroughCommand = new Command("walkthrough")
     const result = loadWalkthrough(topic);
 
     if (isJsonMode()) {
-      outputResult({
+      outputSuccess({
         command: "walkthrough",
-        action: "show",
-        ...result,
+        startedAt,
+        data: {
+          action: "show",
+          ...result,
+        },
       });
       return;
     }


### PR DESCRIPTION
## Summary

Sweep 2 of 3. Migrates 13 command files (~55 \`outputResult\` sites) to the new \`outputSuccess()\` envelope established in #194 / #195. After this PR, the only commands still on the old envelope are: \`scene.*\`, \`timeline.*\`, \`pipeline.*\`, \`analyze.*\`, \`ai-highlights.ts\`, \`ai-script-pipeline-cli.ts\`, \`ai-review.ts\` — all 2c-sweep-3 territory.

## Files

| File | Sites | Notes |
|---|---|---|
| \`edit-cmd.ts\` | 14 | 7 edit subcommands |
| \`ai-edit-cli.ts\` | 12 | more edit subcommands |
| \`audio.ts\` | 10 | 6 audio subcommands |
| \`batch.ts\` | 4 | batch subcommands |
| \`detect.ts\` | 3 | scenes/silence/beats |
| \`project.ts\` | 2 | create/info |
| \`export.ts\` | 2 | threaded \`startedAt\` through \`runHyperframesExport\` helper |
| \`run.ts\` | 2 | pipeline runner |
| \`ai-motion.ts\` | 1 | \`generate motion\` (registered under generateCommand) |
| \`init.ts\` | 1 | scaffolder |
| \`doctor.ts\` | 1 | flattened \`data.result.scope\` → \`data.scope\` (saves one nesting level) |
| \`demo.ts\` | 1 | preserved \`success: passed === total\` as \`data.allPassed\` |
| \`walkthrough.ts\` | 2 | onboarding |

## Test fixes (also in this PR)

The envelope change broke 17 test assertions in 2 files. Both fixed:

- **\`doctor.test.ts\`** — 17 sites: \`json.result.X\` → \`json.data.X\`. Doctor's emit was simplified at the same time: previously \`data: { result: results }\` (redundant), now \`data: results\` directly.
- **\`init.test.ts\`** — 7 sites: \`result.actions\` / \`result.targetHosts\` → \`result.data.X\`. Top-level \`result.command\` left as-is (correctly top-level in new envelope).

## Smoke tests (verified locally)

\`\`\`
$ vibe detect scenes /tmp/x.mp4 --dry-run --json
{ \"command\": \"detect scenes\", \"dryRun\": true, \"costUsd\": 0, \"warnings\": [], \"data\": { \"params\": {...} } }

$ vibe project create /tmp/test --dry-run --json
{ \"command\": \"project create\", \"dryRun\": true, \"costUsd\": 0, \"warnings\": [], \"data\": { \"params\": {...} } }

$ vibe doctor --json
{ \"command\": \"doctor\", \"elapsedMs\": 87, \"costUsd\": 0, \"warnings\": [], \"data\": { \"system\": {...}, \"scope\": {...}, ... } }
\`\`\`

## Note on \`run.ts\` pipeline failure semantics

Pre-2c, the pipeline runner emitted \`success: result.success\` at top level — could be \`false\` when steps fail but the runner itself completes. The new envelope drops that key per design (exit code is the success signal). Pipeline failure is still derivable from \`data.error\` presence and per-step \`data.steps[].success\`.

If we want hard-fail exit codes for partial pipeline failure, that's a follow-up: set \`process.exitCode = 1\` when \`!result.success\`. Out of sweep-2 scope; filed for later if it matters.

## Test plan

- [x] \`pnpm -F @vibeframe/cli exec tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors (8 pre-existing warnings in untouched sweep-3 files)
- [x] \`pnpm -F @vibeframe/cli exec vitest run\` — 700 passed, 9 skipped, 1 pre-existing flake (\`generate music\` cold-start timeout under full-suite parallel load; passes in isolation in 9.8s — environment-dependent on ELEVENLABS_API_KEY)
- [x] \`grep -rn outputResult\` across 13 migrated files: 0 hits
- [x] Smoke tests above