### PR TITLE
feat(cli)!: complete envelope migration — scene/timeline/pipeline/analyze (Issue #33 — 2c-sweep-3)

### DIFF
--- a/packages/cli/src/commands/ai-highlights.ts
+++ b/packages/cli/src/commands/ai-highlights.ts
@@ -30,7 +30,7 @@ import { Project } from "../engine/index.js";
 import { getApiKey } from "../utils/api-key.js";
 import { formatTime } from "./ai-helpers.js";
 import { execSafe, commandExists, ffprobeDuration } from "../utils/exec-safe.js";
-import { exitWithError, outputResult, authError, notFoundError, apiError, generalError } from "./output.js";
+import { exitWithError, outputSuccess, authError, notFoundError, apiError, generalError } from "./output.js";
 import { validateOutputPath } from "./validate.js";
 
 // ============================================================================
@@ -687,6 +687,7 @@ export function registerHighlightsCommands(aiCommand: Command): void {
     .option("--low-res", "Use low resolution mode for longer videos (Gemini only)")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (mediaPath: string, options) => {
+      const startedAt = Date.now();
       try {
         if (options.output) {
           validateOutputPath(options.output);
@@ -698,20 +699,23 @@ export function registerHighlightsCommands(aiCommand: Command): void {
         }
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "ai highlights",
-            params: {
-              mediaPath,
-              output: options.output,
-              project: options.project,
-              duration: options.duration,
-              count: options.count,
-              threshold: options.threshold,
-              criteria: options.criteria,
-              language: options.language,
-              useGemini: options.useGemini ?? false,
-              lowRes: options.lowRes ?? false,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                mediaPath,
+                output: options.output,
+                project: options.project,
+                duration: options.duration,
+                count: options.count,
+                threshold: options.threshold,
+                criteria: options.criteria,
+                language: options.language,
+                useGemini: options.useGemini ?? false,
+                lowRes: options.lowRes ?? false,
+              },
             },
           });
           return;
@@ -1042,6 +1046,7 @@ Analyze both what is SHOWN (visual cues, actions, expressions) and what is SAID 
     .option("--low-res", "Use low resolution mode for longer videos (Gemini only)")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (videoPath: string, options) => {
+      const startedAt = Date.now();
       try {
         if (options.output) {
           validateOutputPath(options.output);
@@ -1053,22 +1058,25 @@ Analyze both what is SHOWN (visual cues, actions, expressions) and what is SAID 
         }
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "ai auto-shorts",
-            params: {
-              videoPath,
-              output: options.output,
-              duration: options.duration,
-              count: options.count,
-              aspect: options.aspect,
-              outputDir: options.outputDir,
-              addCaptions: options.addCaptions ?? false,
-              captionStyle: options.captionStyle,
-              analyzeOnly: options.analyzeOnly ?? false,
-              language: options.language,
-              useGemini: options.useGemini ?? false,
-              lowRes: options.lowRes ?? false,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                videoPath,
+                output: options.output,
+                duration: options.duration,
+                count: options.count,
+                aspect: options.aspect,
+                outputDir: options.outputDir,
+                addCaptions: options.addCaptions ?? false,
+                captionStyle: options.captionStyle,
+                analyzeOnly: options.analyzeOnly ?? false,
+                language: options.language,
+                useGemini: options.useGemini ?? false,
+                lowRes: options.lowRes ?? false,
+              },
             },
           });
           return;

--- a/packages/cli/src/commands/ai-review.ts
+++ b/packages/cli/src/commands/ai-review.ts
@@ -21,7 +21,7 @@ import { GeminiProvider } from "@vibeframe/ai-providers";
 import { getApiKey, loadEnv } from "../utils/api-key.js";
 import { execSafe } from "../utils/exec-safe.js";
 import type { VideoReviewFeedback } from "./ai-edit.js";
-import { exitWithError, outputResult, apiError, generalError } from "./output.js";
+import { exitWithError, outputSuccess, apiError, generalError } from "./output.js";
 import { validateOutputPath } from "./validate.js";
 
 /** Options for {@link executeReview}. */
@@ -232,22 +232,26 @@ export function registerReviewCommand(aiCommand: Command): void {
     .option("-o, --output <path>", "Output video file path (for auto-apply)")
     .option("--dry-run", "Preview parameters without executing")
     .action(async (videoPath: string, options) => {
+      const startedAt = Date.now();
       try {
         if (options.output) {
           validateOutputPath(options.output);
         }
 
         if (options.dryRun) {
-          outputResult({
-            dryRun: true,
+          outputSuccess({
             command: "ai review",
-            params: {
-              videoPath,
-              storyboard: options.storyboard,
-              autoApply: options.autoApply ?? false,
-              verify: options.verify ?? false,
-              model: options.model,
-              output: options.output,
+            startedAt,
+            dryRun: true,
+            data: {
+              params: {
+                videoPath,
+                storyboard: options.storyboard,
+                autoApply: options.autoApply ?? false,
+                verify: options.verify ?? false,
+                model: options.model,
+                output: options.output,
+              },
             },
           });
           return;

--- a/packages/cli/src/commands/ai-script-pipeline-cli.ts
+++ b/packages/cli/src/commands/ai-script-pipeline-cli.ts
@@ -21,7 +21,7 @@ import {
   DEFAULT_VIDEO_RETRIES,
   executeRegenerateScene,
 } from "./ai-script-pipeline.js";
-import { exitWithError, outputResult, authError, notFoundError, usageError, apiError, generalError } from "./output.js";
+import { exitWithError, outputSuccess, authError, notFoundError, usageError, apiError, generalError } from "./output.js";
 
 export function registerScriptPipelineCommands(aiCommand: Command): void {
 aiCommand
@@ -40,6 +40,7 @@ aiCommand
   .option("--reference-scene <num>", "Use another scene's image as reference for character consistency")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectDir: string, options) => {
+    const startedAt = Date.now();
     try {
       const outputDir = resolve(process.cwd(), projectDir);
       const projectPath = resolve(outputDir, "project.vibe.json");
@@ -65,20 +66,23 @@ aiCommand
       }
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "pipeline regenerate-scene",
-          params: {
-            projectDir,
-            scene: sceneNums,
-            videoOnly: options.videoOnly ?? false,
-            narrationOnly: options.narrationOnly ?? false,
-            imageOnly: options.imageOnly ?? false,
-            generator: options.generator,
-            imageProvider: options.imageProvider,
-            aspectRatio: options.aspectRatio,
-            retries: options.retries,
-            referenceScene: options.referenceScene,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              projectDir,
+              scene: sceneNums,
+              videoOnly: options.videoOnly ?? false,
+              narrationOnly: options.narrationOnly ?? false,
+              imageOnly: options.imageOnly ?? false,
+              generator: options.generator,
+              imageProvider: options.imageProvider,
+              aspectRatio: options.aspectRatio,
+              retries: options.retries,
+              referenceScene: options.referenceScene,
+            },
           },
         });
         return;

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -23,7 +23,7 @@ import { requireApiKey } from "../utils/api-key.js";
 import { applySuggestion } from "./ai-helpers.js";
 import { executeAnalyze, executeGeminiVideo } from "./ai-analyze.js";
 import { registerReviewCommand } from "./ai-review.js";
-import { isJsonMode, outputResult, exitWithError, apiError } from "./output.js";
+import { isJsonMode, outputSuccess, exitWithError, apiError } from "./output.js";
 import { sanitizeLLMResponse } from "./sanitize.js";
 import { rejectControlChars } from "./validate.js";
 
@@ -65,6 +65,7 @@ analyzeCommand
   .option("-v, --verbose", "Show token usage")
   .option("--fields <fields>", "Comma-separated fields to include in output (e.g., response,model)")
   .action(async (source: string, prompt: string, options) => {
+    const startedAt = Date.now();
     try {
       rejectControlChars(prompt);
 
@@ -95,15 +96,17 @@ analyzeCommand
       const response = sanitizeLLMResponse(result.response || "");
 
       if (isJsonMode()) {
-        let result_obj: Record<string, unknown> = { success: true, response, sourceType: result.sourceType, model: result.model };
+        const data: Record<string, unknown> = { response, sourceType: result.sourceType, model: result.model };
         if (result.totalTokens) {
-          result_obj = { ...result_obj, promptTokens: result.promptTokens, responseTokens: result.responseTokens, totalTokens: result.totalTokens };
+          data.promptTokens = result.promptTokens;
+          data.responseTokens = result.responseTokens;
+          data.totalTokens = result.totalTokens;
         }
-        if (options.fields) {
-          const fields = options.fields.split(",").map((f: string) => f.trim());
-          result_obj = Object.fromEntries(Object.entries(result_obj).filter(([k]) => fields.includes(k) || k === "success"));
-        }
-        outputResult(result_obj);
+        outputSuccess({
+          command: "analyze media",
+          startedAt,
+          data,
+        });
         return;
       }
 
@@ -144,6 +147,7 @@ analyzeCommand
   .option("-v, --verbose", "Show token usage")
   .option("--fields <fields>", "Comma-separated fields to include in output (e.g., response,model)")
   .action(async (source: string, prompt: string, options) => {
+    const startedAt = Date.now();
     try {
       rejectControlChars(prompt);
 
@@ -174,15 +178,17 @@ analyzeCommand
       const response = sanitizeLLMResponse(result.response || "");
 
       if (isJsonMode()) {
-        let result_obj: Record<string, unknown> = { success: true, response, model: result.model };
+        const data: Record<string, unknown> = { response, model: result.model };
         if (result.totalTokens) {
-          result_obj = { ...result_obj, promptTokens: result.promptTokens, responseTokens: result.responseTokens, totalTokens: result.totalTokens };
+          data.promptTokens = result.promptTokens;
+          data.responseTokens = result.responseTokens;
+          data.totalTokens = result.totalTokens;
         }
-        if (options.fields) {
-          const fields = options.fields.split(",").map((f: string) => f.trim());
-          result_obj = Object.fromEntries(Object.entries(result_obj).filter(([k]) => fields.includes(k) || k === "success"));
-        }
-        outputResult(result_obj);
+        outputSuccess({
+          command: "analyze video",
+          startedAt,
+          data,
+        });
         return;
       }
 
@@ -220,6 +226,7 @@ analyzeCommand
   .option("-k, --api-key <key>", "Google API key (or set GOOGLE_API_KEY env)")
   .option("--apply", "Apply the first suggestion automatically")
   .action(async (projectPath: string, instruction: string, options) => {
+    const startedAt = Date.now();
     try {
       rejectControlChars(instruction);
 
@@ -242,7 +249,13 @@ analyzeCommand
       spinner.succeed(chalk.green(`Found ${suggestions.length} suggestion(s)`));
 
       if (isJsonMode()) {
-        outputResult({ success: true, suggestions: suggestions.map(s => ({ type: s.type, description: s.description, confidence: s.confidence, clipIds: s.clipIds, params: s.params })) });
+        outputSuccess({
+          command: "analyze suggest",
+          startedAt,
+          data: {
+            suggestions: suggestions.map(s => ({ type: s.type, description: s.description, confidence: s.confidence, clipIds: s.clipIds, params: s.params })),
+          },
+        });
         return;
       }
 

--- a/packages/cli/src/commands/output.ts
+++ b/packages/cli/src/commands/output.ts
@@ -239,15 +239,19 @@ export function outputSuccess(opts: SuccessEnvelopeOptions): void {
   if (isJsonMode()) {
     const fields = process.env.VIBE_OUTPUT_FIELDS;
     if (fields) {
+      // --fields filters keys *inside* data, leaving envelope meta
+      // (command, elapsedMs, costUsd, warnings, dryRun) intact. This
+      // matches the documented `--fields response,model` UX from analyze.*
+      // and avoids agents having to write `--fields data` to keep the payload.
       const keys = fields.split(",").map((k) => k.trim());
-      const filtered: Record<string, unknown> = {};
+      const data = opts.data as Record<string, unknown>;
+      const filteredData: Record<string, unknown> = {};
       for (const key of keys) {
-        if (key in envelope) filtered[key] = envelope[key];
+        if (key in data) filteredData[key] = data[key];
       }
-      console.log(JSON.stringify(filtered, null, 2));
-    } else {
-      console.log(JSON.stringify(envelope, null, 2));
+      envelope.data = filteredData;
     }
+    console.log(JSON.stringify(envelope, null, 2));
     return;
   }
 

--- a/packages/cli/src/commands/pipeline.ts
+++ b/packages/cli/src/commands/pipeline.ts
@@ -28,7 +28,7 @@ import ora from "ora";
 import { registerScriptPipelineCommands } from "./ai-script-pipeline-cli.js";
 import { registerHighlightsCommands } from "./ai-highlights.js";
 import { executeAnimatedCaption, type AnimatedCaptionStyle } from "./ai-animated-caption.js";
-import { isJsonMode, outputResult, exitWithError, notFoundError, usageError, apiError, generalError } from "./output.js";
+import { isJsonMode, outputSuccess, exitWithError, notFoundError, usageError, apiError, generalError } from "./output.js";
 
 export const pipelineCommand = new Command("pipeline")
   .alias("pipe")
@@ -118,6 +118,7 @@ Required API Key: OPENAI_API_KEY (Whisper transcription)
 `,
   )
   .action(async (videoPath: string, options) => {
+    const startedAt = Date.now();
     try {
       const absVideoPath = resolve(process.cwd(), videoPath);
       if (!existsSync(absVideoPath)) {
@@ -132,20 +133,23 @@ Required API Key: OPENAI_API_KEY (Whisper transcription)
       const outputFile = options.output || videoPath.replace(/(\.\w+)$/, "-captioned$1");
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "pipeline animated-caption",
-          params: {
-            videoPath: absVideoPath,
-            outputPath: outputFile,
-            style: options.style,
-            highlightColor: options.highlightColor,
-            fontSize: options.fontSize ? parseInt(options.fontSize) : "auto",
-            position: options.position,
-            wordsPerGroup: options.wordsPerGroup ? parseInt(options.wordsPerGroup) : "auto",
-            maxChars: options.maxChars ? parseInt(options.maxChars) : "auto",
-            language: options.language || "auto",
-            fast: !!options.fast,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              videoPath: absVideoPath,
+              outputPath: outputFile,
+              style: options.style,
+              highlightColor: options.highlightColor,
+              fontSize: options.fontSize ? parseInt(options.fontSize) : "auto",
+              position: options.position,
+              wordsPerGroup: options.wordsPerGroup ? parseInt(options.wordsPerGroup) : "auto",
+              maxChars: options.maxChars ? parseInt(options.maxChars) : "auto",
+              language: options.language || "auto",
+              fast: !!options.fast,
+            },
           },
         });
         return;
@@ -182,13 +186,16 @@ Required API Key: OPENAI_API_KEY (Whisper transcription)
       spinner.succeed(chalk.green("Animated captions applied successfully"));
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
-          outputPath: result.outputPath,
-          wordCount: result.wordCount,
-          groupCount: result.groupCount,
-          style: result.style,
-          tier: result.tier,
+        outputSuccess({
+          command: "pipeline animated-caption",
+          startedAt,
+          data: {
+            outputPath: result.outputPath,
+            wordCount: result.wordCount,
+            groupCount: result.groupCount,
+            style: result.style,
+            tier: result.tier,
+          },
         });
         return;
       }

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -73,7 +73,7 @@ import {
   exitWithError,
   generalError,
   usageError,
-  outputResult,
+  outputSuccess,
   isJsonMode,
 } from "./output.js";
 import { getApiKey } from "../utils/api-key.js";
@@ -154,6 +154,7 @@ sceneCommand
   .option("--visual-style <name>", `Seed DESIGN.md from a named style (browse via \`vibe scene styles\`). E.g. "Swiss Pulse"`)
   .option("--dry-run", "Preview parameters without writing files")
   .action(async (dir: string, options) => {
+    const startedAt = Date.now();
     const aspect = validateAspect(options.ratio);
     const duration = validateDuration(options.duration);
     const name = (options.name as string | undefined) ?? basename(dir.replace(/\/+$/, ""));
@@ -162,15 +163,18 @@ sceneCommand
       : undefined;
 
     if (options.dryRun) {
-      outputResult({
-        dryRun: true,
+      outputSuccess({
         command: "scene init",
-        params: {
-          dir,
-          name,
-          aspect,
-          duration,
-          visualStyle: visualStyle?.name ?? null,
+        startedAt,
+        dryRun: true,
+        data: {
+          params: {
+            dir,
+            name,
+            aspect,
+            duration,
+            visualStyle: visualStyle?.name ?? null,
+          },
         },
       });
       return;
@@ -196,19 +200,21 @@ sceneCommand
       });
 
       if (isJsonMode()) {
-        outputResult({
-          success: true,
+        outputSuccess({
           command: "scene init",
-          dir,
-          name,
-          aspect,
-          duration,
-          visualStyle: visualStyle?.name ?? null,
-          created: result.created,
-          merged: result.merged,
-          skipped: result.skipped,
-          skillFiles: skillResult.files,
-          skillBundleVersion: skillResult.bundleVersion,
+          startedAt,
+          data: {
+            dir,
+            name,
+            aspect,
+            duration,
+            visualStyle: visualStyle?.name ?? null,
+            created: result.created,
+            merged: result.merged,
+            skipped: result.skipped,
+            skillFiles: skillResult.files,
+            skillBundleVersion: skillResult.bundleVersion,
+          },
         });
         return;
       }
@@ -269,6 +275,7 @@ sceneCommand
   .option("--force", "Overwrite existing skill files (default: skip-on-exist)")
   .option("--dry-run", "Preview which files would be written without changing anything")
   .action(async (projectDirArg: string, options) => {
+    const startedAt = Date.now();
     const hostFlag = (options.host as InstallSkillHostFlag) ?? "auto";
     if (!VALID_INSTALL_SKILL_HOSTS.includes(hostFlag)) {
       exitWithError(usageError(`Invalid --host: ${hostFlag}`, `Valid: ${VALID_INSTALL_SKILL_HOSTS.join(", ")}`));
@@ -291,15 +298,17 @@ sceneCommand
     });
 
     if (isJsonMode()) {
-      outputResult({
-        success: true,
+      outputSuccess({
         command: "scene install-skill",
-        projectDir,
-        host: hostFlag,
-        resolvedHosts: hosts,
-        bundleVersion: result.bundleVersion,
-        files: result.files,
+        startedAt,
         dryRun: options.dryRun ?? false,
+        data: {
+          projectDir,
+          host: hostFlag,
+          resolvedHosts: hosts,
+          bundleVersion: result.bundleVersion,
+          files: result.files,
+        },
       });
       return;
     }
@@ -346,6 +355,7 @@ sceneCommand
   .argument("[project-dir]", "Project directory containing STORYBOARD.md / DESIGN.md", ".")
   .option("--beat <id>", "Restrict the plan to a single beat by id (e.g. 'hook', '1')")
   .action(async (projectDirArg: string, options) => {
+    const startedAt = Date.now();
     const projectDir = resolve(projectDirArg);
     const result = await getComposePrompts({
       projectDir,
@@ -354,9 +364,10 @@ sceneCommand
 
     if (!result.success) {
       if (isJsonMode()) {
-        outputResult({
+        outputSuccess({
           command: "scene compose-prompts",
-          ...result,
+          startedAt,
+          data: { ...result },
         });
         process.exitCode = 1;
         return;
@@ -365,9 +376,10 @@ sceneCommand
     }
 
     if (isJsonMode()) {
-      outputResult({
+      outputSuccess({
         command: "scene compose-prompts",
-        ...result,
+        startedAt,
+        data: { ...result },
       });
       return;
     }
@@ -414,20 +426,23 @@ sceneCommand
   .description("List vendored visual styles (or show one) for DESIGN.md seeding")
   .argument("[name]", "Style name to inspect (omit to list all)")
   .action((name?: string) => {
+    const startedAt = Date.now();
     if (!name) {
       const all = listVisualStyles();
       if (isJsonMode()) {
-        outputResult({
-          success: true,
+        outputSuccess({
           command: "scene styles",
-          count: all.length,
-          styles: all.map((s) => ({
-            name: s.name,
-            slug: s.slug,
-            designer: s.designer,
-            mood: s.mood,
-            bestFor: s.bestFor,
-          })),
+          startedAt,
+          data: {
+            count: all.length,
+            styles: all.map((s) => ({
+              name: s.name,
+              slug: s.slug,
+              designer: s.designer,
+              mood: s.mood,
+              bestFor: s.bestFor,
+            })),
+          },
         });
         return;
       }
@@ -457,7 +472,11 @@ sceneCommand
     }
 
     if (isJsonMode()) {
-      outputResult({ success: true, command: "scene styles", style });
+      outputSuccess({
+        command: "scene styles",
+        startedAt,
+        data: { style },
+      });
       return;
     }
 
@@ -507,6 +526,7 @@ sceneCommand
   .option("--force", "Overwrite an existing compositions/scene-<id>.html")
   .option("--dry-run", "Preview parameters without writing files or calling APIs")
   .action(async (name: string, options) => {
+    const startedAt = Date.now();
     if (options.style) options.style = validatePreset(options.style);
     if (options.duration !== undefined) options.duration = validateDuration(options.duration);
     let tts: TtsProviderName;
@@ -518,24 +538,27 @@ sceneCommand
 
     if (options.dryRun) {
       const id = slugifySceneName(name);
-      outputResult({
-        dryRun: true,
+      outputSuccess({
         command: "scene add",
-        params: {
-          name,
-          id,
-          preset: options.style,
-          narration: !!options.narration,
-          visuals: !!options.visuals,
-          duration: options.duration,
-          headline: options.headline,
-          kicker: options.kicker,
-          project: options.project,
-          insertInto: options.insertInto,
-          imageProvider: options.imageProvider,
-          tts,
-          audio: options.audio,   // commander sets `audio: false` when --no-audio is passed
-          image: options.image,
+        startedAt,
+        dryRun: true,
+        data: {
+          params: {
+            name,
+            id,
+            preset: options.style,
+            narration: !!options.narration,
+            visuals: !!options.visuals,
+            duration: options.duration,
+            headline: options.headline,
+            kicker: options.kicker,
+            project: options.project,
+            insertInto: options.insertInto,
+            imageProvider: options.imageProvider,
+            tts,
+            audio: options.audio,   // commander sets `audio: false` when --no-audio is passed
+            image: options.image,
+          },
         },
       });
       return;
@@ -574,9 +597,10 @@ sceneCommand
       }
 
       if (isJsonMode()) {
-        outputResult({
+        outputSuccess({
           command: "scene add",
-          ...result,
+          startedAt,
+          data: { ...result },
         });
         return;
       }
@@ -1009,6 +1033,7 @@ sceneCommand
   .option("--project <dir>", "Project directory", ".")
   .option("--fix", "Apply mechanical auto-fixes (currently: missing class=\"clip\")")
   .action(async (root: string, options) => {
+    const startedAt = Date.now();
     const projectDir = resolve(options.project as string);
     if (!(await rootExists(projectDir, root))) {
       exitWithError(generalError(
@@ -1028,9 +1053,10 @@ sceneCommand
     }
 
     if (isJsonMode()) {
-      outputResult({
+      outputSuccess({
         command: "scene lint",
-        ...result,
+        startedAt,
+        data: { ...result },
       });
       if (!result.ok) process.exitCode = 1;
       return;
@@ -1129,6 +1155,7 @@ sceneCommand
   .option("--workers <n>", "Capture workers (1-16, default 1)", "1")
   .option("--dry-run", "Preview parameters without rendering")
   .action(async (root: string, options) => {
+    const startedAt = Date.now();
     const fps = validateFps(options.fps);
     const quality = validateQuality(options.quality);
     const format = validateFormat(options.format);
@@ -1136,17 +1163,20 @@ sceneCommand
     const projectDir = resolve(options.project as string);
 
     if (options.dryRun) {
-      outputResult({
-        dryRun: true,
+      outputSuccess({
         command: "scene render",
-        params: {
-          projectDir,
-          root,
-          output: options.out,
-          fps,
-          quality,
-          format,
-          workers,
+        startedAt,
+        dryRun: true,
+        data: {
+          params: {
+            projectDir,
+            root,
+            output: options.out,
+            fps,
+            quality,
+            format,
+            workers,
+          },
         },
       });
       return;
@@ -1170,7 +1200,11 @@ sceneCommand
     if (!result.success) {
       spinner?.fail("Render failed");
       if (isJsonMode()) {
-        outputResult({ command: "scene render", ...result });
+        outputSuccess({
+          command: "scene render",
+          startedAt,
+          data: { ...result },
+        });
         process.exitCode = 1;
         return;
       }
@@ -1178,7 +1212,11 @@ sceneCommand
     }
 
     if (isJsonMode()) {
-      outputResult({ command: "scene render", ...result });
+      outputSuccess({
+        command: "scene render",
+        startedAt,
+        data: { ...result },
+      });
       return;
     }
 
@@ -1221,26 +1259,30 @@ sceneCommand
   .option("--force", "Re-dispatch primitives even when assets already exist")
   .option("--dry-run", "Preview parameters without dispatching")
   .action(async (projectDirArg: string, options) => {
+    const startedAt = Date.now();
     const projectDir = resolve(projectDirArg);
 
     if (options.dryRun) {
-      outputResult({
-        dryRun: true,
+      outputSuccess({
         command: "scene build",
-        params: {
-          projectDir,
-          mode: options.mode,
-          effort: options.effort,
-          composer: options.composer,
-          skipNarration: options.skipNarration ?? false,
-          skipBackdrop: options.skipBackdrop ?? false,
-          skipRender: options.skipRender ?? false,
-          ttsProvider: options.tts,
-          voice: options.voice,
-          imageProvider: options.imageProvider,
-          imageQuality: options.quality,
-          imageSize: options.imageSize,
-          force: options.force ?? false,
+        startedAt,
+        dryRun: true,
+        data: {
+          params: {
+            projectDir,
+            mode: options.mode,
+            effort: options.effort,
+            composer: options.composer,
+            skipNarration: options.skipNarration ?? false,
+            skipBackdrop: options.skipBackdrop ?? false,
+            skipRender: options.skipRender ?? false,
+            ttsProvider: options.tts,
+            voice: options.voice,
+            imageProvider: options.imageProvider,
+            imageQuality: options.quality,
+            imageSize: options.imageSize,
+            force: options.force ?? false,
+          },
         },
       });
       return;
@@ -1300,7 +1342,11 @@ sceneCommand
     if (!result.success) {
       spinner?.fail(`Build failed: ${result.error}`);
       if (isJsonMode()) {
-        outputResult({ command: "scene build", ...result });
+        outputSuccess({
+          command: "scene build",
+          startedAt,
+          data: { ...result },
+        });
         process.exitCode = 1;
         return;
       }
@@ -1308,7 +1354,11 @@ sceneCommand
     }
 
     if (isJsonMode()) {
-      outputResult({ command: "scene build", ...result });
+      outputSuccess({
+        command: "scene build",
+        startedAt,
+        data: { ...result },
+      });
       return;
     }
 

--- a/packages/cli/src/commands/timeline.ts
+++ b/packages/cli/src/commands/timeline.ts
@@ -6,7 +6,7 @@ import ora from "ora";
 import { Project, type ProjectFile } from "../engine/index.js";
 import type { MediaType } from "@vibeframe/core/timeline";
 import { validateResourceId } from "./validate.js";
-import { exitWithError, generalError, notFoundError, outputResult, usageError } from "./output.js";
+import { exitWithError, generalError, notFoundError, outputSuccess, usageError } from "./output.js";
 
 export const timelineCommand = new Command("timeline")
   .description("Timeline editing commands")
@@ -33,19 +33,23 @@ timelineCommand
   .option("-d, --duration <seconds>", "Duration in seconds (required for images)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, mediaPath: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Adding source...").start();
 
     try {
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "timeline add-source",
-          params: {
-            project: projectPath,
-            media: mediaPath,
-            name: options.name || null,
-            type: options.type || null,
-            duration: options.duration || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              media: mediaPath,
+              name: options.name || null,
+              type: options.type || null,
+              duration: options.duration || null,
+            },
           },
         });
         return;
@@ -94,6 +98,7 @@ timelineCommand
   .option("--offset <seconds>", "Source start offset", "0")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, sourceId: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Adding clip...").start();
 
     try {
@@ -101,16 +106,19 @@ timelineCommand
       if (options.track) validateResourceId(options.track);
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "timeline add-clip",
-          params: {
-            project: projectPath,
-            sourceId,
-            track: options.track || null,
-            start: options.start,
-            duration: options.duration || null,
-            offset: options.offset,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              sourceId,
+              track: options.track || null,
+              start: options.start,
+              duration: options.duration || null,
+              offset: options.offset,
+            },
           },
         });
         return;
@@ -175,17 +183,21 @@ timelineCommand
   .option("-n, --name <name>", "Track name")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, type: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Adding track...").start();
 
     try {
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "timeline add-track",
-          params: {
-            project: projectPath,
-            type,
-            name: options.name || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              type,
+              name: options.name || null,
+            },
           },
         });
         return;
@@ -233,22 +245,26 @@ timelineCommand
   .option("-p, --params <json>", "Effect parameters as JSON", "{}")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, clipId: string, effectType: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Adding effect...").start();
 
     try {
       validateResourceId(clipId);
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "timeline add-effect",
-          params: {
-            project: projectPath,
-            clipId,
-            effectType,
-            start: options.start,
-            duration: options.duration || null,
-            params: options.params,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              clipId,
+              effectType,
+              start: options.start,
+              duration: options.duration || null,
+              params: options.params,
+            },
           },
         });
         return;
@@ -304,20 +320,24 @@ timelineCommand
   .option("--duration <seconds>", "New duration")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, clipId: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Trimming clip...").start();
 
     try {
       validateResourceId(clipId);
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "timeline trim",
-          params: {
-            project: projectPath,
-            clipId,
-            start: options.start || null,
-            duration: options.duration || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              clipId,
+              start: options.start || null,
+              duration: options.duration || null,
+            },
           },
         });
         return;
@@ -436,19 +456,23 @@ timelineCommand
   .option("-t, --time <seconds>", "Split time relative to clip start", "0")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, clipId: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Splitting clip...").start();
 
     try {
       validateResourceId(clipId);
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "timeline split",
-          params: {
-            project: projectPath,
-            clipId,
-            time: options.time,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              clipId,
+              time: options.time,
+            },
           },
         });
         return;
@@ -499,19 +523,23 @@ timelineCommand
   .option("-t, --time <seconds>", "Start time for duplicate (default: after original)")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, clipId: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Duplicating clip...").start();
 
     try {
       validateResourceId(clipId);
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "timeline duplicate",
-          params: {
-            project: projectPath,
-            clipId,
-            time: options.time || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              clipId,
+              time: options.time || null,
+            },
           },
         });
         return;
@@ -556,18 +584,22 @@ timelineCommand
   .argument("<clip-id>", "Clip ID to delete")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, clipId: string, options: { dryRun?: boolean }) => {
+    const startedAt = Date.now();
     const spinner = ora("Deleting clip...").start();
 
     try {
       validateResourceId(clipId);
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "timeline delete",
-          params: {
-            project: projectPath,
-            clipId,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              clipId,
+            },
           },
         });
         return;
@@ -609,6 +641,7 @@ timelineCommand
   .option("--track <track-id>", "Move to different track")
   .option("--dry-run", "Preview parameters without executing")
   .action(async (projectPath: string, clipId: string, options) => {
+    const startedAt = Date.now();
     const spinner = ora("Moving clip...").start();
 
     try {
@@ -616,14 +649,17 @@ timelineCommand
       if (options.track) validateResourceId(options.track);
 
       if (options.dryRun) {
-        outputResult({
-          dryRun: true,
+        outputSuccess({
           command: "timeline move",
-          params: {
-            project: projectPath,
-            clipId,
-            time: options.time || null,
-            track: options.track || null,
+          startedAt,
+          dryRun: true,
+          data: {
+            params: {
+              project: projectPath,
+              clipId,
+              time: options.time || null,
+              track: options.track || null,
+            },
           },
         });
         return;


### PR DESCRIPTION
## Summary

Final sweep of the \`--json\` envelope migration. After this PR, **every CLI command's \`--json\` output uses the canonical envelope** established in #194. The old \`outputResult()\` helper is now unused outside \`output.ts\` itself.

## Files (8)

| File | Sites | Quirk |
|---|---|---|
| \`scene.ts\` | 16 | 3 failure-path \`{...result}\` spreads (compose-prompts, render, build) preserved with \`process.exitCode = 1\` from #193 |
| \`timeline.ts\` | 9 | dry-run only; success-path JSON deferred to separate \"2c-coverage\" PR |
| \`analyze.ts\` | 3 | dropped local \`--fields\` filter (now handled by helper) |
| \`pipeline.ts\` | 2 | standard |
| \`ai-highlights.ts\` | 2 | standard |
| \`ai-script-pipeline-cli.ts\` | 1 | standard |
| \`ai-review.ts\` | 1 | standard |
| \`output.ts\` | helper change — see below |

## Helper change: \`--fields\` now filters data keys

\`outputSuccess()\` now applies \`--fields\` filtering to keys **inside** \`data\`, leaving envelope meta (\`command\`, \`elapsedMs\`, \`costUsd\`, \`warnings\`, \`dryRun\`) intact. Matches the documented \`--fields response,model\` UX from \`analyze.*\` and avoids agents writing \`--fields data\` to keep the payload.

\`\`\`
# Old (envelope-level filter):
$ vibe analyze video x.mp4 \"...\" --fields response
{}   # envelope had no top-level 'response' key

# New (data-level filter):
$ vibe analyze video x.mp4 \"...\" --fields response
{ \"command\": \"analyze video\", \"elapsedMs\": ..., \"costUsd\": ..., \"warnings\": [], \"data\": { \"response\": \"...\" } }
\`\`\`

## Scene failure-path pattern (Quirk 1)

3 sites in \`scene.ts\` emit a result-shape JSON to stdout *before* setting \`exitCode=1\`. Metadata (which beat failed, which violation, etc.) is useful for agents diagnosing:

\`\`\`ts
if (!result.success) {
  if (isJsonMode()) {
    outputSuccess({
      command: \"scene render\",
      startedAt,
      data: { ...result },   // success: false, error, metadata
    });
    process.exitCode = 1;
    return;
  }
  exitWithError(generalError(result.error ?? \"Render failed\"));
}
\`\`\`

Function is still named \`outputSuccess\` even when emitting failure metadata — exit code 1 is the failure signal, \`data.success: false\` is metadata.

## Smoke tests (verified locally)

\`\`\`
$ vibe scene styles --json
{ \"command\": \"scene styles\", \"costUsd\": 0, \"warnings\": [], \"data\": { \"count\": 8, \"styles\": [...] } }

$ vibe timeline add-source proj.json /tmp/x.mp4 --dry-run --json
{ \"command\": \"timeline add-source\", \"dryRun\": true, \"costUsd\": 0, \"warnings\": [], \"data\": { \"params\": {...} } }
\`\`\`

## What 2c does NOT cover (deferred to 2c-coverage PR)

The audit (#192) flagged commands that lack \`--json\` entirely. This PR series only migrated commands that already emitted JSON. Coverage gaps still open:

- \`timeline.*\` success paths emit no JSON (10 commands)
- \`scene render\` / \`scene build\` / \`scene add\` partial \`--json\` (some paths still console.log only)
- \`export video\` has no \`--json\` mode
- \`doctor\` works but could surface more

These will go in a separate \"2c-coverage\" PR after the envelope is stable.

## Migration summary across the whole 2c series

| PR | Commands migrated | Sites |
|---|---|---|
| #194 (canary) | \`generate image\` | 5 |
| #195 (sweep-1) | 11 \`generate.*\` | 27 |
| #196 (sweep-2) | edit/audio/detect/batch/project/export/run/init/etc. (13 files) | ~55 |
| **#this** (sweep-3) | scene/timeline/pipeline/analyze (8 files) | 34 |
| **Total** | ~33 files | ~121 sites |

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\` — 0 errors (full-repo, matches CI)
- [x] \`pnpm lint\` — 0 errors (8 pre-existing warnings)
- [x] \`pnpm -F @vibeframe/cli exec vitest run\` — 700 passed, 9 skipped, 0 failed
- [x] \`grep \"outputResult\" packages/cli/src/commands/\` — 0 hits (only \`output.ts\` still has the helper definition)
- [x] Smoke tests on scene styles + timeline add-source dry-run