### PR TITLE
release: v0.72.0 — Issue #33 --json envelope standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.72.0] - 2026-04-28
+
+**Issue #33 — CLI UX standardization.** Every CLI command now emits a canonical `--json` envelope. **Breaking change** for agents that parse `--json` output: payload moved from top-level keys into a `data` namespace, the redundant `success: true` key was dropped (exit code 0 is the success signal), and `estimatedCost` (formatted string) was replaced with numeric `costUsd`. Pre-1.0 → no transition shim; one-version migration via `jq .data | <existing>`.
+
+Closes part of #33. Sub-PRs: #192 (audit baseline), #193 (raw `process.exit` cleanup), #194 (canary), #195/#196/#197 (sweep). Remaining work tracked in #33: 2c-coverage (commands lacking `--json`), 2d (`--describe` quality sweep), 2e (snapshot tests).
+
+### Breaking changes
+
+- **`--json` envelope shape** — every command's success output is now:
+  ```json
+  {
+    "command": "generate image",
+    "dryRun"?: true,
+    "elapsedMs": 1234,
+    "costUsd": 0.04,
+    "warnings": [],
+    "data": { /* domain-specific keys (provider, images, outputPath, …) */ }
+  }
+  ```
+  Agent migration:
+  - `jq .images` / `.video` / `.outputPath` / etc. → `jq .data.<same>`
+  - `jq .estimatedCost` (string) → `jq .costUsd` (number)
+  - `jq .success` → drop; rely on exit code (`$?`) or check `data.success: false` for the few sites that emit failure metadata to stdout (scene render/build/compose-prompts when JSON mode is on)
+
+- **Errors still go to stderr** (unchanged): `{ success: false, error, code, exitCode, suggestion?, retryable }` via `exitWithError()`. The new envelope only changes the **stdout success** shape.
+
+- **`--fields` filter now targets `data` keys, not envelope keys** — `vibe analyze video x.mp4 "..." --fields response,model` now returns the envelope with `data.response` and `data.model` filled in, not an empty envelope. Matches the documented `--fields response,model` UX.
+
+### Added
+
+- **Canonical `outputSuccess()` helper** in `packages/cli/src/commands/output.ts` — takes `{ command, data, startedAt, costUsd?, warnings?, dryRun? }`, computes `elapsedMs`, defaults `costUsd` to `COST_ESTIMATES[command].max` for dry-run / 0 for real run.
+- **First real demo case for `warnings`** — `generate image` with Gemini's `latest`/`3.1-flash` auto-fallback to `flash` now surfaces the fallback as a structured warning in `data.warnings` instead of a stderr-mixed log line.
+- **CLI UX audit doc** at `docs/CLI_UX_AUDIT.md` (#192) — inventories every command's `--json` / `--dry-run` / envelope shape / exit code path; defines the `ExitCode` enum (0–6) as the canonical scheme.
+
+### Changed
+
+- **Raw `process.exit()` replaced** in 7 sites inside Commander action handlers (#193): `ai-highlights.ts` (2× `process.exit(0)` → `return`), `scene.ts` (5× `process.exit(1)` → `process.exitCode = 1; return;`). Lets Commander finish cleanly so `finally` blocks run, multiple actions can run in one process for tests, etc.
+- **Doctor JSON shape flattened** — `data: { result: { scope, system, … } }` → `data: { scope, system, … }`. Saves one nesting level for agents.
+
+### Note for downstream consumers
+
+VibeFrame is pre-1.0 (semver allows breaking minor bumps). 105 stars, no known npm-package downstream consumers, so we skipped the dual-emit transition shim. If your agent code parses `--json` output and breaks, the migration is a one-liner: `jq .data | <existing-jq-expression>`. The full migration table is in the audit doc.
+
 ## [0.71.0] - 2026-04-28
 
 Agent-host coverage + CLI-only walkthroughs. Closes the last Claude-Code-only positioning gap on top of Plan H. All changes are additive — no breaking changes. Counts: MCP 65 → 66, Agent 81 → 82.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "VibeFrame Web - Next.js preview UI for video editing",
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "AI-native video editing tool. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "VibeFrame CLI - natural language video editing from the terminal",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps 0.71.0 → 0.72.0 + CHANGELOG entry. Triggers auto-tag + auto-publish to npm on merge (\`@vibeframe/cli\` and \`@vibeframe/mcp-server\` 0.72.0).

## What ships in v0.72.0

**Breaking change**: every CLI command's \`--json\` output now uses a canonical envelope:

\`\`\`json
{
  \"command\": \"generate image\",
  \"dryRun\"?: true,
  \"elapsedMs\": 1234,
  \"costUsd\": 0.04,
  \"warnings\": [],
  \"data\": { \"provider\": \"openai\", \"images\": [...], \"outputPath\": \"...\" }
}
\`\`\`

Closes Issue #33's primary deliverable. Sub-PRs landed on main:

- #192 audit baseline (docs only)
- #193 raw \`process.exit\` cleanup (7 sites)
- #194 envelope canary on \`generate image\`
- #195 sweep-1: 11 \`generate.*\` commands
- #196 sweep-2: edit/audio/detect/batch/project/export/run/init (~55 sites)
- #197 sweep-3: scene/timeline/pipeline/analyze (34 sites)

**Total**: ~33 files, ~121 sites, plus a new \`outputSuccess()\` helper that handles \`--fields\` filtering on \`data\` keys.

## Migration for agents

| Old | New |
|---|---|
| \`jq .images\` / \`.video\` / \`.outputPath\` / etc. | \`jq .data.<same>\` |
| \`jq .estimatedCost\` (string) | \`jq .costUsd\` (number) |
| \`jq .success\` | drop — exit code 0 is success |

Errors unchanged: still go to stderr as \`StructuredError\` via \`exitWithError()\`.

## Why pre-1.0 breaking

VibeFrame is 0.71.0 (semver allows breaking minor bumps). 105 stars, no known npm-package downstream consumers, so we skipped the dual-emit transition shim. One-line migration via \`jq .data | <existing>\`.

## Remaining for full Issue #33 closure (post-release)

- 2c-coverage: add \`--json\` to commands lacking it (timeline 10 success paths, scene render/build, export video, doctor enhancements)
- 2d: \`--describe\` quality sweep (option enum + format hints)
- 2e: CI snapshot tests for envelope drift detection

## Test plan

- [x] All sub-PRs (#192-#197) green and merged on main
- [x] \`pnpm -r exec tsc --noEmit\` — 0 errors on this branch
- [x] \`bash scripts/sync-counts.sh --check\` — green
- [x] All 7 package.json files bumped to 0.72.0 (sed verified)
- [x] CHANGELOG entry written under \`## [0.72.0] - 2026-04-28\`