### PR TITLE
feat(cli): --json coverage for timeline + project + export (Issue #33 — 2c-coverage)

### DIFF
--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { Project, type ProjectFile } from "../engine/index.js";
 import { execSafe, ffprobeDuration } from "../utils/exec-safe.js";
-import { exitWithError, generalError, notFoundError, outputSuccess, usageError } from "./output.js";
+import { exitWithError, generalError, isJsonMode, notFoundError, outputSuccess, usageError } from "./output.js";
 import { validateOutputPath } from "./validate.js";
 
 /**
@@ -389,6 +389,26 @@ Run 'vibe schema export' for structured parameter info.`)
       });
 
       spinner.succeed(chalk.green(`Exported: ${outputPath}`));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "export",
+          startedAt,
+          data: {
+            outputPath,
+            backend: "ffmpeg",
+            format: options.format,
+            preset: options.preset,
+            resolution: presetSettings.resolution,
+            duration: summary.duration,
+            clipCount: summary.clipCount,
+            bitrate: options.bitrate ?? null,
+            fps: options.fps ?? null,
+            codec: options.codec ?? null,
+          },
+        });
+        return;
+      }
 
       console.log();
       console.log(chalk.dim("  Duration:"), `${summary.duration.toFixed(1)}s`);

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import chalk from "chalk";
 import ora from "ora";
 import { Project, type ProjectFile } from "../engine/index.js";
-import { exitWithError, generalError, outputSuccess } from "./output.js";
+import { exitWithError, generalError, isJsonMode, outputSuccess } from "./output.js";
 import { validateOutputPath } from "./validate.js";
 
 /**
@@ -95,6 +95,21 @@ projectCommand
       await writeFile(outputPath, data, "utf-8");
 
       spinner.succeed(chalk.green(`Project created: ${outputPath}`));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "project create",
+          startedAt,
+          data: {
+            outputPath,
+            name: projectName,
+            aspectRatio: options.ratio,
+            frameRate: parseInt(options.fps, 10),
+          },
+        });
+        return;
+      }
+
       console.log();
       console.log(chalk.dim("  Name:"), projectName);
       console.log(chalk.dim("  Aspect Ratio:"), options.ratio);
@@ -111,6 +126,7 @@ projectCommand
   .description("Show project information")
   .argument("<file>", "Project file path")
   .action(async (file: string) => {
+    const startedAt = Date.now();
     const spinner = ora("Loading project...").start();
 
     try {
@@ -123,6 +139,25 @@ projectCommand
 
       const summary = project.getSummary();
       const meta = project.getMeta();
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "project info",
+          startedAt,
+          data: {
+            name: summary.name,
+            duration: summary.duration,
+            aspectRatio: summary.aspectRatio,
+            frameRate: summary.frameRate,
+            trackCount: summary.trackCount,
+            clipCount: summary.clipCount,
+            sourceCount: summary.sourceCount,
+            createdAt: meta.createdAt.toISOString(),
+            updatedAt: meta.updatedAt.toISOString(),
+          },
+        });
+        return;
+      }
 
       console.log();
       console.log(chalk.bold.cyan("Project Info"));
@@ -188,6 +223,22 @@ projectCommand
       await writeFile(filePath, JSON.stringify(project.toJSON(), null, 2), "utf-8");
 
       spinner.succeed(chalk.green("Project updated"));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "project set",
+          startedAt,
+          data: {
+            file: filePath,
+            updates: {
+              name: options.name ?? null,
+              ratio: options.ratio ?? null,
+              fps: options.fps ? parseInt(options.fps, 10) : null,
+            },
+          },
+        });
+        return;
+      }
     } catch (error) {
       spinner.fail("Failed to update project");
       const msg = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/commands/timeline.test.ts
+++ b/packages/cli/src/commands/timeline.test.ts
@@ -301,9 +301,13 @@ describe("timeline commands", () => {
     });
 
     it("lists all timeline contents", () => {
+      // VIBE_HUMAN_OUTPUT=1 forces human render even when piped (non-TTY).
+      // Without it, auto-JSON mode kicks in for execSync (no TTY) and the
+      // test would parse JSON instead of asserting on the human table.
       const output = execSync(`${CLI} timeline list "${projectFile}"`, {
         cwd: process.cwd(),
         encoding: "utf-8",
+        env: { ...process.env, VIBE_HUMAN_OUTPUT: "1" },
       });
 
       expect(output).toContain("Sources");
@@ -316,7 +320,11 @@ describe("timeline commands", () => {
     it("lists only sources", () => {
       const output = execSync(
         `${CLI} timeline list "${projectFile}" --sources`,
-        { cwd: process.cwd(), encoding: "utf-8" }
+        {
+          cwd: process.cwd(),
+          encoding: "utf-8",
+          env: { ...process.env, VIBE_HUMAN_OUTPUT: "1" },
+        }
       );
 
       expect(output).toContain("Sources");
@@ -328,7 +336,11 @@ describe("timeline commands", () => {
     it("lists only tracks", () => {
       const output = execSync(
         `${CLI} timeline list "${projectFile}" --tracks`,
-        { cwd: process.cwd(), encoding: "utf-8" }
+        {
+          cwd: process.cwd(),
+          encoding: "utf-8",
+          env: { ...process.env, VIBE_HUMAN_OUTPUT: "1" },
+        }
       );
 
       expect(output).toContain("Tracks");

--- a/packages/cli/src/commands/timeline.ts
+++ b/packages/cli/src/commands/timeline.ts
@@ -6,7 +6,7 @@ import ora from "ora";
 import { Project, type ProjectFile } from "../engine/index.js";
 import type { MediaType } from "@vibeframe/core/timeline";
 import { validateResourceId } from "./validate.js";
-import { exitWithError, generalError, notFoundError, outputSuccess, usageError } from "./output.js";
+import { exitWithError, generalError, isJsonMode, notFoundError, outputSuccess, usageError } from "./output.js";
 
 export const timelineCommand = new Command("timeline")
   .description("Timeline editing commands")
@@ -75,6 +75,22 @@ timelineCommand
       await writeFile(filePath, JSON.stringify(project.toJSON(), null, 2), "utf-8");
 
       spinner.succeed(chalk.green(`Source added: ${source.id}`));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "timeline add-source",
+          startedAt,
+          data: {
+            id: source.id,
+            name: mediaName,
+            type: mediaType,
+            path: absMediaPath,
+            duration,
+          },
+        });
+        return;
+      }
+
       console.log();
       console.log(chalk.dim("  Name:"), mediaName);
       console.log(chalk.dim("  Type:"), mediaType);
@@ -163,6 +179,23 @@ timelineCommand
       await writeFile(filePath, JSON.stringify(project.toJSON(), null, 2), "utf-8");
 
       spinner.succeed(chalk.green(`Clip added: ${clip.id}`));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "timeline add-clip",
+          startedAt,
+          data: {
+            id: clip.id,
+            sourceId,
+            sourceName: source.name,
+            trackId,
+            startTime,
+            duration,
+          },
+        });
+        return;
+      }
+
       console.log();
       console.log(chalk.dim("  Source:"), source.name);
       console.log(chalk.dim("  Track:"), trackId);
@@ -224,6 +257,20 @@ timelineCommand
       await writeFile(filePath, JSON.stringify(project.toJSON(), null, 2), "utf-8");
 
       spinner.succeed(chalk.green(`Track added: ${track.id}`));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "timeline add-track",
+          startedAt,
+          data: {
+            id: track.id,
+            name: track.name,
+            type: track.type,
+          },
+        });
+        return;
+      }
+
       console.log();
       console.log(chalk.dim("  Name:"), track.name);
       console.log(chalk.dim("  Type:"), track.type);
@@ -300,6 +347,23 @@ timelineCommand
       await writeFile(filePath, JSON.stringify(project.toJSON(), null, 2), "utf-8");
 
       spinner.succeed(chalk.green(`Effect added: ${effect.id}`));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "timeline add-effect",
+          startedAt,
+          data: {
+            id: effect.id,
+            type: effectType,
+            clipId,
+            startTime,
+            duration,
+            params,
+          },
+        });
+        return;
+      }
+
       console.log();
       console.log(chalk.dim("  Type:"), effectType);
       console.log(chalk.dim("  Start:"), startTime, "s");
@@ -365,6 +429,20 @@ timelineCommand
 
       const updatedClip = project.getClip(clipId)!;
       spinner.succeed(chalk.green("Clip trimmed"));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "timeline trim",
+          startedAt,
+          data: {
+            id: updatedClip.id,
+            startTime: updatedClip.startTime,
+            duration: updatedClip.duration,
+          },
+        });
+        return;
+      }
+
       console.log();
       console.log(chalk.dim("  Start:"), updatedClip.startTime, "s");
       console.log(chalk.dim("  Duration:"), updatedClip.duration, "s");
@@ -383,6 +461,7 @@ timelineCommand
   .option("--tracks", "List tracks only")
   .option("--clips", "List clips only")
   .action(async (projectPath: string, options) => {
+    const startedAt = Date.now();
     try {
       const filePath = resolve(process.cwd(), projectPath);
       const content = await readFile(filePath, "utf-8");
@@ -390,12 +469,56 @@ timelineCommand
       const project = Project.fromJSON(data);
 
       const showAll = !options.sources && !options.tracks && !options.clips;
+      const sources = project.getSources();
+      const tracks = project.getTracks();
+      const clips = project.getClips();
+
+      if (isJsonMode()) {
+        const result: Record<string, unknown> = {};
+        if (showAll || options.sources) {
+          result.sources = sources.map((s) => ({
+            id: s.id,
+            name: s.name,
+            type: s.type,
+            duration: s.duration,
+          }));
+        }
+        if (showAll || options.tracks) {
+          result.tracks = tracks.map((t) => ({
+            id: t.id,
+            name: t.name,
+            type: t.type,
+            isMuted: t.isMuted,
+            isLocked: t.isLocked,
+            isVisible: t.isVisible,
+          }));
+        }
+        if (showAll || options.clips) {
+          result.clips = clips.map((c) => {
+            const source = project.getSource(c.sourceId);
+            return {
+              id: c.id,
+              sourceId: c.sourceId,
+              sourceName: source?.name ?? null,
+              trackId: c.trackId,
+              startTime: c.startTime,
+              duration: c.duration,
+              effects: c.effects.map((e) => ({ id: e.id, type: e.type })),
+            };
+          });
+        }
+        outputSuccess({
+          command: "timeline list",
+          startedAt,
+          data: result,
+        });
+        return;
+      }
 
       if (showAll || options.sources) {
         console.log();
         console.log(chalk.bold.cyan("Sources"));
         console.log(chalk.dim("─".repeat(60)));
-        const sources = project.getSources();
         if (sources.length === 0) {
           console.log(chalk.dim("  (none)"));
         } else {
@@ -410,7 +533,6 @@ timelineCommand
         console.log();
         console.log(chalk.bold.cyan("Tracks"));
         console.log(chalk.dim("─".repeat(60)));
-        const tracks = project.getTracks();
         for (const track of tracks) {
           const status = [
             track.isMuted ? "muted" : null,
@@ -426,7 +548,6 @@ timelineCommand
         console.log();
         console.log(chalk.bold.cyan("Clips"));
         console.log(chalk.dim("─".repeat(60)));
-        const clips = project.getClips();
         if (clips.length === 0) {
           console.log(chalk.dim("  (none)"));
         } else {
@@ -505,6 +626,19 @@ timelineCommand
 
       const [first, second] = result;
       spinner.succeed(chalk.green("Clip split successfully"));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "timeline split",
+          startedAt,
+          data: {
+            first: { id: first.id, duration: first.duration },
+            second: { id: second.id, duration: second.duration },
+          },
+        });
+        return;
+      }
+
       console.log();
       console.log(chalk.dim("  First clip:"), first.id, `(${first.duration.toFixed(2)}s)`);
       console.log(chalk.dim("  Second clip:"), second.id, `(${second.duration.toFixed(2)}s)`);
@@ -567,6 +701,21 @@ timelineCommand
       await writeFile(filePath, JSON.stringify(project.toJSON(), null, 2), "utf-8");
 
       spinner.succeed(chalk.green(`Clip duplicated: ${duplicated.id}`));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "timeline duplicate",
+          startedAt,
+          data: {
+            id: duplicated.id,
+            sourceClipId: clipId,
+            startTime: duplicated.startTime,
+            duration: duplicated.duration,
+          },
+        });
+        return;
+      }
+
       console.log();
       console.log(chalk.dim("  Start:"), duplicated.startTime, "s");
       console.log(chalk.dim("  Duration:"), duplicated.duration, "s");
@@ -625,6 +774,18 @@ timelineCommand
       await writeFile(filePath, JSON.stringify(project.toJSON(), null, 2), "utf-8");
 
       spinner.succeed(chalk.green("Clip deleted"));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "timeline delete",
+          startedAt,
+          data: {
+            id: clipId,
+            deleted: true,
+          },
+        });
+        return;
+      }
     } catch (error) {
       spinner.fail("Failed to delete clip");
       const msg = error instanceof Error ? error.message : String(error);
@@ -689,6 +850,20 @@ timelineCommand
 
       const updated = project.getClip(clipId)!;
       spinner.succeed(chalk.green("Clip moved"));
+
+      if (isJsonMode()) {
+        outputSuccess({
+          command: "timeline move",
+          startedAt,
+          data: {
+            id: updated.id,
+            trackId: updated.trackId,
+            startTime: updated.startTime,
+          },
+        });
+        return;
+      }
+
       console.log();
       console.log(chalk.dim("  Track:"), updated.trackId);
       console.log(chalk.dim("  Start:"), updated.startTime, "s");


### PR DESCRIPTION
## Summary

Closes the audit-flagged blocker from #192: commands that emitted human text to stdout when \`--json\` was on (or when piped via auto-JSON) didn't emit a JSON envelope at all. Agents got polluted stdout with no machine-readable success signal.

After this PR, the following commands emit clean JSON in \`--json\` (or non-TTY) mode:

## Files

| File | Commands fixed | Notes |
|---|---|---|
| \`timeline.ts\` | add-source, add-clip, add-track, add-effect, trim, list, split, duplicate, delete, move | 10/10 \`.action()\` blocks. \`list\` restructured to share data extraction between JSON and human render so they stay in sync. |
| \`project.ts\` | create, info, set | All 3 previously emitted human text without a JSON envelope. |
| \`export.ts\` | \`export video\` (FFmpeg path) | Hyperframes path already had outputSuccess from sweep-2. |

## Smoke tests (non-TTY, piped)

\`\`\`
$ vibe timeline add-source proj.json /tmp/x.mp4 -t video --json | jq .data.id
\"1777391906290-w6pinzpn4\"

$ vibe project create /tmp/cov-test -o /tmp/cov-test.vibe.json --json
{
  \"command\": \"project create\",
  \"elapsedMs\": 2,
  \"costUsd\": 0,
  \"warnings\": [],
  \"data\": { \"outputPath\": \"...\", \"name\": \"cov-test\", \"aspectRatio\": \"16:9\", \"frameRate\": 30 }
}

$ vibe project info /tmp/cov-test.vibe.json --json
{
  \"command\": \"project info\",
  \"elapsedMs\": 2, ...,
  \"data\": { \"name\": \"cov-test\", \"duration\": 0, \"trackCount\": 2, \"clipCount\": 0, \"sourceCount\": 0, ... }
}
\`\`\`

## Test fix

3 \`timeline list\` tests in \`timeline.test.ts\` were asserting on human text labels (\"Sources\", \"Tracks\", \"Clips\"). Auto-JSON mode kicks in for \`execSync\`'s non-TTY stdout, so they were getting JSON instead. Tests now set \`VIBE_HUMAN_OUTPUT=1\` to force human render — same intent, just explicit about which mode they're testing.

## scene.ts + doctor.ts

Verified by the agent — both already clean from previous sweeps. Their \`if (isJsonMode())\` early-return blocks happen before any \`console.log\`.

## Auto-JSON behavior (worth knowing)

\`packages/cli/src/index.ts:119\` sets \`VIBE_JSON_OUTPUT=1\` whenever \`stdout.isTTY\` is false (unless \`VIBE_HUMAN_OUTPUT\` is set). This means **piping any command into a tool triggers JSON mode automatically**, no \`--json\` flag needed. So \"clean stdout in JSON mode\" really means \"clean stdout when piped into anything\". Coverage of this PR ensures that contract holds for timeline / project / export.

## Out of scope (defer to 2d / 2e / follow-ups)

- Other commands using raw \`console.log\` instead of \`log()\` helper that may pollute stdout if they bypass \`output.ts\` patterns. Audit doesn't list specific blockers but a sweep wouldn't hurt.
- Adding \`--json\` to demo, walkthrough, agent (interactive REPLs by design)

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm -F @vibeframe/cli exec vitest run\` — 700 passed, 9 skipped, 0 failed
- [x] \`bash scripts/sync-counts.sh --check\` — green
- [x] Smoke tests on stdout-only output (head -1 returns \`{\` not human text)