### PR TITLE
fix(cli): replace explicit any with proper types (#207)

### DIFF
--- a/packages/cli/src/commands/ai-helpers.ts
+++ b/packages/cli/src/commands/ai-helpers.ts
@@ -5,7 +5,16 @@
  * ai.ts imports and re-uses these internally.
  */
 
+import type { EditSuggestion } from "@vibeframe/ai-providers";
+import type { EffectType } from "@vibeframe/core/timeline";
 import { Project } from "../engine/index.js";
+
+/**
+ * Minimal shape required by {@link applySuggestion}. Accepts the canonical
+ * {@link EditSuggestion} from the AI provider as well as the CLI's local
+ * `SuggestEditEntry`, which omits the optional `id`/`previewUrl`.
+ */
+export type ApplicableSuggestion = Pick<EditSuggestion, "type" | "clipIds" | "params">;
 
 /**
  * Download a video from URL, handling Veo/Google API authentication.
@@ -34,29 +43,45 @@ export function formatTime(seconds: number): string {
 }
 
 /** Apply a single AI edit suggestion to a project */
-export function applySuggestion(project: Project, suggestion: any): boolean {
+export function applySuggestion(project: Project, suggestion: ApplicableSuggestion): boolean {
   const { type, clipIds, params } = suggestion;
 
   if (clipIds.length === 0) return false;
   const clipId = clipIds[0];
 
   switch (type) {
-    case "trim":
-      if (params.newDuration) {
-        return project.trimClipEnd(clipId, params.newDuration);
+    case "trim": {
+      const newDuration = params.newDuration;
+      if (typeof newDuration === "number") {
+        return project.trimClipEnd(clipId, newDuration);
       }
       break;
-    case "add-effect":
-      if (params.effectType) {
+    }
+    case "add-effect": {
+      const effectType = params.effectType;
+      if (typeof effectType === "string") {
+        const startTime = typeof params.startTime === "number" ? params.startTime : 0;
+        const duration = typeof params.duration === "number" ? params.duration : 1;
+        const rawEffectParams =
+          params.effectParams && typeof params.effectParams === "object"
+            ? (params.effectParams as Record<string, unknown>)
+            : {};
+        const effectParams: Record<string, string | number | boolean> = {};
+        for (const [k, v] of Object.entries(rawEffectParams)) {
+          if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+            effectParams[k] = v;
+          }
+        }
         const effect = project.addEffect(clipId, {
-          type: params.effectType,
-          startTime: params.startTime || 0,
-          duration: params.duration || 1,
-          params: params.effectParams || {},
+          type: effectType as EffectType,
+          startTime,
+          duration,
+          params: effectParams,
         });
         return effect !== null;
       }
       break;
+    }
     case "delete":
       return project.removeClip(clipId);
   }

--- a/packages/cli/src/commands/ai-suggest-edit.ts
+++ b/packages/cli/src/commands/ai-suggest-edit.ts
@@ -8,11 +8,11 @@
  * @see MODELS.md for AI model configuration
  */
 
-import { readFile, writeFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { GeminiProvider } from '@vibeframe/ai-providers';
-import { Project, type ProjectFile } from '../engine/index.js';
-import { applySuggestion } from './ai-helpers.js';
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { GeminiProvider, type EditSuggestion } from "@vibeframe/ai-providers";
+import { Project, type ProjectFile } from "../engine/index.js";
+import { applySuggestion } from "./ai-helpers.js";
 
 export interface ExecuteSuggestEditOptions {
   projectPath: string;
@@ -20,8 +20,9 @@ export interface ExecuteSuggestEditOptions {
   apply?: boolean;
   apiKey?: string;
 }
+
 export interface SuggestEditEntry {
-  type: string;
+  type: EditSuggestion["type"];
   description: string;
   confidence: number;
   clipIds: string[];
@@ -36,7 +37,9 @@ export interface ExecuteSuggestEditResult {
   error?: string;
 }
 
-export async function executeSuggestEdit(options: ExecuteSuggestEditOptions): Promise<ExecuteSuggestEditResult> {
+export async function executeSuggestEdit(
+  options: ExecuteSuggestEditOptions
+): Promise<ExecuteSuggestEditResult> {
   try {
     const apiKey = options.apiKey ?? process.env.GOOGLE_API_KEY;
     if (!apiKey) return { success: false, error: "GOOGLE_API_KEY required for suggest" };
@@ -70,6 +73,9 @@ export async function executeSuggestEdit(options: ExecuteSuggestEditOptions): Pr
 
     return { success: true, suggestions };
   } catch (error) {
-    return { success: false, error: `Suggest failed: ${error instanceof Error ? error.message : String(error)}` };
+    return {
+      success: false,
+      error: `Suggest failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
   }
 }

--- a/packages/cli/src/commands/batch.test.ts
+++ b/packages/cli/src/commands/batch.test.ts
@@ -1,14 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execSync } from "child_process";
-import {
-  readFileSync,
-  writeFileSync,
-  mkdtempSync,
-  mkdirSync,
-  rmSync,
-} from "fs";
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from "fs";
 import { join, resolve } from "path";
 import { tmpdir } from "os";
+import type { ProjectFile } from "../engine/index.js";
+
+type SourceLike = ProjectFile["state"]["sources"][number];
+type ClipLike = ProjectFile["state"]["clips"][number];
 
 const CLI = `node ${resolve(__dirname, "../../dist/index.js")}`;
 
@@ -53,16 +51,16 @@ describe("batch commands", () => {
     });
 
     it("filters files by extension", () => {
-      execSync(
-        `${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`,
-        { cwd: tempDir, encoding: "utf-8" }
-      );
+      execSync(`${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`, {
+        cwd: tempDir,
+        encoding: "utf-8",
+      });
 
       const content = JSON.parse(readFileSync(projectFile, "utf-8"));
       expect(content.state.sources).toHaveLength(3);
-      expect(content.state.sources.every((s: any) => s.name.endsWith(".mp4"))).toBe(
-        true
-      );
+      expect(
+        (content as ProjectFile).state.sources.every((s: SourceLike) => s.name.endsWith(".mp4"))
+      ).toBe(true);
     });
 
     it("imports recursively", () => {
@@ -84,14 +82,14 @@ describe("batch commands", () => {
   describe("batch concat", () => {
     beforeEach(() => {
       // Import media first
-      execSync(
-        `${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`,
-        { cwd: tempDir, encoding: "utf-8" }
-      );
+      execSync(`${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`, {
+        cwd: tempDir,
+        encoding: "utf-8",
+      });
 
       // Set durations for sources
       const content = JSON.parse(readFileSync(projectFile, "utf-8"));
-      content.state.sources.forEach((s: any, i: number) => {
+      (content as ProjectFile).state.sources.forEach((s: SourceLike, i: number) => {
         s.duration = 5 + i; // 5, 6, 7 seconds
       });
       writeFileSync(projectFile, JSON.stringify(content, null, 2), "utf-8");
@@ -141,13 +139,13 @@ describe("batch commands", () => {
 
     beforeEach(() => {
       // Import and concat
-      execSync(
-        `${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`,
-        { cwd: tempDir, encoding: "utf-8" }
-      );
+      execSync(`${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`, {
+        cwd: tempDir,
+        encoding: "utf-8",
+      });
 
       let content = JSON.parse(readFileSync(projectFile, "utf-8"));
-      content.state.sources.forEach((s: any) => {
+      (content as ProjectFile).state.sources.forEach((s: SourceLike) => {
         s.duration = 5;
       });
       writeFileSync(projectFile, JSON.stringify(content, null, 2), "utf-8");
@@ -158,7 +156,7 @@ describe("batch commands", () => {
       });
 
       content = JSON.parse(readFileSync(projectFile, "utf-8"));
-      clipIds = content.state.clips.map((c: any) => c.id);
+      clipIds = (content as ProjectFile).state.clips.map((c: ClipLike) => c.id);
     });
 
     it("applies effect to all clips", () => {
@@ -175,20 +173,20 @@ describe("batch commands", () => {
     });
 
     it("applies effect with custom duration", () => {
-      execSync(
-        `${CLI} batch apply-effect "${projectFile}" fadeOut --all -d 2`,
-        { cwd: tempDir, encoding: "utf-8" }
-      );
+      execSync(`${CLI} batch apply-effect "${projectFile}" fadeOut --all -d 2`, {
+        cwd: tempDir,
+        encoding: "utf-8",
+      });
 
       const content = JSON.parse(readFileSync(projectFile, "utf-8"));
       expect(content.state.clips[0].effects[0].duration).toBe(2);
     });
 
     it("applies effect to specific clips", () => {
-      execSync(
-        `${CLI} batch apply-effect "${projectFile}" blur ${clipIds[0]} ${clipIds[2]}`,
-        { cwd: tempDir, encoding: "utf-8" }
-      );
+      execSync(`${CLI} batch apply-effect "${projectFile}" blur ${clipIds[0]} ${clipIds[2]}`, {
+        cwd: tempDir,
+        encoding: "utf-8",
+      });
 
       const content = JSON.parse(readFileSync(projectFile, "utf-8"));
       expect(content.state.clips[0].effects).toHaveLength(1);
@@ -200,13 +198,13 @@ describe("batch commands", () => {
   describe("batch remove-clips", () => {
     beforeEach(() => {
       // Import and concat
-      execSync(
-        `${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`,
-        { cwd: tempDir, encoding: "utf-8" }
-      );
+      execSync(`${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`, {
+        cwd: tempDir,
+        encoding: "utf-8",
+      });
 
       const content = JSON.parse(readFileSync(projectFile, "utf-8"));
-      content.state.sources.forEach((s: any) => {
+      (content as ProjectFile).state.sources.forEach((s: SourceLike) => {
         s.duration = 5;
       });
       writeFileSync(projectFile, JSON.stringify(content, null, 2), "utf-8");
@@ -247,13 +245,13 @@ describe("batch commands", () => {
   describe("batch info", () => {
     beforeEach(() => {
       // Import and concat
-      execSync(
-        `${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`,
-        { cwd: tempDir, encoding: "utf-8" }
-      );
+      execSync(`${CLI} batch import "${projectFile}" "${mediaDir}" --filter ".mp4"`, {
+        cwd: tempDir,
+        encoding: "utf-8",
+      });
 
       const content = JSON.parse(readFileSync(projectFile, "utf-8"));
-      content.state.sources.forEach((s: any) => {
+      (content as ProjectFile).state.sources.forEach((s: SourceLike) => {
         s.duration = 5;
       });
       writeFileSync(projectFile, JSON.stringify(content, null, 2), "utf-8");

--- a/packages/cli/src/commands/timeline.ts
+++ b/packages/cli/src/commands/timeline.ts
@@ -5,9 +5,16 @@ import { resolve, basename, extname } from "node:path";
 import chalk from "chalk";
 import ora from "ora";
 import { Project, type ProjectFile } from "../engine/index.js";
-import type { MediaType } from "@vibeframe/core/timeline";
+import type { MediaType, EffectType } from "@vibeframe/core/timeline";
 import { validateResourceId } from "./validate.js";
-import { exitWithError, generalError, isJsonMode, notFoundError, outputSuccess, usageError } from "./output.js";
+import {
+  exitWithError,
+  generalError,
+  isJsonMode,
+  notFoundError,
+  outputSuccess,
+  usageError,
+} from "./output.js";
 import { applyTiers } from "./_shared/cost-tier.js";
 import { resolveTimelineFile } from "../utils/project-resolver.js";
 import {
@@ -18,7 +25,9 @@ import {
 
 export const timelineCommand = new Command("timeline")
   .description("Low-level timeline JSON commands")
-  .addHelpText("after", `
+  .addHelpText(
+    "after",
+    `
 Examples:
   $ vibe timeline create my-video                               # my-video/timeline.json
   $ vibe timeline add-source my-video video.mp4                 # Returns source ID
@@ -30,7 +39,8 @@ Examples:
 
 Typical workflow: create → add-source → add-clip → trim-clip/split-clip → export
 Cost: Free (no API keys needed).
-Run 'vibe schema timeline.<command>' for structured parameter info.`);
+Run 'vibe schema timeline.<command>' for structured parameter info.`
+  );
 
 timelineCommand
   .command("create")
@@ -283,7 +293,9 @@ timelineCommand
       const project = Project.fromJSON(data);
 
       const existingTracks = project.getTracksByType(type as MediaType);
-      const trackName = options.name || `${type.charAt(0).toUpperCase() + type.slice(1)} ${existingTracks.length + 1}`;
+      const trackName =
+        options.name ||
+        `${type.charAt(0).toUpperCase() + type.slice(1)} ${existingTracks.length + 1}`;
       const order = project.getTracks().length;
 
       const track = project.addTrack({
@@ -327,7 +339,10 @@ timelineCommand
   .description("Add an effect to a clip")
   .argument("<project>", "Timeline file or directory")
   .argument("<clip-id>", "Clip ID")
-  .argument("<effect-type>", "Effect type (fadeIn, fadeOut, blur, brightness, contrast, saturation, speed, volume)")
+  .argument(
+    "<effect-type>",
+    "Effect type (fadeIn, fadeOut, blur, brightness, contrast, saturation, speed, volume)"
+  )
   .option("--start <seconds>", "Effect start time (relative to clip)", "0")
   .option("-d, --duration <seconds>", "Effect duration (defaults to clip duration)")
   .option("--params <json>", "Effect parameters as JSON", "{}")
@@ -374,7 +389,7 @@ timelineCommand
       const params = JSON.parse(options.params);
 
       const effect = project.addEffect(clipId, {
-        type: effectType as any,
+        type: effectType as EffectType,
         startTime,
         duration,
         params,
@@ -582,7 +597,9 @@ timelineCommand
             track.isMuted ? "muted" : null,
             track.isLocked ? "locked" : null,
             !track.isVisible ? "hidden" : null,
-          ].filter(Boolean).join(", ");
+          ]
+            .filter(Boolean)
+            .join(", ");
           console.log(`  ${chalk.yellow(track.id)}`);
           console.log(`    ${track.name} (${track.type})${status ? ` [${status}]` : ""}`);
         }
@@ -598,7 +615,9 @@ timelineCommand
           for (const clip of clips) {
             const source = project.getSource(clip.sourceId);
             console.log(`  ${chalk.yellow(clip.id)}`);
-            console.log(`    ${source?.name || "unknown"} @ ${clip.startTime}s (${clip.duration}s)`);
+            console.log(
+              `    ${source?.name || "unknown"} @ ${clip.startTime}s (${clip.duration}s)`
+            );
             if (clip.effects.length > 0) {
               console.log(`    Effects: ${clip.effects.map((e) => e.type).join(", ")}`);
             }
@@ -935,10 +954,10 @@ function detectMediaType(path: string): MediaType {
 // no FFmpeg renders. Tag every one as `free` so `vibe schema --filter free`
 // finds them and the doctor's cost mix counts them honestly.
 applyTiers(timelineCommand, {
-  "create": "free",
-  "info": "free",
-  "set": "free",
-  "list": "free",
+  create: "free",
+  info: "free",
+  set: "free",
+  list: "free",
   "add-source": "free",
   "add-clip": "free",
   "add-track": "free",


### PR DESCRIPTION
Closes the 8 `@typescript-eslint/no-explicit-any` warnings listed in #207.

### Changes
- **ai-helpers.ts** — introduce local `ApplicableSuggestion` interface derived from `EditSuggestion` (imported from `@vibeframe/ai-providers`); replaces `suggestion: any`.
- **ai-suggest-edit.ts** — re-export `EditSuggestion` as a type and narrow `SuggestEditEntry.type` to `EditSuggestion['type']` via indexed access so the union stays in sync with the provider package.
- **timeline.ts** — import `EffectType` from `@vibeframe/core/timeline` and use it instead of `as any`.
- **batch.test.ts** — import `ProjectFile` and replace 6 `: any` sites with `as ProjectFile` casts on the parsed test fixtures.

### Verification
- `pnpm -F @vibeframe/cli lint` — the 8 warnings listed in #207 are gone.
- `pnpm -F @vibeframe/cli exec tsc --noEmit` — clean, 0 errors.
- `vitest run src/commands/batch.test.ts` — 12/12 passing.

### Out of scope
The CLI package currently has 2 additional `no-explicit-any` warnings in `scene-build.test.ts:209,214` that aren't listed in #207 (file drift since the issue was filed). Happy to address in a follow-up PR — initial attempt with `unknown` cascaded into 12+ unrelated narrowing fixes, so I kept this PR scoped to the issue.

Refs #207