### PR TITLE
fix(cli): replace Record<string, any> with typed BuildReport in scene-build tests

### DIFF
--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -9,7 +9,7 @@ import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { executeSceneBuild } from "./scene-build.js";
+import { executeSceneBuild, type BuildReport } from "./scene-build.js";
 import { buildEmptyRootHtml } from "./scene-project.js";
 
 // ── Module mocks (must be hoisted before the imported module loads) ─────
@@ -232,12 +232,12 @@ afterEach(() => {
   delete process.env.VIBE_BUILD_MODE;
 });
 
-function readBuildReport(): Record<string, any> {
+function readBuildReport(): BuildReport {
   return JSON.parse(readFileSync(join(projectDir, "build-report.json"), "utf-8"));
 }
 
 function expectBuildReportContract(
-  report: Record<string, any>,
+  report: BuildReport,
   expected: Record<string, unknown> = {}
 ): void {
   expect(report).toMatchObject({
@@ -557,7 +557,7 @@ backdrop: "../outside.png"
       selectedStage: "sync",
       success: true,
     });
-    expect(report.stageReports.render.status).toBe("skipped");
+    expect(report.stageReports!.render.status).toBe("skipped");
   });
 
   it("writes a stable beat-only assets build-report contract", async () => {
@@ -741,7 +741,7 @@ backdrop: "This should not dispatch."
       currentStage: "assets",
     });
     expect(report.code).toBe("STORYBOARD_VALIDATION_FAILED");
-    expect(report.validation.ok).toBe(false);
+    expect(report.validation!.ok).toBe(false);
     expect(report.retryWith).toEqual(r.retryWith);
   });
 

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -2118,7 +2118,9 @@ async function finalizeBuildResult(
   return withMeta;
 }
 
-function toBuildReport(projectDir: string, result: SceneBuildResult): Record<string, unknown> {
+export type BuildReport = ReturnType<typeof toBuildReport>;
+
+function toBuildReport(projectDir: string, result: SceneBuildResult) {
   let beatCursor = 0;
   return {
     schemaVersion: "1",


### PR DESCRIPTION
Closes #207

## What

Replaces the two `Record<string, any>` annotations in `scene-build.test.ts` with a properly typed `BuildReport`.

## How

- Export `type BuildReport = ReturnType<typeof toBuildReport>` from `scene-build.ts` (single source of truth, auto-tracks the report shape)
- Use it in `readBuildReport()` and `expectBuildReportContract()` in the test
- Tighten two optional-field accesses (`report.stageReports!.render`, `report.validation!.ok`) where the test path guarantees they exist

## Why this shape

Hand-writing a parallel `BuildReport` interface would be ~80 lines of types that drift from `toBuildReport`'s actual return value. `ReturnType<typeof ...>` keeps it impossible to drift.

## Scope

Intentionally narrow:
- `scene-build.ts` (1 type alias + return-type change)
- `scene-build.test.ts` (import + 2 annotation swaps + 2 `!` non-null assertions)

Downstream consumers (`status.ts`, `inspect.ts`) already only consume the JSON file via `readFileSync` + `JSON.parse`, so this PR doesn't touch them.

## Verification

```
pnpm -F @vibeframe/cli test scene-build
# Test Files  2 passed (2)
# Tests       33 passed (33)
```