### PR TITLE
Fix host app MCP setup and package smoke

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -13,3 +13,10 @@ multi_agent = true
 
 [tools]
 view_image = true
+
+# >>> VibeFrame MCP server >>>
+[mcp_servers.vibeframe]
+command = "npx"
+args = ["-y", "@vibeframe/mcp-server"]
+enabled = true
+# <<< VibeFrame MCP server <<<

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "vibeframe": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@vibeframe/mcp-server"
+      ]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.106.5] - 2026-06-10
+
+### Added
+
+- add Codex, Claude, and Cursor host app setup commands
+
+### Fixed
+
+- make the MCP server bundle runnable from clean npx installs
+
+### Testing
+
+- smoke test packed MCP server startup and tools/list responses
+
 ## [0.106.4] - 2026-06-07
+
+### Fixed
+
+- build cli before mcp server in installer
+
+## [0.106.3] - 2026-06-07
 
 ### CI/CD
 
@@ -14,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- build cli before mcp server in installer
 - handle root help and version shortcut
 
 ## [0.106.2] - 2026-06-07
@@ -1910,5 +1929,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Debug
 
 - add REPL startup logging
-
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,17 @@ helps humans and AI coding agents turn a written brief into `STORYBOARD.md`,
 `DESIGN.md`, generated assets, timed scene compositions, review reports, and a
 final MP4.
 
-The primary interface is plain shell commands with JSON output, dry runs,
-cost gates, deterministic project files, and machine-readable reports that
-Codex, Claude Code, Cursor, and other coding agents can act on. VibeFrame also
-includes FFmpeg-style editing commands, AI media primitives, YAML pipelines,
-and an optional MCP server, but the north-star path is the storyboard-driven
-project loop.
+VibeFrame is **CLI-first, not terminal-only**. The CLI is the stable runtime:
+JSON output, dry runs, cost gates, deterministic project files, and
+machine-readable reports that Codex, Claude Code, Cursor, and other host apps
+can act on. VibeFrame also includes FFmpeg-style editing commands, AI media
+primitives, YAML pipelines, and an optional MCP server, but the north-star path
+is the storyboard-driven project loop.
 
-Most users do not need a new chat UI. Use VibeFrame from your terminal,
-Claude Code, Codex, Cursor, Aider, Gemini CLI, OpenCode, or any other agent
-that can run shell commands. `vibe agent` exists as an optional built-in
+Most users do not need a new chat UI. Install the runtime once, then ask Codex,
+Claude Code, Cursor, Aider, Gemini CLI, OpenCode, or any other shell-capable
+agent to operate the video project. For app hosts that prefer typed tools, use
+`vibe host setup` to configure MCP. `vibe agent` exists as an optional built-in
 fallback when you do not already have an AI coding agent.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -45,6 +46,7 @@ EOF
 
 vibe setup --scope project
 vibe init launch --from brief.md --json
+vibe host setup all launch # optional: print Codex/Claude/Cursor app config
 
 # Ask Codex, Claude Code, Cursor, or another host agent:
 # "Research this topic and update launch/STORYBOARD.md and launch/DESIGN.md.
@@ -399,11 +401,25 @@ guidance files, not a separate VibeFrame chat surface.
 Code, Codex, Cursor, Aider, Gemini CLI, OpenCode, and a universal `AGENTS.md`
 fallback.
 
+`vibe host` turns that guidance into app-ready configuration for Codex, Claude,
+and Cursor:
+
+```bash
+vibe host list --json
+vibe host setup all              # print snippets only
+vibe host setup cursor --write   # write .cursor/mcp.json
+vibe host doctor all --json      # verify guidance + MCP config
+```
+
+By default, `vibe host setup` does **not** modify files; pass `--write` to
+apply the printed config. Claude Desktop global config is also opt-in and is
+backed up before merge.
+
 How agents discover the right command:
 
 - Claude Code reads `CLAUDE.md`, which imports `AGENTS.md`.
-- Codex reads `AGENTS.md` directly.
-- Cursor/OpenCode can use `AGENTS.md` and MCP.
+- Codex reads `AGENTS.md` directly, and can load `.codex/config.toml` for MCP.
+- Cursor can use `AGENTS.md`, `.cursor/rules`, and `.cursor/mcp.json`.
 - Every host can fall back to `vibe schema`, `vibe context`, `vibe doctor`,
   and `vibe guide`.
 
@@ -423,8 +439,14 @@ the CLI through `AGENTS.md`, `--json`, `--dry-run`, `vibe context`, and
 
 ## MCP Server
 
-The CLI is the primary interface. For hosts that prefer MCP, VibeFrame also
-ships `@vibeframe/mcp-server`.
+The CLI is the primary runtime. For hosts that prefer MCP, VibeFrame also
+ships `@vibeframe/mcp-server`. Generate host-specific snippets with:
+
+```bash
+vibe host setup codex
+vibe host setup claude
+vibe host setup cursor
+```
 
 ```json
 {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -413,16 +413,21 @@ export default function LandingPage() {
               <span>Use with your AI agent</span>
             </div>
             <h2 className="text-3xl sm:text-4xl font-bold mb-4">
-              Natural language, report-driven commands
+              CLI-first, not terminal-only
             </h2>
             <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-              Describe the video. Your coding agent edits project files, calls
+              Describe the video in Codex, Claude, Cursor, or a terminal. Your host agent edits
+              project files, calls
               <code className="text-primary bg-primary/10 px-2 py-0.5 rounded mx-1">vibe</code>
               with JSON output, then uses reports for the next pass.
             </p>
           </div>
 
           <div className="space-y-4 max-w-3xl mx-auto mb-12">
+            <AgentCommandExample
+              input="Connect this repo to my AI apps"
+              command="vibe host setup all && vibe host doctor all --json"
+            />
             <AgentCommandExample
               input="Build a 45-second launch video from brief.md and media/"
               command="vibe init launch --from brief.md --json && vibe build launch --dry-run --json"
@@ -443,18 +448,30 @@ export default function LandingPage() {
               <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
                 vibe doctor
               </code>{" "}
-              auto-detects six host families today and{" "}
+              auto-detects host families and{" "}
               <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
-                vibe init
+                vibe host setup
               </code>{" "}
-              scaffolds the right project file for each.
+              prints or writes Codex, Claude, and Cursor integration config.
             </p>
           </div>
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3 max-w-4xl mx-auto">
             {[
-              { name: "Claude Code", scaffold: "CLAUDE.md + AGENTS.md", note: "project guidance" },
-              { name: "OpenAI Codex", scaffold: "AGENTS.md", note: "agents.md spec" },
-              { name: "Cursor", scaffold: "AGENTS.md + .cursor/rules", note: "MCP-ready" },
+              {
+                name: "OpenAI Codex",
+                scaffold: "AGENTS.md + .codex/config.toml",
+                note: "shell + MCP",
+              },
+              {
+                name: "Claude Code",
+                scaffold: "CLAUDE.md + .mcp.json",
+                note: "shell + optional MCP",
+              },
+              {
+                name: "Cursor",
+                scaffold: ".cursor/rules + .cursor/mcp.json",
+                note: "rules + MCP",
+              },
               { name: "Aider", scaffold: "AGENTS.md", note: "binary-detected" },
               { name: "Gemini CLI", scaffold: "AGENTS.md", note: "universal fallback" },
               { name: "OpenCode", scaffold: "AGENTS.md", note: "MCP-ready" },
@@ -475,7 +492,11 @@ export default function LandingPage() {
             <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs mx-1">
               AGENTS.md
             </code>
-            fallback.
+            fallback; app hosts can add typed tools with
+            <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs mx-1">
+              vibe host setup
+            </code>
+            .
           </p>
         </div>
       </section>
@@ -566,9 +587,9 @@ export default function LandingPage() {
                 <div>
                   <h2 className="text-2xl sm:text-3xl font-bold mb-2">MCP Ready</h2>
                   <p className="text-muted-foreground">
-                    {process.env.NEXT_PUBLIC_MCP_TOOLS} tools for Claude Desktop, Cursor, OpenCode,
-                    or Claude Code. MCP is optional; use it when your host prefers typed JSON-RPC
-                    tool calls over shell commands.
+                    {process.env.NEXT_PUBLIC_MCP_TOOLS} tools for Claude Desktop, Cursor, Claude
+                    Code, and Codex project configs. MCP is optional; use it when your host prefers
+                    typed JSON-RPC tool calls over shell commands.
                   </p>
                 </div>
               </div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.106.4",
+  "version": "0.106.5",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,13 @@ vibe schema --list --json
 vibe schema <command.path> --json
 ```
 
+For Codex, Claude, and Cursor app setup, use:
+
+```bash
+vibe host setup all
+vibe host doctor all --json
+```
+
 ## Public Docs
 
 - [CLI reference](cli-reference.md) - generated command catalog from the live

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.106.4`
+> CLI version: `0.106.5`
 
 ## Mental model
 
@@ -94,7 +94,7 @@ surface, and inspect `replacement` on legacy commands before using them.
 | ------------ | ----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Public**   |    36 | `generate.image` · `generate.video` · `generate.narration` · `generate.sound-effect` · `generate.music` · `generate.thumbnail` · `edit.silence-cut` · `edit.caption` · `edit.noise-reduce` · `edit.jump-cut` · +26 more   |
 | **Agent**    |     8 | `storyboard.list` · `storyboard.get` · `storyboard.set` · `storyboard.move` · `run` · `scene.lint` · `scene.repair` · `context`                                                                                           |
-| **Advanced** |    40 | `generate.motion` · `generate.video-cancel` · `generate.video-extend` · `edit.fade` · `edit.translate-srt` · `edit.fill-gaps` · `edit.motion-overlay` · `edit.grade` · `edit.text-overlay` · `edit.speed-ramp` · +30 more |
+| **Advanced** |    43 | `generate.motion` · `generate.video-cancel` · `generate.video-extend` · `edit.fade` · `edit.translate-srt` · `edit.fill-gaps` · `edit.motion-overlay` · `edit.grade` · `edit.text-overlay` · `edit.speed-ramp` · +33 more |
 | **Legacy**   |     8 | `generate.speech` · `generate.music-status` · `generate.storyboard` · `generate.background` · `generate.video-status` · `inspect.video` · `inspect.review` · `remix.regenerate-scene`                                     |
 | **Internal** |     2 | `scene.install-skill` · `scene.compose-prompts`                                                                                                                                                                           |
 
@@ -106,7 +106,7 @@ listed in their command sections for compatibility.
 
 | Tier           | Count | Examples                                                                                                                                                                    | Per-call cost                                                                                     |
 | -------------- | ----: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Free**       |    46 | `audio.duck` · `detect.beats` · `detect.scenes` · `detect.silence` · `edit.noise-reduce` · `generate.thumbnail` · `inspect.project` · `scene.list-styles` · +38 more        | FFmpeg only, no API call                                                                          |
+| **Free**       |    49 | `audio.duck` · `detect.beats` · `detect.scenes` · `detect.silence` · `edit.noise-reduce` · `generate.thumbnail` · `inspect.project` · `scene.list-styles` · +41 more        | FFmpeg only, no API call                                                                          |
 | **Low**        |    22 | `audio.transcribe` · `edit.caption` · `edit.jump-cut` · `edit.silence-cut` · `generate.music` · `generate.narration` · `generate.sound-effect` · `inspect.media` · +14 more | $0.01–$0.10 per call                                                                              |
 | **High**       |    10 | `audio.dub` · `edit.reframe` · `edit.upscale` · `generate.image` · `remix.auto-shorts` · `remix.highlights` · `edit.image` · `generate.motion` · +2 more                    | $1–$5 per call                                                                                    |
 | **Very High**  |     4 | `generate.video` · `edit.fill-gaps` · `generate.video-extend` · `remix.regenerate-scene`                                                                                    | $5–$50+ per call                                                                                  |
@@ -326,6 +326,7 @@ Cost tier: _not tagged_
 - `duration` _(number)_ _(default: `10`)_ — Default scene/root duration in seconds
 - `visualStyle` _(string)_ — Seed scene DESIGN.md from a named style
 - `agent` _(string)_ _(default: `"auto"`)_ — Agent target: claude-code | codex | cursor | aider | gemini-cli | opencode | all | auto
+- `mcp` _(boolean)_ — Also write project-scoped MCP config for Codex/Claude Code/Cursor
 - `force` _(boolean)_ — Overwrite existing files instead of skipping
 - `dryRun` _(boolean)_ — Print the file list without writing anything
 
@@ -1943,3 +1944,44 @@ Cost tier: `free`
 - `refresh` _(boolean)_ — Refresh active supported jobs before summarizing
 
 JSON payload: `data.kind` is `"project"` and includes `status`, `currentStage`, `beats` readiness counts, `jobs.latest`, `build`, `review`, `warnings`, and `retryWith`. `review` includes `mode`, issue/error/warning/info counts, `fixOwners`, `sourceReports`, and `retryWith`; top-level `retryWith` is the resume contract.
+
+### `host`
+
+#### `vibe host doctor`
+
+Check Codex/Claude/Cursor app integration readiness
+
+Product surface: `advanced`
+
+Cost tier: `free`
+
+**Parameters:**
+
+- `host` _(string)_ — Host target: codex | claude | claude-code | claude-desktop | cursor | all
+- `project-dir` _(string)_ — Project directory to inspect
+
+#### `vibe host list`
+
+List supported app hosts and integration surfaces
+
+Product surface: `advanced`
+
+Cost tier: `free`
+
+_No parameters._
+
+#### `vibe host setup`
+
+Print or write Codex/Claude/Cursor MCP and project integration config
+
+Product surface: `advanced`
+
+Cost tier: `free`
+
+**Parameters:**
+
+- `host` _(string)_ — Host target: codex | claude | claude-code | claude-desktop | cursor | all
+- `project-dir` _(string)_ — Project directory for project-scoped config
+- `write` _(boolean)_ — Write config files instead of printing snippets only
+- `dryRun` _(boolean)_ — Show file actions without writing
+- `force` _(boolean)_ — Replace an existing vibeframe MCP entry

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -17,6 +17,7 @@ Use these commands first:
 ```bash
 mkdir -p my-video/media
 vibe init my-video --from "45-second launch video"
+vibe host setup all my-video
 vibe storyboard validate my-video
 vibe plan my-video
 vibe build my-video --dry-run --max-cost 5
@@ -61,6 +62,13 @@ asset: "media/logo.png"
 | `full`    | You want all render/backend files up front                              | authoring docs, agent guidance, render scaffold |
 
 The default is `agent`.
+
+Pass `--mcp` to `vibe init` when you want project-scoped MCP config for Codex,
+Claude Code, and Cursor created during init:
+
+```bash
+vibe init my-video --from brief.md --mcp
+```
 
 ## Backend Metadata
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeframe",
-  "version": "0.106.4",
-  "description": "AI-native video editing tool. CLI-first, MCP-ready.",
+  "version": "0.106.5",
+  "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",
   "repository": {

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.106.4",
+  "version": "0.106.5",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.106.4",
-  "description": "VibeFrame CLI - natural language video editing from the terminal",
+  "version": "0.106.5",
+  "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -2517,6 +2517,75 @@ exports[`CLI --describe schemas (drift detection) > vibe guide --describe 1`] = 
 }
 `;
 
+exports[`CLI --describe schemas (drift detection) > vibe host doctor --describe 1`] = `
+{
+  "cost": "free",
+  "description": "Check Codex/Claude/Cursor app integration readiness",
+  "name": "host.doctor",
+  "parameters": {
+    "properties": {
+      "host": {
+        "description": "Host target: codex | claude | claude-code | claude-desktop | cursor | all",
+        "type": "string",
+      },
+      "project-dir": {
+        "description": "Project directory to inspect",
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+  "surface": "advanced",
+}
+`;
+
+exports[`CLI --describe schemas (drift detection) > vibe host list --describe 1`] = `
+{
+  "cost": "free",
+  "description": "List supported app hosts and integration surfaces",
+  "name": "host.list",
+  "parameters": {
+    "properties": {},
+    "type": "object",
+  },
+  "surface": "advanced",
+}
+`;
+
+exports[`CLI --describe schemas (drift detection) > vibe host setup --describe 1`] = `
+{
+  "cost": "free",
+  "description": "Print or write Codex/Claude/Cursor MCP and project integration config",
+  "name": "host.setup",
+  "parameters": {
+    "properties": {
+      "dryRun": {
+        "description": "Show file actions without writing",
+        "type": "boolean",
+      },
+      "force": {
+        "description": "Replace an existing vibeframe MCP entry",
+        "type": "boolean",
+      },
+      "host": {
+        "description": "Host target: codex | claude | claude-code | claude-desktop | cursor | all",
+        "type": "string",
+      },
+      "project-dir": {
+        "description": "Project directory for project-scoped config",
+        "type": "string",
+      },
+      "write": {
+        "description": "Write config files instead of printing snippets only",
+        "type": "boolean",
+      },
+    },
+    "type": "object",
+  },
+  "surface": "advanced",
+}
+`;
+
 exports[`CLI --describe schemas (drift detection) > vibe init --describe 1`] = `
 {
   "description": "Scaffold a VibeFrame project (video scene project or project-scope agent files)",
@@ -2545,6 +2614,10 @@ exports[`CLI --describe schemas (drift detection) > vibe init --describe 1`] = `
       "from": {
         "description": "Draft STORYBOARD.md and DESIGN.md from a brief string or text/markdown file",
         "type": "string",
+      },
+      "mcp": {
+        "description": "Also write project-scoped MCP config for Codex/Claude Code/Cursor",
+        "type": "boolean",
       },
       "profile": {
         "default": "agent",

--- a/packages/cli/src/commands/_shared/host-integration.test.ts
+++ b/packages/cli/src/commands/_shared/host-integration.test.ts
@@ -1,0 +1,101 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { hostDefinitions, planHostSetup, renderHostSnippet } from "./host-integration.js";
+
+let projectDir: string;
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), "vibe-host-integration-"));
+});
+
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+function host(id: string) {
+  const match = hostDefinitions(projectDir).find((h) => h.id === id);
+  if (!match) throw new Error(`missing host ${id}`);
+  return match;
+}
+
+describe("host integration helpers", () => {
+  it("renders a Codex TOML MCP snippet", () => {
+    expect(renderHostSnippet(host("codex"), projectDir)).toContain("[mcp_servers.vibeframe]");
+    expect(renderHostSnippet(host("codex"), projectDir)).toContain("@vibeframe/mcp-server");
+  });
+
+  it("renders a JSON MCP snippet for Cursor", () => {
+    const snippet = JSON.parse(renderHostSnippet(host("cursor"), projectDir));
+    expect(snippet.mcpServers.vibeframe.command).toBe("npx");
+    expect(snippet.mcpServers.vibeframe.args).toEqual(["-y", "@vibeframe/mcp-server"]);
+  });
+
+  it("snippet mode does not write files", async () => {
+    const plan = await planHostSetup(host("cursor"), projectDir, { write: false });
+    expect(plan.files.some((file) => file.status === "would-write")).toBe(true);
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(false);
+  });
+
+  it("writes Cursor MCP config while preserving other servers", async () => {
+    const configPath = join(projectDir, ".cursor", "mcp.json");
+    await mkdir(join(projectDir, ".cursor"), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({ mcpServers: { existing: { command: "node", args: ["server.js"] } } }),
+      "utf-8"
+    );
+
+    const plan = await planHostSetup(host("cursor"), projectDir, { write: true });
+    const json = JSON.parse(await readFile(configPath, "utf-8"));
+
+    expect(plan.files.find((file) => file.path === configPath)?.status).toBe("merged");
+    expect(json.mcpServers.existing.command).toBe("node");
+    expect(json.mcpServers.vibeframe.args).toEqual(["-y", "@vibeframe/mcp-server"]);
+  });
+
+  it("does not replace an existing MCP entry without --force", async () => {
+    const configPath = join(projectDir, ".cursor", "mcp.json");
+    await mkdir(join(projectDir, ".cursor"), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({ mcpServers: { vibeframe: { command: "custom", args: [] } } }),
+      "utf-8"
+    );
+
+    const plan = await planHostSetup(host("cursor"), projectDir, { write: true });
+    const json = JSON.parse(await readFile(configPath, "utf-8"));
+
+    expect(plan.files.find((file) => file.path === configPath)?.status).toBe("skipped-exists");
+    expect(json.mcpServers.vibeframe.command).toBe("custom");
+  });
+
+  it("creates and updates a Codex managed block", async () => {
+    const configPath = join(projectDir, ".codex", "config.toml");
+    await planHostSetup(host("codex"), projectDir, { write: true });
+    let toml = await readFile(configPath, "utf-8");
+
+    expect(toml).toContain("# >>> VibeFrame MCP server >>>");
+    expect(toml).toContain("[mcp_servers.vibeframe]");
+
+    await planHostSetup(host("codex"), projectDir, { write: true });
+    toml = await readFile(configPath, "utf-8");
+    expect(toml.match(/\[mcp_servers\.vibeframe\]/g)).toHaveLength(1);
+  });
+
+  it("preserves existing Codex settings when appending MCP config", async () => {
+    const configPath = join(projectDir, ".codex", "config.toml");
+    await mkdir(join(projectDir, ".codex"), { recursive: true });
+    await writeFile(configPath, "project_doc_max_bytes = 65536\n", "utf-8");
+
+    await planHostSetup(host("codex"), projectDir, { write: true });
+    const toml = await readFile(configPath, "utf-8");
+
+    expect(toml).toContain("project_doc_max_bytes = 65536");
+    expect(toml).toContain("[mcp_servers.vibeframe]");
+  });
+});

--- a/packages/cli/src/commands/_shared/host-integration.ts
+++ b/packages/cli/src/commands/_shared/host-integration.ts
@@ -1,0 +1,338 @@
+/**
+ * @module _shared/host-integration
+ *
+ * Host-app integration helpers for Codex, Claude, and Cursor.
+ * Default UX is snippet-first: print exactly what to paste, and only write
+ * files when the user passes an explicit --write flag.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type HostSetupId = "codex" | "claude-code" | "claude-desktop" | "cursor";
+export type HostSelection = HostSetupId | "claude" | "all";
+
+export const HOST_SELECTIONS: readonly HostSelection[] = [
+  "codex",
+  "claude",
+  "claude-code",
+  "claude-desktop",
+  "cursor",
+  "all",
+];
+
+export interface HostDefinition {
+  id: HostSetupId;
+  label: string;
+  surfaces: Array<"shell" | "project-guidance" | "mcp">;
+  guidanceFiles: string[];
+  configPath: (projectDir: string) => string;
+  configKind: "codex-toml" | "mcp-json";
+  notes: string[];
+}
+
+export interface HostFileAction {
+  path: string;
+  status: "would-write" | "wrote" | "would-merge" | "merged" | "skipped-exists" | "missing";
+  reason?: string;
+}
+
+export interface HostSetupPlan {
+  host: HostDefinition;
+  snippet: string;
+  command?: string;
+  configPath: string;
+  files: HostFileAction[];
+  warnings: string[];
+  nextSteps: string[];
+}
+
+export interface HostDoctorResult {
+  host: HostDefinition;
+  configPath: string;
+  configured: boolean;
+  guidanceFiles: HostFileAction[];
+  warnings: string[];
+  nextSteps: string[];
+}
+
+const VIBEFRAME_MCP_JSON = {
+  command: "npx",
+  args: ["-y", "@vibeframe/mcp-server"],
+};
+
+const CODEX_MCP_BLOCK = `[mcp_servers.vibeframe]
+command = "npx"
+args = ["-y", "@vibeframe/mcp-server"]
+enabled = true
+`;
+
+const CODEX_MANAGED_START = "# >>> VibeFrame MCP server >>>";
+const CODEX_MANAGED_END = "# <<< VibeFrame MCP server <<<";
+
+export function hostDefinitions(_projectDir = process.cwd()): HostDefinition[] {
+  return [
+    {
+      id: "codex",
+      label: "OpenAI Codex",
+      surfaces: ["shell", "project-guidance", "mcp"],
+      guidanceFiles: ["AGENTS.md"],
+      configPath: (dir: string) => join(resolve(dir), ".codex", "config.toml"),
+      configKind: "codex-toml",
+      notes: [
+        "Codex reads AGENTS.md and can also load project-scoped .codex/config.toml after the project is trusted.",
+        "Keep provider/auth keys in VibeFrame config or environment, not in project-local Codex config.",
+      ],
+    },
+    {
+      id: "claude-code",
+      label: "Claude Code",
+      surfaces: ["shell", "project-guidance", "mcp"],
+      guidanceFiles: ["AGENTS.md", "CLAUDE.md", ".claude/skills/hyperframes/"],
+      configPath: (dir: string) => join(resolve(dir), ".mcp.json"),
+      configKind: "mcp-json",
+      notes: [
+        "Claude Code can drive vibe directly through shell plus AGENTS.md/CLAUDE.md.",
+        "The MCP entry is optional and gives Claude Code a typed tool surface.",
+      ],
+    },
+    {
+      id: "claude-desktop",
+      label: "Claude Desktop",
+      surfaces: ["mcp"],
+      guidanceFiles: [],
+      configPath: (_dir: string) => claudeDesktopConfigPath(),
+      configKind: "mcp-json",
+      notes: [
+        "Claude Desktop uses MCP config rather than project shell commands.",
+        "With --write, VibeFrame backs up the existing config before merging.",
+      ],
+    },
+    {
+      id: "cursor",
+      label: "Cursor",
+      surfaces: ["shell", "project-guidance", "mcp"],
+      guidanceFiles: ["AGENTS.md", ".cursor/rules/hyperframes.mdc"],
+      configPath: (dir: string) => join(resolve(dir), ".cursor", "mcp.json"),
+      configKind: "mcp-json",
+      notes: [
+        "Cursor can use AGENTS.md/rules for shell-driven work and .cursor/mcp.json for typed MCP tools.",
+      ],
+    },
+  ];
+}
+
+export function resolveHostSelection(selection: HostSelection): HostSetupId[] {
+  if (selection === "all") return ["codex", "claude-code", "claude-desktop", "cursor"];
+  if (selection === "claude") return ["claude-code", "claude-desktop"];
+  return [selection];
+}
+
+export function renderHostSnippet(host: HostDefinition, _projectDir: string): string {
+  if (host.configKind === "codex-toml") return CODEX_MCP_BLOCK.trimEnd();
+  return JSON.stringify({ mcpServers: { vibeframe: VIBEFRAME_MCP_JSON } }, null, 2);
+}
+
+export function claudeCodeAddCommand(): string {
+  return "claude mcp add vibeframe --scope project -- npx -y @vibeframe/mcp-server";
+}
+
+export async function planHostSetup(
+  host: HostDefinition,
+  projectDir: string,
+  opts: { write?: boolean; dryRun?: boolean; force?: boolean }
+): Promise<HostSetupPlan> {
+  const configPath = host.configPath(projectDir);
+  const snippet = renderHostSnippet(host, projectDir);
+  const files: HostFileAction[] = [];
+  const warnings: string[] = [];
+  const nextSteps = hostNextSteps(host);
+
+  for (const relPath of host.guidanceFiles.filter((p) => !p.endsWith("/"))) {
+    const absPath = join(resolve(projectDir), relPath);
+    files.push({
+      path: absPath,
+      status: existsSync(absPath) ? "skipped-exists" : "missing",
+      reason: existsSync(absPath) ? "already present" : "run vibe init --agent all first",
+    });
+  }
+
+  if (!opts.write || opts.dryRun) {
+    files.push({
+      path: configPath,
+      status: opts.write ? "would-merge" : "would-write",
+      reason: opts.write ? "dry run" : "snippet only; pass --write to modify",
+    });
+    return { host, snippet, command: host.id === "claude-code" ? claudeCodeAddCommand() : undefined, configPath, files, warnings, nextSteps };
+  }
+
+  try {
+    const action =
+      host.configKind === "codex-toml"
+        ? await mergeCodexToml(configPath, { force: opts.force === true })
+        : await mergeMcpJson(configPath, {
+            force: opts.force === true,
+            backup: host.id === "claude-desktop",
+          });
+    files.push(action);
+  } catch (error) {
+    warnings.push(error instanceof Error ? error.message : String(error));
+  }
+
+  return { host, snippet, command: host.id === "claude-code" ? claudeCodeAddCommand() : undefined, configPath, files, warnings, nextSteps };
+}
+
+export async function inspectHost(host: HostDefinition, projectDir: string): Promise<HostDoctorResult> {
+  const configPath = host.configPath(projectDir);
+  const warnings: string[] = [];
+  const nextSteps = hostNextSteps(host);
+  const guidanceFiles = host.guidanceFiles.map((relPath) => {
+    const absPath = relPath.endsWith("/")
+      ? join(resolve(projectDir), relPath)
+      : join(resolve(projectDir), relPath);
+    return {
+      path: absPath,
+      status: existsSync(absPath) ? "skipped-exists" : "missing",
+      reason: existsSync(absPath) ? "present" : "missing",
+    } satisfies HostFileAction;
+  });
+
+  let configured = false;
+  if (existsSync(configPath)) {
+    try {
+      const content = await readFile(configPath, "utf-8");
+      configured =
+        host.configKind === "codex-toml"
+          ? /\[mcp_servers\.vibeframe\]/.test(content)
+          : hasVibeframeMcpServer(JSON.parse(content));
+    } catch (error) {
+      warnings.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  return { host, configPath, configured, guidanceFiles, warnings, nextSteps };
+}
+
+async function mergeMcpJson(
+  configPath: string,
+  opts: { force: boolean; backup: boolean }
+): Promise<HostFileAction> {
+  let root: Record<string, unknown> = {};
+  const exists = existsSync(configPath);
+  if (exists) {
+    const raw = await readFile(configPath, "utf-8");
+    try {
+      root = raw.trim() ? (JSON.parse(raw) as Record<string, unknown>) : {};
+    } catch (error) {
+      throw new Error(`Invalid JSON in ${configPath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  const mcpServers =
+    typeof root.mcpServers === "object" && root.mcpServers !== null && !Array.isArray(root.mcpServers)
+      ? (root.mcpServers as Record<string, unknown>)
+      : {};
+
+  if (mcpServers.vibeframe && !opts.force) {
+    return {
+      path: configPath,
+      status: "skipped-exists",
+      reason: "vibeframe MCP server already exists; pass --force to replace",
+    };
+  }
+
+  root.mcpServers = { ...mcpServers, vibeframe: VIBEFRAME_MCP_JSON };
+  await mkdir(dirname(configPath), { recursive: true });
+  if (exists && opts.backup) {
+    await writeFile(`${configPath}.bak-${timestamp()}`, await readFile(configPath, "utf-8"), "utf-8");
+  }
+  await writeFile(configPath, JSON.stringify(root, null, 2) + "\n", "utf-8");
+  return { path: configPath, status: exists ? "merged" : "wrote" };
+}
+
+async function mergeCodexToml(configPath: string, opts: { force: boolean }): Promise<HostFileAction> {
+  const exists = existsSync(configPath);
+  const block = `${CODEX_MANAGED_START}\n${CODEX_MCP_BLOCK}${CODEX_MANAGED_END}`;
+  if (!exists) {
+    await mkdir(dirname(configPath), { recursive: true });
+    await writeFile(configPath, `#:schema https://developers.openai.com/codex/config-schema.json\n\n${block}\n`, "utf-8");
+    return { path: configPath, status: "wrote" };
+  }
+
+  const raw = await readFile(configPath, "utf-8");
+  if (raw.includes(CODEX_MANAGED_START)) {
+    const updated = raw.replace(
+      new RegExp(`${escapeRegExp(CODEX_MANAGED_START)}[\\s\\S]*?${escapeRegExp(CODEX_MANAGED_END)}`),
+      block
+    );
+    await writeFile(configPath, ensureTrailingNewline(updated), "utf-8");
+    return { path: configPath, status: "merged", reason: "updated managed VibeFrame block" };
+  }
+
+  if (/\[mcp_servers\.vibeframe\]/.test(raw)) {
+    if (!opts.force) {
+      return {
+        path: configPath,
+        status: "skipped-exists",
+        reason: "vibeframe MCP table already exists; pass --force to replace",
+      };
+    }
+    const updated = raw.replace(/\n?\[mcp_servers\.vibeframe\][\s\S]*?(?=\n\[|$)/, `\n${block}\n`);
+    await writeFile(configPath, ensureTrailingNewline(updated), "utf-8");
+    return { path: configPath, status: "merged", reason: "replaced existing VibeFrame MCP table" };
+  }
+
+  await writeFile(configPath, `${ensureTrailingNewline(raw)}\n${block}\n`, "utf-8");
+  return { path: configPath, status: "merged" };
+}
+
+function hasVibeframeMcpServer(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const root = value as { mcpServers?: unknown };
+  if (!root.mcpServers || typeof root.mcpServers !== "object") return false;
+  return Object.prototype.hasOwnProperty.call(root.mcpServers, "vibeframe");
+}
+
+function hostNextSteps(host: HostDefinition): string[] {
+  if (host.id === "codex") {
+    return [
+      "Trust the project in Codex so .codex/config.toml is loaded.",
+      "Run /mcp in Codex to confirm the vibeframe server is connected.",
+    ];
+  }
+  if (host.id === "claude-code") {
+    return [
+      "Restart Claude Code or run /mcp to approve the project-scoped server.",
+      "Use AGENTS.md/CLAUDE.md for shell-driven vibe workflows.",
+    ];
+  }
+  if (host.id === "claude-desktop") {
+    return ["Restart Claude Desktop after updating its MCP config."];
+  }
+  return ["Restart Cursor or reload MCP servers, then ask Cursor to use the vibeframe MCP tools."];
+}
+
+function claudeDesktopConfigPath(): string {
+  const home = homedir();
+  if (process.platform === "darwin") {
+    return join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json");
+  }
+  if (process.platform === "win32") {
+    return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Claude", "claude_desktop_config.json");
+  }
+  return join(home, ".config", "Claude", "claude_desktop_config.json");
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function ensureTrailingNewline(value: string): string {
+  return value.endsWith("\n") ? value : `${value}\n`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -58,6 +58,8 @@ vibe schema --list             # full machine-readable catalog (80+)
 vibe schema --list --surface public  # small first-run/product command surface
 vibe schema generate.video     # JSON Schema for any single command
 vibe doctor                    # available providers + system health
+vibe host setup all            # print Codex/Claude/Cursor app integration snippets
+vibe host doctor all --json    # verify project guidance + MCP config
 vibe guide motion              # choose text-overlay vs motion-overlay vs generate motion
 vibe guide scene               # step-by-step authoring guide (scene)
 vibe guide pipeline            # step-by-step authoring guide (pipeline)
@@ -181,6 +183,22 @@ unless the user explicitly asks for a non-VibeFrame asset.
 
 \`.env\` is still supported as a gitignored fallback. Copy \`.env.example\`
 to start if you prefer environment variables.
+
+## App host setup
+
+VibeFrame is CLI-first, not terminal-only. Codex, Claude Code, and Cursor can
+drive the same project through shell commands, and app hosts can also use
+VibeFrame's MCP server as a typed tool surface.
+
+\`\`\`bash
+vibe host setup all         # print snippets only
+vibe host setup all --write # write project/app config
+vibe host doctor all --json # verify readiness
+\`\`\`
+
+Default setup is snippet-only; use \`--write\` when you want VibeFrame to merge
+the generated config. Keep provider keys in \`.vibeframe/config.yaml\`, user
+config, or env files — not in app host config.
 
 ### Composition rules (scene HTML)
 

--- a/packages/cli/src/commands/_shared/product-surface.ts
+++ b/packages/cli/src/commands/_shared/product-surface.ts
@@ -15,6 +15,7 @@ const EXPLICIT_COMMAND_METADATA: Record<string, ProductSurfaceMetadata> = {
   build: { surface: "public", note: "Primary storyboard-to-video build engine." },
   render: { surface: "public", note: "Project render entrypoint." },
   doctor: { surface: "public", note: "System and provider health check." },
+  host: { surface: "public", note: "Codex, Claude, and Cursor app integration setup." },
   guide: { surface: "public", note: "Workflow chooser and first-run guidance." },
   demo: { surface: "advanced", note: "Smoke-test/demo helper, not a core workflow." },
   run: { surface: "agent", note: "Automation surface for YAML pipelines." },

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -408,6 +408,18 @@ a host agent's built-in image/audio generation tool for VibeFrame project
 assets unless the user explicitly requests an external, non-VibeFrame
 asset.
 
+## App host setup
+
+VibeFrame is CLI-first, not terminal-only. Codex, Claude Code, and Cursor can
+drive this project through shell commands, and app hosts can use the MCP server
+as a typed tool surface.
+
+\`\`\`bash
+vibe host setup all         # print Codex/Claude/Cursor snippets
+vibe host setup all --write # write project/app config
+vibe host doctor all --json # verify readiness
+\`\`\`
+
 ## Skills — USE THESE FIRST
 
 @SKILL.md

--- a/packages/cli/src/commands/host.test.ts
+++ b/packages/cli/src/commands/host.test.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const CLI = resolve(__dirname, "..", "..", "dist", "index.js");
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "vibe-host-test-"));
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+function runHost(args: string[]): string {
+  return execFileSync(process.execPath, [CLI, "host", ...args, "--json"], {
+    env: { ...process.env, NO_COLOR: "1" },
+    encoding: "utf-8",
+  });
+}
+
+describe("vibe host (black-box)", () => {
+  it("lists supported hosts", () => {
+    const result = JSON.parse(runHost(["list"]));
+    expect(result.command).toBe("host list");
+    expect(result.data.hosts.map((host: { id: string }) => host.id)).toEqual([
+      "codex",
+      "claude-code",
+      "claude-desktop",
+      "cursor",
+    ]);
+  });
+
+  it("prints setup snippets without writing by default", () => {
+    const result = JSON.parse(runHost(["setup", "cursor", projectDir]));
+    expect(result.command).toBe("host setup");
+    expect(result.data.hosts[0].snippet).toContain("@vibeframe/mcp-server");
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(false);
+  });
+
+  it("writes project-scoped Cursor MCP config with --write", () => {
+    const result = JSON.parse(runHost(["setup", "cursor", projectDir, "--write"]));
+    const mcpPath = join(projectDir, ".cursor", "mcp.json");
+    expect(result.data.hosts[0].files.some((file: { status: string }) => file.status === "wrote")).toBe(true);
+    expect(JSON.parse(readFileSync(mcpPath, "utf-8")).mcpServers.vibeframe.command).toBe("npx");
+  });
+
+  it("reports host doctor status", () => {
+    runHost(["setup", "codex", projectDir, "--write"]);
+    const result = JSON.parse(runHost(["doctor", "codex", projectDir]));
+    expect(result.command).toBe("host doctor");
+    expect(result.data.hosts[0].configured).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/host.ts
+++ b/packages/cli/src/commands/host.ts
@@ -1,0 +1,248 @@
+/**
+ * @module commands/host
+ *
+ * App-host integration helpers. VibeFrame remains CLI-first, but host apps
+ * can connect through project guidance files and the MCP server.
+ */
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { resolve } from "node:path";
+
+import { commandExists } from "../utils/exec-safe.js";
+import { applyTier } from "./_shared/cost-tier.js";
+import {
+  HOST_SELECTIONS,
+  hostDefinitions,
+  inspectHost,
+  planHostSetup,
+  resolveHostSelection,
+  type HostSelection,
+  type HostSetupPlan,
+  type HostDoctorResult,
+} from "./_shared/host-integration.js";
+import { exitWithError, isJsonMode, outputSuccess, usageError } from "./output.js";
+
+export const hostCommand = new Command("host")
+  .description("Set up Codex, Claude, and Cursor app integrations")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ vibe host list --json
+  $ vibe host setup all                 Print MCP/project config snippets
+  $ vibe host setup cursor --write      Write .cursor/mcp.json
+  $ vibe host doctor all --json         Check host-app readiness
+`
+  );
+
+hostCommand
+  .command("list")
+  .description("List supported app hosts and integration surfaces")
+  .action(() => {
+    const startedAt = Date.now();
+    const hosts = hostDefinitions(resolve(".")).map((host) => ({
+      id: host.id,
+      label: host.label,
+      surfaces: host.surfaces,
+      guidanceFiles: host.guidanceFiles,
+      notes: host.notes,
+    }));
+
+    if (isJsonMode()) {
+      outputSuccess({ command: "host list", startedAt, data: { hosts } });
+      return;
+    }
+
+    console.log();
+    console.log(chalk.bold.cyan("Supported Host Apps"));
+    console.log(chalk.dim("─".repeat(60)));
+    for (const host of hosts) {
+      console.log(`  ${chalk.bold(host.label)} ${chalk.dim(`(${host.id})`)}`);
+      console.log(chalk.dim(`    surfaces: ${host.surfaces.join(", ")}`));
+      if (host.guidanceFiles.length > 0) {
+        console.log(chalk.dim(`    files:    ${host.guidanceFiles.join(", ")}`));
+      }
+    }
+    console.log();
+  });
+applyTier(hostCommand.commands[hostCommand.commands.length - 1], "free");
+
+hostCommand
+  .command("setup")
+  .description("Print or write Codex/Claude/Cursor MCP and project integration config")
+  .argument("[host]", `Host target: ${HOST_SELECTIONS.join(" | ")}`, "all")
+  .argument("[project-dir]", "Project directory for project-scoped config", ".")
+  .option("--write", "Write config files instead of printing snippets only")
+  .option("--dry-run", "Show file actions without writing")
+  .option("--force", "Replace an existing vibeframe MCP entry")
+  .action(async (hostArg: string, projectDirArg: string, options) => {
+    const startedAt = Date.now();
+    const selection = validateHostSelection(hostArg);
+    const projectDir = resolve(projectDirArg);
+    const ids = resolveHostSelection(selection);
+    const defs = hostDefinitions(projectDir).filter((host) => ids.includes(host.id));
+    const plans: HostSetupPlan[] = [];
+
+    for (const host of defs) {
+      plans.push(
+        await planHostSetup(host, projectDir, {
+          write: Boolean(options.write),
+          dryRun: Boolean(options.dryRun),
+          force: Boolean(options.force),
+        })
+      );
+    }
+
+    if (isJsonMode()) {
+      outputSuccess({
+        command: "host setup",
+        startedAt,
+        ...(options.dryRun ? { dryRun: true } : {}),
+        data: {
+          projectDir,
+          selection,
+          write: Boolean(options.write),
+          hosts: plans.map(serializeSetupPlan),
+        },
+        warnings: plans.flatMap((plan) => plan.warnings),
+      });
+      return;
+    }
+
+    printSetupPlans(plans, { write: Boolean(options.write), dryRun: Boolean(options.dryRun) });
+  });
+applyTier(hostCommand.commands[hostCommand.commands.length - 1], "free");
+
+hostCommand
+  .command("doctor")
+  .description("Check Codex/Claude/Cursor app integration readiness")
+  .argument("[host]", `Host target: ${HOST_SELECTIONS.join(" | ")}`, "all")
+  .argument("[project-dir]", "Project directory to inspect", ".")
+  .action(async (hostArg: string, projectDirArg: string) => {
+    const startedAt = Date.now();
+    const selection = validateHostSelection(hostArg);
+    const projectDir = resolve(projectDirArg);
+    const ids = resolveHostSelection(selection);
+    const defs = hostDefinitions(projectDir).filter((host) => ids.includes(host.id));
+    const hosts = await Promise.all(defs.map((host) => inspectHost(host, projectDir)));
+    const system = {
+      vibe: commandExists("vibe"),
+      npx: commandExists("npx"),
+    };
+    const warnings = [
+      ...(system.vibe ? [] : ["vibe binary not found on PATH"]),
+      ...(system.npx ? [] : ["npx not found on PATH; MCP stdio config needs npx"]),
+      ...hosts.flatMap((host) => host.warnings),
+    ];
+
+    if (isJsonMode()) {
+      outputSuccess({
+        command: "host doctor",
+        startedAt,
+        data: {
+          projectDir,
+          selection,
+          system,
+          hosts: hosts.map(serializeDoctorResult),
+        },
+        warnings,
+      });
+      return;
+    }
+
+    printDoctor(hosts, system, warnings);
+  });
+applyTier(hostCommand.commands[hostCommand.commands.length - 1], "free");
+
+function validateHostSelection(value: string): HostSelection {
+  if ((HOST_SELECTIONS as readonly string[]).includes(value)) return value as HostSelection;
+  exitWithError(
+    usageError(`Invalid host target: ${value}`, `Must be one of: ${HOST_SELECTIONS.join(", ")}`)
+  );
+}
+
+function serializeSetupPlan(plan: HostSetupPlan): Record<string, unknown> {
+  return {
+    id: plan.host.id,
+    label: plan.host.label,
+    surfaces: plan.host.surfaces,
+    configPath: plan.configPath,
+    snippet: plan.snippet,
+    ...(plan.command ? { command: plan.command } : {}),
+    files: plan.files,
+    warnings: plan.warnings,
+    nextSteps: plan.nextSteps,
+  };
+}
+
+function serializeDoctorResult(result: HostDoctorResult): Record<string, unknown> {
+  return {
+    id: result.host.id,
+    label: result.host.label,
+    surfaces: result.host.surfaces,
+    configPath: result.configPath,
+    configured: result.configured,
+    guidanceFiles: result.guidanceFiles,
+    warnings: result.warnings,
+    nextSteps: result.nextSteps,
+  };
+}
+
+function printSetupPlans(plans: HostSetupPlan[], opts: { write: boolean; dryRun: boolean }): void {
+  console.log();
+  console.log(chalk.bold.cyan("VibeFrame Host Setup"));
+  console.log(chalk.dim("─".repeat(60)));
+  if (!opts.write) {
+    console.log(chalk.dim("Snippet mode — no files were changed. Pass --write to apply."));
+  } else if (opts.dryRun) {
+    console.log(chalk.dim("Dry run — no files were changed."));
+  }
+
+  for (const plan of plans) {
+    console.log();
+    console.log(chalk.bold(plan.host.label) + chalk.dim(` (${plan.host.id})`));
+    console.log(chalk.dim(`Config: ${plan.configPath}`));
+    if (plan.command) console.log(chalk.dim(`Command: ${plan.command}`));
+    console.log();
+    console.log(plan.snippet);
+    if (plan.files.length > 0) {
+      console.log();
+      for (const file of plan.files) {
+        console.log(`  ${formatAction(file.status)} ${file.path}${file.reason ? chalk.dim(` ${file.reason}`) : ""}`);
+      }
+    }
+    for (const warning of plan.warnings) console.log(chalk.yellow(`  Warning: ${warning}`));
+  }
+  console.log();
+}
+
+function printDoctor(
+  hosts: HostDoctorResult[],
+  system: { vibe: boolean; npx: boolean },
+  warnings: string[]
+): void {
+  console.log();
+  console.log(chalk.bold.cyan("VibeFrame Host Doctor"));
+  console.log(chalk.dim("─".repeat(60)));
+  console.log(`  vibe: ${system.vibe ? chalk.green("OK") : chalk.red("MISSING")}`);
+  console.log(`  npx:  ${system.npx ? chalk.green("OK") : chalk.red("MISSING")}`);
+  console.log();
+  for (const host of hosts) {
+    console.log(chalk.bold(host.host.label) + chalk.dim(` (${host.host.id})`));
+    console.log(`  MCP config: ${host.configured ? chalk.green("OK") : chalk.yellow("missing")} ${chalk.dim(host.configPath)}`);
+    for (const file of host.guidanceFiles) {
+      const ok = file.status !== "missing";
+      console.log(`  ${ok ? chalk.green("OK") : chalk.yellow("MISSING")} ${chalk.dim(file.path)}`);
+    }
+    console.log();
+  }
+  for (const warning of warnings) console.log(chalk.yellow(`Warning: ${warning}`));
+}
+
+function formatAction(status: string): string {
+  if (status === "wrote" || status === "merged") return chalk.green("✓");
+  if (status.startsWith("would")) return chalk.cyan("→");
+  if (status === "missing") return chalk.yellow("!");
+  return chalk.dim("○");
+}

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -137,6 +137,18 @@ describe("vibe init (black-box)", () => {
     expect(existsSync(join(projectDir, "AGENTS.md"))).toBe(false);
   });
 
+  it("--mcp writes project-scoped MCP config for Codex, Claude Code, and Cursor", () => {
+    const { stdout } = runInit(["--agent", "all", "--mcp"]);
+    const result = JSON.parse(stdout);
+
+    expect(result.data.actions.some((a: { path: string }) => a.path.endsWith(".codex/config.toml"))).toBe(true);
+    expect(result.data.actions.some((a: { path: string }) => a.path.endsWith(".mcp.json"))).toBe(true);
+    expect(result.data.actions.some((a: { path: string }) => a.path.endsWith(".cursor/mcp.json"))).toBe(true);
+    expect(readFileSync(join(projectDir, ".codex", "config.toml"), "utf-8")).toContain("[mcp_servers.vibeframe]");
+    expect(JSON.parse(readFileSync(join(projectDir, ".mcp.json"), "utf-8")).mcpServers.vibeframe.command).toBe("npx");
+    expect(JSON.parse(readFileSync(join(projectDir, ".cursor", "mcp.json"), "utf-8")).mcpServers.vibeframe.command).toBe("npx");
+  });
+
   it("rejects invalid --agent values", () => {
     const { stderr } = runInit(["--agent", "bogus"]);
     expect(stderr).toMatch(/Invalid --agent: bogus/);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -38,6 +38,7 @@ import { getVisualStyle, visualStyleNames } from "./_shared/visual-styles.js";
 import { draftStoryboardFromBrief } from "./_shared/storyboard-draft.js";
 import { projectConfigJson, VIBE_CONFIG_FILENAME } from "./_shared/project-config.js";
 import { deriveInstallHosts, installHyperframesSkill } from "./_shared/install-skill.js";
+import { hostDefinitions, planHostSetup, type HostSetupId } from "./_shared/host-integration.js";
 import {
   AGENTS_MD,
   CLAUDE_MD,
@@ -89,6 +90,7 @@ export const initCommand = new Command("init")
   .option("-d, --duration <sec>", "Default scene/root duration in seconds", "10")
   .option("--visual-style <name>", "Seed scene DESIGN.md from a named style")
   .option("--agent <id>", `Agent target: ${VALID_AGENTS.join(" | ")}`, "auto")
+  .option("--mcp", "Also write project-scoped MCP config for Codex/Claude Code/Cursor")
   .option("--force", "Overwrite existing files instead of skipping")
   .option("--dry-run", "Print the file list without writing anything")
   .action(async (projectDirArg: string, options) => {
@@ -211,6 +213,15 @@ export const initCommand = new Command("init")
         options.dryRun
       )
     );
+
+    if (options.mcp === true) {
+      actions.push(
+        ...(await setupProjectMcpTargets(projectDir, targetHosts, {
+          force: options.force === true,
+          dryRun: options.dryRun === true,
+        }))
+      );
+    }
 
     // ── Output ─────────────────────────────────────────────────────────
     if (isJsonMode()) {
@@ -391,6 +402,13 @@ async function runSceneInit(
           hosts: deriveInstallHosts(detectedIds),
         })
       : { success: true, files: [], bundleVersion: "not-installed" };
+  const mcpActions =
+    options.mcp === true
+      ? await setupProjectMcpTargets(projectDir, detectedIds, {
+          force: options.force === true,
+          dryRun: false,
+        })
+      : [];
 
   if (isJsonMode()) {
     outputSuccess({
@@ -411,6 +429,7 @@ async function runSceneInit(
         groups: result.groups,
         skillFiles: skillResult.files,
         skillBundleVersion: skillResult.bundleVersion,
+        mcpFiles: mcpActions,
         warnings: draftWarnings,
       },
     });
@@ -448,6 +467,10 @@ async function runSceneInit(
     console.log(chalk.dim(`    · ${p.replace(projectDir + "/", "")} (kept existing)`));
   for (const f of skillResult.files.filter((f) => f.status === "wrote")) {
     console.log(chalk.green(`    + ${f.path.replace(projectDir + "/", "")}`));
+  }
+  for (const f of mcpActions) {
+    const icon = f.status === "wrote" || f.status === "merged" ? chalk.green("+") : chalk.dim("·");
+    console.log(`${icon} ${f.path.replace(projectDir + "/", "")} ${chalk.dim(`(${f.status})`)}`);
   }
   console.log();
   console.log(chalk.dim(`Tip: cd ${projectDirArg} before running the next commands.`));
@@ -533,6 +556,46 @@ function resolveTargets(agent: AgentSelection): AgentHostId[] {
     return [];
   }
   return [agent];
+}
+
+async function setupProjectMcpTargets(
+  projectDir: string,
+  targetHosts: AgentHostId[],
+  opts: { force: boolean; dryRun: boolean }
+): Promise<InitFileAction[]> {
+  const ids = new Set<HostSetupId>();
+  if (targetHosts.includes("codex")) ids.add("codex");
+  if (targetHosts.includes("claude-code")) ids.add("claude-code");
+  if (targetHosts.includes("cursor")) ids.add("cursor");
+  if (targetHosts.length === 0) {
+    ids.add("codex");
+    ids.add("claude-code");
+    ids.add("cursor");
+  }
+
+  const actions: InitFileAction[] = [];
+  for (const host of hostDefinitions(projectDir).filter((h) => ids.has(h.id))) {
+    const plan = await planHostSetup(host, projectDir, {
+      write: true,
+      dryRun: opts.dryRun,
+      force: opts.force,
+    });
+    const configAction = plan.files.find((file) => file.path === plan.configPath);
+    if (!configAction) continue;
+    actions.push({
+      path: configAction.path,
+      status: normalizeHostAction(configAction.status),
+      reason: configAction.reason,
+    });
+  }
+  return actions;
+}
+
+function normalizeHostAction(status: string): InitFileAction["status"] {
+  if (status === "merged") return "merged";
+  if (status === "wrote") return "wrote";
+  if (status === "skipped-exists") return "skipped-exists";
+  return "would-write";
 }
 
 async function writeIfMissing(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,6 +35,7 @@ import { buildCommand } from "./commands/build.js";
 import { renderCommand } from "./commands/render.js";
 import { statusCommand } from "./commands/status.js";
 import { doctorCommand } from "./commands/doctor.js";
+import { hostCommand } from "./commands/host.js";
 import { demoCommand } from "./commands/demo.js";
 import { contextCommand } from "./commands/context.js";
 import { runCommand } from "./commands/run.js";
@@ -176,6 +177,7 @@ this section shows the typical entry points by use case):
     vibe schema --list --surface public Compact first-run command catalog
     vibe schema generate.video          JSON schema for any command
     vibe context                        Agent integration quickstart
+    vibe host setup all                 Configure Codex/Claude/Cursor app integrations
     vibe agent                          Optional built-in agent when you do not use Claude Code/Codex/etc.
 
 Common-flag note: most commands accept --dry-run to preview cost/output
@@ -303,6 +305,7 @@ program.addCommand(buildCommand);
 program.addCommand(renderCommand);
 program.addCommand(statusCommand);
 program.addCommand(doctorCommand);
+program.addCommand(hostCommand);
 program.addCommand(demoCommand, { hidden: true });
 program.addCommand(runCommand);
 program.addCommand(agentCommand);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.106.4",
+  "version": "0.106.5",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -2,7 +2,9 @@
 
 The MCP (Model Context Protocol) **server** for [VibeFrame](https://github.com/vericontext/vibeframe). This package is *only* the MCP adapter — it exposes VibeFrame's operations as typed MCP tools so an MCP-capable host can call them by natural language.
 
-Confirmed MCP hosts today: **Claude Desktop**, **Cursor**, **OpenCode**, and **Claude Code** (Claude Code can drive `vibe` natively via shell + `AGENTS.md`; the `claude mcp add` route below adds the typed-tool option for users who prefer it). For non-MCP hosts (Codex, Aider, Gemini CLI, anything else that shells out to bash), use [`@vibeframe/cli`](https://www.npmjs.com/package/@vibeframe/cli) directly — same operations.
+VibeFrame is CLI-first, not terminal-only. The CLI is the stable runtime; MCP is the app-host surface for clients that prefer typed tools over shell commands.
+
+Confirmed MCP hosts today: **Claude Desktop**, **Cursor**, and **Claude Code**. Codex can drive `vibe` natively via shell + `AGENTS.md`, and can also load a project-scoped MCP server through `.codex/config.toml`. For other shell-capable hosts, use [`@vibeframe/cli`](https://www.npmjs.com/package/@vibeframe/cli) directly — same operations.
 
 > **Just want a CLI?** Use [`@vibeframe/cli`](https://www.npmjs.com/package/@vibeframe/cli) instead — same operations, invoked directly in your shell as `vibe <command>`. This package and the CLI wrap the same underlying engine; pick whichever fits your workflow. Many users install both.
 
@@ -15,6 +17,29 @@ Confirmed MCP hosts today: **Claude Desktop**, **Cursor**, **OpenCode**, and **C
 The tool list below is what the MCP host sees. The same operations exist as `vibe <verb> <noun>` subcommands in the CLI — see `vibe --help`.
 
 ## Quick Setup
+
+The easiest way to generate the right snippet is:
+
+```bash
+vibe host setup codex
+vibe host setup claude
+vibe host setup cursor
+vibe host doctor all
+```
+
+`vibe host setup` prints snippets by default. Add `--write` to merge the config
+into the relevant project/app file.
+
+### Codex
+
+Add to `.codex/config.toml`:
+
+```toml
+[mcp_servers.vibeframe]
+command = "npx"
+args = ["-y", "@vibeframe/mcp-server"]
+enabled = true
+```
 
 ### Claude Desktop
 
@@ -66,7 +91,7 @@ Add to `.opencode/mcp.json` (or your global config per [opencode.ai/docs/config]
 Claude Code drives `vibe` natively via shell + the scaffolded `AGENTS.md` / `CLAUDE.md` — MCP isn't required. If you'd like the typed-tool surface anyway:
 
 ```bash
-claude mcp add vibeframe -- npx -y @vibeframe/mcp-server
+claude mcp add vibeframe --scope project -- npx -y @vibeframe/mcp-server
 ```
 
 ## What You Can Do

--- a/packages/mcp-server/build.js
+++ b/packages/mcp-server/build.js
@@ -1,8 +1,29 @@
 import { build } from "esbuild";
 import { rmSync } from "node:fs";
+import { resolve } from "node:path";
 
 // Clean dist
 rmSync("dist", { recursive: true, force: true });
+
+const root = resolve("../..");
+const cliSrc = resolve(root, "packages/cli/src");
+
+const cliSourceAliases = new Map([
+  ["@vibeframe/cli/engine", resolve(cliSrc, "engine/index.ts")],
+  ["@vibeframe/cli/tools/manifest", resolve(cliSrc, "tools/manifest/index.ts")],
+  ["@vibeframe/cli/tools/adapters/mcp", resolve(cliSrc, "tools/adapters/mcp.ts")],
+]);
+
+const cliSourceAliasPlugin = {
+  name: "cli-source-alias",
+  setup(pluginBuild) {
+    pluginBuild.onResolve({ filter: /^@vibeframe\/cli\/(engine|tools\/manifest|tools\/adapters\/mcp)$/ }, (args) => {
+      const path = cliSourceAliases.get(args.path);
+      if (!path) return undefined;
+      return { path };
+    });
+  },
+};
 
 await build({
   entryPoints: ["src/index.ts"],
@@ -23,16 +44,13 @@ await build({
   },
   // Externals are limited to:
   // 1. MCP SDK + zod — host communicates through these; must match host version
-  // 2. Optional AI provider SDKs — declared as peerDependencies (user brings their own)
-  // Everything else (chalk, ora, commander, yaml, dotenv, etc.) is bundled
-  // to keep runtime deps minimal and avoid version-drift bugs like ERR_MODULE_NOT_FOUND
+  // 2. Native/heavy optional graphs that are only loaded dynamically.
+  // Provider SDKs are bundled so `npx -y @vibeframe/mcp-server` works in a
+  // clean MCP host without requiring users to install peer dependencies.
   external: [
     "@modelcontextprotocol/sdk",
     "@modelcontextprotocol/sdk/*",
     "zod",
-    "@anthropic-ai/sdk",
-    "@google/generative-ai",
-    "openai",
     // KokoroProvider only fires its dynamic import when textToSpeech() is
     // called, which never happens through the MCP surface. Marking the heavy
     // native graph (~150 MB across onnxruntime-node + transformers.js) as
@@ -47,6 +65,7 @@ await build({
   sourcemap: false,
   minify: false,
   treeShaking: true,
+  plugins: [cliSourceAliasPlugin],
 });
 
 console.log("Bundle complete: dist/index.js");

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.106.4",
+  "version": "0.106.5",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.106.4",
+  "version": "0.106.5",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",

--- a/scripts/package-smoke.mts
+++ b/scripts/package-smoke.mts
@@ -1,6 +1,8 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -60,6 +62,108 @@ async function smokeImport(label: string, absPath: string): Promise<void> {
   console.log(`ok import ${label}`);
 }
 
+async function smokeMcpCommand(
+  label: string,
+  command: string,
+  args: string[],
+  cwd: string
+): Promise<void> {
+  const child = spawn(command, args, {
+    cwd,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let buffer = "";
+  let stderr = "";
+
+  const result = await new Promise<{ toolCount: number; firstTools: string[] }>((resolvePromise, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`${label} did not answer tools/list within 10s${stderr ? `\n${stderr}` : ""}`));
+    }, 10_000);
+
+    function send(message: unknown): void {
+      child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk.toString();
+      let idx: number;
+      while ((idx = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        if (!line) continue;
+        const message = JSON.parse(line) as {
+          id?: number;
+          result?: { tools?: Array<{ name: string }> };
+        };
+        if (message.id === 1 && message.result) {
+          send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+        }
+        if (message.id === 2 && message.result?.tools) {
+          clearTimeout(timeout);
+          resolvePromise({
+            toolCount: message.result.tools.length,
+            firstTools: message.result.tools.slice(0, 5).map((tool) => tool.name),
+          });
+          child.kill("SIGTERM");
+        }
+      }
+    });
+
+    child.on("exit", (code, signal) => {
+      if (code === 0 || signal === "SIGTERM") return;
+      clearTimeout(timeout);
+      reject(new Error(`${label} exited before smoke completed: code=${code} signal=${signal}${stderr ? `\n${stderr}` : ""}`));
+    });
+
+    send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "vibeframe-package-smoke", version: "0.0.0" },
+      },
+    });
+  });
+
+  if (result.toolCount <= 0) throw new Error("MCP server returned no tools");
+  console.log(`ok ${label} tools/list (${result.toolCount} tools; first: ${result.firstTools.join(", ")})`);
+}
+
+async function smokeMcpServer(absPath: string): Promise<void> {
+  await smokeMcpCommand("mcp server", process.execPath, [absPath], root);
+}
+
+async function smokePackedMcpServer(pkgDir: string): Promise<void> {
+  const tmp = await mkdtemp(join(tmpdir(), "vibeframe-mcp-pack-"));
+  try {
+    const tarballName = execFileSync(
+      "npm",
+      ["pack", pkgDir, "--pack-destination", tmp, "--silent"],
+      { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] }
+    ).trim().split(/\r?\n/).pop();
+    if (!tarballName) throw new Error("npm pack returned no tarball name");
+    const runCwd = join(tmp, "run");
+    await mkdir(runCwd, { recursive: true });
+    await smokeMcpCommand(
+      "packed mcp server",
+      "npm",
+      ["exec", "--yes", "--package", resolve(tmp, tarballName), "--", "vibeframe-mcp"],
+      runCwd
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
 const cliDir = resolve(root, "packages/cli");
 const mcpDir = resolve(root, "packages/mcp-server");
 
@@ -94,5 +198,7 @@ await smokeImport(
   "@vibeframe/cli/tools/adapters/agent",
   resolve(cliDir, "dist/tools/adapters/agent.js")
 );
+await smokeMcpServer(resolve(mcpDir, "dist/index.js"));
+await smokePackedMcpServer(mcpDir);
 
 console.log("Package smoke checks passed.");


### PR DESCRIPTION
## Summary
- add `vibe host` setup/doctor commands for Codex, Claude Code/Desktop, and Cursor
- add `vibe init --mcp` for project-scoped host config
- fix `@vibeframe/mcp-server` bundling so clean `npx` installs can start and list MCP tools
- bump packages to 0.106.5 and strengthen package smoke with local + packed MCP startup checks

## Verification
- `pnpm build`
- `pnpm lint`
- `pnpm gen:reference:check`
- `bash scripts/sync-counts.sh --check`
- `pnpm -F @vibeframe/cli exec vitest run --bail 1`
- `pnpm -F @vibeframe/mcp-server test`
- `pnpm package:check`
- `bash scripts/pre-push-validate.sh`
- `codex mcp get vibeframe`
- `claude mcp get vibeframe`