### PR TITLE
Fix MCP workspace path guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.106.5] - 2026-06-10
-
-### Added
-
-- add Codex, Claude, and Cursor host app setup commands
+## [0.106.6] - 2026-06-09
 
 ### Fixed
 
-- make the MCP server bundle runnable from clean npx installs
+- support host app MCP setup
+- anchor Claude Desktop MCP servers to the configured workspace with `cwd`
+- guide MCP agents to create projects under the workspace instead of `/tmp`
+- include workspace/project context in MCP status and inspect responses
 
 ### Testing
 
-- smoke test packed MCP server startup and tools/list responses
+- smoke test local and packed MCP server initialize instructions
 
 ## [0.106.4] - 2026-06-07
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,12 @@ vibe host doctor all --json      # verify guidance + MCP config
 
 By default, `vibe host setup` does **not** modify files; pass `--write` to
 apply the printed config. Claude Desktop global config is also opt-in and is
-backed up before merge.
+backed up before merge. For Claude Desktop, pass the workspace directory you
+want relative project names to resolve under:
+
+```bash
+vibe host setup claude-desktop ~/dev/videos --write
+```
 
 How agents discover the right command:
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.106.5",
+  "version": "0.106.6",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,13 @@ vibe host setup all
 vibe host doctor all --json
 ```
 
+For Claude Desktop, provide the workspace directory when writing config so
+relative project names resolve under that directory:
+
+```bash
+vibe host setup claude-desktop ~/dev/videos --write
+```
+
 ## Public Docs
 
 - [CLI reference](cli-reference.md) - generated command catalog from the live

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.106.5`
+> CLI version: `0.106.6`
 
 ## Mental model
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -25,6 +25,13 @@ vibe build my-video --max-cost 5
 vibe render my-video -o renders/final.mp4
 ```
 
+Claude Desktop uses global MCP config, so anchor it to the workspace you want
+relative project names to resolve under:
+
+```bash
+vibe host setup claude-desktop ~/dev/videos --write
+```
+
 `vibe scene ...` is the advanced namespace. It remains useful when you want to add a single HTML scene, lint scene files, install agent rules, or render a scene project with low-level options.
 
 ## Project File Roles

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.106.5",
+  "version": "0.106.6",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.106.5",
+  "version": "0.106.6",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.106.5",
+  "version": "0.106.6",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/host-integration.test.ts
+++ b/packages/cli/src/commands/_shared/host-integration.test.ts
@@ -8,12 +8,20 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { hostDefinitions, planHostSetup, renderHostSnippet } from "./host-integration.js";
 
 let projectDir: string;
+let originalHome: string | undefined;
 
 beforeEach(async () => {
   projectDir = await mkdtemp(join(tmpdir(), "vibe-host-integration-"));
+  originalHome = process.env.HOME;
+  process.env.HOME = projectDir;
 });
 
 afterEach(async () => {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
   await rm(projectDir, { recursive: true, force: true });
 });
 
@@ -33,6 +41,14 @@ describe("host integration helpers", () => {
     const snippet = JSON.parse(renderHostSnippet(host("cursor"), projectDir));
     expect(snippet.mcpServers.vibeframe.command).toBe("npx");
     expect(snippet.mcpServers.vibeframe.args).toEqual(["-y", "@vibeframe/mcp-server"]);
+    expect(snippet.mcpServers.vibeframe.cwd).toBeUndefined();
+  });
+
+  it("renders Claude Desktop config with an anchored cwd", () => {
+    const snippet = JSON.parse(renderHostSnippet(host("claude-desktop"), projectDir));
+    expect(snippet.mcpServers.vibeframe.command).toBe("npx");
+    expect(snippet.mcpServers.vibeframe.args).toEqual(["-y", "@vibeframe/mcp-server"]);
+    expect(snippet.mcpServers.vibeframe.cwd).toBe(projectDir);
   });
 
   it("snippet mode does not write files", async () => {
@@ -72,6 +88,46 @@ describe("host integration helpers", () => {
 
     expect(plan.files.find((file) => file.path === configPath)?.status).toBe("skipped-exists");
     expect(json.mcpServers.vibeframe.command).toBe("custom");
+  });
+
+  it("adds missing Claude Desktop cwd without replacing the existing server", async () => {
+    const configPath = host("claude-desktop").configPath(projectDir);
+    await mkdir(join(configPath, ".."), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          existing: { command: "node", args: ["server.js"] },
+          vibeframe: { command: "npx", args: ["-y", "@vibeframe/mcp-server"] },
+        },
+      }),
+      "utf-8"
+    );
+
+    const plan = await planHostSetup(host("claude-desktop"), projectDir, { write: true });
+    const json = JSON.parse(await readFile(configPath, "utf-8"));
+
+    expect(plan.files.find((file) => file.path === configPath)?.status).toBe("merged");
+    expect(json.mcpServers.existing.command).toBe("node");
+    expect(json.mcpServers.vibeframe.command).toBe("npx");
+    expect(json.mcpServers.vibeframe.cwd).toBe(projectDir);
+  });
+
+  it("does not add Claude Desktop cwd to a custom server without --force", async () => {
+    const configPath = host("claude-desktop").configPath(projectDir);
+    await mkdir(join(configPath, ".."), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({ mcpServers: { vibeframe: { command: "custom", args: [] } } }),
+      "utf-8"
+    );
+
+    const plan = await planHostSetup(host("claude-desktop"), projectDir, { write: true });
+    const json = JSON.parse(await readFile(configPath, "utf-8"));
+
+    expect(plan.files.find((file) => file.path === configPath)?.status).toBe("skipped-exists");
+    expect(json.mcpServers.vibeframe.command).toBe("custom");
+    expect(json.mcpServers.vibeframe.cwd).toBeUndefined();
   });
 
   it("creates and updates a Codex managed block", async () => {

--- a/packages/cli/src/commands/_shared/host-integration.ts
+++ b/packages/cli/src/commands/_shared/host-integration.ts
@@ -58,7 +58,13 @@ export interface HostDoctorResult {
   nextSteps: string[];
 }
 
-const VIBEFRAME_MCP_JSON = {
+interface McpServerJson {
+  command: string;
+  args: string[];
+  cwd?: string;
+}
+
+const VIBEFRAME_MCP_JSON: McpServerJson = {
   command: "npx",
   args: ["-y", "@vibeframe/mcp-server"],
 };
@@ -130,9 +136,15 @@ export function resolveHostSelection(selection: HostSelection): HostSetupId[] {
   return [selection];
 }
 
-export function renderHostSnippet(host: HostDefinition, _projectDir: string): string {
+function vibeframeMcpJson(host: HostDefinition, projectDir: string): McpServerJson {
+  return host.id === "claude-desktop"
+    ? { ...VIBEFRAME_MCP_JSON, cwd: resolve(projectDir) }
+    : { ...VIBEFRAME_MCP_JSON };
+}
+
+export function renderHostSnippet(host: HostDefinition, projectDir: string): string {
   if (host.configKind === "codex-toml") return CODEX_MCP_BLOCK.trimEnd();
-  return JSON.stringify({ mcpServers: { vibeframe: VIBEFRAME_MCP_JSON } }, null, 2);
+  return JSON.stringify({ mcpServers: { vibeframe: vibeframeMcpJson(host, projectDir) } }, null, 2);
 }
 
 export function claudeCodeAddCommand(): string {
@@ -173,6 +185,7 @@ export async function planHostSetup(
       host.configKind === "codex-toml"
         ? await mergeCodexToml(configPath, { force: opts.force === true })
         : await mergeMcpJson(configPath, {
+            server: vibeframeMcpJson(host, projectDir),
             force: opts.force === true,
             backup: host.id === "claude-desktop",
           });
@@ -203,10 +216,18 @@ export async function inspectHost(host: HostDefinition, projectDir: string): Pro
   if (existsSync(configPath)) {
     try {
       const content = await readFile(configPath, "utf-8");
-      configured =
-        host.configKind === "codex-toml"
-          ? /\[mcp_servers\.vibeframe\]/.test(content)
-          : hasVibeframeMcpServer(JSON.parse(content));
+      if (host.configKind === "codex-toml") {
+        configured = /\[mcp_servers\.vibeframe\]/.test(content);
+      } else {
+        const json = JSON.parse(content);
+        configured = hasVibeframeMcpServer(json);
+        const server = readVibeframeMcpServer(json);
+        if (host.id === "claude-desktop" && configured && !server?.cwd) {
+          warnings.push(
+            "Claude Desktop vibeframe MCP config has no cwd; run `vibe host setup claude-desktop <workspace> --write` to anchor relative paths."
+          );
+        }
+      }
     } catch (error) {
       warnings.push(error instanceof Error ? error.message : String(error));
     }
@@ -217,7 +238,7 @@ export async function inspectHost(host: HostDefinition, projectDir: string): Pro
 
 async function mergeMcpJson(
   configPath: string,
-  opts: { force: boolean; backup: boolean }
+  opts: { server: McpServerJson; force: boolean; backup: boolean }
 ): Promise<HostFileAction> {
   let root: Record<string, unknown> = {};
   const exists = existsSync(configPath);
@@ -236,6 +257,19 @@ async function mergeMcpJson(
       : {};
 
   if (mcpServers.vibeframe && !opts.force) {
+    const existing = mcpServers.vibeframe;
+    if (canAddMissingCwd(existing, opts.server)) {
+      root.mcpServers = {
+        ...mcpServers,
+        vibeframe: { ...(existing as Record<string, unknown>), cwd: opts.server.cwd },
+      };
+      await mkdir(dirname(configPath), { recursive: true });
+      if (exists && opts.backup) {
+        await writeFile(`${configPath}.bak-${timestamp()}`, await readFile(configPath, "utf-8"), "utf-8");
+      }
+      await writeFile(configPath, JSON.stringify(root, null, 2) + "\n", "utf-8");
+      return { path: configPath, status: "merged", reason: "added cwd to existing vibeframe MCP server" };
+    }
     return {
       path: configPath,
       status: "skipped-exists",
@@ -243,7 +277,7 @@ async function mergeMcpJson(
     };
   }
 
-  root.mcpServers = { ...mcpServers, vibeframe: VIBEFRAME_MCP_JSON };
+  root.mcpServers = { ...mcpServers, vibeframe: opts.server };
   await mkdir(dirname(configPath), { recursive: true });
   if (exists && opts.backup) {
     await writeFile(`${configPath}.bak-${timestamp()}`, await readFile(configPath, "utf-8"), "utf-8");
@@ -293,6 +327,25 @@ function hasVibeframeMcpServer(value: unknown): boolean {
   const root = value as { mcpServers?: unknown };
   if (!root.mcpServers || typeof root.mcpServers !== "object") return false;
   return Object.prototype.hasOwnProperty.call(root.mcpServers, "vibeframe");
+}
+
+function readVibeframeMcpServer(value: unknown): (McpServerJson & Record<string, unknown>) | null {
+  if (!value || typeof value !== "object") return null;
+  const root = value as { mcpServers?: unknown };
+  if (!root.mcpServers || typeof root.mcpServers !== "object" || Array.isArray(root.mcpServers)) return null;
+  const server = (root.mcpServers as Record<string, unknown>).vibeframe;
+  if (!server || typeof server !== "object" || Array.isArray(server)) return null;
+  return server as McpServerJson & Record<string, unknown>;
+}
+
+function canAddMissingCwd(existing: unknown, target: McpServerJson): boolean {
+  if (!target.cwd) return false;
+  if (!existing || typeof existing !== "object" || Array.isArray(existing)) return false;
+  const current = existing as Record<string, unknown>;
+  if (current.cwd) return false;
+  if (current.command !== target.command) return false;
+  if (!Array.isArray(current.args)) return false;
+  return JSON.stringify(current.args) === JSON.stringify(target.args);
 }
 
 function hostNextSteps(host: HostDefinition): string[] {

--- a/packages/cli/src/tools/adapters/mcp.ts
+++ b/packages/cli/src/tools/adapters/mcp.ts
@@ -106,7 +106,13 @@ export function buildMcpDispatcher(manifest: readonly ToolDefinition[]): McpDisp
       });
       const text = result.success
         ? JSON.stringify({ success: true, ...result.data })
-        : `${name} failed: ${result.error ?? "unknown error"}`;
+        : result.data
+          ? JSON.stringify({
+              success: false,
+              error: result.error ?? "unknown error",
+              ...result.data,
+            })
+          : `${name} failed: ${result.error ?? "unknown error"}`;
       return { content: [{ type: "text", text }] };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/tools/manifest/generate.ts
+++ b/packages/cli/src/tools/manifest/generate.ts
@@ -332,7 +332,7 @@ export const generateBackgroundTool = defineTool({
     output: z
       .string()
       .optional()
-      .describe("Output PNG path. Relative paths resolve against the surface's cwd."),
+      .describe("Output PNG path. Relative paths resolve against the surface's cwd; in MCP hosts, that is the configured server workspace."),
   }),
   async execute(args) {
     const result = await executeBackground(args);

--- a/packages/cli/src/tools/manifest/inspect.ts
+++ b/packages/cli/src/tools/manifest/inspect.ts
@@ -18,6 +18,9 @@ import { executeSuggestEdit } from "../../commands/ai-suggest-edit.js";
 import { inspectProject } from "../../commands/_shared/scene-inspect.js";
 import { inspectRender, previewInspectRender } from "../../commands/_shared/render-inspect.js";
 
+const PROJECT_DIR_DESCRIPTION =
+  "Project directory. Defaults to the surface's cwd; in MCP hosts, relative paths resolve under the configured server workspace.";
+
 // ── inspect_project ────────────────────────────────────────────────────────
 
 export const inspectProjectTool = defineTool({
@@ -27,7 +30,7 @@ export const inspectProjectTool = defineTool({
   description:
     "Local project inspection: checks STORYBOARD.md, DESIGN.md, config, build-report, scene lint, composition files, and referenced assets. Writes review-report.json by default.",
   schema: z.object({
-    projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+    projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
     beat: z.string().optional().describe("Inspect only one storyboard beat where beat-scoped checks apply."),
     outputPath: z.string().optional().describe("Optional review report path. Defaults to <project>/review-report.json."),
     report: z.boolean().optional().describe("Write review-report.json. Default true."),
@@ -42,7 +45,11 @@ export const inspectProjectTool = defineTool({
     });
     return {
       success: result.status !== "fail",
-      data: result as unknown as Record<string, unknown>,
+      data: {
+        ...(result as unknown as Record<string, unknown>),
+        workingDirectory: ctx.workingDirectory,
+        projectDir,
+      },
       error: result.status === "fail" ? `${result.issues.filter((issue) => issue.severity === "error").length} project inspection error(s)` : undefined,
       humanLines: [
         `${result.status === "pass" ? "✅" : result.status === "warn" ? "⚠️" : "❌"} Project inspection ${result.status} — score ${result.score}/100`,
@@ -61,7 +68,7 @@ export const inspectRenderTool = defineTool({
   description:
     "Render inspection: runs cheap local video checks by default, optionally adds Gemini AI review with ai: true, and writes review-report.json by default.",
   schema: z.object({
-    projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+    projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
     beat: z.string().optional().describe("Inspect a render for one storyboard beat."),
     videoPath: z.string().optional().describe("Rendered video path. Defaults to build-report outputPath or latest renders/* video."),
     outputPath: z.string().optional().describe("Optional review report path. Defaults to <project>/review-report.json."),
@@ -84,7 +91,11 @@ export const inspectRenderTool = defineTool({
       });
       return {
         success: true,
-        data: result as unknown as Record<string, unknown>,
+        data: {
+          ...(result as unknown as Record<string, unknown>),
+          workingDirectory: ctx.workingDirectory,
+          projectDir,
+        },
         humanLines: [
           `Render inspection dry-run — ${result.videoPath ? "render found" : "render missing"}`,
           ...(result.reportPath ? [`report: ${result.reportPath}`] : []),
@@ -102,7 +113,11 @@ export const inspectRenderTool = defineTool({
     });
     return {
       success: result.status !== "fail",
-      data: result as unknown as Record<string, unknown>,
+      data: {
+        ...(result as unknown as Record<string, unknown>),
+        workingDirectory: ctx.workingDirectory,
+        projectDir,
+      },
       error: result.status === "fail" ? `${result.issues.filter((issue) => issue.severity === "error").length} render inspection error(s)` : undefined,
       humanLines: [
         `${result.status === "pass" ? "✅" : result.status === "warn" ? "⚠️" : "❌"} Render inspection ${result.status} — score ${result.score}/100`,

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -35,6 +35,12 @@ const SCENE_PRESETS = [
   "product-shot",
 ] as const;
 
+const PROJECT_DIR_DESCRIPTION =
+  "Project directory. Defaults to the surface's cwd; in MCP hosts, relative paths resolve under the configured server workspace.";
+
+const INIT_DIR_DESCRIPTION =
+  "Project directory to create. Prefer a project name or workspace-relative path; in MCP hosts, relative paths resolve under the configured server workspace. Do not use /tmp or /home/claude unless the user explicitly asks.";
+
 const sceneStylesSchema = z.object({
   name: z
     .string()
@@ -105,7 +111,7 @@ export const sceneStylesTool = defineTool({
 // ---------------------------------------------------------------------------
 
 const sceneInitSchema = z.object({
-  dir: z.string().describe("Project directory (created if missing)."),
+  dir: z.string().describe(INIT_DIR_DESCRIPTION),
   name: z.string().optional().describe("Project name. Defaults to the directory basename."),
   aspect: z.enum(["16:9", "9:16", "1:1", "4:5"]).optional().describe("Aspect ratio. Default 16:9."),
   duration: z
@@ -182,7 +188,7 @@ const sceneAddSchema = z.object({
     .string()
     .optional()
     .describe("Small label above the headline (used by 'explainer' and 'product-shot' presets)."),
-  projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+  projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
   insertInto: z
     .string()
     .optional()
@@ -258,7 +264,7 @@ export const sceneAddTool = defineTool({
 // ---------------------------------------------------------------------------
 
 const sceneLintSchema = z.object({
-  projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+  projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
   root: z
     .string()
     .optional()
@@ -332,7 +338,7 @@ export const sceneLintTool = defineTool({
 // ---------------------------------------------------------------------------
 
 const sceneRepairSchema = z.object({
-  projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+  projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
   root: z
     .string()
     .optional()
@@ -376,7 +382,7 @@ export const sceneRepairTool = defineTool({
 // ---------------------------------------------------------------------------
 
 const sceneRenderSchema = z.object({
-  projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+  projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
   root: z
     .string()
     .optional()
@@ -452,7 +458,7 @@ const sceneBuildSchema = z.object({
     .string()
     .optional()
     .describe(
-      "Project directory containing STORYBOARD.md, DESIGN.md, index.html. Defaults to the surface's cwd."
+      "Project directory containing STORYBOARD.md, DESIGN.md, index.html. Defaults to the surface's cwd; in MCP hosts, relative paths resolve under the configured server workspace."
     ),
   stage: z
     .enum(["assets", "compose", "sync", "render", "all"])
@@ -633,7 +639,7 @@ const sceneInstallSkillSchema = z.object({
   projectDir: z
     .string()
     .describe(
-      "Project directory containing STORYBOARD.md / DESIGN.md. Required to keep cross-host calls explicit and prevent accidental installs in unintended cwd."
+      "Project directory containing STORYBOARD.md / DESIGN.md. Required to keep cross-host calls explicit; in MCP hosts, relative paths resolve under the configured server workspace."
     ),
   host: z
     .enum(["claude-code", "cursor", "auto", "all"])
@@ -704,7 +710,7 @@ const sceneComposePromptsSchema = z.object({
   projectDir: z
     .string()
     .describe(
-      "Project directory containing STORYBOARD.md / DESIGN.md. Required to keep cross-host calls explicit."
+      "Project directory containing STORYBOARD.md / DESIGN.md. Required to keep cross-host calls explicit; in MCP hosts, relative paths resolve under the configured server workspace."
     ),
   beat: z
     .string()

--- a/packages/cli/src/tools/manifest/status.ts
+++ b/packages/cli/src/tools/manifest/status.ts
@@ -15,6 +15,9 @@ import {
   refreshJobRecord,
 } from "../../commands/_shared/status-jobs.js";
 
+const PROJECT_DIR_DESCRIPTION =
+  "Project directory. Defaults to the surface's cwd; in MCP hosts, relative paths resolve under the configured server workspace.";
+
 export const statusJobTool = defineTool({
   name: "status_job",
   category: "status",
@@ -23,7 +26,7 @@ export const statusJobTool = defineTool({
     "Read one local async job record and optionally refresh supported provider status. Supports Runway/Kling video and Replicate music live checks.",
   schema: z.object({
     jobId: z.string().describe("Local job id returned by a no-wait command."),
-    projectDir: z.string().optional().describe("Project directory containing .vibeframe/jobs. Defaults to nearest project root."),
+    projectDir: z.string().optional().describe("Project directory containing .vibeframe/jobs. Defaults to nearest project root; in MCP hosts, relative paths resolve under the configured server workspace."),
     refresh: z.boolean().optional().describe("Call provider status APIs when supported. Default true."),
     wait: z.boolean().optional().describe("Wait for completion when supported."),
     output: z.string().optional().describe("Download result media to this path when complete."),
@@ -61,7 +64,7 @@ export const statusProjectTool = defineTool({
   description:
     "Summarize build-report.json, review-report.json, and local async job records for a VibeFrame project.",
   schema: z.object({
-    projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+    projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
     refresh: z.boolean().optional().describe("Refresh active supported jobs before summarizing. Default false."),
   }),
   async execute(args, ctx) {
@@ -69,7 +72,11 @@ export const statusProjectTool = defineTool({
     const result = await inspectProjectStatus(projectDir, { refresh: args.refresh === true });
     return {
       success: true,
-      data: result as unknown as Record<string, unknown>,
+      data: {
+        ...(result as unknown as Record<string, unknown>),
+        workingDirectory: ctx.workingDirectory,
+        projectDir,
+      },
       humanLines: [
         `Project status: ${result.status} (${result.currentStage}), ${result.jobs.active} active job(s), ${result.jobs.failed} failed job(s)`,
         ...(result.build ? [`build: ${result.build.phase ?? "unknown"}`] : []),

--- a/packages/cli/src/tools/manifest/storyboard.ts
+++ b/packages/cli/src/tools/manifest/storyboard.ts
@@ -14,8 +14,11 @@ import {
 import { executeStoryboardRevision } from "../../commands/_shared/storyboard-revise.js";
 import { createBuildPlan } from "../../commands/_shared/build-plan.js";
 
+const PROJECT_DIR_DESCRIPTION =
+  "Project directory. Defaults to the surface's cwd; in MCP hosts, relative paths resolve under the configured server workspace.";
+
 const projectDirSchema = z.object({
-  projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+  projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
 });
 
 async function readStoryboard(
@@ -96,7 +99,7 @@ export const storyboardGetTool = defineTool({
   cost: "free",
   description: "Return one STORYBOARD.md beat as structured data.",
   schema: z.object({
-    projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+    projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
     beat: z.string().describe("Beat id to return."),
   }),
   async execute(args, ctx) {
@@ -121,7 +124,7 @@ export const storyboardSetTool = defineTool({
   cost: "free",
   description: "Set or unset one cue on one beat in STORYBOARD.md.",
   schema: z.object({
-    projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+    projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
     beat: z.string().describe("Beat id to mutate."),
     key: z.string().describe("Cue key to set."),
     value: z.string().optional().describe("Cue value. Required unless unset is true."),
@@ -161,7 +164,7 @@ export const storyboardMoveTool = defineTool({
   cost: "free",
   description: "Move one beat after another beat in STORYBOARD.md.",
   schema: z.object({
-    projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+    projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
     beat: z.string().describe("Beat id to move."),
     after: z.string().describe("Beat id that should precede the moved beat."),
   }),
@@ -195,7 +198,7 @@ export const storyboardReviseTool = defineTool({
   description:
     "Revise an existing STORYBOARD.md from a natural-language request. Reads project context, validates the revised storyboard, and writes unless dryRun is true.",
   schema: z.object({
-    projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+    projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
     request: z
       .string()
       .describe("Revision request, e.g. 'make the hook punchier and shorten to 30 seconds'."),
@@ -237,7 +240,7 @@ export const planTool = defineTool({
   description:
     "Read STORYBOARD.md and return the build plan, missing artifacts, provider needs, and estimated cost.",
   schema: z.object({
-    projectDir: z.string().optional().describe("Project directory. Defaults to the surface's cwd."),
+    projectDir: z.string().optional().describe(PROJECT_DIR_DESCRIPTION),
     stage: z
       .enum(["assets", "compose", "sync", "render", "all"])
       .optional()

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.106.5",
+  "version": "0.106.6",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -50,11 +50,16 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "vibeframe": {
       "command": "npx",
-      "args": ["-y", "@vibeframe/mcp-server"]
+      "args": ["-y", "@vibeframe/mcp-server"],
+      "cwd": "/absolute/path/to/your/vibeframe-workspace"
     }
   }
 }
 ```
+
+`cwd` is important for Claude Desktop because it is a global app config. It
+anchors relative project paths so prompts like "create a project named launch"
+create `launch/` under your workspace instead of a temporary directory.
 
 ### Cursor
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.106.5",
+  "version": "0.106.6",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -12,6 +12,7 @@ import {
 import { tools, handleToolCall } from "./tools/index.js";
 import { resources, readResource } from "./resources/index.js";
 import { prompts, getPrompt } from "./prompts/index.js";
+import { buildServerInstructions } from "./instructions.js";
 
 /**
  * VibeFrame MCP Server
@@ -33,6 +34,7 @@ const server = new Server(
       resources: {},
       prompts: {},
     },
+    instructions: buildServerInstructions(),
   }
 );
 

--- a/packages/mcp-server/src/instructions.test.ts
+++ b/packages/mcp-server/src/instructions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildServerInstructions, resolveServerWorkspaceRoot } from "./instructions.js";
+
+describe("MCP server instructions", () => {
+  it("announces the configured workspace root and path rules", () => {
+    const instructions = buildServerInstructions("/Users/example/video-workspace");
+
+    expect(instructions).toContain("VibeFrame MCP workspace root: /Users/example/video-workspace");
+    expect(instructions).toContain("workspace-relative paths");
+    expect(instructions).toContain("Do not create projects in /tmp");
+    expect(instructions).toContain("/home/claude");
+    expect(instructions).toContain("dry-run or plan");
+  });
+
+  it("uses INIT_CWD when npm or npx launched the server from a workspace", () => {
+    expect(
+      resolveServerWorkspaceRoot({ INIT_CWD: "/Users/example/mcp-workspace" }, "/private/tmp/npm-exec")
+    ).toBe("/Users/example/mcp-workspace");
+  });
+
+  it("resolves relative INIT_CWD values against the process cwd", () => {
+    expect(resolveServerWorkspaceRoot({ INIT_CWD: "video-workspace" }, "/Users/example")).toBe(
+      "/Users/example/video-workspace"
+    );
+  });
+});

--- a/packages/mcp-server/src/instructions.ts
+++ b/packages/mcp-server/src/instructions.ts
@@ -1,0 +1,20 @@
+import { isAbsolute, resolve } from "node:path";
+
+export function resolveServerWorkspaceRoot(
+  env: NodeJS.ProcessEnv = process.env,
+  cwd = process.cwd()
+): string {
+  const initCwd = env.INIT_CWD?.trim();
+  if (!initCwd) return cwd;
+  return isAbsolute(initCwd) ? initCwd : resolve(cwd, initCwd);
+}
+
+export function buildServerInstructions(cwd = resolveServerWorkspaceRoot()): string {
+  return [
+    `VibeFrame MCP workspace root: ${cwd}. Treat this directory as the default workspace for relative paths.`,
+    "For args named dir, projectDir, output, videoPath, or source, prefer workspace-relative paths unless the user explicitly provides an absolute path.",
+    "When creating projects with init, use a project name or workspace-relative path under the workspace root.",
+    "Do not create projects in /tmp, /home/claude, /workspace, or other synthetic roots unless the user explicitly asks.",
+    "Before high or very-high cost provider work, run a dry-run or plan when available and ask the user to confirm provider spend.",
+  ].join("\n");
+}

--- a/packages/mcp-server/src/tools/scene.test.ts
+++ b/packages/mcp-server/src/tools/scene.test.ts
@@ -64,6 +64,15 @@ describe("MCP scene tools — registration", () => {
     expect(byName.scene_lint.inputSchema.required).toEqual([]);
     expect(byName.render.inputSchema.required).toEqual([]);
   });
+
+  it("explains MCP workspace-relative project paths", () => {
+    const byName = Object.fromEntries(sceneMcpTools.map((t) => [t.name, t]));
+    expect(byName.init.inputSchema.properties.dir.description).toContain("workspace-relative");
+    expect(byName.init.inputSchema.properties.dir.description).toContain("Do not use /tmp");
+    expect(byName.scene_lint.inputSchema.properties.projectDir.description).toContain(
+      "configured server workspace"
+    );
+  });
 });
 
 describe("handleToolCall — scene offline path", () => {
@@ -108,6 +117,32 @@ describe("handleToolCall — scene offline path", () => {
       projectDir: resolve(await makeTmp(), "missing"),
     });
     expect(text).toMatch(/render failed|Project directory not found|Chrome not found|Root composition not found/);
+  });
+
+  it("status_project returns the MCP working directory and resolved projectDir", async () => {
+    const projectDir = await makeTmp();
+    const text = await callScene("status_project", { projectDir });
+    const parsed = JSON.parse(text) as {
+      success: boolean;
+      workingDirectory: string;
+      projectDir: string;
+    };
+    expect(parsed.success).toBe(true);
+    expect(parsed.workingDirectory).toBe(process.cwd());
+    expect(parsed.projectDir).toBe(projectDir);
+  });
+
+  it("inspect_project preserves path context even when inspection fails", async () => {
+    const projectDir = await makeTmp();
+    const text = await callScene("inspect_project", { projectDir, report: false });
+    const parsed = JSON.parse(text) as {
+      success: boolean;
+      workingDirectory: string;
+      projectDir: string;
+    };
+    expect(parsed.success).toBe(false);
+    expect(parsed.workingDirectory).toBe(process.cwd());
+    expect(parsed.projectDir).toBe(projectDir);
   });
 
   it("handleToolCall enforces required args (init without dir → error message)", async () => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.106.5",
+  "version": "0.106.6",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",

--- a/scripts/package-smoke.mts
+++ b/scripts/package-smoke.mts
@@ -1,6 +1,6 @@
 import { execFileSync, spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -76,7 +76,8 @@ async function smokeMcpCommand(
   let buffer = "";
   let stderr = "";
 
-  const result = await new Promise<{ toolCount: number; firstTools: string[] }>((resolvePromise, reject) => {
+  const result = await new Promise<{ toolCount: number; firstTools: string[]; instructions: string }>((resolvePromise, reject) => {
+    let instructions = "";
     const timeout = setTimeout(() => {
       child.kill("SIGTERM");
       reject(new Error(`${label} did not answer tools/list within 10s${stderr ? `\n${stderr}` : ""}`));
@@ -99,9 +100,10 @@ async function smokeMcpCommand(
         if (!line) continue;
         const message = JSON.parse(line) as {
           id?: number;
-          result?: { tools?: Array<{ name: string }> };
+          result?: { instructions?: string; tools?: Array<{ name: string }> };
         };
         if (message.id === 1 && message.result) {
+          instructions = message.result.instructions ?? "";
           send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
           send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
         }
@@ -110,6 +112,7 @@ async function smokeMcpCommand(
           resolvePromise({
             toolCount: message.result.tools.length,
             firstTools: message.result.tools.slice(0, 5).map((tool) => tool.name),
+            instructions,
           });
           child.kill("SIGTERM");
         }
@@ -135,6 +138,19 @@ async function smokeMcpCommand(
   });
 
   if (result.toolCount <= 0) throw new Error("MCP server returned no tools");
+  const realCwd = await realpath(cwd).catch(() => cwd);
+  const acceptedCwds = new Set([cwd, realCwd]);
+  const hasExpectedCwd = [...acceptedCwds].some((expectedCwd) =>
+    result.instructions.includes(`VibeFrame MCP workspace root: ${expectedCwd}`)
+  );
+  if (!hasExpectedCwd) {
+    throw new Error(
+      `${label} initialize instructions did not include cwd ${cwd}\nInstructions:\n${result.instructions}`
+    );
+  }
+  if (!result.instructions.includes("Do not create projects in /tmp")) {
+    throw new Error(`${label} initialize instructions did not include workspace path guard`);
+  }
   console.log(`ok ${label} tools/list (${result.toolCount} tools; first: ${result.firstTools.join(", ")})`);
 }
 


### PR DESCRIPTION
## Summary
- add MCP initialize instructions that tell host apps to use the configured workspace for relative paths
- anchor Claude Desktop MCP setup with `cwd`, and repair existing default configs missing `cwd`
- include workspace/project context in MCP status and inspect responses, including failed inspect output
- bump packages to 0.106.6 and update docs/reference/changelog

## Verification
- pnpm build
- pnpm lint
- pnpm -F @vibeframe/mcp-server test
- pnpm -F @vibeframe/cli exec vitest run src/commands/_shared/host-integration.test.ts src/commands/host.test.ts --bail 1
- pnpm -F @vibeframe/cli exec vitest run --bail 1
- pnpm package:check
- pnpm gen:reference:check
- bash scripts/sync-counts.sh --check
- bash scripts/pre-push-validate.sh