### PR TITLE
Fix Claude Desktop MCP workspace anchoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.106.7] - 2026-06-10
+
+### Fixed
+
+- write Claude Desktop MCP config with a workspace shell wrapper because the app may strip raw `cwd`
+- upgrade default Claude Desktop `npx` MCP entries to workspace-anchored wrappers without requiring `--force`
+
 ## [0.106.6] - 2026-06-09
 
 ### Fixed
 
+- add MCP workspace instructions and status/inspect path context
+- anchor MCP project paths for hosts that preserve server working-directory config
+
+## [0.106.5] - 2026-06-09
+
+### Fixed
+
 - support host app MCP setup
-- anchor Claude Desktop MCP servers to the configured workspace with `cwd`
-- guide MCP agents to create projects under the workspace instead of `/tmp`
-- include workspace/project context in MCP status and inspect responses
-
-### Testing
-
-- smoke test local and packed MCP server initialize instructions
 
 ## [0.106.4] - 2026-06-07
 

--- a/README.md
+++ b/README.md
@@ -414,7 +414,8 @@ vibe host doctor all --json      # verify guidance + MCP config
 By default, `vibe host setup` does **not** modify files; pass `--write` to
 apply the printed config. Claude Desktop global config is also opt-in and is
 backed up before merge. For Claude Desktop, pass the workspace directory you
-want relative project names to resolve under:
+want relative project names to resolve under; VibeFrame writes a shell wrapper
+so Claude Desktop preserves that workspace anchor:
 
 ```bash
 vibe host setup claude-desktop ~/dev/videos --write

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.106.6",
+  "version": "0.106.7",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,8 @@ vibe host doctor all --json
 ```
 
 For Claude Desktop, provide the workspace directory when writing config so
-relative project names resolve under that directory:
+relative project names resolve under that directory. VibeFrame writes a shell
+wrapper because Claude Desktop may not preserve a raw `cwd` field:
 
 ```bash
 vibe host setup claude-desktop ~/dev/videos --write

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.106.6`
+> CLI version: `0.106.7`
 
 ## Mental model
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -26,7 +26,8 @@ vibe render my-video -o renders/final.mp4
 ```
 
 Claude Desktop uses global MCP config, so anchor it to the workspace you want
-relative project names to resolve under:
+relative project names to resolve under. VibeFrame writes a shell wrapper
+because Claude Desktop may not preserve a raw `cwd` field:
 
 ```bash
 vibe host setup claude-desktop ~/dev/videos --write

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.106.6",
+  "version": "0.106.7",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.106.6",
+  "version": "0.106.7",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.106.6",
+  "version": "0.106.7",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/host-integration.test.ts
+++ b/packages/cli/src/commands/_shared/host-integration.test.ts
@@ -44,11 +44,13 @@ describe("host integration helpers", () => {
     expect(snippet.mcpServers.vibeframe.cwd).toBeUndefined();
   });
 
-  it("renders Claude Desktop config with an anchored cwd", () => {
+  it("renders Claude Desktop config with a workspace-anchored wrapper", () => {
     const snippet = JSON.parse(renderHostSnippet(host("claude-desktop"), projectDir));
-    expect(snippet.mcpServers.vibeframe.command).toBe("npx");
-    expect(snippet.mcpServers.vibeframe.args).toEqual(["-y", "@vibeframe/mcp-server"]);
-    expect(snippet.mcpServers.vibeframe.cwd).toBe(projectDir);
+    expect(snippet.mcpServers.vibeframe.command).toBe("bash");
+    expect(snippet.mcpServers.vibeframe.args).toEqual([
+      "-lc",
+      `cd '${projectDir}' && exec npx -y @vibeframe/mcp-server`,
+    ]);
   });
 
   it("snippet mode does not write files", async () => {
@@ -90,7 +92,7 @@ describe("host integration helpers", () => {
     expect(json.mcpServers.vibeframe.command).toBe("custom");
   });
 
-  it("adds missing Claude Desktop cwd without replacing the existing server", async () => {
+  it("upgrades the default Claude Desktop server to a workspace-anchored wrapper", async () => {
     const configPath = host("claude-desktop").configPath(projectDir);
     await mkdir(join(configPath, ".."), { recursive: true });
     await writeFile(
@@ -109,11 +111,14 @@ describe("host integration helpers", () => {
 
     expect(plan.files.find((file) => file.path === configPath)?.status).toBe("merged");
     expect(json.mcpServers.existing.command).toBe("node");
-    expect(json.mcpServers.vibeframe.command).toBe("npx");
-    expect(json.mcpServers.vibeframe.cwd).toBe(projectDir);
+    expect(json.mcpServers.vibeframe.command).toBe("bash");
+    expect(json.mcpServers.vibeframe.args).toEqual([
+      "-lc",
+      `cd '${projectDir}' && exec npx -y @vibeframe/mcp-server`,
+    ]);
   });
 
-  it("does not add Claude Desktop cwd to a custom server without --force", async () => {
+  it("does not replace a custom Claude Desktop server without --force", async () => {
     const configPath = host("claude-desktop").configPath(projectDir);
     await mkdir(join(configPath, ".."), { recursive: true });
     await writeFile(
@@ -127,7 +132,6 @@ describe("host integration helpers", () => {
 
     expect(plan.files.find((file) => file.path === configPath)?.status).toBe("skipped-exists");
     expect(json.mcpServers.vibeframe.command).toBe("custom");
-    expect(json.mcpServers.vibeframe.cwd).toBeUndefined();
   });
 
   it("creates and updates a Codex managed block", async () => {

--- a/packages/cli/src/commands/_shared/host-integration.ts
+++ b/packages/cli/src/commands/_shared/host-integration.ts
@@ -61,7 +61,6 @@ export interface HostDoctorResult {
 interface McpServerJson {
   command: string;
   args: string[];
-  cwd?: string;
 }
 
 const VIBEFRAME_MCP_JSON: McpServerJson = {
@@ -137,9 +136,20 @@ export function resolveHostSelection(selection: HostSelection): HostSetupId[] {
 }
 
 function vibeframeMcpJson(host: HostDefinition, projectDir: string): McpServerJson {
-  return host.id === "claude-desktop"
-    ? { ...VIBEFRAME_MCP_JSON, cwd: resolve(projectDir) }
-    : { ...VIBEFRAME_MCP_JSON };
+  if (host.id !== "claude-desktop") return { ...VIBEFRAME_MCP_JSON };
+
+  const workspace = resolve(projectDir);
+  if (process.platform === "win32") {
+    return {
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", `cd /d ${cmdQuote(workspace)} && npx -y @vibeframe/mcp-server`],
+    };
+  }
+
+  return {
+    command: "bash",
+    args: ["-lc", `cd ${shellQuote(workspace)} && exec npx -y @vibeframe/mcp-server`],
+  };
 }
 
 export function renderHostSnippet(host: HostDefinition, projectDir: string): string {
@@ -222,9 +232,9 @@ export async function inspectHost(host: HostDefinition, projectDir: string): Pro
         const json = JSON.parse(content);
         configured = hasVibeframeMcpServer(json);
         const server = readVibeframeMcpServer(json);
-        if (host.id === "claude-desktop" && configured && !server?.cwd) {
+        if (host.id === "claude-desktop" && configured && !isAnchoredClaudeDesktopServer(server)) {
           warnings.push(
-            "Claude Desktop vibeframe MCP config has no cwd; run `vibe host setup claude-desktop <workspace> --write` to anchor relative paths."
+            "Claude Desktop vibeframe MCP config is not workspace-anchored; run `vibe host setup claude-desktop <workspace> --write` to anchor relative paths."
           );
         }
       }
@@ -258,17 +268,17 @@ async function mergeMcpJson(
 
   if (mcpServers.vibeframe && !opts.force) {
     const existing = mcpServers.vibeframe;
-    if (canAddMissingCwd(existing, opts.server)) {
+    if (canUpgradeDefaultServer(existing, opts.server)) {
       root.mcpServers = {
         ...mcpServers,
-        vibeframe: { ...(existing as Record<string, unknown>), cwd: opts.server.cwd },
+        vibeframe: opts.server,
       };
       await mkdir(dirname(configPath), { recursive: true });
       if (exists && opts.backup) {
         await writeFile(`${configPath}.bak-${timestamp()}`, await readFile(configPath, "utf-8"), "utf-8");
       }
       await writeFile(configPath, JSON.stringify(root, null, 2) + "\n", "utf-8");
-      return { path: configPath, status: "merged", reason: "added cwd to existing vibeframe MCP server" };
+      return { path: configPath, status: "merged", reason: "anchored existing default vibeframe MCP server" };
     }
     return {
       path: configPath,
@@ -338,14 +348,25 @@ function readVibeframeMcpServer(value: unknown): (McpServerJson & Record<string,
   return server as McpServerJson & Record<string, unknown>;
 }
 
-function canAddMissingCwd(existing: unknown, target: McpServerJson): boolean {
-  if (!target.cwd) return false;
+function isAnchoredClaudeDesktopServer(server: (McpServerJson & Record<string, unknown>) | null): boolean {
+  if (!server) return false;
+  if (server.command === "bash" && Array.isArray(server.args)) {
+    return server.args[0] === "-lc" && typeof server.args[1] === "string" && server.args[1].includes("exec npx -y @vibeframe/mcp-server");
+  }
+  if (server.command === "cmd.exe" && Array.isArray(server.args)) {
+    return server.args.some((arg) => typeof arg === "string" && arg.includes("npx -y @vibeframe/mcp-server"));
+  }
+  return false;
+}
+
+function canUpgradeDefaultServer(existing: unknown, target: McpServerJson): boolean {
   if (!existing || typeof existing !== "object" || Array.isArray(existing)) return false;
   const current = existing as Record<string, unknown>;
-  if (current.cwd) return false;
-  if (current.command !== target.command) return false;
   if (!Array.isArray(current.args)) return false;
-  return JSON.stringify(current.args) === JSON.stringify(target.args);
+  if (current.command === target.command && JSON.stringify(current.args) === JSON.stringify(target.args)) {
+    return false;
+  }
+  return current.command === VIBEFRAME_MCP_JSON.command && JSON.stringify(current.args) === JSON.stringify(VIBEFRAME_MCP_JSON.args);
 }
 
 function hostNextSteps(host: HostDefinition): string[] {
@@ -388,4 +409,12 @@ function ensureTrailingNewline(value: string): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function cmdQuote(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.106.6",
+  "version": "0.106.7",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -49,17 +49,20 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 {
   "mcpServers": {
     "vibeframe": {
-      "command": "npx",
-      "args": ["-y", "@vibeframe/mcp-server"],
-      "cwd": "/absolute/path/to/your/vibeframe-workspace"
+      "command": "bash",
+      "args": [
+        "-lc",
+        "cd '/absolute/path/to/your/vibeframe-workspace' && exec npx -y @vibeframe/mcp-server"
+      ]
     }
   }
 }
 ```
 
-`cwd` is important for Claude Desktop because it is a global app config. It
-anchors relative project paths so prompts like "create a project named launch"
-create `launch/` under your workspace instead of a temporary directory.
+The shell wrapper is important for Claude Desktop because it is a global app
+config and may not preserve a raw `cwd` field. It anchors relative project paths
+so prompts like "create a project named launch" create `launch/` under your
+workspace instead of a temporary directory.
 
 ### Cursor
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.106.6",
+  "version": "0.106.7",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.106.6",
+  "version": "0.106.7",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary
- change Claude Desktop MCP setup to use a shell wrapper that `cd`s into the selected workspace before starting the VibeFrame MCP server
- upgrade existing default `npx -y @vibeframe/mcp-server` Claude Desktop entries without requiring `--force`
- update docs and bump packages to 0.106.7

## Verification
- pnpm build
- pnpm lint
- pnpm -F @vibeframe/cli exec vitest run src/commands/_shared/host-integration.test.ts src/commands/host.test.ts --bail 1
- pnpm -F @vibeframe/cli exec vitest run --bail 1
- pnpm package:check
- pnpm gen:reference:check
- bash scripts/sync-counts.sh --check
- bash scripts/pre-push-validate.sh
- local Claude Desktop wrapper smoke: MCP initialize reports `/Users/kiyeonjeon/dev/personal/labs/vibeframe-lab` as workspace root