### PR TITLE
fix: improve MCP render output UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.106.8] - 2026-06-10
+
+### Added
+
+- add render open/reveal commands and absolute output paths for MCP/host UX
+
+### Fixed
+
+- capture MCP tool stdout so renderer logs do not corrupt stdio JSON-RPC
+
 ## [0.106.7] - 2026-06-10
 
 ### Fixed
@@ -1935,4 +1945,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Debug
 
 - add REPL startup logging
-

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.106.7",
+  "version": "0.106.8",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.106.7`
+> CLI version: `0.106.8`
 
 ## Mental model
 
@@ -381,6 +381,8 @@ Cost tier: _not tagged_
 - `quality` _(string)_ _(default: `"standard"`)_ — Quality preset: draft|standard|high
 - `format` _(string)_ _(default: `"mp4"`)_ — Output container: mp4|webm|mov
 - `workers` _(number)_ _(default: `1`)_ — Capture workers (1-16, default 1)
+- `open` _(boolean)_ — Open the rendered video in the OS default app after render
+- `reveal` _(boolean)_ — Reveal the rendered video in Finder/file manager after render
 - `dryRun` _(boolean)_ — Preview parameters without rendering
 
 #### `vibe run`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.106.7",
+  "version": "0.106.8",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.106.7",
+  "version": "0.106.8",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.106.7",
+  "version": "0.106.8",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -3399,6 +3399,10 @@ exports[`CLI --describe schemas (drift detection) > vibe render --describe 1`] =
         "description": "Frames per second: 24|30|60",
         "type": "number",
       },
+      "open": {
+        "description": "Open the rendered video in the OS default app after render",
+        "type": "boolean",
+      },
       "out": {
         "description": "Output file (default: renders/<name>-<timestamp>.<format>)",
         "type": "string",
@@ -3411,6 +3415,10 @@ exports[`CLI --describe schemas (drift detection) > vibe render --describe 1`] =
         "default": "standard",
         "description": "Quality preset: draft|standard|high",
         "type": "string",
+      },
+      "reveal": {
+        "description": "Reveal the rendered video in Finder/file manager after render",
+        "type": "boolean",
       },
       "root": {
         "default": "index.html",

--- a/packages/cli/src/commands/_shared/scene-render.test.ts
+++ b/packages/cli/src/commands/_shared/scene-render.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
+  buildMediaOpenCommand,
   buildRenderConfig,
   defaultOutputPath,
   executeSceneRender,
@@ -71,6 +72,44 @@ describe("buildRenderConfig", () => {
       entryFile: "alt.html",
       crf: 18,
       workers: 4,
+    });
+  });
+});
+
+// ── buildMediaOpenCommand ──────────────────────────────────────────────────
+
+describe("buildMediaOpenCommand", () => {
+  it("builds macOS open and reveal commands", () => {
+    expect(buildMediaOpenCommand("open", "/tmp/My Video/out.mp4", "darwin")).toEqual({
+      command: "open",
+      args: ["/tmp/My Video/out.mp4"],
+      display: 'open "/tmp/My Video/out.mp4"',
+    });
+    expect(buildMediaOpenCommand("reveal", "/tmp/My Video/out.mp4", "darwin")).toEqual({
+      command: "open",
+      args: ["-R", "/tmp/My Video/out.mp4"],
+      display: 'open -R "/tmp/My Video/out.mp4"',
+    });
+  });
+
+  it("reveals the parent directory on Linux", () => {
+    expect(buildMediaOpenCommand("reveal", "/tmp/My Video/out.mp4", "linux")).toEqual({
+      command: "xdg-open",
+      args: ["/tmp/My Video"],
+      display: 'xdg-open "/tmp/My Video"',
+    });
+  });
+
+  it("builds Windows open and reveal commands", () => {
+    expect(buildMediaOpenCommand("open", "C:\\tmp\\out.mp4", "win32")).toEqual({
+      command: "cmd",
+      args: ["/c", "start", "", "C:\\tmp\\out.mp4"],
+      display: 'cmd /c start "" "C:\\\\tmp\\\\out.mp4"',
+    });
+    expect(buildMediaOpenCommand("reveal", "C:\\tmp\\out.mp4", "win32")).toEqual({
+      command: "explorer",
+      args: ["/select,C:\\tmp\\out.mp4"],
+      display: 'explorer "/select,C:\\\\tmp\\\\out.mp4"',
     });
   });
 });
@@ -271,6 +310,9 @@ describe("executeSceneRender — Chrome-gated render", () => {
 
     expect(result.success).toBe(true);
     expect(existsSync(out)).toBe(true);
+    expect(result.absoluteOutputPath).toBe(out);
+    expect(result.openCommand).toContain(out);
+    expect(result.revealCommand).toContain(out);
     expect(result.fps).toBe(30);
     expect(result.quality).toBe("draft");
     expect(result.format).toBe("mp4");

--- a/packages/cli/src/commands/_shared/scene-render.ts
+++ b/packages/cli/src/commands/_shared/scene-render.ts
@@ -13,9 +13,11 @@
  * returns a structured result instead of throwing or exiting.
  */
 
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { resolve, relative, dirname, basename, join, isAbsolute } from "node:path";
+import { promisify } from "node:util";
 import {
   createRenderJob,
   executeRenderJob,
@@ -31,6 +33,9 @@ import { aspectToDims, type SceneAspect } from "./scene-project.js";
 export type RenderFps = 24 | 30 | 60;
 export type RenderQuality = "draft" | "standard" | "high";
 export type RenderFormat = "mp4" | "webm" | "mov";
+export type RenderOpenAction = "open" | "reveal";
+
+const execFileAsync = promisify(execFile);
 
 export interface SceneRenderOptions {
   /** Project directory (defaults to cwd). */
@@ -48,6 +53,10 @@ export interface SceneRenderOptions {
   /** Hyperframes capture worker count. Default 1 (the existing backend's
    *  default — auto-worker mode times out on small comps). */
   workers?: number;
+  /** Open the rendered media in the OS default app after a successful render. */
+  openAfterRender?: boolean;
+  /** Reveal the rendered media in Finder/file manager after a successful render. */
+  revealInFinder?: boolean;
   signal?: AbortSignal;
   onProgress?: (pct: number, stage: string) => void;
 }
@@ -58,6 +67,13 @@ export interface SceneRenderResult {
   beat?: string | null;
   root?: string;
   outputPath?: string;
+  absoluteOutputPath?: string;
+  openCommand?: string;
+  revealCommand?: string;
+  opened?: boolean;
+  revealed?: boolean;
+  openError?: string;
+  revealError?: string;
   durationMs?: number;
   framesRendered?: number;
   totalFrames?: number;
@@ -74,6 +90,12 @@ export interface SceneRenderResult {
   code?: string;
   error?: string;
   retryWith?: string[];
+}
+
+export interface MediaOpenCommand {
+  command: string;
+  args: string[];
+  display: string;
 }
 
 /** Map a quality preset to an x264 CRF (lower = higher quality). */
@@ -124,6 +146,45 @@ export function buildRenderConfig(opts: {
     entryFile: opts.entryFile ?? "index.html",
     crf: qualityToCrf(quality),
     workers: opts.workers ?? 1,
+  };
+}
+
+export function buildMediaOpenCommand(
+  action: RenderOpenAction,
+  filePath: string,
+  platform: NodeJS.Platform = process.platform,
+): MediaOpenCommand {
+  if (platform === "darwin") {
+    const args = action === "reveal" ? ["-R", filePath] : [filePath];
+    return {
+      command: "open",
+      args,
+      display: ["open", ...args].map(quoteCliArg).join(" "),
+    };
+  }
+
+  if (platform === "win32") {
+    if (action === "reveal") {
+      const args = [`/select,${filePath}`];
+      return {
+        command: "explorer",
+        args,
+        display: ["explorer", ...args].map(quoteCliArg).join(" "),
+      };
+    }
+    const args = ["/c", "start", "", filePath];
+    return {
+      command: "cmd",
+      args,
+      display: ["cmd", ...args].map(quoteCliArg).join(" "),
+    };
+  }
+
+  const target = action === "reveal" ? dirname(filePath) : filePath;
+  return {
+    command: "xdg-open",
+    args: [target],
+    display: ["xdg-open", target].map(quoteCliArg).join(" "),
   };
 }
 
@@ -273,6 +334,9 @@ export async function executeSceneRender(opts: SceneRenderOptions = {}): Promise
     beat: opts.beatId ?? null,
     root,
     outputPath: relative(process.cwd(), outputPath) || outputPath,
+    absoluteOutputPath: outputPath,
+    openCommand: buildMediaOpenCommand("open", outputPath).display,
+    revealCommand: buildMediaOpenCommand("reveal", outputPath).display,
     durationMs: Date.now() - start,
     framesRendered: job.framesRendered,
     totalFrames: job.totalFrames,
@@ -283,11 +347,42 @@ export async function executeSceneRender(opts: SceneRenderOptions = {}): Promise
     audioMuxApplied,
     audioMuxWarning,
   };
+
+  if (opts.revealInFinder) {
+    try {
+      await runMediaOpenAction("reveal", outputPath);
+      result.revealed = true;
+    } catch (err) {
+      result.revealed = false;
+      result.revealError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  if (opts.openAfterRender) {
+    try {
+      await runMediaOpenAction("open", outputPath);
+      result.opened = true;
+    } catch (err) {
+      result.opened = false;
+      result.openError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
   result.reportPath = await writeRenderReport(projectDir, {
     ...result,
     outputPath,
   });
   return result;
+}
+
+async function runMediaOpenAction(action: RenderOpenAction, filePath: string): Promise<void> {
+  const cmd = buildMediaOpenCommand(action, filePath);
+  await execFileAsync(cmd.command, cmd.args);
+}
+
+function quoteCliArg(value: string): string {
+  if (/^[A-Za-z0-9_/@%+=:,.-]+$/.test(value)) return value;
+  return `"${value.replace(/(["\\$`])/g, "\\$1")}"`;
 }
 
 async function safeStat(p: string): Promise<{ isDirectory: () => boolean } | null> {
@@ -522,6 +617,13 @@ async function writeRenderReport(
           beat: result.beat ?? null,
           root: result.root,
           outputPath: result.outputPath,
+          absoluteOutputPath: result.absoluteOutputPath,
+          openCommand: result.openCommand,
+          revealCommand: result.revealCommand,
+          opened: result.opened,
+          revealed: result.revealed,
+          openError: result.openError,
+          revealError: result.revealError,
           fps: result.fps,
           quality: result.quality,
           format: result.format,

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -26,6 +26,8 @@ export const renderCommand = new Command("render")
   .option("--quality <q>", `Quality preset: ${VALID_QUALITIES.join("|")}`, "standard")
   .option("--format <f>", `Output container: ${VALID_FORMATS.join("|")}`, "mp4")
   .option("--workers <n>", "Capture workers (1-16, default 1)", "1")
+  .option("--open", "Open the rendered video in the OS default app after render")
+  .option("--reveal", "Reveal the rendered video in Finder/file manager after render")
   .option("--dry-run", "Preview parameters without rendering")
   .addHelpText("after", `
 Examples:
@@ -50,6 +52,8 @@ Alias note: this is the project-level entrypoint for \`vibe scene render\`.`)
       quality,
       format,
       workers,
+      openAfterRender: Boolean(options.open),
+      revealInFinder: Boolean(options.reveal),
     };
 
     if (options.dryRun) {
@@ -76,6 +80,8 @@ Alias note: this is the project-level entrypoint for \`vibe scene render\`.`)
       quality,
       format,
       workers,
+      openAfterRender: Boolean(options.open),
+      revealInFinder: Boolean(options.reveal),
       onProgress: (pct, stage) => {
         if (spinner) spinner.text = `Rendering [${Math.round(pct * 100)}%] ${stage}`;
       },
@@ -108,6 +114,8 @@ type RenderDryRunParams = {
   quality: RenderQuality;
   format: RenderFormat;
   workers: number;
+  openAfterRender: boolean;
+  revealInFinder: boolean;
 };
 
 function printRenderDryRun(projectDirArg: string, params: RenderDryRunParams): void {
@@ -121,6 +129,8 @@ function printRenderDryRun(projectDirArg: string, params: RenderDryRunParams): v
   console.log(`  Format:        ${chalk.bold(params.format)}`);
   console.log(`  Quality/FPS:   ${chalk.bold(`${params.quality} / ${params.fps}`)}`);
   console.log(`  Workers:       ${chalk.bold(String(params.workers))}`);
+  if (params.openAfterRender) console.log(`  Open:          ${chalk.bold("yes")}`);
+  if (params.revealInFinder) console.log(`  Reveal:        ${chalk.bold("yes")}`);
   console.log();
   console.log(chalk.dim("No browser capture, FFmpeg mux, or video files were created."));
 }
@@ -130,7 +140,7 @@ function printRenderResult(spinner: ReturnType<typeof ora> | null, result: Scene
   console.log();
   console.log(chalk.bold.cyan("Output"));
   console.log(chalk.dim("-".repeat(60)));
-  console.log(`  File:      ${chalk.bold(result.outputPath)}`);
+  console.log(`  File:      ${chalk.bold(result.absoluteOutputPath ?? result.outputPath)}`);
   if (result.beat) console.log(`  Beat:      ${result.beat}`);
   if (result.root) console.log(`  Root:      ${result.root}`);
   console.log(`  Format:    ${result.format ?? "mp4"}`);
@@ -145,6 +155,12 @@ function printRenderResult(spinner: ReturnType<typeof ora> | null, result: Scene
     console.log(`  Audio:     ${audio}`);
   }
   if (result.audioMuxWarning) console.log(chalk.yellow(`  Warning:   ${result.audioMuxWarning}`));
+  if (result.openCommand) console.log(`  Open:      ${chalk.dim(result.openCommand)}`);
+  if (result.revealCommand) console.log(`  Reveal:    ${chalk.dim(result.revealCommand)}`);
+  if (result.opened) console.log(chalk.green("  Opened:    yes"));
+  if (result.revealed) console.log(chalk.green("  Revealed:  yes"));
+  if (result.openError) console.log(chalk.yellow(`  Open warn: ${result.openError}`));
+  if (result.revealError) console.log(chalk.yellow(`  Reveal warn: ${result.revealError}`));
 }
 
 function parseFps(value: string): RenderFps {

--- a/packages/cli/src/tools/adapters/mcp.ts
+++ b/packages/cli/src/tools/adapters/mcp.ts
@@ -32,6 +32,69 @@ export type McpDispatcher = (
   args: Record<string, unknown>,
 ) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
 
+type StdoutWrite = typeof process.stdout.write;
+
+function formatConsolePart(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.stack ?? value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function invokeWriteCallback(encodingOrCallback?: unknown, callback?: unknown): void {
+  const cb = typeof encodingOrCallback === "function"
+    ? encodingOrCallback
+    : typeof callback === "function"
+      ? callback
+      : undefined;
+  if (cb) queueMicrotask(() => (cb as () => void)());
+}
+
+function formatStdoutChunk(chunk: unknown, encodingOrCallback?: unknown): string {
+  if (Buffer.isBuffer(chunk)) {
+    const encoding = typeof encodingOrCallback === "string"
+      ? encodingOrCallback as BufferEncoding
+      : "utf8";
+    return chunk.toString(encoding);
+  }
+  return String(chunk);
+}
+
+async function withCapturedStdout<T>(fn: () => Promise<T>): Promise<T> {
+  const originalWrite = process.stdout.write;
+  const originalConsoleLog = console.log;
+  const originalConsoleInfo = console.info;
+  const originalConsoleDebug = console.debug;
+  let captured = "";
+  const captureConsole = (...values: unknown[]) => {
+    captured += `${values.map(formatConsolePart).join(" ")}\n`;
+  };
+
+  process.stdout.write = ((chunk: unknown, encodingOrCallback?: unknown, callback?: unknown) => {
+    captured += formatStdoutChunk(chunk, encodingOrCallback);
+    invokeWriteCallback(encodingOrCallback, callback);
+    return true;
+  }) as StdoutWrite;
+  console.log = captureConsole;
+  console.info = captureConsole;
+  console.debug = captureConsole;
+
+  try {
+    return await fn();
+  } finally {
+    process.stdout.write = originalWrite;
+    console.log = originalConsoleLog;
+    console.info = originalConsoleInfo;
+    console.debug = originalConsoleDebug;
+    if (captured.trim() && process.env.VIBE_MCP_DEBUG_STDIO === "1") {
+      process.stderr.write(captured);
+    }
+  }
+}
+
 function formatZodError(err: ZodError): string {
   // Surface "this required field is missing/null/undefined" as the legacy
   // "missing required argument" phrasing so existing MCP-host integrations
@@ -100,10 +163,12 @@ export function buildMcpDispatcher(manifest: readonly ToolDefinition[]): McpDisp
       };
     }
     try {
-      const result = await tool.execute(parsed.data, {
-        workingDirectory: process.cwd(),
-        surface: "mcp",
-      });
+      const result = await withCapturedStdout(() =>
+        tool.execute(parsed.data, {
+          workingDirectory: process.cwd(),
+          surface: "mcp",
+        })
+      );
       const text = result.success
         ? JSON.stringify({ success: true, ...result.data })
         : result.data

--- a/packages/cli/src/tools/manifest.test.ts
+++ b/packages/cli/src/tools/manifest.test.ts
@@ -12,11 +12,13 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import { manifest } from "./manifest/index.js";
-import { manifestToMcpTools } from "./adapters/mcp.js";
+import { buildMcpDispatcher, manifestToMcpTools } from "./adapters/mcp.js";
 import {
   registerManifestIntoAgent,
 } from "./adapters/agent.js";
+import { defineTool, type AnyTool } from "./define-tool.js";
 import { ToolRegistry } from "../agent/tools/index.js";
 
 describe("tool manifest invariants", () => {
@@ -62,6 +64,43 @@ describe("tool manifest invariants", () => {
       expect(tool.inputSchema.type).toBe("object");
       expect(tool.inputSchema.properties).toBeDefined();
       expect(Array.isArray(tool.inputSchema.required)).toBe(true);
+    }
+  });
+
+  it("MCP dispatcher captures noisy tool stdout so stdio transport stays JSON-only", async () => {
+    const originalWrite = process.stdout.write;
+    const leaked: string[] = [];
+    process.stdout.write = ((chunk: unknown, encodingOrCallback?: unknown, callback?: unknown) => {
+      leaked.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk));
+      const cb = typeof encodingOrCallback === "function"
+        ? encodingOrCallback
+        : typeof callback === "function"
+          ? callback
+          : undefined;
+      if (cb) queueMicrotask(() => (cb as () => void)());
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const noisyTool = defineTool({
+        name: "noisy_tool",
+        category: "test",
+        cost: "free",
+        surfaces: ["mcp"],
+        description: "Test tool that writes logs while returning JSON.",
+        schema: z.object({}),
+        async execute() {
+          console.log("[Compiler] this must not leak into MCP stdout");
+          process.stdout.write("[INFO] also not JSON\n");
+          return { success: true, data: { ok: true } };
+        },
+      });
+      const dispatch = buildMcpDispatcher([noisyTool as unknown as AnyTool]);
+      const response = await dispatch("noisy_tool", {});
+      expect(leaked).toEqual([]);
+      expect(JSON.parse(response.content[0].text)).toEqual({ success: true, ok: true });
+    } finally {
+      process.stdout.write = originalWrite;
     }
   });
 

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -399,6 +399,14 @@ const sceneRenderSchema = z.object({
     .describe("Quality preset. Default 'standard'."),
   format: z.enum(["mp4", "webm", "mov"]).optional().describe("Container format. Default 'mp4'."),
   workers: z.number().optional().describe("Capture worker count (1-16). Default 1."),
+  openAfterRender: z
+    .boolean()
+    .optional()
+    .describe("Open the rendered video in the OS default app after render. Default false."),
+  revealInFinder: z
+    .boolean()
+    .optional()
+    .describe("Reveal the rendered video in Finder/file manager after render. Default false."),
 });
 
 export const sceneRenderTool = defineTool({
@@ -421,6 +429,8 @@ export const sceneRenderTool = defineTool({
       quality: args.quality as RenderQuality | undefined,
       format: args.format as RenderFormat | undefined,
       workers: args.workers,
+      openAfterRender: args.openAfterRender,
+      revealInFinder: args.revealInFinder,
     });
     if (!result.success) {
       return { success: false, error: result.error ?? "render failed" };
@@ -429,6 +439,13 @@ export const sceneRenderTool = defineTool({
       success: true,
       data: {
         outputPath: result.outputPath,
+        absoluteOutputPath: result.absoluteOutputPath,
+        openCommand: result.openCommand,
+        revealCommand: result.revealCommand,
+        opened: result.opened,
+        revealed: result.revealed,
+        openError: result.openError,
+        revealError: result.revealError,
         beat: result.beat,
         root: result.root,
         reportPath: result.reportPath,
@@ -438,12 +455,23 @@ export const sceneRenderTool = defineTool({
         fps: result.fps,
         quality: result.quality,
         format: result.format,
+        audioCount: result.audioCount,
+        audioMuxApplied: result.audioMuxApplied,
+        audioMuxWarning: result.audioMuxWarning,
       },
       humanLines: [
-        `✅ Render complete: ${result.outputPath}`,
+        `✅ Render complete: ${result.absoluteOutputPath ?? result.outputPath}`,
         `   duration: ${((result.durationMs ?? 0) / 1000).toFixed(1)}s`,
         `   frames:   ${result.framesRendered ?? "?"}${result.totalFrames ? ` / ${result.totalFrames}` : ""}`,
         `   config:   ${result.fps}fps · ${result.quality} · ${result.format}`,
+        `   audio:    ${result.audioCount && result.audioCount > 0 ? `${result.audioCount} track${result.audioCount === 1 ? "" : "s"} muxed` : "silent"}`,
+        ...(result.openCommand ? [`   open:     ${result.openCommand}`] : []),
+        ...(result.revealCommand ? [`   reveal:   ${result.revealCommand}`] : []),
+        `   inspect:  vibe inspect render ${projectDir} --cheap --json`,
+        ...(result.opened ? [`   opened:   yes`] : []),
+        ...(result.revealed ? [`   revealed: yes`] : []),
+        ...(result.openError ? [`   open warning: ${result.openError}`] : []),
+        ...(result.revealError ? [`   reveal warning: ${result.revealError}`] : []),
       ],
     };
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.106.7",
+  "version": "0.106.8",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.106.7",
+  "version": "0.106.8",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/tools/scene.test.ts
+++ b/packages/mcp-server/src/tools/scene.test.ts
@@ -63,6 +63,8 @@ describe("MCP scene tools — registration", () => {
     expect(byName.scene_add.inputSchema.required).toEqual(["name"]);
     expect(byName.scene_lint.inputSchema.required).toEqual([]);
     expect(byName.render.inputSchema.required).toEqual([]);
+    expect(byName.render.inputSchema.properties).toHaveProperty("openAfterRender");
+    expect(byName.render.inputSchema.properties).toHaveProperty("revealInFinder");
   });
 
   it("explains MCP workspace-relative project paths", () => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.106.7",
+  "version": "0.106.8",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary
- capture stdout emitted by MCP tool executors so renderer/compiler logs do not corrupt stdio JSON-RPC
- expose absolute render paths plus open/reveal commands for host apps like Claude Desktop
- add render --open / --reveal options and update MCP render schema
- bump packages to 0.106.8

## Verification
- pnpm build
- pnpm lint
- pnpm gen:reference:check
- pnpm -F @vibeframe/cli test
- pnpm -F @vibeframe/mcp-server test
- bash scripts/pre-push-validate.sh