### PR TITLE
feat: complete the agent action contract + precise Seedance dry-run cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,14 @@ When invoking VibeFrame commands from an agent context:
 - Treat native Codex Goal mode, Claude Code `/goal`, Cursor agent loops, or
   another host's equivalent as the outer loop for long-running video work.
   VibeFrame should provide video-specific commands, JSON reports, cost gates,
-  deterministic repair, render inspection, and `retryWith`/`fixOwner` recovery
-  contracts, not a competing primary goal runner.
+  deterministic repair, render inspection, and `nextActions`/`fixOwner`
+  recovery contracts, not a competing primary goal runner.
 - Prefer `--json` for structured output.
 - Run `--dry-run` before paid or mutating operations when the command supports it.
+- When a review report includes `nextActions`, prefer it over inventing
+  commands: run only `safeToAutoRun:true` actions automatically, ask before
+  `requiresConfirmation:true`, and treat `retryWith` as the compatibility
+  fallback.
 - Use `vibe schema <command>` before constructing non-trivial arguments.
 - Confirm with the user before high/very-high cost operations such as
   `generate video`, `edit fill-gaps`, and provider-backed `remix` workflows.

--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ Copy-paste for Codex:
 Use vibe context/schema first when command details are unclear. Use --json for
 all vibe commands. Run --dry-run before paid operations and keep generated-asset
 spend under $5 with --max-cost 5 where supported. Read build-report.json and
-review-report.json before choosing the next action. Run retryWith commands
-before inventing recovery steps. Treat fixOwner:"vibe" issues as deterministic
-CLI repair work and fixOwner:"host-agent" issues as storyboard, DESIGN.md, or
-composition edits.
+review-report.json before choosing the next action. Prefer nextActions:
+run only safeToAutoRun:true actions automatically, ask before
+requiresConfirmation:true actions, and use retryWith only as the compatibility
+fallback. Treat fixOwner:"vibe" issues as deterministic CLI repair work and
+fixOwner:"host-agent" issues as storyboard, DESIGN.md, or composition edits.
 
 Stop only when launch/renders/final.mp4 exists, the target duration is 30s or
 less, the aspect ratio is 16:9 unless brief.md says otherwise,
@@ -143,9 +144,10 @@ Copy-paste for Claude Code:
 Claude Code goal loop as the outer loop. Use vibe commands with --json, run
 dry-run before paid operations, cap build spend at $5 with --max-cost 5, and
 use build-report.json plus review-report.json as the loop state. Follow
-retryWith before guessing, and distinguish fixOwner:"vibe" from
-fixOwner:"host-agent" when deciding whether to run vibe scene repair or edit
-STORYBOARD.md, DESIGN.md, or compositions.
+nextActions first, run only safeToAutoRun:true actions automatically, ask
+before requiresConfirmation:true actions, and use retryWith only as a fallback.
+Distinguish fixOwner:"vibe" from fixOwner:"host-agent" when deciding whether
+to run vibe scene repair or edit STORYBOARD.md, DESIGN.md, or compositions.
 
 Stop only when launch/renders/final.mp4 exists, duration is within the requested
 30s target, aspect ratio is 16:9 unless the brief overrides it, render
@@ -295,7 +297,7 @@ vibe inspect project my-video --beat hook --json
 vibe render my-video --beat hook --json
 vibe inspect render my-video --beat hook --cheap --json
 
-# Let a host agent handle semantic issues from the report
+# Let a host agent handle semantic issues from nextActions/review-report.json
 codex "fix issues from my-video/review-report.json"
 ```
 
@@ -342,7 +344,11 @@ the intent layer, `DESIGN.md` is the visual system, `vibe.config.json` stores
 provider/model defaults, `media/` stores user-provided source media, and files
 under `assets/` and `compositions/` are generated or canonical build artifacts.
 `build-report.json` records build results and costs;
-`review-report.json` records inspection findings and suggested fixes.
+`review-report.json` records inspection findings, issue-level actions, and
+top-level nextActions. Agents should prefer nextActions, run only
+safeToAutoRun:true commands automatically, ask before
+requiresConfirmation:true actions, and keep retryWith as the compatibility
+fallback.
 When paid video or music providers return async jobs, `vibe status project
 --refresh` downloads completed outputs, updates `build-report.json`, and
 writes freshness metadata under `.vibeframe/assets/`. The sync stage wires

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,7 +34,7 @@ Canonical native-goal loop:
 ```
 native host goal → vibe context/schema → plan dry-run → build with budget
 → status polling → inspect project → render → inspect render
-→ repair/edit using retryWith/fixOwner → repeat until stop rules pass
+→ repair/edit using nextActions/fixOwner → repeat until stop rules pass
 ```
 
 `vibe plan --json` emits `data.kind:"build-plan"`,
@@ -67,13 +67,16 @@ render code or `code:"RENDER_FAILED"`. Both include `currentStage`,
 `review-report.json` by default. The file uses `kind:"review"`,
 `mode:"project"|"render"`, `status`, `score`, `issues[]`,
 `summary:{issueCount,errorCount,warningCount,infoCount,fixOwners}`,
-`sourceReports`, and `retryWith`. Issue-level `fixOwner:"vibe"` means
-deterministic CLI recovery; `fixOwner:"host-agent"` means storyboard/design/
-composition edits should be handled by the host agent. A host-native goal
-should stop only after the final MP4 exists, duration and aspect ratio match
-the brief, render inspection has no errors, any AI review score meets the goal
-threshold when AI review is requested, and every host-agent issue is fixed, accepted with rationale, or
-reported as blocked.
+`sourceReports`, `nextActions`, and `retryWith`. `nextActions` is the
+preferred agent contract: run only `safeToAutoRun:true` actions automatically,
+ask before `requiresConfirmation:true`, and use `retryWith` only as the
+compatibility fallback. Issue-level `fixOwner:"vibe"` means deterministic CLI
+recovery; `fixOwner:"host-agent"` means storyboard/design/composition edits
+should be handled by the host agent. A host-native goal should stop only after
+the final MP4 exists, duration and aspect ratio match the brief, render
+inspection has no errors, any AI review score meets the goal threshold when AI
+review is requested, and every host-agent issue is fixed, accepted with
+rationale, or reported as blocked.
 
 ## Global flags
 
@@ -1068,7 +1071,7 @@ Cost tier: `free`
 - `output` _(string)_ — Write review report to this path (default: <project>/review-report.json)
 - `noReport` _(boolean)_ — Do not write review-report.json
 
-`review-report.json` payload uses `kind:"review"`, `mode:"project"`, `summary`, `sourceReports`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. Command output keeps `data.kind:"project"`.
+`review-report.json` payload uses `kind:"review"`, `mode:"project"`, `summary`, `sourceReports`, `nextActions`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. Command output keeps `data.kind:"project"`.
 
 #### `vibe inspect render`
 
@@ -1090,7 +1093,7 @@ Cost tier: `low`
 - `noReport` _(boolean)_ — Do not write review-report.json
 - `dryRun` _(boolean)_ — Preview parameters without probing video or calling Gemini
 
-`review-report.json` payload uses `kind:"review"`, `mode:"render"`, `summary`, `sourceReports`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. `--ai` maps Gemini findings to host-agent-owned issues.
+`review-report.json` payload uses `kind:"review"`, `mode:"render"`, `summary`, `sourceReports`, `nextActions`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. `--ai` maps Gemini findings to host-agent-owned issues.
 
 #### `vibe inspect review`
 
@@ -1979,7 +1982,7 @@ Cost tier: `free`
 - `project-dir` _(string)_ — VibeFrame project directory
 - `refresh` _(boolean)_ — Refresh active supported jobs before summarizing
 
-JSON payload: `data.kind` is `"project"` and includes `status`, `currentStage`, `beats` readiness counts, `jobs.latest`, `build`, `review`, `warnings`, and `retryWith`. `review` includes `mode`, issue/error/warning/info counts, `fixOwners`, `sourceReports`, and `retryWith`; top-level `retryWith` is the resume contract.
+JSON payload: `data.kind` is `"project"` and includes `status`, `currentStage`, `beats` readiness counts, `jobs.latest`, `build`, `review`, `warnings`, `nextActions`, and `retryWith`. `review` includes `mode`, issue/error/warning/info counts, `fixOwners`, `sourceReports`, `nextActions`, and `retryWith`; top-level `nextActions` is the preferred resume contract, while `retryWith` remains the compatibility fallback.
 
 ### `host`
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -35,7 +35,7 @@ paths:
 ```text
 native host goal -> vibe context/schema -> plan dry-run -> build with budget
 -> status polling -> inspect project -> render -> inspect render
--> repair/edit using retryWith/fixOwner -> repeat
+-> repair/edit using nextActions/fixOwner -> repeat
 ```
 
 The goal should stop only when the final MP4 path exists, duration and aspect
@@ -44,7 +44,9 @@ meets the goal threshold when AI review is requested, and unresolved
 `fixOwner:"host-agent"` issues are fixed,
 accepted with rationale, or reported as blocked. Agents should read
 `build-report.json` and `review-report.json` before choosing the next action
-and run `retryWith` commands before inventing recovery steps.
+and prefer `nextActions`: run only `safeToAutoRun:true` actions automatically,
+ask before `requiresConfirmation:true`, and use `retryWith` only as the
+compatibility fallback.
 
 Claude Desktop uses global MCP config, so anchor it to the workspace you want
 relative project names to resolve under. VibeFrame writes a shell wrapper

--- a/packages/ai-providers/src/fal/FalProvider.test.ts
+++ b/packages/ai-providers/src/fal/FalProvider.test.ts
@@ -22,7 +22,7 @@ vi.mock("@fal-ai/client", () => ({
   },
 }));
 
-import { FalProvider } from "./FalProvider.js";
+import { FalProvider, estimateSeedanceVideoCostUsd } from "./FalProvider.js";
 
 describe("FalProvider", () => {
   let provider: FalProvider;
@@ -294,5 +294,42 @@ describe("FalProvider", () => {
       expect(result.status).toBe("failed");
       expect(result.error).toMatch(/FAL_API_KEY/);
     });
+  });
+});
+
+describe("estimateSeedanceVideoCostUsd", () => {
+  it("matches fal's published per-second rates for 16:9", () => {
+    // 720p 16:9 standard = $0.3024/s; 1080p 16:9 = $0.682/s.
+    expect(estimateSeedanceVideoCostUsd({ durationSec: 5, resolution: "720p", aspectRatio: "16:9" })).toBe(1.51);
+    expect(estimateSeedanceVideoCostUsd({ durationSec: 10, resolution: "1080p", aspectRatio: "16:9" })).toBe(6.8);
+  });
+
+  it("applies the fast-tier 0.8x factor (and only up to 720p)", () => {
+    expect(
+      estimateSeedanceVideoCostUsd({ durationSec: 5, resolution: "720p", aspectRatio: "16:9", fast: true })
+    ).toBe(1.21);
+    // 1080p has no fast tier — the factor must not apply.
+    expect(
+      estimateSeedanceVideoCostUsd({ durationSec: 10, resolution: "1080p", aspectRatio: "16:9", fast: true })
+    ).toBe(6.8);
+  });
+
+  it("costs less for square/portrait ratios (fewer pixels)", () => {
+    expect(estimateSeedanceVideoCostUsd({ durationSec: 5, resolution: "720p", aspectRatio: "1:1" })).toBe(0.85);
+  });
+
+  it("applies the 0.6x reference-video discount", () => {
+    const base = estimateSeedanceVideoCostUsd({ durationSec: 5, resolution: "720p", aspectRatio: "16:9" });
+    const withVideo = estimateSeedanceVideoCostUsd({
+      durationSec: 5,
+      resolution: "720p",
+      aspectRatio: "16:9",
+      hasVideoReference: true,
+    });
+    expect(withVideo).toBeCloseTo(base * 0.6, 2);
+  });
+
+  it("defaults to 720p 16:9 when resolution/ratio are omitted", () => {
+    expect(estimateSeedanceVideoCostUsd({ durationSec: 5 })).toBe(1.51);
   });
 });

--- a/packages/ai-providers/src/fal/FalProvider.ts
+++ b/packages/ai-providers/src/fal/FalProvider.ts
@@ -51,6 +51,44 @@ type SeedanceResolution = (typeof VALID_RESOLUTIONS)[number];
 const VALID_ASPECTS = ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16", "auto"] as const;
 type SeedanceAspect = (typeof VALID_ASPECTS)[number];
 
+/**
+ * Seedance 2.0 is billed per token on fal.ai, not per second:
+ *   cost = (tokens / 1000) × $0.014,  tokens/sec = (width × height × 24) / 1024
+ * The "p" in a resolution is the SHORT side (720p 16:9 → 1280×720). The `fast`
+ * tier bills ≈ 0.8× standard (and tops out at 720p), and supplying a reference
+ * video applies ≈ 0.6× (a 40% discount). Verified against fal's published rates
+ * (720p 16:9 = $0.3024/s, 1080p 16:9 = $0.682/s):
+ * https://fal.ai/models/bytedance/seedance-2.0/reference-to-video
+ */
+const SEEDANCE_USD_PER_1K_TOKENS = 0.014;
+const SEEDANCE_FAST_FACTOR = 0.8;
+const SEEDANCE_VIDEO_REF_FACTOR = 0.6;
+const SEEDANCE_SHORT_SIDE: Record<string, number> = { "480p": 480, "720p": 720, "1080p": 1080 };
+
+/**
+ * Estimate the fal.ai charge for a Seedance 2.0 generation from its token-based
+ * pricing. Used by `generate video --dry-run` so the previewed `costUsd` is
+ * accurate to resolution/ratio/duration/tier instead of a flat cost-tier upper
+ * bound. Audio is included at no extra charge, so it is not modelled.
+ */
+export function estimateSeedanceVideoCostUsd(opts: {
+  durationSec: number;
+  resolution?: string;
+  aspectRatio?: string;
+  fast?: boolean;
+  hasVideoReference?: boolean;
+}): number {
+  const shortSide = SEEDANCE_SHORT_SIDE[opts.resolution ?? "720p"] ?? 720;
+  const [a, b] = (opts.aspectRatio ?? "16:9").split(":").map(Number);
+  const ratioFactor = a > 0 && b > 0 ? Math.max(a, b) / Math.min(a, b) : 16 / 9;
+  const longSide = Math.round(shortSide * ratioFactor);
+  const tokensPerSecond = (shortSide * longSide * 24) / 1024;
+  let usdPerSecond = (tokensPerSecond / 1000) * SEEDANCE_USD_PER_1K_TOKENS;
+  if (opts.fast && shortSide <= 720) usdPerSecond *= SEEDANCE_FAST_FACTOR;
+  if (opts.hasVideoReference) usdPerSecond *= SEEDANCE_VIDEO_REF_FACTOR;
+  return Number((usdPerSecond * Math.max(0, opts.durationSec)).toFixed(2));
+}
+
 /** Shape of the video object Seedance returns. */
 interface SeedanceOutput {
   video?: { url?: string; content_type?: string; file_size?: number };

--- a/packages/ai-providers/src/index.ts
+++ b/packages/ai-providers/src/index.ts
@@ -74,7 +74,7 @@ export { KlingProvider, klingProvider } from "./kling/index.js";
 export type { KlingVideoExtendOptions } from "./kling/index.js";
 export { GrokProvider, grokProvider } from "./grok/index.js";
 export type { GrokModel, GrokVideoOptions, GrokImageOptions, GrokEditOptions } from "./grok/index.js";
-export { FalProvider, falProvider } from "./fal/index.js";
+export { FalProvider, falProvider, estimateSeedanceVideoCostUsd } from "./fal/index.js";
 export type { SeedanceVariant } from "./fal/index.js";
 export { ReplicateProvider, replicateProvider } from "./replicate/index.js";
 export type { ReplicateUpscaleOptions, ReplicateUpscaleResult, ReplicateInpaintOptions, MusicGenerationOptions, MusicGenerationResult, AudioRestorationOptions, AudioRestorationResult } from "./replicate/index.js";

--- a/packages/cli/CONTEXT.md
+++ b/packages/cli/CONTEXT.md
@@ -23,7 +23,7 @@ goal runner. The canonical loop is:
 ```text
 native host goal -> vibe context/schema -> plan dry-run -> build with budget
 -> status polling -> inspect project -> render -> inspect render
--> repair/edit using retryWith/fixOwner -> repeat until stop rules pass
+-> repair/edit using nextActions/fixOwner -> repeat until stop rules pass
 ```
 
 Copy-paste Codex goal:
@@ -32,8 +32,10 @@ Copy-paste Codex goal:
 /goal Build my-video/ into a reviewed VibeFrame MP4. Use --json for every vibe
 command, run --dry-run before paid operations, cap generated-asset spend with
 --max-cost 5 where supported, and read build-report.json plus
-review-report.json before deciding the next action. Run retryWith commands
-before guessing. Treat fixOwner:"vibe" as deterministic CLI repair work and
+review-report.json before deciding the next action. Prefer nextActions: run
+only safeToAutoRun:true actions automatically, ask before
+requiresConfirmation:true actions, and use retryWith only as the compatibility
+fallback. Treat fixOwner:"vibe" as deterministic CLI repair work and
 fixOwner:"host-agent" as storyboard, DESIGN.md, or composition edits.
 Stop only when my-video/renders/final.mp4 exists, duration is within the target,
 aspect ratio matches the brief, inspect render --cheap has no errors, review
@@ -46,7 +48,7 @@ Copy-paste Claude Code goal:
 ```text
 /goal Finish the VibeFrame render for my-video/ using Claude Code goal mode as
 the outer loop. Use vibe context/schema when unsure, --json everywhere,
-dry-run before paid operations, --max-cost 5 for builds, retryWith before
+dry-run before paid operations, --max-cost 5 for builds, nextActions before
 custom recovery, and build-report.json/review-report.json as loop state.
 Stop only when renders/final.mp4 exists, target duration and aspect ratio are
 met, render inspection has no errors, any AI review score is at least 90 when AI review is requested, and every
@@ -216,12 +218,14 @@ Review report contract:
 `review-report.json` by default. The file uses `kind:"review"`,
 `mode:"project"|"render"`, `status`, `score`, `issues[]`,
 `summary:{issueCount,errorCount,warningCount,infoCount,fixOwners}`,
-`sourceReports`, and `retryWith`. Each issue has `fixOwner:"vibe"` for
-deterministic CLI recovery or `fixOwner:"host-agent"` for storyboard/design/
-composition edits the host agent should make. Use `retryWith` first, then
-hand remaining `host-agent` issues to the agent. A host-native goal should not
-stop while `host-agent` issues remain unless they are fixed, intentionally
-accepted with a written reason, or reported as blocked.
+`sourceReports`, `nextActions`, and `retryWith`. Each issue has
+`fixOwner:"vibe"` for deterministic CLI recovery or `fixOwner:"host-agent"`
+for storyboard/design/composition edits the host agent should make. Prefer
+`nextActions` first: run only `safeToAutoRun:true` actions automatically, ask
+before `requiresConfirmation:true`, and use `retryWith` only as the fallback.
+A host-native goal should not stop while `host-agent` issues remain unless
+they are fixed, intentionally accepted with a written reason, or reported as
+blocked.
 
 Product surface contract:
 
@@ -287,7 +291,7 @@ vibe scene repair --project my-video --json
 
 `vibe status job --json` emits the normal success envelope with `data.kind:"job"`, flat job fields (`id`, `jobType`, `provider`, `status`, timestamps), `progress`, `result`, `retryWith`, and the raw `job` record for compatibility.
 
-`vibe status project --json` emits `data.kind:"project"`, `status`, `currentStage`, `beats:{total,assetsReady,compositionsReady,needsAuthor}`, `jobs.latest`, `build`, `review`, `warnings`, and `retryWith`. `review` includes `mode`, `issueCount`, `errorCount`, `warningCount`, `infoCount`, `fixOwners`, `sourceReports`, and its own `retryWith`; top-level `retryWith` carries the next resume command. Use `retryWith` rather than guessing the next command.
+`vibe status project --json` emits `data.kind:"project"`, `status`, `currentStage`, `beats:{total,assetsReady,compositionsReady,needsAuthor}`, `jobs.latest`, `build`, `review`, `warnings`, `nextActions`, and `retryWith`. `review` includes `mode`, `issueCount`, `errorCount`, `warningCount`, `infoCount`, `fixOwners`, `sourceReports`, `nextActions`, and its own `retryWith`; top-level `nextActions` carries the preferred resume contract while `retryWith` remains the compatibility fallback.
 
 ### Storyboard revision contract
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,7 +65,7 @@
     "lint": "eslint --ext .ts,.tsx src/",
     "test": "vitest run",
     "test:watch": "vitest",
-    "pretest": "node build.js",
+    "pretest": "pnpm --dir ../core build && pnpm --dir ../ai-providers build && node build.js",
     "prepublishOnly": "node build.js"
   },
   "dependencies": {

--- a/packages/cli/src/commands/_shared/host-integration.ts
+++ b/packages/cli/src/commands/_shared/host-integration.ts
@@ -88,7 +88,7 @@ export function hostDefinitions(_projectDir = process.cwd()): HostDefinition[] {
       configKind: "codex-toml",
       notes: [
         "Codex reads AGENTS.md and can also load project-scoped .codex/config.toml after the project is trusted.",
-        "Use Codex /goal as the outer loop for long-running VibeFrame projects; vibe supplies JSON reports, retryWith, and repair commands.",
+        "Use Codex /goal as the outer loop for long-running VibeFrame projects; vibe supplies JSON reports, nextActions classified by cost/safety (prefer these), retryWith as a compatibility fallback, and repair commands.",
         "Keep provider/auth keys in VibeFrame config or environment, not in project-local Codex config.",
       ],
     },
@@ -101,7 +101,7 @@ export function hostDefinitions(_projectDir = process.cwd()): HostDefinition[] {
       configKind: "mcp-json",
       notes: [
         "Claude Code can drive vibe directly through shell plus AGENTS.md/CLAUDE.md.",
-        "Use Claude Code /goal as the outer loop for long-running VibeFrame projects; vibe supplies JSON reports, retryWith, and repair commands.",
+        "Use Claude Code /goal as the outer loop for long-running VibeFrame projects; vibe supplies JSON reports, nextActions classified by cost/safety (prefer these), retryWith as a compatibility fallback, and repair commands.",
         "The MCP entry is optional and gives Claude Code a typed tool surface.",
       ],
     },

--- a/packages/cli/src/commands/_shared/init-templates.test.ts
+++ b/packages/cli/src/commands/_shared/init-templates.test.ts
@@ -37,7 +37,11 @@ describe("AGENTS_MD template", () => {
     expect(AGENTS_MD).toContain("Claude Code `/goal`");
     expect(AGENTS_MD).toContain("build-report.json");
     expect(AGENTS_MD).toContain("review-report.json");
+    expect(AGENTS_MD).toContain("nextActions");
+    expect(AGENTS_MD).toContain("safeToAutoRun");
+    expect(AGENTS_MD).toContain("requiresConfirmation");
     expect(AGENTS_MD).toContain("retryWith");
+    expect(AGENTS_MD).toMatch(/compatibility\s+fallback/);
     expect(AGENTS_MD).toContain('fixOwner:"vibe"');
     expect(AGENTS_MD).toContain('fixOwner:"host-agent"');
     expect(AGENTS_MD).toContain("renders/final.mp4");

--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -205,9 +205,9 @@ config, or env files — not in app host config.
 For long-running work, use Codex Goal mode, Claude Code \`/goal\`, Cursor, or
 another host-native goal feature as the outer loop. VibeFrame should not own a
 competing project-level goal runner. It provides \`--json\` commands, dry runs,
-budget caps, \`build-report.json\`, \`review-report.json\`, \`retryWith\`,
-\`fixOwner\`, deterministic repair, and render inspection for the host agent
-to decide what to do next.
+budget caps, \`build-report.json\`, \`review-report.json\`, \`nextActions\`,
+\`safeToAutoRun\`, \`requiresConfirmation\`, \`fixOwner\`, deterministic repair,
+and render inspection for the host agent to decide what to do next.
 
 Copy-paste Codex:
 
@@ -215,9 +215,11 @@ Copy-paste Codex:
 /goal Build this VibeFrame project into renders/final.mp4. Use --json for every
 vibe command, run --dry-run before paid operations, use --max-cost 5 for builds
 unless the user gives another budget, read build-report.json and
-review-report.json before deciding the next action, and run retryWith commands
-before custom recovery. Treat fixOwner:"vibe" as CLI repair work and
-fixOwner:"host-agent" as STORYBOARD.md, DESIGN.md, or composition edits.
+review-report.json before deciding the next action, prefer nextActions before
+guessing, run only safeToAutoRun:true actions automatically, and ask before
+requiresConfirmation:true actions. Treat retryWith as the compatibility
+fallback, fixOwner:"vibe" as CLI repair work, and fixOwner:"host-agent" as
+STORYBOARD.md, DESIGN.md, or composition edits.
 Stop only when renders/final.mp4 exists, target duration and aspect ratio are
 met, inspect render --cheap has no errors, any AI review score is >= 90 when AI review is requested, and every
 remaining host-agent issue is fixed, accepted with rationale, or reported as
@@ -229,9 +231,10 @@ Copy-paste Claude Code:
 \`\`\`text
 /goal Finish this VibeFrame render using Claude Code goal mode as the outer
 loop. Use vibe context/schema when unsure, --json everywhere, dry-run before
-paid operations, budget cap via --max-cost 5, retryWith before guessing,
-build-report.json/review-report.json as loop state, and fixOwner to decide
-between vibe scene repair and host-agent edits. Stop only after final MP4,
+paid operations, budget cap via --max-cost 5, nextActions before guessing,
+build-report.json/review-report.json as loop state, and safeToAutoRun,
+requiresConfirmation, and fixOwner to decide between vibe scene repair and
+host-agent edits. Stop only after final MP4,
 target duration/aspect ratio, clean render inspection, any AI review score >= 90 when AI review is requested, and
 no unresolved unacknowledged host-agent issues.
 \`\`\`

--- a/packages/cli/src/commands/_shared/render-inspect.test.ts
+++ b/packages/cli/src/commands/_shared/render-inspect.test.ts
@@ -246,6 +246,19 @@ describe("render inspect parsers", () => {
     expect(result.beat).toBe("hook");
     expect(result.summary.errorCount).toBe(1);
     expect(result.issues[0].fixOwner).toBe("vibe");
+    expect(result.issues[0].actions).toEqual([
+      expect.objectContaining({
+        command: `vibe render ${dir} --beat hook --json`,
+        safeToAutoRun: true,
+        requiresConfirmation: false,
+        sourceIssueCodes: ["RENDER_NOT_FOUND"],
+      }),
+    ]);
+    expect(result.nextActions).toEqual([
+      expect.objectContaining({
+        command: `vibe render ${dir} --beat hook --json`,
+      }),
+    ]);
     expect(result.retryWith).toEqual([`vibe render ${dir} --beat hook --json`]);
   });
 
@@ -263,6 +276,12 @@ describe("render inspect parsers", () => {
       project: resolve(dir),
       status: "fail",
       summary: { errorCount: 1, fixOwners: { vibe: 1, hostAgent: 0 } },
+      nextActions: expect.arrayContaining([
+        expect.objectContaining({
+          command: `vibe render ${dir} --json`,
+          safeToAutoRun: true,
+        }),
+      ]),
     });
   });
 

--- a/packages/cli/src/commands/_shared/render-inspect.ts
+++ b/packages/cli/src/commands/_shared/render-inspect.ts
@@ -10,12 +10,14 @@ import { parseStoryboard } from "./storyboard-parse.js";
 import {
   buildReviewReport,
   defaultReviewReportPath,
+  deriveNextReviewActions,
   normalizeReviewIssues,
   scoreIssues,
   statusFromIssues,
   summarizeReviewIssues,
   uniqueRetryWith,
   writeReviewReport,
+  type ReviewAction,
   type ReviewIssue,
   type ReviewSeverity,
   type ReviewSummary,
@@ -92,6 +94,7 @@ export interface RenderInspectResult {
   score: number;
   issues: ReviewIssue[];
   summary: ReviewSummary;
+  nextActions: ReviewAction[];
   sourceReports: string[];
   checks: {
     renderFound: boolean;
@@ -421,6 +424,8 @@ export async function inspectRender(opts: RenderInspectOptions): Promise<RenderI
       message: opts.beatId
         ? `No rendered video was found for beat "${opts.beatId}". Pass --video or render the beat first.`
         : "No rendered video was found. Pass --video or render the project first.",
+      beatId: opts.beatId,
+      scene: opts.beatId,
       suggestedFix: opts.beatId
         ? "Run `vibe render <project> --beat <id> --json`."
         : "Run `vibe build --stage render --json` or `vibe render --json`.",
@@ -448,6 +453,8 @@ export async function inspectRender(opts: RenderInspectOptions): Promise<RenderI
       code: "EMPTY_RENDER",
       message: "Rendered video file is empty.",
       file: displayPath(videoPath),
+      beatId: opts.beatId,
+      scene: opts.beatId,
       suggestedFix: opts.beatId
         ? "Render again with `vibe render --beat <id> --json`."
         : "Render again with `vibe render --json`.",
@@ -826,7 +833,11 @@ function makeRenderResult(
   retryWith: string[],
   score: number
 ): RenderInspectResult {
-  const normalizedIssues = normalizeReviewIssues(issues);
+  const normalizedRetryWith = uniqueRetryWith(retryWith);
+  const normalizedIssues = normalizeReviewIssues(issues, {
+    projectDir,
+    retryWith: normalizedRetryWith,
+  });
   const status = statusFromIssues(normalizedIssues);
   return {
     schemaVersion: "1",
@@ -839,9 +850,14 @@ function makeRenderResult(
     score,
     issues: normalizedIssues,
     summary: summarizeReviewIssues(normalizedIssues),
+    nextActions: deriveNextReviewActions({
+      issues: normalizedIssues,
+      retryWith: normalizedRetryWith,
+      projectDir,
+    }),
     sourceReports: renderSourceReports(projectDir, videoPath, checks),
     checks,
-    retryWith: uniqueRetryWith(retryWith),
+    retryWith: normalizedRetryWith,
   };
 }
 

--- a/packages/cli/src/commands/_shared/review-report.test.ts
+++ b/packages/cli/src/commands/_shared/review-report.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  commandReviewAction,
+  deriveNextReviewActions,
+  normalizeReviewActions,
+  normalizeReviewIssues,
+  reviewActionsFromRetryWith,
+} from "./review-report.js";
+
+describe("review report actions", () => {
+  it("classifies deterministic local commands as safe to auto-run", () => {
+    expect(
+      commandReviewAction("vibe scene repair /tmp/demo --json", {
+        reason: "repair",
+      })
+    ).toMatchObject({
+      kind: "command",
+      costTier: "free",
+      safeToAutoRun: true,
+      requiresConfirmation: false,
+    });
+
+    expect(
+      commandReviewAction("vibe inspect render /tmp/demo --cheap --json", {
+        reason: "inspect",
+      })
+    ).toMatchObject({
+      costTier: "free",
+      safeToAutoRun: true,
+      requiresConfirmation: false,
+    });
+  });
+
+  it("requires confirmation for provider-backed or ambiguous commands", () => {
+    expect(
+      commandReviewAction("vibe build /tmp/demo --stage assets --force --json", {
+        reason: "assets",
+      })
+    ).toMatchObject({
+      costTier: "unknown",
+      safeToAutoRun: false,
+      requiresConfirmation: true,
+    });
+
+    expect(
+      commandReviewAction("vibe inspect render /tmp/demo --ai --json", {
+        reason: "ai",
+      })
+    ).toMatchObject({
+      costTier: "low",
+      safeToAutoRun: false,
+      requiresConfirmation: true,
+    });
+  });
+
+  it("deduplicates actions and merges source issue codes", () => {
+    const actions = normalizeReviewActions([
+      commandReviewAction("vibe render /tmp/demo --json", {
+        reason: "first",
+        sourceIssueCodes: ["A"],
+      }),
+      commandReviewAction("vibe render /tmp/demo --json", {
+        reason: "second",
+        sourceIssueCodes: ["B"],
+      }),
+    ]);
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      command: "vibe render /tmp/demo --json",
+      sourceIssueCodes: ["A", "B"],
+    });
+  });
+
+  it("adds issue-level defaults and top-level retry actions", () => {
+    const retryWith = ["vibe render /tmp/demo --beat hook --json"];
+    const issues = normalizeReviewIssues(
+      [
+        {
+          severity: "error",
+          code: "MISSING_COMPOSITION",
+          message: "Missing composition",
+          beatId: "hook",
+        },
+      ],
+      { projectDir: "/tmp/demo", retryWith }
+    );
+
+    expect(issues[0].actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: "vibe build /tmp/demo --beat hook --stage compose --json",
+          sourceIssueCodes: ["MISSING_COMPOSITION"],
+          safeToAutoRun: false,
+          requiresConfirmation: true,
+        }),
+      ])
+    );
+    expect(deriveNextReviewActions({ issues, retryWith })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ command: "vibe render /tmp/demo --beat hook --json" }),
+      ])
+    );
+  });
+
+  it("maps host-agent retry hints to agent actions", () => {
+    expect(reviewActionsFromRetryWith(['codex "fix issues from review-report.json"'])).toEqual([
+      expect.objectContaining({
+        kind: "agent",
+        fixOwner: "host-agent",
+        safeToAutoRun: false,
+        requiresConfirmation: false,
+      }),
+    ]);
+  });
+});

--- a/packages/cli/src/commands/_shared/review-report.ts
+++ b/packages/cli/src/commands/_shared/review-report.ts
@@ -5,6 +5,22 @@ export type ReviewSeverity = "error" | "warning" | "info";
 export type ReviewStatus = "pass" | "warn" | "fail";
 export type ReviewMode = "project" | "render";
 export type ReviewFixOwner = "vibe" | "host-agent";
+export type ReviewActionKind = "command" | "agent" | "manual";
+export type ReviewActionCostTier = "free" | "low" | "high" | "very-high" | "unknown";
+
+export interface ReviewAction {
+  id: string;
+  kind: ReviewActionKind;
+  label: string;
+  command?: string;
+  agentPrompt?: string;
+  fixOwner: ReviewFixOwner;
+  costTier: ReviewActionCostTier;
+  safeToAutoRun: boolean;
+  requiresConfirmation: boolean;
+  reason: string;
+  sourceIssueCodes?: string[];
+}
 
 export interface ReviewIssue {
   severity: ReviewSeverity;
@@ -23,6 +39,7 @@ export interface ReviewIssue {
   audioCoverageRatio?: number;
   fixOwner?: ReviewFixOwner;
   suggestedFix?: string;
+  actions?: ReviewAction[];
 }
 
 export interface ReviewSummary {
@@ -46,6 +63,7 @@ export interface ReviewReport {
   score: number;
   issues: ReviewIssue[];
   summary: ReviewSummary;
+  nextActions: ReviewAction[];
   retryWith: string[];
   sourceReports: string[];
   reportPath?: string;
@@ -73,6 +91,138 @@ export function uniqueRetryWith(items: Array<string | undefined | null>): string
   ];
 }
 
+export function commandReviewAction(
+  command: string,
+  opts: {
+    label?: string;
+    fixOwner?: ReviewFixOwner;
+    reason: string;
+    sourceIssueCodes?: string[];
+    costTier?: ReviewActionCostTier;
+    safeToAutoRun?: boolean;
+    requiresConfirmation?: boolean;
+  }
+): ReviewAction {
+  const classified = classifyReviewCommand(command);
+  return stripUndefined({
+    id: actionId("command", command),
+    kind: "command" as const,
+    label: opts.label ?? command,
+    command,
+    fixOwner: opts.fixOwner ?? classified.fixOwner,
+    costTier: opts.costTier ?? classified.costTier,
+    safeToAutoRun: opts.safeToAutoRun ?? classified.safeToAutoRun,
+    requiresConfirmation: opts.requiresConfirmation ?? classified.requiresConfirmation,
+    reason: opts.reason,
+    sourceIssueCodes: uniqueStrings(opts.sourceIssueCodes ?? []),
+  });
+}
+
+export function agentReviewAction(opts: {
+  label: string;
+  agentPrompt: string;
+  reason: string;
+  sourceIssueCodes?: string[];
+}): ReviewAction {
+  return stripUndefined({
+    id: actionId("agent", opts.agentPrompt),
+    kind: "agent" as const,
+    label: opts.label,
+    agentPrompt: opts.agentPrompt,
+    fixOwner: "host-agent" as const,
+    costTier: "unknown" as const,
+    safeToAutoRun: false,
+    requiresConfirmation: false,
+    reason: opts.reason,
+    sourceIssueCodes: uniqueStrings(opts.sourceIssueCodes ?? []),
+  });
+}
+
+export function manualReviewAction(opts: {
+  label: string;
+  reason: string;
+  fixOwner?: ReviewFixOwner;
+  sourceIssueCodes?: string[];
+}): ReviewAction {
+  return stripUndefined({
+    id: actionId("manual", opts.label),
+    kind: "manual" as const,
+    label: opts.label,
+    fixOwner: opts.fixOwner ?? "host-agent",
+    costTier: "unknown" as const,
+    safeToAutoRun: false,
+    requiresConfirmation: false,
+    reason: opts.reason,
+    sourceIssueCodes: uniqueStrings(opts.sourceIssueCodes ?? []),
+  });
+}
+
+export function reviewActionsFromRetryWith(
+  retryWith: string[],
+  sourceIssueCodes: string[] = []
+): ReviewAction[] {
+  return normalizeReviewActions(
+    retryWith.map((item) => {
+      if (/^codex\s+/i.test(item)) {
+        return agentReviewAction({
+          label: "Ask the host agent to fix review issues",
+          agentPrompt: item,
+          reason: "The review report contains host-agent-owned issues.",
+          sourceIssueCodes,
+        });
+      }
+      return commandReviewAction(item, {
+        reason: "Backward-compatible retryWith command.",
+        sourceIssueCodes,
+      });
+    })
+  );
+}
+
+export function normalizeReviewActions(actions: ReviewAction[]): ReviewAction[] {
+  const merged = new Map<string, ReviewAction>();
+  for (const action of actions) {
+    const key = [action.kind, action.command ?? action.agentPrompt ?? action.label].join("\0");
+    const existing = merged.get(key);
+    if (!existing) {
+      merged.set(key, {
+        ...action,
+        sourceIssueCodes: uniqueStrings(action.sourceIssueCodes ?? []),
+      });
+      continue;
+    }
+    merged.set(key, {
+      ...existing,
+      safeToAutoRun: existing.safeToAutoRun && action.safeToAutoRun,
+      requiresConfirmation: existing.requiresConfirmation || action.requiresConfirmation,
+      sourceIssueCodes: uniqueStrings([
+        ...(existing.sourceIssueCodes ?? []),
+        ...(action.sourceIssueCodes ?? []),
+      ]),
+    });
+  }
+  return [...merged.values()].map((action) =>
+    stripUndefined({
+      ...action,
+      sourceIssueCodes:
+        action.sourceIssueCodes && action.sourceIssueCodes.length > 0
+          ? action.sourceIssueCodes
+          : undefined,
+    })
+  );
+}
+
+export function deriveNextReviewActions(opts: {
+  issues: ReviewIssue[];
+  retryWith: string[];
+  projectDir?: string;
+}): ReviewAction[] {
+  return normalizeReviewActions([
+    ...opts.issues.flatMap((issue) => issue.actions ?? []),
+    ...reviewActionsFromRetryWith(opts.retryWith),
+  ]);
+}
+
 export function fixOwnerForIssue(issue: Pick<ReviewIssue, "code" | "fixOwner">): ReviewFixOwner {
   if (issue.fixOwner) return issue.fixOwner;
   if (issue.code.startsWith("AI_REVIEW_")) return "host-agent";
@@ -90,12 +240,24 @@ export function fixOwnerForIssue(issue: Pick<ReviewIssue, "code" | "fixOwner">):
 
 export function normalizeReviewIssues(
   issues: ReviewIssue[],
-  fallbackOwner?: ReviewFixOwner
+  opts?: ReviewFixOwner | { fallbackOwner?: ReviewFixOwner; projectDir?: string; retryWith?: string[] }
 ): ReviewIssue[] {
-  return issues.map((issue) => ({
-    ...issue,
-    fixOwner: issue.fixOwner ?? fallbackOwner ?? fixOwnerForIssue(issue),
-  }));
+  const fallbackOwner = typeof opts === "string" ? opts : opts?.fallbackOwner;
+  const projectDir = typeof opts === "string" ? undefined : opts?.projectDir;
+  return issues.map((issue) => {
+    const normalized = {
+      ...issue,
+      fixOwner: issue.fixOwner ?? fallbackOwner ?? fixOwnerForIssue(issue),
+    };
+    const actions = normalizeReviewActions([
+      ...(issue.actions ?? []),
+      ...(projectDir ? defaultActionsForIssue(normalized, projectDir) : []),
+    ]);
+    return stripUndefined({
+      ...normalized,
+      actions: actions.length > 0 ? actions : undefined,
+    });
+  });
 }
 
 export function summarizeReviewIssues(issues: ReviewIssue[]): ReviewSummary {
@@ -123,7 +285,11 @@ export function buildReviewReport(opts: {
   sourceReports?: string[];
   reportPath?: string;
 }): ReviewReport {
-  const issues = normalizeReviewIssues(opts.issues);
+  const retryWith = uniqueRetryWith(opts.retryWith);
+  const issues = normalizeReviewIssues(opts.issues, {
+    projectDir: opts.project,
+    retryWith,
+  });
   return stripUndefined({
     schemaVersion: "1",
     kind: "review",
@@ -134,7 +300,8 @@ export function buildReviewReport(opts: {
     score: opts.score,
     issues,
     summary: summarizeReviewIssues(issues),
-    retryWith: uniqueRetryWith(opts.retryWith),
+    nextActions: deriveNextReviewActions({ issues, retryWith, projectDir: opts.project }),
+    retryWith,
     sourceReports: opts.sourceReports ?? [],
     reportPath: opts.reportPath,
   });
@@ -153,4 +320,365 @@ export async function writeReviewReport(
 
 function stripUndefined<T extends object>(value: T): T {
   return Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined)) as T;
+}
+
+function defaultActionsForIssue(issue: ReviewIssue, projectDir: string): ReviewAction[] {
+  const code = issue.code;
+  const beat = issue.beatId ?? issue.scene;
+  const beatFlag = beat ? ` --beat ${beat}` : "";
+  const sourceIssueCodes = [code];
+
+  if (code === "PROJECT_NOT_FOUND" || code === "MISSING_STORYBOARD") {
+    return [
+      commandReviewAction(`vibe init ${projectDir} --from "<brief>" --json`, {
+        label: "Initialize the project from a brief",
+        fixOwner: "host-agent",
+        reason: "The project cannot be inspected until the core project files exist.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "MISSING_DESIGN" || code === "DESIGN_PLACEHOLDER_FIELD") {
+    return [
+      manualReviewAction({
+        label: "Create or complete DESIGN.md",
+        reason: "Visual direction needs host-agent or human input before VibeFrame can repair it.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "BEAT_NOT_FOUND" || code.startsWith("STORYBOARD_")) {
+    const actions = [
+      commandReviewAction(`vibe storyboard validate ${projectDir} --json`, {
+        label: "Validate the storyboard",
+        fixOwner: "host-agent",
+        reason: "The storyboard issue needs structured validation before editing.",
+        sourceIssueCodes,
+      }),
+    ];
+    if (code === "STORYBOARD_PLACEHOLDER_CUE") {
+      actions.push(
+        commandReviewAction(
+          `vibe storyboard revise ${projectDir} --from "<make cues concrete>" --dry-run --json`,
+          {
+            label: "Preview a storyboard revision",
+            fixOwner: "host-agent",
+            reason: "Placeholder cues should be revised into concrete video intent.",
+            sourceIssueCodes,
+          }
+        )
+      );
+    }
+    return actions;
+  }
+
+  if (code === "MISSING_ROOT_COMPOSITION" || code === "ROOT_SYNC_CHECK_FAILED") {
+    return [
+      commandReviewAction(`vibe build ${projectDir} --stage sync --json`, {
+        label: "Sync the project root composition",
+        reason: "The root composition is missing or could not be verified.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code.startsWith("ROOT_")) {
+    return issue.fixOwner === "host-agent"
+      ? [
+          agentReviewAction({
+            label: "Repair the root composition shell",
+            agentPrompt: "Fix host-agent-owned root composition issues from review-report.json",
+            reason: "The root composition cannot be repaired deterministically.",
+            sourceIssueCodes,
+          }),
+        ]
+      : [
+          commandReviewAction(`vibe scene repair ${projectDir} --json`, {
+            label: "Repair deterministic scene/root issues",
+            reason: "The root composition has deterministic sync issues.",
+            sourceIssueCodes,
+          }),
+          commandReviewAction(`vibe build ${projectDir} --stage sync --json`, {
+            label: "Resync root composition after repair",
+            reason: "The root composition should be synced after deterministic repair.",
+            sourceIssueCodes,
+          }),
+        ];
+  }
+
+  if (code === "MISSING_COMPOSITION") {
+    return [
+      commandReviewAction(`vibe build ${projectDir}${beatFlag} --stage compose --json`, {
+        label: beat ? `Compose beat ${beat}` : "Compose missing scenes",
+        reason: "Missing scene compositions must be generated or authored before render.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "MISSING_BUILD_REPORT") {
+    return [
+      commandReviewAction(`vibe build ${projectDir} --dry-run --json`, {
+        label: "Preview the build plan",
+        reason: "A dry-run build report is needed before choosing a paid or mutating build step.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "BUILD_REPORT_BEAT_MISSING") {
+    return [
+      commandReviewAction(`vibe build ${projectDir}${beatFlag} --stage sync --json`, {
+        label: beat ? `Sync build report for beat ${beat}` : "Sync the build report",
+        reason: "The build report does not include the inspected beat.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "MALFORMED_BUILD_REPORT") {
+    return [
+      commandReviewAction(`vibe build ${projectDir} --json`, {
+        label: "Regenerate the build report",
+        reason: "The existing build report cannot be parsed.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (
+    code === "MISSING_REPORTED_ASSET" ||
+    code === "STALE_ASSET" ||
+    code === "UNKNOWN_ASSET_FRESHNESS"
+  ) {
+    return [
+      commandReviewAction(`vibe build ${projectDir}${beatFlag} --stage assets --force --json`, {
+        label: beat ? `Regenerate assets for beat ${beat}` : "Regenerate stale or missing assets",
+        reason: "Asset generation may call providers, so the host should confirm first.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "MUSIC_CUE_NOT_READY") {
+    return [
+      commandReviewAction(`vibe build ${projectDir}${beatFlag} --stage assets --json`, {
+        label: beat ? `Generate music for beat ${beat}` : "Generate missing music assets",
+        reason: "Music generation may call providers, so the host should confirm first.",
+        sourceIssueCodes,
+      }),
+      commandReviewAction(`vibe build ${projectDir} --stage sync --json`, {
+        label: "Sync music into the root composition",
+        reason: "Generated music needs root composition wiring.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code.startsWith("SCENE_LINT_")) {
+    return [
+      commandReviewAction(`vibe scene repair ${projectDir} --json`, {
+        label: "Repair deterministic scene lint issues",
+        reason: "Scene lint reported an issue VibeFrame may be able to repair mechanically.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "RENDER_NOT_FOUND" || code === "EMPTY_RENDER") {
+    return [
+      commandReviewAction(
+        beat
+          ? `vibe render ${projectDir} --beat ${beat} --json`
+          : `vibe render ${projectDir} --json`,
+        {
+          label: beat ? `Render beat ${beat}` : "Render the project",
+          reason: "A render file is required before render inspection can pass.",
+          sourceIssueCodes,
+        }
+      ),
+    ];
+  }
+
+  if (code === "NO_AUDIO_STREAM" || code === "DURATION_DRIFT") {
+    return [
+      commandReviewAction(`vibe build ${projectDir}${beatFlag} --stage sync --json`, {
+        label: beat ? `Sync timing/audio for beat ${beat}` : "Sync timing and audio wiring",
+        reason: "The render output no longer matches synced project state.",
+        sourceIssueCodes,
+      }),
+      commandReviewAction(
+        beat
+          ? `vibe render ${projectDir} --beat ${beat} --json`
+          : `vibe render ${projectDir} --json`,
+        {
+          label: beat ? `Rerender beat ${beat}` : "Rerender the project",
+          reason: "The render should be regenerated after sync repair.",
+          sourceIssueCodes,
+        }
+      ),
+    ];
+  }
+
+  if (code === "BLACK_FRAME_SEGMENT") {
+    return issue.fixOwner === "host-agent"
+      ? [
+          agentReviewAction({
+            label: beat ? `Fix black frames in beat ${beat}` : "Fix black frame segment",
+            agentPrompt: "Fix black-frame issues from review-report.json, then rerender.",
+            reason: "The issue likely needs scene, storyboard, or visual cue changes.",
+            sourceIssueCodes,
+          }),
+        ]
+      : [
+          commandReviewAction(`vibe scene repair ${projectDir} --json`, {
+            label: "Repair deterministic scene timing",
+            reason: "Black frames outside a specific beat may be recoverable with scene repair.",
+            sourceIssueCodes,
+          }),
+        ];
+  }
+
+  if (code === "STATIC_FRAME_SEGMENT") {
+    return [
+      agentReviewAction({
+        label: beat ? `Add motion to beat ${beat}` : "Fix static visual hold",
+        agentPrompt: "Fix static-frame issues from review-report.json, then rerender.",
+        reason: "Static segments usually need creative scene, storyboard, or asset changes.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "LONG_SILENCE") {
+    return issue.fixOwner === "host-agent"
+      ? [
+          agentReviewAction({
+            label: beat ? `Fix long silence in beat ${beat}` : "Fix long silence",
+            agentPrompt: "Fix long-silence issues from review-report.json, then rerender.",
+            reason: "The beat duration, narration, or music cue needs host-agent judgment.",
+            sourceIssueCodes,
+          }),
+        ]
+      : [
+          commandReviewAction(`vibe build ${projectDir}${beatFlag} --stage sync --json`, {
+            label: beat ? `Sync audio for beat ${beat}` : "Sync audio wiring",
+            reason: "The silence may be caused by stale narration or music wiring.",
+            sourceIssueCodes,
+          }),
+        ];
+  }
+
+  if (code.startsWith("AI_REVIEW_")) {
+    return [
+      agentReviewAction({
+        label: "Fix AI review findings",
+        agentPrompt: "Fix host-agent-owned AI review issues from review-report.json, then rerender.",
+        reason: "AI review findings require storyboard, design, or composition judgment.",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "FFPROBE_UNAVAILABLE" || code === "FFMPEG_UNAVAILABLE") {
+    return [
+      manualReviewAction({
+        label: "Install FFmpeg and rerun inspection",
+        reason: "Local media inspection depends on ffmpeg/ffprobe being available.",
+        fixOwner: "host-agent",
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  if (code === "FFPROBE_FAILED" || code === "NO_VIDEO_STREAM") {
+    return [
+      commandReviewAction(
+        beat
+          ? `vibe render ${projectDir} --beat ${beat} --json`
+          : `vibe render ${projectDir} --json`,
+        {
+          label: beat ? `Rerender beat ${beat}` : "Rerender the project",
+          reason: "The rendered media could not be probed as a valid video.",
+          sourceIssueCodes,
+        }
+      ),
+    ];
+  }
+
+  if (code === "ASPECT_MISMATCH") {
+    return [
+      manualReviewAction({
+        label: "Check project aspect and render settings",
+        reason: "Aspect mismatches can come from either config intent or render settings.",
+        fixOwner: issue.fixOwner,
+        sourceIssueCodes,
+      }),
+    ];
+  }
+
+  return [];
+}
+
+function classifyReviewCommand(command: string): {
+  fixOwner: ReviewFixOwner;
+  costTier: ReviewActionCostTier;
+  safeToAutoRun: boolean;
+  requiresConfirmation: boolean;
+} {
+  const lower = command.trim().toLowerCase();
+  if (lower.startsWith("vibe status ")) return safe("free");
+  if (lower.startsWith("vibe scene repair")) return safe("free");
+  if (
+    lower.startsWith("vibe storyboard validate") ||
+    lower.startsWith("vibe storyboard get") ||
+    lower.startsWith("vibe storyboard list")
+  ) {
+    return safe("free", "host-agent");
+  }
+  if (lower.startsWith("vibe inspect project")) return safe("free");
+  if (lower.startsWith("vibe inspect render")) {
+    if (lower.includes("--ai")) return unsafe("low");
+    return safe("free");
+  }
+  if (lower.startsWith("vibe render ")) return safe("free");
+  if (lower.startsWith("vibe build ")) {
+    if (lower.includes("--dry-run")) return safe("free");
+    if (lower.includes("--stage sync") || lower.includes("--stage render")) return safe("free");
+    return unsafe("unknown");
+  }
+  if (
+    lower.startsWith("vibe generate video") ||
+    lower.startsWith("vibe edit fill-gaps") ||
+    lower.startsWith("vibe remix ")
+  ) {
+    return unsafe("very-high");
+  }
+  if (lower.startsWith("vibe storyboard revise")) return unsafe("unknown", "host-agent");
+  return unsafe("unknown");
+}
+
+function safe(costTier: ReviewActionCostTier, fixOwner: ReviewFixOwner = "vibe") {
+  return { fixOwner, costTier, safeToAutoRun: true, requiresConfirmation: false };
+}
+
+function unsafe(costTier: ReviewActionCostTier, fixOwner: ReviewFixOwner = "vibe") {
+  return { fixOwner, costTier, safeToAutoRun: false, requiresConfirmation: true };
+}
+
+function actionId(kind: ReviewActionKind, value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80);
+  return `${kind}:${slug || "action"}`;
+}
+
+function uniqueStrings(items: Array<string | undefined | null>): string[] {
+  return [
+    ...new Set(items.filter((item): item is string => typeof item === "string" && item.length > 0)),
+  ];
 }

--- a/packages/cli/src/commands/_shared/scene-inspect.test.ts
+++ b/packages/cli/src/commands/_shared/scene-inspect.test.ts
@@ -49,7 +49,22 @@ Body.
     expect(result.issues.find((issue) => issue.code === "MISSING_COMPOSITION")).toMatchObject({
       beatId: "hook",
       fixOwner: "vibe",
+      actions: [
+        expect.objectContaining({
+          command: `vibe build ${dir} --beat hook --stage compose --json`,
+          safeToAutoRun: false,
+          requiresConfirmation: true,
+        }),
+      ],
     });
+    expect(result.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: `vibe build ${dir} --beat hook --stage compose --json`,
+          sourceIssueCodes: ["MISSING_COMPOSITION"],
+        }),
+      ])
+    );
     expect(result.reportPath).toBe(resolve(dir, "review-report.json"));
     const report = JSON.parse(await readFile(resolve(dir, "review-report.json"), "utf-8"));
     expect(report).toMatchObject({
@@ -59,6 +74,11 @@ Body.
       project: resolve(dir),
       status: "fail",
       summary: { issueCount: result.issues.length },
+      nextActions: expect.arrayContaining([
+        expect.objectContaining({
+          command: `vibe build ${dir} --beat hook --stage compose --json`,
+        }),
+      ]),
     });
     expect(report.sourceReports).toEqual(expect.arrayContaining(["STORYBOARD.md", "DESIGN.md"]));
   });

--- a/packages/cli/src/commands/_shared/scene-inspect.ts
+++ b/packages/cli/src/commands/_shared/scene-inspect.ts
@@ -10,12 +10,14 @@ import { createProjectRootSyncPlan } from "./root-sync.js";
 import {
   buildReviewReport,
   defaultReviewReportPath,
+  deriveNextReviewActions,
   normalizeReviewIssues,
   scoreIssues,
   statusFromIssues,
   summarizeReviewIssues,
   uniqueRetryWith,
   writeReviewReport,
+  type ReviewAction,
   type ReviewIssue,
   type ReviewSummary,
   type ReviewStatus,
@@ -38,6 +40,7 @@ export interface ProjectInspectResult {
   score: number;
   issues: ReviewIssue[];
   summary: ReviewSummary;
+  nextActions: ReviewAction[];
   sourceReports: string[];
   checks: {
     files: Record<string, boolean>;
@@ -332,7 +335,11 @@ function makeProjectResult(
   retryWith: string[],
   beatId?: string
 ): ProjectInspectResult {
-  const normalizedIssues = normalizeReviewIssues(issues);
+  const normalizedRetryWith = uniqueRetryWith(retryWith);
+  const normalizedIssues = normalizeReviewIssues(issues, {
+    projectDir,
+    retryWith: normalizedRetryWith,
+  });
   const status = statusFromIssues(normalizedIssues);
   return {
     schemaVersion: "1",
@@ -344,9 +351,14 @@ function makeProjectResult(
     score: scoreIssues(normalizedIssues),
     issues: normalizedIssues,
     summary: summarizeReviewIssues(normalizedIssues),
+    nextActions: deriveNextReviewActions({
+      issues: normalizedIssues,
+      retryWith: normalizedRetryWith,
+      projectDir,
+    }),
     sourceReports: projectSourceReports(checks),
     checks,
-    retryWith: uniqueRetryWith(retryWith),
+    retryWith: normalizedRetryWith,
   };
 }
 

--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -156,7 +156,11 @@ describe("buildProjectAgentsMd", () => {
     expect(md).toContain("Claude Code `/goal`");
     expect(md).toContain("build-report.json");
     expect(md).toContain("review-report.json");
+    expect(md).toContain("nextActions");
+    expect(md).toContain("safeToAutoRun");
+    expect(md).toContain("requiresConfirmation");
     expect(md).toContain("retryWith");
+    expect(md).toMatch(/compatibility\s+fallback/);
     expect(md).toContain('fixOwner:"vibe"');
     expect(md).toContain('fixOwner:"host-agent"');
     expect(md).toContain("renders/final.mp4");

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -427,8 +427,9 @@ vibe host doctor all --json # verify readiness
 For long-running work, use Codex Goal mode, Claude Code \`/goal\`, or the
 host's equivalent as the outer loop. VibeFrame should not run a competing
 project-level goal loop; it provides \`--json\` commands, dry runs, cost caps,
-\`build-report.json\`, \`review-report.json\`, \`retryWith\`, \`fixOwner\`,
-deterministic repair, and render inspection for the host agent to reason over.
+\`build-report.json\`, \`review-report.json\`, \`nextActions\`, \`safeToAutoRun\`,
+\`requiresConfirmation\`, \`fixOwner\`, deterministic repair, and render
+inspection for the host agent to reason over.
 
 Copy-paste examples:
 
@@ -436,9 +437,11 @@ Copy-paste examples:
 /goal Build this VibeFrame project into renders/final.mp4. Use --json for every
 vibe command, run --dry-run before paid operations, use --max-cost 5 for builds
 unless the user sets another budget, read build-report.json and
-review-report.json before deciding the next action, and run retryWith commands
-before custom recovery. Treat fixOwner:"vibe" as CLI repair work and
-fixOwner:"host-agent" as STORYBOARD.md, DESIGN.md, or composition edits.
+review-report.json before deciding the next action, prefer nextActions before
+guessing, run only safeToAutoRun:true actions automatically, and ask before
+requiresConfirmation:true actions. Treat retryWith as the compatibility
+fallback, fixOwner:"vibe" as CLI repair work, and fixOwner:"host-agent" as
+STORYBOARD.md, DESIGN.md, or composition edits.
 Stop only when renders/final.mp4 exists, duration and aspect ratio match the
 brief, inspect render --cheap has no errors, any AI review score is >= 90 when AI review is requested, and every
 remaining host-agent issue is fixed, accepted with rationale, or reported as
@@ -448,9 +451,10 @@ blocked.
 \`\`\`text
 /goal Finish this VibeFrame render using Claude Code goal mode as the outer
 loop. Use vibe context/schema when unsure, --json everywhere, dry-run before
-paid operations, budget cap via --max-cost 5, retryWith before guessing,
-build-report.json/review-report.json as loop state, and fixOwner to decide
-between vibe scene repair and host-agent edits. Stop only after final MP4,
+paid operations, budget cap via --max-cost 5, nextActions before guessing,
+build-report.json/review-report.json as loop state, and safeToAutoRun,
+requiresConfirmation, and fixOwner to decide between vibe scene repair and
+host-agent edits. Stop only after final MP4,
 target duration/aspect ratio, clean render inspection, any AI review score >= 90 when AI review is requested, and
 no unresolved unacknowledged host-agent issues.
 \`\`\`

--- a/packages/cli/src/commands/_shared/status-jobs.test.ts
+++ b/packages/cli/src/commands/_shared/status-jobs.test.ts
@@ -116,6 +116,20 @@ describe("status job records", () => {
           fixOwners: { vibe: 0, hostAgent: 1 },
         },
         sourceReports: ["render-report.json", "ffprobe"],
+        nextActions: [
+          {
+            id: "command:vibe-scene-repair-project-json",
+            kind: "command",
+            label: "Repair deterministic scene issues",
+            command: `vibe scene repair --project ${dir} --json`,
+            fixOwner: "vibe",
+            costTier: "free",
+            safeToAutoRun: true,
+            requiresConfirmation: false,
+            reason: "Fixture action",
+            sourceIssueCodes: ["X"],
+          },
+        ],
         retryWith: [`vibe scene repair --project ${dir} --json`],
       }),
       "utf-8"
@@ -149,8 +163,19 @@ describe("status job records", () => {
       infoCount: 0,
       fixOwners: { vibe: 0, hostAgent: 1 },
       sourceReports: ["render-report.json", "ffprobe"],
+      nextActions: [
+        expect.objectContaining({
+          command: `vibe scene repair --project ${dir} --json`,
+          safeToAutoRun: true,
+        }),
+      ],
       retryWith: [`vibe scene repair --project ${dir} --json`],
     });
+    expect(status.nextActions).toEqual([
+      expect.objectContaining({
+        command: `vibe scene repair --project ${dir} --json`,
+      }),
+    ]);
     expect(status.retryWith).toContain(`vibe scene repair --project ${dir} --json`);
     expect(status.jobs).toMatchObject({ total: 1, completed: 1, active: 0 });
   });
@@ -203,6 +228,19 @@ describe("status job records", () => {
       needsAuthor: ["cta"],
     });
     expect(status.retryWith).toContain(`vibe build ${dir} --stage compose --json`);
+    // The needs-author state has no review-report.json, yet nextActions is still
+    // populated by converting the workflow-state retryWith command.
+    expect(status.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "command",
+          command: `vibe build ${dir} --stage compose --json`,
+          costTier: "unknown",
+          safeToAutoRun: false,
+          requiresConfirmation: true,
+        }),
+      ])
+    );
   });
 
   it("uses completed job records to refresh asset readiness", async () => {
@@ -264,6 +302,62 @@ describe("status job records", () => {
     expect(status.status).toBe("ready");
     expect(status.currentStage).toBe("compose");
     expect(status.retryWith).toContain(`vibe build ${dir} --stage compose --json`);
+    expect(status.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: `vibe build ${dir} --stage compose --json`,
+          safeToAutoRun: false,
+          requiresConfirmation: true,
+        }),
+      ])
+    );
+  });
+
+  it("emits nextActions for an empty project with no review report", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vibe-status-jobs-empty-"));
+
+    const status = await inspectProjectStatus(dir);
+
+    expect(status.status).toBe("empty");
+    expect(status.review).toBeNull();
+    expect(status.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "command",
+          command: `vibe init ${dir} --from "<brief>" --json`,
+          safeToAutoRun: false,
+        }),
+      ])
+    );
+  });
+
+  it("emits a safe refresh nextAction while jobs are running", async () => {
+    const dir = await tempProject();
+    await createAndWriteJobRecord({
+      id: "job_video",
+      jobType: "generate-video",
+      provider: "runway",
+      providerTaskId: "video_1",
+      projectDir: dir,
+      command: "build --stage assets",
+      beatId: "hook",
+      status: "running",
+    });
+
+    const status = await inspectProjectStatus(dir);
+
+    expect(status.status).toBe("running");
+    expect(status.review).toBeNull();
+    expect(status.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: `vibe status project ${dir} --refresh --json`,
+          costTier: "free",
+          safeToAutoRun: true,
+          requiresConfirmation: false,
+        }),
+      ])
+    );
   });
 
   it("normalizes provider status strings", () => {

--- a/packages/cli/src/commands/_shared/status-jobs.ts
+++ b/packages/cli/src/commands/_shared/status-jobs.ts
@@ -7,6 +7,8 @@ import { executeVideoStatus } from "../ai-video.js";
 import { executeMusicStatus } from "../generate/music-status.js";
 import type { BuildAssetKind } from "./build-cache.js";
 import { writeAssetMetadata } from "./build-asset-metadata.js";
+import type { ReviewAction, ReviewActionCostTier, ReviewFixOwner } from "./review-report.js";
+import { normalizeReviewActions, reviewActionsFromRetryWith } from "./review-report.js";
 import { parseStoryboard } from "./storyboard-parse.js";
 
 export type JobStatus = "queued" | "running" | "completed" | "failed" | "cancelled" | "unknown";
@@ -159,6 +161,7 @@ export interface ProjectStatusResult {
     latest: JobSummary[];
   };
   warnings: string[];
+  nextActions: ReviewAction[];
   retryWith: string[];
 }
 
@@ -195,6 +198,7 @@ export interface ReviewSummary {
   };
   sourceReports: string[];
   updatedAt?: string;
+  nextActions: ReviewAction[];
   retryWith: string[];
 }
 
@@ -529,6 +533,16 @@ export async function inspectProjectStatus(
     ...(review?.retryWith ?? []),
     ...workflow.retryWith,
   ];
+  // Prefer the rich, classified review actions; then convert the workflow/build
+  // state commands so non-review states (empty/failed/running/ready/needs-author)
+  // also surface a top-level nextActions instead of only retryWith. Review
+  // actions are listed first so they win the dedup in normalizeReviewActions.
+  // review.retryWith is intentionally excluded — review.nextActions already
+  // derives from it.
+  const nextActions = normalizeReviewActions([
+    ...(review?.nextActions ?? []),
+    ...reviewActionsFromRetryWith([...(build?.retryWith ?? []), ...workflow.retryWith]),
+  ]);
 
   return {
     schemaVersion: "1",
@@ -541,6 +555,7 @@ export async function inspectProjectStatus(
     review,
     jobs,
     warnings,
+    nextActions,
     retryWith: unique(retryWith),
   };
 }
@@ -940,7 +955,52 @@ async function readReviewSummary(projectDir: string): Promise<ReviewSummary | nu
     },
     sourceReports: stringArray(report.sourceReports),
     updatedAt: info?.mtime.toISOString(),
+    nextActions: reviewActionsFromUnknown(report.nextActions),
     retryWith: stringArray(report.retryWith),
+  });
+}
+
+function reviewActionsFromUnknown(value: unknown): ReviewAction[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item): ReviewAction[] => {
+    if (!item || typeof item !== "object") return [];
+    const record = item as Record<string, unknown>;
+    const kind = stringEnum(record.kind, ["command", "agent", "manual"] as const);
+    const fixOwner = stringEnum(record.fixOwner, ["vibe", "host-agent"] as const);
+    const costTier = stringEnum(record.costTier, [
+      "free",
+      "low",
+      "high",
+      "very-high",
+      "unknown",
+    ] as const);
+    if (
+      !kind ||
+      !fixOwner ||
+      !costTier ||
+      typeof record.id !== "string" ||
+      typeof record.label !== "string" ||
+      typeof record.safeToAutoRun !== "boolean" ||
+      typeof record.requiresConfirmation !== "boolean" ||
+      typeof record.reason !== "string"
+    ) {
+      return [];
+    }
+    return [
+      stripUndefined({
+        id: record.id,
+        kind,
+        label: record.label,
+        command: typeof record.command === "string" ? record.command : undefined,
+        agentPrompt: typeof record.agentPrompt === "string" ? record.agentPrompt : undefined,
+        fixOwner: fixOwner as ReviewFixOwner,
+        costTier: costTier as ReviewActionCostTier,
+        safeToAutoRun: record.safeToAutoRun,
+        requiresConfirmation: record.requiresConfirmation,
+        reason: record.reason,
+        sourceIssueCodes: stringArray(record.sourceIssueCodes),
+      }),
+    ];
   });
 }
 
@@ -1251,6 +1311,12 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === "string" && item.length > 0)
     : [];
+}
+
+function stringEnum<T extends readonly string[]>(value: unknown, allowed: T): T[number] | undefined {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+    ? (value as T[number])
+    : undefined;
 }
 
 function isActiveStatus(status: JobStatus): boolean {

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -59,9 +59,9 @@ export const contextCommand = new Command("context")
         owner:
           "host-native goal mode (Codex /goal, Claude Code /goal, Cursor or other host equivalent)",
         vibeRole:
-          "video-specific commands, JSON reports, cost gates, deterministic repair, render inspection, and retryWith recovery hints",
+          "video-specific commands, JSON reports, cost gates, deterministic repair, render inspection, nextActions, and retryWith compatibility hints",
         canonicalLoop:
-          "native host goal -> vibe context/schema -> plan dry-run -> build with budget -> status polling -> inspect project -> render -> inspect render -> repair/edit using retryWith/fixOwner -> repeat",
+          "native host goal -> vibe context/schema -> plan dry-run -> build with budget -> status polling -> inspect project -> render -> inspect render -> repair/edit using nextActions/fixOwner -> repeat",
         stopRules: [
           "final MP4 exists at the requested output path",
           "duration and aspect ratio match the brief or explicitly accepted constraints",
@@ -104,7 +104,9 @@ export const contextCommand = new Command("context")
       reviewReportContract: {
         kind: "review",
         modes: ["project", "render"],
-        fields: ["status", "score", "issues", "summary", "sourceReports", "retryWith"],
+        fields: ["status", "score", "issues", "summary", "sourceReports", "nextActions", "retryWith"],
+        recovery:
+          "prefer nextActions (classified by costTier/safeToAutoRun/requiresConfirmation/fixOwner); retryWith is the compatibility fallback",
         issueFixOwner: {
           vibe: "deterministic CLI recovery",
           "host-agent": "storyboard/design/composition edits the host agent should make",
@@ -113,7 +115,8 @@ export const contextCommand = new Command("context")
       machineStatusContract: {
         buildReport:
           "kind/status/currentStage/beatSummary/jobs/sceneRepair/stageReports/warnings/retryWith plus beat timing and nested per-beat asset metadata",
-        projectStatus: "kind/status/currentStage/beats/jobs.latest/build/review/warnings/retryWith",
+        projectStatus:
+          "kind/status/currentStage/beats/jobs.latest/build/review/warnings/nextActions/retryWith (nextActions is populated for every workflow state, not only when a review report exists)",
         reviewSummary:
           "review.mode/issueCount/errorCount/warningCount/infoCount/fixOwners/sourceReports/retryWith",
       },
@@ -202,12 +205,13 @@ render. Repair failures return \`code:"SCENE_REPAIR_FAILED"\` with
 render with \`currentStage:"assets"\` and \`code:"ASSET_REFERENCE_INVALID"\`,
 \`code:"MISSING_API_KEY"\`, or \`code:"ASSET_GENERATION_FAILED"\`.
 \`build-report.json\` includes \`sceneRepair\`, and \`status project\` carries
-review issue counts, \`fixOwners\`, \`sourceReports\`, and
-\`review.retryWith\`.
+review issue counts, \`fixOwners\`, \`sourceReports\`, top-level
+\`nextActions\` (populated for every workflow state), and \`retryWith\`.
+Prefer \`nextActions\` and treat \`retryWith\` as the compatibility fallback.
 
 \`review-report.json\` is written by \`inspect project\` and \`inspect render\`
 as \`kind:"review"\` with \`mode:"project"|"render"\`, \`summary\`,
-\`sourceReports\`, \`retryWith\`, and issue-level
+\`sourceReports\`, \`nextActions\`, \`retryWith\`, and issue-level
 \`fixOwner:"vibe"|"host-agent"\`.
 \`inspect render --cheap\` checks duration drift, audio presence, black frames,
 long silence, and static-frame holds. Static or semantic beat issues are

--- a/packages/cli/src/commands/generate/video.ts
+++ b/packages/cli/src/commands/generate/video.ts
@@ -17,6 +17,7 @@ import {
   KlingProvider,
   RunwayProvider,
   FalProvider,
+  estimateSeedanceVideoCostUsd,
   type MediaReference,
 } from "@vibeframe/ai-providers";
 import { requireApiKey, hasConfiguredApiKey } from "../../utils/api-key.js";
@@ -245,10 +246,24 @@ Examples:
         }
 
         if (options.dryRun) {
+          // For Seedance, replace the flat cost-tier upper bound with a
+          // token-accurate estimate so agents can gate spend precisely. Other
+          // providers fall back to the tier bound (costUsd left undefined).
+          const costUsd =
+            provider === "seedance" || provider === "fal"
+              ? estimateSeedanceVideoCostUsd({
+                  durationSec: Number(options.duration) || 5,
+                  resolution: options.resolution,
+                  aspectRatio: options.ratio,
+                  fast: options.seedanceModel === "fast",
+                  hasVideoReference: Boolean(options.refVideos),
+                })
+              : undefined;
           outputSuccess({
             command: "generate video",
             startedAt,
             dryRun: true,
+            costUsd,
             data: {
               params: {
                 prompt,

--- a/packages/cli/src/commands/review-actions-cli.test.ts
+++ b/packages/cli/src/commands/review-actions-cli.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { projectConfigJson } from "./_shared/project-config.js";
+
+const CLI = resolve(__dirname, "..", "..", "dist", "index.js");
+
+let projectDir: string;
+let fakeHome: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "vibe-review-actions-cli-"));
+  fakeHome = mkdtempSync(join(tmpdir(), "vibe-review-actions-home-"));
+  writeFileSync(join(projectDir, "vibe.config.json"), projectConfigJson({ name: "promo" }));
+  writeFileSync(join(projectDir, "DESIGN.md"), "# Design\n");
+  writeFileSync(join(projectDir, "index.html"), "<!doctype html><html><body></body></html>");
+  writeFileSync(
+    join(projectDir, "STORYBOARD.md"),
+    `# Promo
+
+## Beat hook - Hook
+
+\`\`\`yaml
+duration: 3
+narration: "Hello."
+\`\`\`
+
+Body.
+`
+  );
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
+});
+
+function runVibe(args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: fakeHome,
+    NO_COLOR: "1",
+    VIBE_HUMAN_OUTPUT: "1",
+  };
+  delete env.VIBE_JSON_OUTPUT;
+  delete env.VIBE_QUIET_OUTPUT;
+  delete env.VIBE_OUTPUT_FIELDS;
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    env,
+    encoding: "utf-8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+describe("review nextActions CLI contract", () => {
+  it("surfaces nextActions through inspect reports and status project", () => {
+    const project = runVibe(["inspect", "project", projectDir, "--json"]);
+    expect(project.status).toBe(1);
+    const projectJson = JSON.parse(project.stdout);
+
+    expect(projectJson.command).toBe("inspect project");
+    expect(projectJson.data.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: `vibe build ${projectDir} --beat hook --stage compose --json`,
+          requiresConfirmation: true,
+          safeToAutoRun: false,
+        }),
+      ])
+    );
+
+    const projectReport = JSON.parse(readFileSync(join(projectDir, "review-report.json"), "utf-8"));
+    expect(projectReport.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: `vibe build ${projectDir} --beat hook --stage compose --json`,
+        }),
+      ])
+    );
+
+    const render = runVibe(["inspect", "render", projectDir, "--cheap", "--json"]);
+    expect(render.status).toBe(1);
+    const renderJson = JSON.parse(render.stdout);
+    expect(renderJson.command).toBe("inspect render");
+    expect(renderJson.data.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: `vibe render ${projectDir} --json`,
+          safeToAutoRun: true,
+          requiresConfirmation: false,
+        }),
+      ])
+    );
+
+    const status = runVibe(["status", "project", projectDir, "--json"]);
+    expect(status.status).toBe(0);
+    const statusJson = JSON.parse(status.stdout);
+    expect(statusJson.command).toBe("status project");
+    expect(statusJson.data.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: `vibe render ${projectDir} --json`,
+          safeToAutoRun: true,
+        }),
+      ])
+    );
+  });
+
+  it("prints next actions in human-readable project status", () => {
+    const inspect = runVibe(["inspect", "render", projectDir, "--cheap", "--json"]);
+    expect(inspect.status).toBe(1);
+    expect(existsSync(join(projectDir, "review-report.json"))).toBe(true);
+
+    const status = runVibe(["status", "project", projectDir]);
+    expect(status.status).toBe(0);
+    expect(status.stdout).toContain("Next actions");
+    expect(status.stdout).toContain("vibe render");
+    expect(status.stdout).toContain("auto");
+  });
+});

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -130,6 +130,18 @@ function printProjectStatus(result: ProjectStatusResult): void {
   console.log(`  Build:     ${result.build ? formatBuild(result.build) : chalk.dim("no build-report.json")}`);
   console.log(`  Review:    ${result.review ? formatReview(result.review) : chalk.dim("no review-report.json")}`);
   console.log(`  Jobs:      ${result.jobs.total} total, ${result.jobs.active} active, ${result.jobs.failed} failed`);
+  if (result.nextActions.length > 0) {
+    console.log();
+    console.log(chalk.bold("Next actions"));
+    for (const action of result.nextActions.slice(0, 5)) {
+      console.log(formatNextAction(action));
+      if (action.command) console.log(chalk.dim(`      ${action.command}`));
+      if (action.agentPrompt) console.log(chalk.dim(`      ${action.agentPrompt}`));
+    }
+    if (result.nextActions.length > 5) {
+      console.log(chalk.dim(`  ... ${result.nextActions.length - 5} more`));
+    }
+  }
   if (result.jobs.latest.length > 0) {
     console.log();
     for (const job of result.jobs.latest.slice(0, 5)) {
@@ -151,6 +163,15 @@ function formatBuild(build: NonNullable<ProjectStatusResult["build"]>): string {
 function formatReview(review: NonNullable<ProjectStatusResult["review"]>): string {
   const status = review.status ?? "unknown";
   return `${formatStatus(status)} score ${review.score ?? "-"} (${review.issueCount} issue${review.issueCount === 1 ? "" : "s"})`;
+}
+
+function formatNextAction(action: ProjectStatusResult["nextActions"][number]): string {
+  const badge = action.safeToAutoRun
+    ? "auto"
+    : action.requiresConfirmation
+      ? "confirm"
+      : action.kind;
+  return `  ${chalk.dim(`[${badge}]`)} ${action.label}`;
 }
 
 function formatStatus(status: string): string {

--- a/scripts/gen-cli-reference.mts
+++ b/scripts/gen-cli-reference.mts
@@ -120,7 +120,7 @@ Canonical native-goal loop:
 \`\`\`
 native host goal → vibe context/schema → plan dry-run → build with budget
 → status polling → inspect project → render → inspect render
-→ repair/edit using retryWith/fixOwner → repeat until stop rules pass
+→ repair/edit using nextActions/fixOwner → repeat until stop rules pass
 \`\`\`
 
 \`vibe plan --json\` emits \`data.kind:"build-plan"\`,
@@ -153,13 +153,16 @@ render code or \`code:"RENDER_FAILED"\`. Both include \`currentStage\`,
 \`review-report.json\` by default. The file uses \`kind:"review"\`,
 \`mode:"project"|"render"\`, \`status\`, \`score\`, \`issues[]\`,
 \`summary:{issueCount,errorCount,warningCount,infoCount,fixOwners}\`,
-\`sourceReports\`, and \`retryWith\`. Issue-level \`fixOwner:"vibe"\` means
-deterministic CLI recovery; \`fixOwner:"host-agent"\` means storyboard/design/
-composition edits should be handled by the host agent. A host-native goal
-should stop only after the final MP4 exists, duration and aspect ratio match
-the brief, render inspection has no errors, any AI review score meets the goal
-threshold when AI review is requested, and every host-agent issue is fixed, accepted with rationale, or
-reported as blocked.
+\`sourceReports\`, \`nextActions\`, and \`retryWith\`. \`nextActions\` is the
+preferred agent contract: run only \`safeToAutoRun:true\` actions automatically,
+ask before \`requiresConfirmation:true\`, and use \`retryWith\` only as the
+compatibility fallback. Issue-level \`fixOwner:"vibe"\` means deterministic CLI
+recovery; \`fixOwner:"host-agent"\` means storyboard/design/composition edits
+should be handled by the host agent. A host-native goal should stop only after
+the final MP4 exists, duration and aspect ratio match the brief, render
+inspection has no errors, any AI review score meets the goal threshold when AI
+review is requested, and every host-agent issue is fixed, accepted with
+rationale, or reported as blocked.
 `;
 
 const GLOBAL_FLAGS = `## Global flags
@@ -426,17 +429,17 @@ function leafNotes(pathDots: string): string[] {
   }
   if (pathDots === "status.project") {
     return [
-      'JSON payload: `data.kind` is `"project"` and includes `status`, `currentStage`, `beats` readiness counts, `jobs.latest`, `build`, `review`, `warnings`, and `retryWith`. `review` includes `mode`, issue/error/warning/info counts, `fixOwners`, `sourceReports`, and `retryWith`; top-level `retryWith` is the resume contract.',
+      'JSON payload: `data.kind` is `"project"` and includes `status`, `currentStage`, `beats` readiness counts, `jobs.latest`, `build`, `review`, `warnings`, `nextActions`, and `retryWith`. `review` includes `mode`, issue/error/warning/info counts, `fixOwners`, `sourceReports`, `nextActions`, and `retryWith`; top-level `nextActions` is the preferred resume contract, while `retryWith` remains the compatibility fallback.',
     ];
   }
   if (pathDots === "inspect.project") {
     return [
-      '`review-report.json` payload uses `kind:"review"`, `mode:"project"`, `summary`, `sourceReports`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. Command output keeps `data.kind:"project"`.',
+      '`review-report.json` payload uses `kind:"review"`, `mode:"project"`, `summary`, `sourceReports`, `nextActions`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. Command output keeps `data.kind:"project"`.',
     ];
   }
   if (pathDots === "inspect.render") {
     return [
-      '`review-report.json` payload uses `kind:"review"`, `mode:"render"`, `summary`, `sourceReports`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. `--ai` maps Gemini findings to host-agent-owned issues.',
+      '`review-report.json` payload uses `kind:"review"`, `mode:"render"`, `summary`, `sourceReports`, `nextActions`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. `--ai` maps Gemini findings to host-agent-owned issues.',
     ];
   }
   if (pathDots === "storyboard.revise") {


### PR DESCRIPTION
Two related changes that harden VibeFrame's agent-facing recovery/cost contract.

## 1. `nextActions` for every workflow state (`4f8a760`)

`vibe status project` previously derived `nextActions` only from a review
report, so non-review states (`empty`/`failed`/`running`/`ready`/`needs-author`)
forced an agent to fall back to parsing `retryWith`. `inspectProjectStatus` now
converts the workflow/build state commands into classified `ReviewAction`s
(reusing `reviewActionsFromRetryWith` + `normalizeReviewActions`), with the rich
review actions kept first so they win the dedup. `review.retryWith` is excluded
(already covered by `review.nextActions`).

- Top-level `nextActions` populated for all states; CLI + `status_project` MCP
  tool surface it unchanged.
- Agent guidance (`context.ts`, `host-integration.ts`) now leads with
  `nextActions`, `retryWith` as the compatibility fallback.
- Tests cover empty/running/needs-author/ready states.

## 2. Token-accurate Seedance cost in video dry-run (`bfcfe8e`)

`generate video --dry-run` reported a flat cost-tier upper bound ($5) for
Seedance, ignoring resolution/ratio/duration/tier. Added
`estimateSeedanceVideoCostUsd()` in the fal provider using fal's token billing
(`(w*h*24/1024)/1000 * $0.014`, fast `0.8x` up to 720p, reference-video `0.6x`)
and wired it into the dry-run path. Other providers keep the tier-bound fallback.

| case | before | after | fal rate |
|---|---|---|---|
| fast 720p 16:9 5s | $5 | $1.21 | $0.2419/s |
| std 720p 16:9 5s | $5 | $1.51 | $0.3024/s |
| std 1080p 16:9 10s | $5 | $6.80 | $0.682/s |
| runway (other provider) | $5 | $5 | tier fallback |

## Verification

- `pnpm -F @vibeframe/cli test` (full suite) + `@vibeframe/ai-providers` FalProvider tests — green
- `pnpm lint` 0 errors (both packages)
- `pnpm gen:reference:check` up-to-date
- `scripts/pre-push-validate.sh` exit 0
- Real end-to-end probe of the GPT-Image-2 → Seedance reference-to-video workflow validated the dry-run figure ($1.21 matched).