### PR TITLE
chore: enforce patch-primary versioning + document git/PR strategy

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -8,15 +8,19 @@ description: Bump VibeFrame versions, regenerate release artifacts, run verifica
 Use this skill when the user asks Codex to run a VibeFrame release bump or fix a
 missing version bump after `feat:` / `fix:` commits.
 
-The requested bump must be one of: `patch`, `minor`, or `major`.
+The bump is one of `patch`, `minor`, or `major`. **Default to `patch`** when
+no bump is specified or when there is any doubt.
 
 ## Version Policy
 
-VibeFrame is still in `0.x`, so default to `patch` unless the change clearly
-needs a larger release signal.
+VibeFrame is still in `0.x`. **`patch` is the default and by far the most
+common bump.** `minor` is rare and must be explicitly justified — the shared
+push gate (`scripts/pre-push-validate.sh`) blocks a non-patch bump that lacks a
+`Release-Type:` trailer (see step 10).
 
 - `patch`: bug fixes, docs/tooling, UX polish, internal refactors, and most
-  ordinary `feat:` / `fix:` commits.
+  ordinary `feat:` / `fix:` commits. **Use this unless a rule below clearly
+  applies.**
 - `minor`: new public CLI command namespace, new MCP tool family, public API
   contract additions, or a large product milestone.
 - `major`: breaking changes or an intentional 1.0 milestone.
@@ -89,10 +93,17 @@ npm version` for this step because recursive pnpm includes the root package.
    git add package.json packages/*/package.json apps/*/package.json CHANGELOG.md docs/cli-reference.md
    ```
 
-10. Commit:
+10. Commit. For a `patch` bump, a plain message:
 
 ```bash
 git commit -m "chore: bump version to $NEW_VERSION"
+```
+
+   For a `minor` or `major` bump, the push gate requires a justification
+   trailer in the commit body, or it blocks the push:
+
+```bash
+git commit -m "chore: bump version to $NEW_VERSION" -m "Release-Type: minor: <why this is not a patch>"
 ```
 
 Do not create a local tag. Do not push unless the user explicitly asks.

--- a/.claude/rules/versioning.md
+++ b/.claude/rules/versioning.md
@@ -9,13 +9,21 @@ paths:
 
 All packages share the same version number. Update versions when making significant changes.
 
-**When to bump versions:**
+**When to bump versions:** `patch` is the default and by far the most common
+bump during `0.x`. `minor` is rare.
 
 - `patch` (0.1.0 → 0.1.1): Default for bug fixes, docs/tooling, UX polish,
-  internal refactors, and most ordinary `feat:` / `fix:` commits
+  internal refactors, and most ordinary `feat:` / `fix:` commits. **Use this
+  unless a `minor`/`major` rule clearly applies.**
 - `minor` (0.1.0 → 0.2.0): New public CLI command namespaces, new MCP tool
   families, public API contract additions, or large product milestones
 - `major` (0.1.0 → 1.0.0): Breaking changes or the intentional 1.0 milestone
+
+> **Enforced.** `scripts/pre-push-validate.sh` blocks a `minor`/`major` bump
+> unless the `chore: bump version` commit body carries a
+> `Release-Type: minor: <reason>` (or `major`) trailer, or `VIBE_ALLOW_MINOR=1`
+> is set. This keeps the minor `y` from drifting — non-patch is a deliberate,
+> justified choice.
 
 **Quick bump:** Use `/release patch`, `/release minor`, or `/release major` skill to automate the full workflow.
 
@@ -24,7 +32,9 @@ After committing `feat:` or `fix:` changes, bump the version before pushing:
 
 - Default to `patch`, including most ordinary `feat:` and `fix:` commits.
 - Use `minor` only when the change adds a new public command namespace, MCP
-  tool family, public API contract, or large release milestone.
+  tool family, public API contract, or large release milestone — and add a
+  `Release-Type: minor: <reason>` trailer to the bump commit so the push gate
+  accepts it.
 - Multiple commits in one session → bump once based on the highest justified level.
 
 **How to update:**

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -10,15 +10,19 @@ disable-model-invocation: true
 Use this skill when the user asks Codex to run a VibeFrame release bump or fix a
 missing version bump after `feat:` / `fix:` commits.
 
-The requested bump must be one of: `patch`, `minor`, or `major`.
+The bump is one of `patch`, `minor`, or `major`. **Default to `patch`** when
+no bump is specified or when there is any doubt.
 
 ## Version Policy
 
-VibeFrame is still in `0.x`, so default to `patch` unless the change clearly
-needs a larger release signal.
+VibeFrame is still in `0.x`. **`patch` is the default and by far the most
+common bump.** `minor` is rare and must be explicitly justified — the shared
+push gate (`scripts/pre-push-validate.sh`) blocks a non-patch bump that lacks a
+`Release-Type:` trailer (see step 10).
 
 - `patch`: bug fixes, docs/tooling, UX polish, internal refactors, and most
-  ordinary `feat:` / `fix:` commits.
+  ordinary `feat:` / `fix:` commits. **Use this unless a rule below clearly
+  applies.**
 - `minor`: new public CLI command namespace, new MCP tool family, public API
   contract additions, or a large product milestone.
 - `major`: breaking changes or an intentional 1.0 milestone.
@@ -91,10 +95,17 @@ npm version` for this step because recursive pnpm includes the root package.
    git add package.json packages/*/package.json apps/*/package.json CHANGELOG.md docs/cli-reference.md
    ```
 
-10. Commit:
+10. Commit. For a `patch` bump, a plain message:
 
 ```bash
 git commit -m "chore: bump version to $NEW_VERSION"
+```
+
+   For a `minor` or `major` bump, the push gate requires a justification
+   trailer in the commit body, or it blocks the push:
+
+```bash
+git commit -m "chore: bump version to $NEW_VERSION" -m "Release-Type: minor: <why this is not a patch>"
 ```
 
 Do not create a local tag. Do not push unless the user explicitly asks.

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ archive/
 /demo/
 /demo-video/
 demo-output/
+/nova-demo/
 test-results/
 
 # Test artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,10 +112,17 @@ General expectation:
 ## Conventions
 
 - Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`.
+- Git & PR workflow: branch off `main` as `feat/<topic>`, `fix/<topic>`, or
+  `chore/<topic>`. **One PR = one coherent scope** — do not stack unrelated
+  commits onto an open PR branch. Rebase/split when scope drifts.
 - Version bumps default to `patch` during `0.x`, including most ordinary
-  `feat:` and `fix:` commits. Use `minor` only for new public CLI command
-  namespaces, new MCP tool families, public API contract additions, or large
-  product milestones. Reserve `major` for breaking changes or the 1.0 milestone.
+  `feat:` and `fix:` commits. **`patch` is the default; `minor` is rare.** Use
+  `minor` only for new public CLI command namespaces, new MCP tool families,
+  public API contract additions, or large product milestones; reserve `major`
+  for breaking changes or the 1.0 milestone. The shared push gate
+  (`scripts/pre-push-validate.sh`) **blocks** a `minor`/`major` bump unless the
+  `chore: bump version` commit carries a `Release-Type: minor: <reason>` (or
+  `major`) trailer, or `VIBE_ALLOW_MINOR=1` is set.
 - API keys belong in local config or `.env`-style files, never committed.
 - See `MODELS.md` for provider details.
 - `CHANGELOG.md` is generated with `git-cliff --tag vX.Y.Z -o CHANGELOG.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,9 @@ pnpm test
 
 ## Development Workflow
 
-1. Make your changes in a feature branch
+1. Make your changes in a feature branch off `main`, named `feat/<topic>`,
+   `fix/<topic>`, or `chore/<topic>`. Keep **one PR to one coherent scope** —
+   don't stack unrelated commits onto an open PR branch.
 2. Write tests for new functionality
 3. Ensure all tests pass: `pnpm -F @vibeframe/cli exec vitest run`
 4. Ensure code is properly formatted: `pnpm format`
@@ -60,6 +62,9 @@ pnpm test
 6. Build to check TypeScript: `pnpm build`
 7. Commit your changes with a conventional commit message
 8. Push to your fork and submit a Pull Request
+
+Version bumps default to `patch`; `minor`/`major` are rare and gated (see the
+"Conventions" and versioning notes in `AGENTS.md`).
 
 ## Adding a New AI Provider
 

--- a/scripts/pre-push-validate.sh
+++ b/scripts/pre-push-validate.sh
@@ -52,6 +52,21 @@ if [ -n "$LATEST_TAG" ]; then
   fi
 fi
 
+# 2b. Non-patch bump guard — during 0.x, patch is the default. A minor/major
+# bump must be explicitly justified, otherwise block. This keeps the minor `y`
+# from drifting: minor becomes a deliberate, friction-ful choice, not the path
+# of least resistance.
+if [ -n "$LATEST_TAG" ] && [ "$ROOT_VERSION" != "$TAG_VERSION" ]; then
+  ROOT_MAJOR=${ROOT_VERSION%%.*}; ROOT_MINOR=${ROOT_VERSION#*.}; ROOT_MINOR=${ROOT_MINOR%%.*}
+  TAG_MAJOR=${TAG_VERSION%%.*}; TAG_MINOR=${TAG_VERSION#*.}; TAG_MINOR=${TAG_MINOR%%.*}
+  if [ "$ROOT_MAJOR" != "$TAG_MAJOR" ] || [ "$ROOT_MINOR" != "$TAG_MINOR" ]; then
+    BUMP_BODY=$(cd "$PROJECT_DIR" && git log "$LATEST_TAG"..HEAD -E --grep="^chore: bump version" --format="%b" 2>/dev/null || true)
+    if [ "${VIBE_ALLOW_MINOR:-}" != "1" ] && ! echo "$BUMP_BODY" | grep -qiE "^Release-Type:[[:space:]]*(minor|major)"; then
+      ERRORS+=("Non-patch bump $TAG_VERSION -> $ROOT_VERSION without justification. During 0.x, patch is the default. If this is intentional (new public command namespace, MCP tool family, public API contract, or 1.0 milestone), add a 'Release-Type: minor: <reason>' (or major) trailer to the 'chore: bump version' commit body, or set VIBE_ALLOW_MINOR=1. Otherwise re-bump as patch: /release patch")
+    fi
+  fi
+fi
+
 # 3. No hardcoded version fallbacks in web app.
 HARDCODED=$(grep -rn '|| "0\.[0-9]*\.[0-9]*"' "$PROJECT_DIR/apps/web/app/" 2>/dev/null || true)
 if [ -n "$HARDCODED" ]; then


### PR DESCRIPTION
## Why

Repo diagnosis surfaced two governance gaps:

1. **Version drift.** The minor \`y\` in \`0.y.z\` climbed to **113** because the bump type is a fully manual, advisory choice. The "default to patch" policy already existed in three docs but nothing **enforced** it, so \`minor\` kept getting picked.
2. **Git/PR scope drift.** No documented branch/PR-scope convention, so unrelated commits stacked onto open PR branches.

Per Claude Code best practice: advisory docs answer *what*; a **hook/gate** makes it *deterministic*.

## What

- **Gate (the lever):** `scripts/pre-push-validate.sh` gains a non-patch bump guard. A `minor`/`major` bump **blocks the push** unless the `chore: bump version` commit carries a `Release-Type: minor|major: <reason>` trailer, or `VIBE_ALLOW_MINOR=1` is set. Patch is now the path of least resistance.
- **`/release` skill:** defaults to `patch`; adds a marker step for `minor`/`major` (canonical `.agents/` + synced `.claude/`).
- **Docs:** sharpen the policy in `AGENTS.md` and `.claude/rules/versioning.md`; document branch naming + "one PR = one coherent scope" in `AGENTS.md` and `CONTRIBUTING.md`.
- **Hygiene:** ignore local `nova-demo/` demo media.

Long-term: accept the historical `0.113.x` minor and move **patch-forward** (no 1.0 reset now).

## Verification

- Guard logic validated across 7 scenarios (patch → OK; minor/major no-marker → BLOCK; with `Release-Type:` trailer or `VIBE_ALLOW_MINOR=1` → OK; no-bump → OK).
- `bash scripts/pre-push-validate.sh` exits 0 on current tree; `pnpm agent-sync:check` in sync; build/lint green.
- `chore`/docs only — no `feat:`/`fix:`, so no version bump required for this PR.