### PR TITLE
feat(scene): character pool → reference-to-video for consistent AI video

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1932,7 +1932,7 @@ Cost tier: `free`
 
 - `project-dir` _(string)_ **required** — Project directory
 - `beat` _(string)_ **required** — Beat id
-- `key` _(string)_ **required** — Cue key: duration | narration | backdrop | video | motion | voice | music | asset
+- `key` _(string)_ **required** — Cue key: duration | narration | backdrop | video | motion | voice | music | asset | characters
 - `value` _(array)_ — Cue value. Use --json-value to pass a JSON scalar/object.
 - `jsonValue` _(boolean)_ — Parse value as JSON instead of a string
 - `unset` _(boolean)_ — Remove the cue key from the beat

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -82,6 +82,36 @@ narration: "media/voice.wav"
 asset: "media/logo.png"
 ```
 
+### Characters (consistent AI video)
+
+Declare a reusable character pool in the document frontmatter, then reference it
+from a beat's `characters` cue. During `vibe build`, each referenced character
+is rendered once as a turnaround sheet (`assets/character-<name>.png`) and used
+as a reference image for that beat's `video` generation (Seedance
+reference-to-video), so the same character stays consistent across beats. A
+character value is a generation prompt, or `{ image: <path> }` to bring your own
+reference (skips generation).
+
+```yaml
+---
+characters:
+  nova: "young female racing engineer, teal team jacket, low ponytail"
+  rival: { image: "media/rival-ref.png" }
+---
+
+## Beat hook — Hook
+
+```yaml
+duration: 5
+characters: [nova]
+video: "NOVA walks through the pit lane, handheld tracking shot, ambient garage sound"
+```
+```
+
+Character sheets add image-generation cost, and each character video beat is a
+provider video call — run `vibe build --dry-run` to see the estimate and gate
+with `--max-cost`.
+
 ## Profiles
 
 `vibe init` supports three profiles:

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -4048,7 +4048,7 @@ exports[`CLI --describe schemas (drift detection) > vibe storyboard set --descri
         "type": "boolean",
       },
       "key": {
-        "description": "Cue key: duration | narration | backdrop | video | motion | voice | music | asset",
+        "description": "Cue key: duration | narration | backdrop | video | motion | voice | music | asset | characters",
         "type": "string",
       },
       "project-dir": {

--- a/packages/cli/src/commands/_shared/build-asset-reference.ts
+++ b/packages/cli/src/commands/_shared/build-asset-reference.ts
@@ -18,6 +18,7 @@ export interface AssetReferenceCandidate {
 const EXTENSIONS: Record<BuildAssetKind, readonly string[]> = {
   narration: [".mp3", ".wav", ".m4a"],
   backdrop: [".png", ".jpg", ".jpeg", ".webp"],
+  character: [".png", ".jpg", ".jpeg", ".webp"],
   video: [".mp4", ".mov", ".webm"],
   music: [".mp3", ".wav", ".m4a"],
 };

--- a/packages/cli/src/commands/_shared/build-cache.test.ts
+++ b/packages/cli/src/commands/_shared/build-cache.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { characterCacheDescriptor, videoCacheDescriptor } from "./build-cache.js";
+
+describe("characterCacheDescriptor", () => {
+  const base = {
+    name: "nova",
+    cue: "teal jacket engineer",
+    provider: "openai",
+    quality: "hd" as const,
+    size: "1536x1024",
+  };
+
+  it("produces a deterministic, character-scoped cache path", () => {
+    const a = characterCacheDescriptor(base);
+    const b = characterCacheDescriptor(base);
+    expect(a.key).toBe(b.key);
+    expect(a.path).toBe(`.vibeframe/cache/assets/character-${a.key}.png`);
+  });
+
+  it("changes the key when the prompt or name changes", () => {
+    const a = characterCacheDescriptor(base);
+    expect(characterCacheDescriptor({ ...base, cue: "red jacket" }).key).not.toBe(a.key);
+    expect(characterCacheDescriptor({ ...base, name: "rival" }).key).not.toBe(a.key);
+  });
+});
+
+describe("videoCacheDescriptor character invalidation", () => {
+  const base = { beatId: "hook", cue: "walk the pit lane", provider: "seedance", duration: 5 };
+
+  it("keeps the legacy key when no characters are supplied", () => {
+    const withoutField = videoCacheDescriptor(base);
+    const withEmpty = videoCacheDescriptor({ ...base, characters: [] });
+    expect(withEmpty.key).toBe(withoutField.key);
+  });
+
+  it("changes the key when character references change", () => {
+    const none = videoCacheDescriptor(base);
+    const nova = videoCacheDescriptor({ ...base, characters: ["assets/character-nova.png"] });
+    const pair = videoCacheDescriptor({
+      ...base,
+      characters: ["assets/character-nova.png", "assets/character-rival.png"],
+    });
+    expect(nova.key).not.toBe(none.key);
+    expect(pair.key).not.toBe(nova.key);
+  });
+});

--- a/packages/cli/src/commands/_shared/build-cache.ts
+++ b/packages/cli/src/commands/_shared/build-cache.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-export type BuildAssetKind = "narration" | "backdrop" | "video" | "music";
+export type BuildAssetKind = "narration" | "backdrop" | "character" | "video" | "music";
 
 export interface CacheAssetDescriptor {
   key: string;
@@ -58,6 +58,23 @@ export function backdropCacheDescriptor(opts: {
   });
 }
 
+export function characterCacheDescriptor(opts: {
+  name: string;
+  cue: string;
+  provider: string;
+  quality: "standard" | "hd";
+  size: string;
+}): CacheAssetDescriptor {
+  return cacheAssetDescriptor("character", {
+    name: opts.name,
+    cue: opts.cue,
+    provider: opts.provider,
+    quality: opts.quality,
+    size: opts.size,
+    ext: "png",
+  });
+}
+
 export function imageRatioForSize(size: string | undefined): string {
   switch (size) {
     case "1024x1024":
@@ -76,6 +93,8 @@ export function videoCacheDescriptor(opts: {
   cue: string;
   provider: string;
   duration: number | undefined;
+  /** Character reference image paths — changing them must invalidate the clip. */
+  characters?: string[];
 }): CacheAssetDescriptor {
   return cacheAssetDescriptor("video", {
     beatId: opts.beatId,
@@ -83,6 +102,8 @@ export function videoCacheDescriptor(opts: {
     provider: opts.provider,
     duration: normalizeVideoDuration(opts.duration),
     ratio: "16:9",
+    // Omit when empty so existing (character-less) clips keep their cache key.
+    characters: opts.characters && opts.characters.length > 0 ? opts.characters : undefined,
     ext: "mp4",
   });
 }

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -19,8 +19,10 @@ import {
   imageRatioForSize,
   musicCacheDescriptor,
   narrationCacheDescriptor,
+  normalizeVideoDuration,
   videoCacheDescriptor,
 } from "./build-cache.js";
+import { estimateSeedanceVideoCostUsd } from "@vibeframe/ai-providers";
 import {
   assetFreshnessFromMetadata,
   assetMetadataPath,
@@ -28,7 +30,12 @@ import {
 } from "./build-asset-metadata.js";
 import { augmentBackdropPrompt } from "./build-backdrop-prompt.js";
 import { composerEnvVar, isComposerProvider, type ComposerProvider } from "./composer-resolve.js";
-import { parseStoryboard, type ParsedStoryboard } from "./storyboard-parse.js";
+import {
+  beatCharacterNames,
+  parseStoryboard,
+  resolveCharacters,
+  type ParsedStoryboard,
+} from "./storyboard-parse.js";
 import { readProjectConfig, type LoadedProjectConfig } from "./project-config.js";
 import { validateStoryboardMarkdown, type StoryboardValidationIssue } from "./storyboard-edit.js";
 
@@ -378,7 +385,14 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
             reference: videoReference,
             projectDir,
             force: opts.force,
-            cost: VIDEO_COST_USD,
+            cost:
+              resolved.video.resolved === "seedance" || resolved.video.resolved === "fal"
+                ? estimateSeedanceVideoCostUsd({
+                    durationSec: normalizeVideoDuration(beat.duration),
+                    resolution: "720p",
+                    aspectRatio: "16:9",
+                  })
+                : VIDEO_COST_USD,
             active: includeAssets,
           })
         : null;
@@ -505,6 +519,28 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
         `Backdrop image generation will run for ${generatedBackdrops.length} beat(s), estimated $${cost.toFixed(2)}. Use --skip-backdrop for HTML/CSS-derived visuals: ${skipCommand}`
       );
       retryWith.push(skipCommand);
+    }
+  }
+
+  // Character sheets are generated once per build (project-level), before
+  // per-beat video. Estimate cost for referenced, prompt-based characters that
+  // are not already on disk so `--max-cost` gates them.
+  if (validationOk && includeAssets && !opts.skipVideo) {
+    const referenced = new Set<string>();
+    for (const beat of sourceBeats) {
+      for (const name of beatCharacterNames(beat.cues)) referenced.add(name);
+    }
+    if (referenced.size > 0) {
+      const toGenerate = resolveCharacters(parsed.frontmatter).filter(
+        (c) =>
+          referenced.has(c.name) &&
+          c.prompt &&
+          (opts.force || !existsSync(join(projectDir, `assets/character-${c.name}.png`)))
+      );
+      if (toGenerate.length > 0) {
+        estimatedCostUsd += toGenerate.length * backdropCostUsd(opts.imageQuality ?? "hd");
+        missing.add("assets");
+      }
     }
   }
 
@@ -687,7 +723,7 @@ function providerResolutionsForPlan(
   opts: CreateBuildPlanOptions,
   includeAssets: boolean
 ): ProviderResolution[] {
-  const needsProvider = (kind: BuildAssetKind) =>
+  const needsProvider = (kind: keyof BuildPlanBeat["assets"]) =>
     beats.some((beat) => {
       const asset = beat.assets[kind];
       return (

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.ts
@@ -278,7 +278,15 @@ ${finalDurationBullet}
   itself. For multi-phase beats, drive phase changes with GSAP \`autoAlpha\`
   inside full-window clips: animate phase A out (\`autoAlpha: 0\`), then
   phase B in, on the same timeline.
-- If \`assets/backdrop-${ctx.beat.id}.png\` exists, use that local file as the
+- If \`assets/video-${ctx.beat.id}.mp4\` exists, it is an AI-generated clip for
+  this beat — use it as the FULL-FRAME visual and prefer it over any backdrop
+  image or CSS. Put one full-bleed \`<video>\` inside a full-window \`.clip\`:
+  \`<video src="assets/video-${ctx.beat.id}.mp4" data-start="0" data-duration="${BEAT_DURATION}" data-media-start="0" muted playsinline style="width:100%;height:100%;object-fit:cover"></video>\`
+  Use the exact path (no \`./\` or \`../\`). The framework seeks the clip to each
+  timeline frame, so do NOT add transform tweens to the \`<video>\` or its
+  ancestors; layer text/motion graphics on top instead.
+- If \`assets/backdrop-${ctx.beat.id}.png\` exists (and no video clip above),
+  use that local file as the
   full-frame visual backdrop. The exact path string is
   \`assets/backdrop-${ctx.beat.id}.png\`; do NOT prefix it with \`../\` or \`./\`
   because fragments are mounted from the project root.

--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -5,7 +5,7 @@
  * budget or starting Chrome.
  */
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -246,6 +246,7 @@ afterEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.GOOGLE_API_KEY;
   delete process.env.XAI_API_KEY;
+  delete process.env.FAL_API_KEY;
   delete process.env.VIBE_BUILD_MODE;
 });
 
@@ -373,6 +374,33 @@ describe("executeSceneBuild", () => {
       sync: expect.objectContaining({ status: "done", costUsd: expect.any(Number) }),
       render: expect.objectContaining({ status: "done", costUsd: expect.any(Number) }),
     });
+  });
+
+  it("generates character sheets and passes them as video reference images", async () => {
+    writeFileSync(
+      join(projectDir, "STORYBOARD.md"),
+      `---\nproviders:\n  video: seedance\ncharacters:\n  nova: "teal jacket racing engineer, low ponytail"\n---\n\n## Beat hook — Hook\n\n\`\`\`yaml\nduration: 5\ncharacters: [nova]\nvideo: "NOVA walks the pit lane, handheld tracking"\n\`\`\`\n\nBody.\n`
+    );
+    process.env.FAL_API_KEY = "test-fal-key";
+    vi.mocked(executeVideoGenerate).mockResolvedValue({
+      success: true,
+      taskId: "vid-1",
+      status: "completed",
+      provider: "seedance",
+      videoUrl: "https://example/clip.mp4",
+    });
+
+    await executeSceneBuild({ projectDir });
+
+    // The referenced character sheet is generated once, up front.
+    expect(existsSync(join(projectDir, "assets", "character-nova.png"))).toBe(true);
+    // dispatchVideo threads it into Seedance reference-to-video.
+    expect(executeVideoGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "seedance",
+        refImages: [join(projectDir, "assets", "character-nova.png")],
+      })
+    );
   });
 
   it("loads OPENAI_API_KEY from the current project's .env for backdrop dispatch", async () => {

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -19,7 +19,7 @@
  *     already have one with sub-composition references.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 
@@ -28,6 +28,7 @@ import {
   GeminiProvider,
   GrokProvider,
   OpenAIImageProvider,
+  estimateSeedanceVideoCostUsd,
   type ImageOptions,
 } from "@vibeframe/ai-providers";
 
@@ -44,7 +45,13 @@ import type { ComposerProvider } from "./composer-resolve.js";
 import { getComposePrompts, type ComposePromptsBeat } from "./compose-prompts.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
 import { executeSceneRender, type SceneRenderResult } from "./scene-render.js";
-import { parseStoryboard, type Beat } from "./storyboard-parse.js";
+import {
+  beatCharacterNames,
+  parseStoryboard,
+  resolveCharacters,
+  type Beat,
+  type ResolvedCharacter,
+} from "./storyboard-parse.js";
 import { scaffoldSceneProject } from "./scene-project.js";
 import {
   backdropCostUsd,
@@ -65,6 +72,7 @@ import {
 } from "./root-sync.js";
 import {
   backdropCacheDescriptor,
+  characterCacheDescriptor,
   type BuildAssetKind,
   imageRatioForSize,
   musicCacheDescriptor,
@@ -105,6 +113,9 @@ const BEAT_PRIMITIVES_CONCURRENCY = 4;
 
 export type SceneBuildProgressEvent =
   | { type: "phase-start"; phase: "primitives" | "compose" | "render" }
+  | { type: "character-cached"; name: string; path: string }
+  | { type: "character-generated"; name: string; path: string; provider: string }
+  | { type: "character-failed"; name: string; error: string }
   | { type: "narration-cached"; beatId: string; path: string }
   | { type: "narration-generated"; beatId: string; path: string; provider: string }
   | { type: "narration-failed"; beatId: string; error: string }
@@ -545,8 +556,36 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
 
   let beatOutcomes: BeatBuildOutcome[] = collectExistingBeatOutcomes(parsed.beats, projectDir);
   let pendingJobs: JobRecord[] = [];
+  let characterCostUsd = 0;
   if (shouldRunStage(selectedStage, "assets")) {
     onProgress({ type: "phase-start", phase: "primitives" });
+
+    // Generate the character sheets referenced by any video beat once, up front,
+    // so dispatchVideo can pass them as reference-to-video inputs.
+    const characterPaths = new Map<string, string>();
+    if (!(opts.skipVideo ?? false)) {
+      const referenced = new Set<string>();
+      for (const beat of activeBeats) {
+        for (const name of beatCharacterNames(beat.cues)) referenced.add(name);
+      }
+      if (referenced.size > 0) {
+        const charResult = await buildCharacters(
+          resolveCharacters(parsed.frontmatter).filter((c) => referenced.has(c.name)),
+          {
+            projectDir,
+            imageProvider,
+            imageSize: opts.imageSize ?? "1536x1024",
+            imageQuality: opts.imageQuality ?? "hd",
+            force: opts.force ?? false,
+            onProgress,
+          }
+        );
+        for (const [name, path] of charResult.paths) characterPaths.set(name, path);
+        characterCostUsd = charResult.costUsd;
+        warnings.push(...charResult.failures);
+      }
+    }
+
     const primitiveResults = await mapWithConcurrency(
       activeBeats,
       BEAT_PRIMITIVES_CONCURRENCY,
@@ -566,6 +605,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
           skipMusic: opts.skipMusic ?? false,
           force: opts.force ?? false,
           onProgress,
+          characterPaths,
         })
     );
     beatOutcomes = primitiveResults.map((result) => result.outcome);
@@ -582,10 +622,8 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
       : pendingJobs.length > 0
         ? "pending-jobs"
         : "done";
-    stageReports.assets.costUsd = estimateActualAssetCost(
-      beatOutcomes,
-      opts.imageQuality ?? "hd"
-    );
+    stageReports.assets.costUsd =
+      estimateActualAssetCost(beatOutcomes, opts.imageQuality ?? "hd") + characterCostUsd;
     stageReports.assets.retryWith = pendingJobs.map(
       (job) => `vibe status job ${job.id} --project ${projectDir} --json`
     );
@@ -767,6 +805,21 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   }
 
   if (stageReports.compose.status === "done") {
+    // A beat with a generated clip whose composition never references it would
+    // silently drop the clip from the render. Warn (don't mutate the
+    // LLM-authored HTML) and offer a targeted recompose.
+    for (const beat of activeBeats) {
+      const videoRel = `assets/video-${beat.id}.mp4`;
+      const compositionAbs = join(projectDir, "compositions", `scene-${beat.id}.html`);
+      if (!existsSync(join(projectDir, videoRel)) || !existsSync(compositionAbs)) continue;
+      const html = readFileSync(compositionAbs, "utf-8");
+      if (!html.includes(videoRel)) {
+        warnings.push(
+          `Beat "${beat.id}" has a generated clip (${videoRel}) but its composition does not reference it, so the clip will not appear. Recompose the beat.`
+        );
+        retryWith.push(`vibe build ${projectDir} --beat ${beat.id} --stage compose --force --json`);
+      }
+    }
     const repair = await runBuildSceneRepair(projectDir, "compose", false);
     sceneRepair = mergeSceneRepairSummaries(sceneRepair, repair);
     applySceneRepairToStage(stageReports.compose, repair);
@@ -984,6 +1037,8 @@ interface BeatDispatchContext {
   skipMusic: boolean;
   force: boolean;
   onProgress: (e: SceneBuildProgressEvent) => void;
+  /** name → relative path of generated/supplied character reference images. */
+  characterPaths?: Map<string, string>;
 }
 
 interface BeatPrimitiveResult {
@@ -1281,6 +1336,149 @@ async function dispatchNarration(beat: Beat, ctx: BeatDispatchContext): Promise<
   };
 }
 
+interface CharacterBuildResult {
+  /** name → relative path of the resolved reference image. */
+  paths: Map<string, string>;
+  costUsd: number;
+  failures: string[];
+}
+
+/** Turnaround character-sheet prompt — the layout validated to hold identity. */
+function characterSheetPrompt(name: string, description: string): string {
+  return [
+    `Character turnaround reference sheet of an original fictional character named ${name}: ${description}.`,
+    "Show three full-body views side by side on one clean canvas — front view, side profile, and back view —",
+    "with identical outfit, hairstyle, hair color, and body proportions across all three views.",
+    "Plain light-grey studio background, even neutral lighting, no props.",
+    "Photorealistic digital character, professional concept-art character sheet layout.",
+  ].join(" ");
+}
+
+/**
+ * Generate (or reuse) the project's referenced character sheets once per build,
+ * before per-beat assets. Each generated sheet lands at
+ * `assets/character-<name>.png` and is cached like a backdrop; `image:` entries
+ * are referenced in place. Returns name → path so `dispatchVideo` can pass them
+ * as Seedance references.
+ */
+async function buildCharacters(
+  characters: ResolvedCharacter[],
+  ctx: ImageGenContext & { force: boolean; onProgress: (e: SceneBuildProgressEvent) => void }
+): Promise<CharacterBuildResult> {
+  const paths = new Map<string, string>();
+  const failures: string[] = [];
+  let costUsd = 0;
+  const size = ctx.imageSize ?? "1536x1024";
+
+  for (const character of characters) {
+    // Bring-your-own image: reference it directly when present.
+    if (character.imagePath) {
+      if (existsSync(join(ctx.projectDir, character.imagePath))) {
+        paths.set(character.name, character.imagePath);
+        ctx.onProgress({ type: "character-cached", name: character.name, path: character.imagePath });
+      } else {
+        const error = `character "${character.name}" image not found: ${character.imagePath}`;
+        failures.push(error);
+        ctx.onProgress({ type: "character-failed", name: character.name, error });
+      }
+      continue;
+    }
+    if (!character.prompt) continue;
+
+    const prompt = characterSheetPrompt(character.name, character.prompt);
+    const rel = `assets/character-${character.name}.png`;
+    const abs = join(ctx.projectDir, rel);
+    const metadataOptions = { quality: ctx.imageQuality, size };
+    const cache = characterCacheDescriptor({
+      name: character.name,
+      cue: prompt,
+      provider: ctx.imageProvider,
+      quality: ctx.imageQuality,
+      size,
+    });
+
+    if (existsSync(abs) && !ctx.force) {
+      const metadata = readAssetMetadata(ctx.projectDir, "character", character.name);
+      if (
+        !metadata ||
+        isFreshCanonicalAsset({
+          projectDir: ctx.projectDir,
+          kind: "character",
+          beatId: character.name,
+          cue: prompt,
+          provider: ctx.imageProvider,
+          options: metadataOptions,
+          cacheKey: cache.key,
+        })
+      ) {
+        paths.set(character.name, rel);
+        ctx.onProgress({ type: "character-cached", name: character.name, path: rel });
+        continue;
+      }
+    }
+    const cacheAbs = join(ctx.projectDir, cache.path);
+    if (existsSync(cacheAbs) && !ctx.force) {
+      await mkdir(dirname(abs), { recursive: true });
+      await copyFile(cacheAbs, abs);
+      await writeAssetMetadata({
+        projectDir: ctx.projectDir,
+        kind: "character",
+        beatId: character.name,
+        cue: prompt,
+        provider: ctx.imageProvider,
+        options: metadataOptions,
+        cacheKey: cache.key,
+        canonicalPath: rel,
+        cachePath: cache.path,
+      });
+      paths.set(character.name, rel);
+      ctx.onProgress({ type: "character-cached", name: character.name, path: rel });
+      continue;
+    }
+
+    const generated = await generateBackdropImage(
+      prompt,
+      {
+        projectDir: ctx.projectDir,
+        imageProvider: ctx.imageProvider,
+        imageSize: size,
+        imageQuality: ctx.imageQuality,
+      },
+      imageRatioForSize(size)
+    );
+    if (!generated.success) {
+      failures.push(`character "${character.name}": ${generated.error}`);
+      ctx.onProgress({ type: "character-failed", name: character.name, error: generated.error });
+      continue;
+    }
+    await mkdir(dirname(abs), { recursive: true });
+    await writeFile(abs, generated.buffer);
+    await mkdir(dirname(cacheAbs), { recursive: true });
+    await writeFile(cacheAbs, generated.buffer);
+    await writeAssetMetadata({
+      projectDir: ctx.projectDir,
+      kind: "character",
+      beatId: character.name,
+      cue: prompt,
+      provider: ctx.imageProvider,
+      options: metadataOptions,
+      cacheKey: cache.key,
+      canonicalPath: rel,
+      cachePath: cache.path,
+    });
+    costUsd += backdropCostUsd(ctx.imageQuality);
+    paths.set(character.name, rel);
+    ctx.onProgress({
+      type: "character-generated",
+      name: character.name,
+      path: rel,
+      provider: ctx.imageProvider,
+    });
+  }
+
+  return { paths, costUsd: Number(costUsd.toFixed(2)), failures };
+}
+
 async function dispatchBackdrop(beat: Beat, ctx: BeatDispatchContext): Promise<PrimitiveOutcome> {
   const reference = assetReferenceForBeat(ctx.projectDir, "backdrop", beat);
   if (reference) return referencePrimitiveOutcome("backdrop", beat, ctx, reference);
@@ -1405,9 +1603,17 @@ type GeneratedBackdropResult =
   | { success: true; buffer: Buffer }
   | { success: false; error: string };
 
+/** Minimal context for raw image generation — shared by backdrops and characters. */
+interface ImageGenContext {
+  projectDir: string;
+  imageProvider: BuildImageProvider;
+  imageSize: ImageOptions["size"];
+  imageQuality: "standard" | "hd";
+}
+
 async function generateBackdropImage(
   prompt: string,
-  ctx: BeatDispatchContext,
+  ctx: ImageGenContext,
   ratio: string
 ): Promise<GeneratedBackdropResult> {
   loadSceneBuildEnv(ctx.projectDir);
@@ -1486,6 +1692,14 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
   const prompt = stringOrUndefined(beat.cues?.video);
   if (!prompt) return { status: "no-cue" };
 
+  // Resolve this beat's character sheets (generated up front by buildCharacters)
+  // into Seedance reference-to-video inputs. Relative paths key the cache (stable
+  // across machines); absolute paths are handed to the generator.
+  const characterRefsRel = beatCharacterNames(beat.cues)
+    .map((name) => ctx.characterPaths?.get(name))
+    .filter((p): p is string => typeof p === "string");
+  const characterRefsAbs = characterRefsRel.map((p) => join(ctx.projectDir, p));
+
   const rel = `assets/video-${beat.id}.mp4`;
   const abs = join(ctx.projectDir, rel);
   const cache = videoCacheDescriptor({
@@ -1493,6 +1707,7 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
     cue: prompt,
     provider: ctx.videoProvider,
     duration: normalizeVideoDuration(beat.duration),
+    characters: characterRefsRel,
   });
   const metadataPath = assetMetadataPath("video", beat.id);
   if (existsSync(abs) && !ctx.force) {
@@ -1556,6 +1771,7 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
     ratio: "16:9",
     output: abs,
     wait: false,
+    refImages: characterRefsAbs.length > 0 ? characterRefsAbs : undefined,
     apiKey: await apiKeyForVideoProvider(ctx.videoProvider, ctx.projectDir),
   });
   if (!result.success || !result.taskId) {
@@ -1977,7 +2193,16 @@ function estimateActualAssetCost(
   for (const outcome of outcomes) {
     if (outcome.narrationStatus === "generated") cost += 0.05;
     if (outcome.backdropStatus === "generated") cost += backdropCostUsd(imageQuality);
-    if (outcome.videoStatus === "generated" || outcome.videoStatus === "pending") cost += 5;
+    if (outcome.videoStatus === "generated" || outcome.videoStatus === "pending") {
+      cost +=
+        outcome.videoProvider === "seedance" || outcome.videoProvider === "fal"
+          ? estimateSeedanceVideoCostUsd({
+              durationSec: normalizeVideoDuration(outcome.sceneDurationSec),
+              resolution: "720p",
+              aspectRatio: "16:9",
+            })
+          : 5;
+    }
     if (outcome.musicStatus === "generated" || outcome.musicStatus === "pending") cost += 0.5;
   }
   return Number(cost.toFixed(2));

--- a/packages/cli/src/commands/_shared/storyboard-edit.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-edit.test.ts
@@ -149,3 +149,38 @@ Body.
     expect(result.issues.find((i) => i.code === "BEAT_DURATION_TOO_LONG")).toBeUndefined();
   });
 });
+
+describe("characters cue validation", () => {
+  const withPool = (cue: string) =>
+    `---\ncharacters:\n  nova: "teal jacket engineer"\n---\n\n## Beat hook - Hook\n\n\`\`\`yaml\n${cue}\n\`\`\`\n\nBody.\n`;
+
+  it("accepts a known single name and a known list", () => {
+    expect(validateStoryboardMarkdown(withPool(`characters: nova`)).ok).toBe(true);
+    expect(validateStoryboardMarkdown(withPool(`characters: [nova]`)).ok).toBe(true);
+  });
+
+  it("errors when characters is not a name or list of names", () => {
+    const result = validateStoryboardMarkdown(withPool(`characters: 42`));
+    expect(result.issues.map((i) => i.code)).toContain("INVALID_CHARACTERS_VALUE");
+  });
+
+  it("warns when a referenced character is absent from the pool", () => {
+    const result = validateStoryboardMarkdown(withPool(`characters: [nova, ghost]`));
+    const warning = result.issues.find((i) => i.code === "UNKNOWN_CHARACTER");
+    expect(warning?.message).toContain("ghost");
+    // Unknown character is a warning, not a hard error.
+    expect(result.ok).toBe(true);
+  });
+
+  it("round-trips a characters list cue through setStoryboardCue", () => {
+    const md = setStoryboardCue(buildStoryboardMd("demo"), {
+      beatId: "hook",
+      key: "characters",
+      value: ["nova", "rival"],
+    });
+    expect(parseStoryboard(md).beats.find((b) => b.id === "hook")?.cues?.characters).toEqual([
+      "nova",
+      "rival",
+    ]);
+  });
+});

--- a/packages/cli/src/commands/_shared/storyboard-edit.ts
+++ b/packages/cli/src/commands/_shared/storyboard-edit.ts
@@ -1,6 +1,7 @@
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
 import {
+  beatCharacterNames,
   deriveBeatId,
   parseStoryboard,
   type Beat,
@@ -16,6 +17,7 @@ export const STORYBOARD_CUE_KEYS = [
   "voice",
   "music",
   "asset",
+  "characters",
 ] as const;
 
 export type StoryboardCueKey = (typeof STORYBOARD_CUE_KEYS)[number];
@@ -107,6 +109,11 @@ export function validateStoryboardMarkdown(markdown: string): StoryboardValidati
     }
   }
 
+  const characterPool = new Set<string>(
+    Object.keys(
+      (parsed.frontmatter?.characters as Record<string, unknown> | undefined) ?? {}
+    )
+  );
   for (const beat of parsed.beats) {
     const cues = beat.cues ?? {};
     for (const [key, value] of Object.entries(cues)) {
@@ -117,6 +124,31 @@ export function validateStoryboardMarkdown(markdown: string): StoryboardValidati
           beatId: beat.id,
           message: `Beat "${beat.id}" uses unknown cue "${key}". Supported cues: ${STORYBOARD_CUE_KEYS.join(", ")}.`,
         });
+        continue;
+      }
+      if (key === "characters") {
+        const validShape =
+          typeof value === "string" ||
+          (Array.isArray(value) && value.every((v) => typeof v === "string"));
+        if (!validShape) {
+          issues.push({
+            severity: "error",
+            code: "INVALID_CHARACTERS_VALUE",
+            beatId: beat.id,
+            message: `Beat "${beat.id}" cue "characters" must be a character name or a list of names.`,
+          });
+          continue;
+        }
+        for (const name of beatCharacterNames({ characters: value } as BeatCues)) {
+          if (!characterPool.has(name)) {
+            issues.push({
+              severity: "warning",
+              code: "UNKNOWN_CHARACTER",
+              beatId: beat.id,
+              message: `Beat "${beat.id}" references character "${name}" not defined in the frontmatter \`characters:\` pool.`,
+            });
+          }
+        }
         continue;
       }
       if (key === "duration") {

--- a/packages/cli/src/commands/_shared/storyboard-parse.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  beatCharacterNames,
   deriveBeatId,
   extractBeatCues,
   extractProjectFrontmatter,
   parseBeatDuration,
   parseStoryboard,
+  resolveCharacters,
 } from "./storyboard-parse.js";
 
 describe("parseStoryboard", () => {
@@ -366,5 +368,46 @@ Cold open.
     expect(r.beats[0].cues).toBeUndefined();
     expect(r.beats[0].duration).toBe(3);
     expect(r.beats[0].body).toContain("### Concept");
+  });
+});
+
+describe("resolveCharacters", () => {
+  it("returns [] when no characters are declared", () => {
+    expect(resolveCharacters(undefined)).toEqual([]);
+    expect(resolveCharacters({})).toEqual([]);
+  });
+
+  it("treats a string entry as a generation prompt", () => {
+    expect(resolveCharacters({ characters: { nova: "teal jacket engineer" } })).toEqual([
+      { name: "nova", prompt: "teal jacket engineer" },
+    ]);
+  });
+
+  it("uses image path (skipping generation) and falls back to description", () => {
+    expect(
+      resolveCharacters({
+        characters: {
+          rival: { image: "assets/rival.png" },
+          ace: { description: "stoic veteran driver" },
+        },
+      })
+    ).toEqual([
+      { name: "rival", imagePath: "assets/rival.png" },
+      { name: "ace", prompt: "stoic veteran driver" },
+    ]);
+  });
+
+  it("drops empty entries", () => {
+    expect(resolveCharacters({ characters: { blank: "   ", empty: {} } })).toEqual([]);
+  });
+});
+
+describe("beatCharacterNames", () => {
+  it("normalizes a single name, a list, and absent cues", () => {
+    expect(beatCharacterNames({ characters: "nova" })).toEqual(["nova"]);
+    expect(beatCharacterNames({ characters: ["nova", " rival "] })).toEqual(["nova", "rival"]);
+    expect(beatCharacterNames({ characters: [1, "ace"] as unknown as string[] })).toEqual(["ace"]);
+    expect(beatCharacterNames(undefined)).toEqual([]);
+    expect(beatCharacterNames({})).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/_shared/storyboard-parse.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.ts
@@ -69,7 +69,57 @@ export interface ProjectFrontmatter {
   defaultDuration?: number;
   /** Visual identity preset hint (informational; e.g. "Swiss Pulse"). */
   style?: string;
+  /**
+   * Reusable character pool. Each entry is either a generation prompt
+   * (string → build renders a turnaround sheet at `assets/character-<name>.png`)
+   * or an object with `description` (same, explicit) and/or `image` (a
+   * bring-your-own reference path, which skips generation). Beats reference
+   * these by name via the `characters:` cue to drive reference-to-video.
+   */
+  characters?: Record<string, CharacterSpec>;
   [key: string]: unknown;
+}
+
+/** A character pool entry — a prompt string or a structured spec. */
+export type CharacterSpec = string | { description?: string; image?: string };
+
+/** Normalized character ready for build: generation prompt and/or supplied image. */
+export interface ResolvedCharacter {
+  name: string;
+  /** Generation prompt when the sheet should be rendered (absent if `image` given). */
+  prompt?: string;
+  /** Bring-your-own reference image path, relative to the project dir. */
+  imagePath?: string;
+}
+
+/**
+ * Flatten the frontmatter `characters` map into build-ready specs. A string or
+ * `{ description }` becomes a generation prompt; `{ image }` is used as-is
+ * (generation skipped). Entries with neither are dropped.
+ */
+export function resolveCharacters(
+  frontmatter: ProjectFrontmatter | undefined
+): ResolvedCharacter[] {
+  const pool = frontmatter?.characters;
+  if (!pool || typeof pool !== "object") return [];
+  const resolved: ResolvedCharacter[] = [];
+  for (const [name, spec] of Object.entries(pool)) {
+    if (typeof spec === "string") {
+      const prompt = spec.trim();
+      if (prompt) resolved.push({ name, prompt });
+      continue;
+    }
+    if (spec && typeof spec === "object") {
+      const image = typeof spec.image === "string" ? spec.image.trim() : "";
+      if (image) {
+        resolved.push({ name, imagePath: image });
+        continue;
+      }
+      const description = typeof spec.description === "string" ? spec.description.trim() : "";
+      if (description) resolved.push({ name, prompt: description });
+    }
+  }
+  return resolved;
 }
 
 /**
@@ -86,7 +136,27 @@ export interface BeatCues {
   duration?: number;
   /** Voice override for this beat (overrides project frontmatter `voice`). */
   voice?: string;
+  /**
+   * Character pool names whose reference sheets drive this beat's
+   * reference-to-video generation. A single name or a list.
+   */
+  characters?: string | string[];
   [key: string]: unknown;
+}
+
+/** Normalize a beat's `characters` cue to a clean string[] (single or list). */
+export function beatCharacterNames(cues: BeatCues | undefined): string[] {
+  const raw = cues?.characters;
+  if (typeof raw === "string") {
+    const name = raw.trim();
+    return name ? [name] : [];
+  }
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
+      .map((v) => v.trim());
+  }
+  return [];
 }
 
 export interface Beat {


### PR DESCRIPTION
Split out of the `feat/report-actions` branch into its own PR for scope clarity
(one PR = one coherent scope).

> **Stacked on #219.** Base is `feat/report-actions` because this commit calls
> `estimateSeedanceVideoCostUsd` introduced there. After #219 merges to `main`,
> retarget this PR's base to `main`.

## What

Adds a character pool to the storyboard build so AI video stays visually
consistent across beats:

- `characters:` frontmatter (turnaround description per character) → a GPT
  Image 2 character sheet generated once at `assets/character-<name>.png`.
- Per-beat `characters: [name]` cue → the sheet is passed to Seedance as a
  **reference image** (reference-to-video), keeping identity consistent.
- Content-addressed caching for the new `character` asset kind; token-accurate
  Seedance cost in both dry-run and the actual-cost report.
- Composer wires the resulting `<video>` as the full-frame visual.

## Verification

- Proven end-to-end on a 3-beat demo (character consistent across pit/wall/grid
  clips; narration + 15s stitched render).
- Focused tests for storyboard parse/edit, build-cache, scene-build, and the
  Seedance cost estimator; build/lint/test green.

Release impact: **patch** (extends existing storyboard/build cue keys — no new
public command namespace, MCP tool family, or API contract).