### PR TITLE
chore: bump version to 0.113.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.1] - 2026-06-15
+## [0.113.2] - 2026-06-18
 
 ### Added
 
+- character pool → reference-to-video for consistent AI video *(scene)*
+- token-accurate Seedance cost in video dry-run *(generate)*
+- emit classified nextActions for every workflow state *(status)*
 - sync scene add with storyboards *(scene)*
 
 ### Maintenance
 
+- harden agent-host sync and document the topology
+- enforce patch-primary versioning and document git/PR strategy
 - align agent goals and manual release workflow
+
+### Testing
+
+- contract-test the structured error envelope *(cli)*
 
 ## [0.113.0] - 2026-06-12
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.1",
+  "version": "0.113.2",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.1`
+> CLI version: `0.113.2`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.1",
+  "version": "0.113.2",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.1",
+  "version": "0.113.2",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.1",
+  "version": "0.113.2",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.1",
+  "version": "0.113.2",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.1",
+  "version": "0.113.2",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.1",
+  "version": "0.113.2",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Patch release covering everything merged since `v0.113.0` (the `0.113.1` bump was
never tagged, so its commits fold in here).

### Added
- character pool → reference-to-video for consistent AI video
- token-accurate Seedance cost in video dry-run
- classified `nextActions` for every workflow state
- sync scene add with storyboards

### Maintenance
- patch-primary versioning enforcement + git/PR strategy
- agent-host sync hardening + topology docs

### Testing
- structured error-envelope contract test

Patch per the versioning policy (no new public command namespace / MCP tool
family / API contract). After this lands on `main` and CI passes: manually run
the **Create release tag** workflow for `v0.113.2`, then **Publish to npm**.