### PR TITLE
feat(scene): keyframe → Seedance image-to-video build mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.113.3] - 2026-06-18
+
+### Added
+
+- keyframe → Seedance image-to-video build mode *(scene)*
+
 ## [0.113.2] - 2026-06-18
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.2",
+  "version": "0.113.3",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.2`
+> CLI version: `0.113.3`
 
 ## Mental model
 
@@ -1932,7 +1932,7 @@ Cost tier: `free`
 
 - `project-dir` _(string)_ **required** — Project directory
 - `beat` _(string)_ **required** — Beat id
-- `key` _(string)_ **required** — Cue key: duration | narration | backdrop | video | motion | voice | music | asset | characters
+- `key` _(string)_ **required** — Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters
 - `value` _(array)_ — Cue value. Use --json-value to pass a JSON scalar/object.
 - `jsonValue` _(boolean)_ — Parse value as JSON instead of a string
 - `unset` _(boolean)_ — Remove the cue key from the beat

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -112,6 +112,26 @@ Character sheets add image-generation cost, and each character video beat is a
 provider video call — run `vibe build --dry-run` to see the estimate and gate
 with `--max-cost`.
 
+### Keyframe → image-to-video
+
+For tighter art direction, a beat can declare a `keyframe` cue. During
+`vibe build`, the keyframe prompt first produces a still
+(`assets/keyframe-<beatId>.png`) — edited from the beat's `characters` sheet when
+present (for consistency), otherwise generated from text — and that exact frame
+is then animated with Seedance **image-to-video**. The `video` cue, if present,
+supplies the motion prompt; otherwise the keyframe prompt is reused.
+
+```yaml
+duration: 5
+characters: [nova]
+keyframe: "NOVA stands on the starting grid, low-angle hero shot, dramatic morning light"
+video: "slow push-in as engines spool up around her"
+```
+
+Keyframe mode costs one extra image generation per beat plus the clip
+(image-to-video uses standard Seedance pricing, with no reference discount) —
+check `vibe build --dry-run` and gate with `--max-cost`.
+
 ## Profiles
 
 `vibe init` supports three profiles:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.2",
+  "version": "0.113.3",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.2",
+  "version": "0.113.3",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.2",
+  "version": "0.113.3",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -4048,7 +4048,7 @@ exports[`CLI --describe schemas (drift detection) > vibe storyboard set --descri
         "type": "boolean",
       },
       "key": {
-        "description": "Cue key: duration | narration | backdrop | video | motion | voice | music | asset | characters",
+        "description": "Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters",
         "type": "string",
       },
       "project-dir": {

--- a/packages/cli/src/commands/_shared/build-asset-reference.ts
+++ b/packages/cli/src/commands/_shared/build-asset-reference.ts
@@ -19,6 +19,7 @@ const EXTENSIONS: Record<BuildAssetKind, readonly string[]> = {
   narration: [".mp3", ".wav", ".m4a"],
   backdrop: [".png", ".jpg", ".jpeg", ".webp"],
   character: [".png", ".jpg", ".jpeg", ".webp"],
+  keyframe: [".png", ".jpg", ".jpeg", ".webp"],
   video: [".mp4", ".mov", ".webm"],
   music: [".mp3", ".wav", ".m4a"],
 };

--- a/packages/cli/src/commands/_shared/build-cache.test.ts
+++ b/packages/cli/src/commands/_shared/build-cache.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { characterCacheDescriptor, videoCacheDescriptor } from "./build-cache.js";
+import {
+  characterCacheDescriptor,
+  keyframeCacheDescriptor,
+  videoCacheDescriptor,
+} from "./build-cache.js";
 
 describe("characterCacheDescriptor", () => {
   const base = {
@@ -43,5 +47,47 @@ describe("videoCacheDescriptor character invalidation", () => {
     });
     expect(nova.key).not.toBe(none.key);
     expect(pair.key).not.toBe(nova.key);
+  });
+});
+
+describe("videoCacheDescriptor keyframe invalidation", () => {
+  const base = { beatId: "hook", cue: "walk the pit lane", provider: "seedance", duration: 5 };
+
+  it("keeps the legacy key when no keyframe is supplied", () => {
+    expect(videoCacheDescriptor({ ...base, keyframe: undefined }).key).toBe(
+      videoCacheDescriptor(base).key
+    );
+  });
+
+  it("changes the key when the keyframe prompt changes", () => {
+    const a = videoCacheDescriptor({ ...base, keyframe: "nova at the pit wall" });
+    const b = videoCacheDescriptor({ ...base, keyframe: "nova on the grid" });
+    expect(a.key).not.toBe(videoCacheDescriptor(base).key);
+    expect(b.key).not.toBe(a.key);
+  });
+});
+
+describe("keyframeCacheDescriptor", () => {
+  const base = {
+    beatId: "hook",
+    cue: "nova walking down the pit lane, cinematic",
+    provider: "openai",
+    quality: "hd" as const,
+    size: "1536x1024",
+    ratio: "3:2",
+  };
+
+  it("produces a deterministic, keyframe-scoped cache path", () => {
+    const a = keyframeCacheDescriptor(base);
+    expect(keyframeCacheDescriptor(base).key).toBe(a.key);
+    expect(a.path).toBe(`.vibeframe/cache/assets/keyframe-${a.key}.png`);
+  });
+
+  it("changes the key when the prompt or character sheets change", () => {
+    const a = keyframeCacheDescriptor(base);
+    expect(keyframeCacheDescriptor({ ...base, cue: "nova on the grid" }).key).not.toBe(a.key);
+    expect(
+      keyframeCacheDescriptor({ ...base, characters: ["assets/character-nova.png"] }).key
+    ).not.toBe(a.key);
   });
 });

--- a/packages/cli/src/commands/_shared/build-cache.ts
+++ b/packages/cli/src/commands/_shared/build-cache.ts
@@ -1,6 +1,12 @@
 import { createHash } from "node:crypto";
 
-export type BuildAssetKind = "narration" | "backdrop" | "character" | "video" | "music";
+export type BuildAssetKind =
+  | "narration"
+  | "backdrop"
+  | "character"
+  | "keyframe"
+  | "video"
+  | "music";
 
 export interface CacheAssetDescriptor {
   key: string;
@@ -75,6 +81,28 @@ export function characterCacheDescriptor(opts: {
   });
 }
 
+export function keyframeCacheDescriptor(opts: {
+  beatId: string;
+  cue: string;
+  provider: string;
+  quality: "standard" | "hd";
+  size: string;
+  ratio?: string;
+  /** Character sheet paths used as edit references — changing them re-keys the keyframe. */
+  characters?: string[];
+}): CacheAssetDescriptor {
+  return cacheAssetDescriptor("keyframe", {
+    beatId: opts.beatId,
+    cue: opts.cue,
+    provider: opts.provider,
+    quality: opts.quality,
+    size: opts.size,
+    ratio: opts.ratio,
+    characters: opts.characters && opts.characters.length > 0 ? opts.characters : undefined,
+    ext: "png",
+  });
+}
+
 export function imageRatioForSize(size: string | undefined): string {
   switch (size) {
     case "1024x1024":
@@ -95,6 +123,11 @@ export function videoCacheDescriptor(opts: {
   duration: number | undefined;
   /** Character reference image paths — changing them must invalidate the clip. */
   characters?: string[];
+  /**
+   * Keyframe still path for image-to-video mode — changing the keyframe must
+   * invalidate the clip. Omitted for text/reference-to-video clips.
+   */
+  keyframe?: string;
 }): CacheAssetDescriptor {
   return cacheAssetDescriptor("video", {
     beatId: opts.beatId,
@@ -104,6 +137,8 @@ export function videoCacheDescriptor(opts: {
     ratio: "16:9",
     // Omit when empty so existing (character-less) clips keep their cache key.
     characters: opts.characters && opts.characters.length > 0 ? opts.characters : undefined,
+    // Omit when absent so existing (non-keyframe) clips keep their cache key.
+    keyframe: opts.keyframe || undefined,
     ext: "mp4",
   });
 }

--- a/packages/cli/src/commands/_shared/build-plan.test.ts
+++ b/packages/cli/src/commands/_shared/build-plan.test.ts
@@ -3,6 +3,8 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
+import { estimateSeedanceVideoCostUsd } from "@vibeframe/ai-providers";
+
 import { createBuildPlan } from "./build-plan.js";
 import { augmentBackdropPrompt } from "./build-backdrop-prompt.js";
 import { backdropCacheDescriptor, narrationCacheDescriptor } from "./build-cache.js";
@@ -101,6 +103,36 @@ describe("createBuildPlan", () => {
       }),
     ]);
     expect(plan.nextCommands).toContain(`vibe build ${dir} --stage assets --json`);
+  });
+
+  it("plans a clip and adds keyframe image cost for a keyframe-only beat", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vibe-build-plan-kf-"));
+    await mkdir(resolve(dir, "assets"), { recursive: true });
+    await mkdir(resolve(dir, ".vibeframe"), { recursive: true });
+    await writeFile(resolve(dir, ".vibeframe/config.yaml"), "providers: {}\n", "utf-8");
+    await writeFile(
+      resolve(dir, "vibe.config.json"),
+      projectConfigJson({ name: "promo", aspect: "16:9" }),
+      "utf-8"
+    );
+    await writeFile(
+      resolve(dir, "STORYBOARD.md"),
+      `# Promo\n\n## Beat hook - Hook\n\n\`\`\`yaml\nduration: 5\nkeyframe: "nova walking the pit lane, cinematic"\n\`\`\`\n\nBody.\n`,
+      "utf-8"
+    );
+
+    const plan = await createBuildPlan({ projectDir: dir, stage: "assets" });
+    // A keyframe cue produces a clip even without a `video:` cue.
+    expect(plan.beats[0].assets.video?.willGenerate).toBe(true);
+    expect(plan.providers).toContain("seedance");
+    expect(plan.providers).toContain("openai"); // keyframe image generation
+    const videoCost = estimateSeedanceVideoCostUsd({
+      durationSec: 5,
+      resolution: "720p",
+      aspectRatio: "16:9",
+    });
+    // total = keyframe still (hd image, 0.2) + image-to-video clip
+    expect(plan.estimatedCostUsd).toBeCloseTo(0.2 + videoCost, 2);
   });
 
   it("does not estimate cost for cached assets", async () => {

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -275,6 +275,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
     const backdropPrompt = stringOrUndefined(cue.backdrop);
     const augmentedBackdropPrompt = backdropPrompt ? augmentBackdropPrompt(backdropPrompt) : null;
     const videoPrompt = stringOrUndefined(cue.video);
+    const keyframePrompt = stringOrUndefined(cue.keyframe);
     const musicPrompt = stringOrUndefined(cue.music);
     const genericReference = resolveGenericAssetReference(projectDir, cue.asset);
     const narrationReference = resolveTypedAssetReference(projectDir, "narration", cue.narration);
@@ -289,7 +290,9 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
       (!musicPrompt && genericReference?.kind === "music" ? genericReference : null);
     const narrationCue = narrationText ?? narrationReference?.raw;
     const backdropCue = backdropPrompt ?? backdropReference?.raw;
-    const videoCue = videoPrompt ?? videoReference?.raw;
+    // A `keyframe:` cue produces a clip via image-to-video even without a
+    // `video:` cue (the keyframe prompt then supplies the motion prompt too).
+    const videoCue = videoPrompt ?? videoReference?.raw ?? keyframePrompt;
     const musicCue = musicPrompt ?? musicReference?.raw;
     const narrationCost =
       resolved.narration.resolved === "elevenlabs"
@@ -319,12 +322,13 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
           })
         : null;
     const videoCache =
-      videoPrompt && !videoReference
+      (videoPrompt || keyframePrompt) && !videoReference
         ? videoCacheDescriptor({
             beatId: beat.id,
-            cue: videoPrompt,
+            cue: videoPrompt ?? keyframePrompt!,
             provider: resolved.video.resolved,
             duration: beat.duration,
+            keyframe: keyframePrompt,
           })
         : null;
     const musicCache =
@@ -441,6 +445,14 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
     if (backdrop?.willGenerate && isSupportedBuildImageProvider(resolved.image.resolved))
       noteProviderNeed(resolved.image, "Backdrop generation");
     if (video?.willGenerate) noteProviderNeed(resolved.video, "Video generation");
+    // Keyframe → image-to-video: when the clip will generate, a keyframe still
+    // is produced first (one image generation per beat).
+    if (keyframePrompt && video?.willGenerate) {
+      estimatedCostUsd += backdropCostUsd(imageQuality);
+      providers.add(resolved.image.resolved);
+      if (isSupportedBuildImageProvider(resolved.image.resolved))
+        noteProviderNeed(resolved.image, "Keyframe generation");
+    }
     if (music?.willGenerate) noteProviderNeed(resolved.music, "Music generation");
     if (!compositionExists) missing.add("compositions");
     if (includeCompose && !compositionExists && mode !== "agent") {

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -73,6 +73,7 @@ import {
 import {
   backdropCacheDescriptor,
   characterCacheDescriptor,
+  keyframeCacheDescriptor,
   type BuildAssetKind,
   imageRatioForSize,
   musicCacheDescriptor,
@@ -183,6 +184,9 @@ export interface BeatBuildOutcome {
   videoMetadataPath?: string;
   videoFreshness?: AssetFreshness;
   videoSourcePath?: string;
+  /** Keyframe still status when the beat uses keyframe → image-to-video mode. */
+  keyframeStatus?: PrimitiveStatus;
+  keyframePath?: string;
   musicStatus: PrimitiveStatus;
   musicPath?: string;
   musicJobId?: string;
@@ -1103,6 +1107,8 @@ async function buildBeatPrimitives(
       videoMetadataPath: video.metadataPath,
       videoFreshness: video.freshness,
       videoSourcePath: video.sourcePath,
+      keyframeStatus: video.keyframeStatus,
+      keyframePath: video.keyframePath,
       musicStatus: music.status,
       musicPath: music.path,
       musicJobId: music.job?.id,
@@ -1132,6 +1138,9 @@ interface PrimitiveOutcome {
   metadataPath?: string;
   freshness?: AssetFreshness;
   sourcePath?: string;
+  /** Set by dispatchVideo in keyframe mode — the still that drove image-to-video. */
+  keyframeStatus?: PrimitiveStatus;
+  keyframePath?: string;
 }
 
 async function referencePrimitiveOutcome(
@@ -1659,6 +1668,150 @@ async function generateBackdropImage(
   return imageBufferFromResult(result);
 }
 
+/**
+ * Generate a keyframe still by editing the character sheet(s) with the
+ * keyframe prompt (so the character stays consistent). Mirrors
+ * `generateBackdropImage` but uses each provider's `editImage`.
+ */
+async function editKeyframeImage(
+  prompt: string,
+  sheetBuffers: Buffer[],
+  ctx: ImageGenContext,
+  ratio: string
+): Promise<GeneratedBackdropResult> {
+  loadSceneBuildEnv(ctx.projectDir);
+  const keyInfo = imageProviderKeyInfo(ctx.imageProvider);
+  const apiKey =
+    (await getApiKeyFromConfig(keyInfo.configKey, { cwd: ctx.projectDir })) ??
+    process.env[keyInfo.envVar] ??
+    "";
+  if (!apiKey) {
+    return {
+      success: false,
+      error: `${keyInfo.envVar} not set — cannot generate keyframe with ${ctx.imageProvider}`,
+    };
+  }
+
+  if (ctx.imageProvider === "openai") {
+    const provider = new OpenAIImageProvider();
+    await provider.initialize({ apiKey });
+    const result = await provider.editImage(sheetBuffers, prompt);
+    return imageBufferFromResult(result);
+  }
+
+  if (ctx.imageProvider === "gemini") {
+    const provider = new GeminiProvider();
+    await provider.initialize({ apiKey });
+    const result = await provider.editImage(sheetBuffers, prompt, {
+      model: "flash",
+      aspectRatio: ratio as "1:1" | "2:3" | "3:2" | "16:9",
+    });
+    return imageBufferFromResult(result);
+  }
+
+  const provider = new GrokProvider();
+  await provider.initialize({ apiKey });
+  // Grok edits a single input image.
+  const result = await provider.editImage(sheetBuffers[0], prompt, { aspectRatio: ratio });
+  return imageBufferFromResult(result);
+}
+
+/**
+ * Ensure `assets/keyframe-<beatId>.png` exists for keyframe → image-to-video
+ * mode. Edits the character sheet(s) with the keyframe prompt when present,
+ * else text-to-image. Cached like a backdrop.
+ */
+async function ensureKeyframe(
+  beat: Beat,
+  ctx: BeatDispatchContext,
+  keyframeCue: string,
+  characterRefsRel: string[]
+): Promise<{ status: "generated" | "cached"; rel: string } | { status: "failed"; error: string }> {
+  const rel = `assets/keyframe-${beat.id}.png`;
+  const abs = join(ctx.projectDir, rel);
+  const size = ctx.imageSize ?? "1536x1024";
+  const ratio = imageRatioForSize(size);
+  const metadataOptions = { quality: ctx.imageQuality, size, ratio };
+  const cache = keyframeCacheDescriptor({
+    beatId: beat.id,
+    cue: keyframeCue,
+    provider: ctx.imageProvider,
+    quality: ctx.imageQuality,
+    size,
+    ratio,
+    characters: characterRefsRel,
+  });
+
+  if (existsSync(abs) && !ctx.force) {
+    const metadata = readAssetMetadata(ctx.projectDir, "keyframe", beat.id);
+    if (
+      !metadata ||
+      isFreshCanonicalAsset({
+        projectDir: ctx.projectDir,
+        kind: "keyframe",
+        beatId: beat.id,
+        cue: keyframeCue,
+        provider: ctx.imageProvider,
+        options: metadataOptions,
+        cacheKey: cache.key,
+      })
+    ) {
+      return { status: "cached", rel };
+    }
+  }
+  const cacheAbs = join(ctx.projectDir, cache.path);
+  if (existsSync(cacheAbs) && !ctx.force) {
+    await mkdir(dirname(abs), { recursive: true });
+    await copyFile(cacheAbs, abs);
+    await writeAssetMetadata({
+      projectDir: ctx.projectDir,
+      kind: "keyframe",
+      beatId: beat.id,
+      cue: keyframeCue,
+      provider: ctx.imageProvider,
+      options: metadataOptions,
+      cacheKey: cache.key,
+      canonicalPath: rel,
+      cachePath: cache.path,
+    });
+    return { status: "cached", rel };
+  }
+
+  const sheetBuffers: Buffer[] = [];
+  for (const relPath of characterRefsRel) {
+    const sheetAbs = join(ctx.projectDir, relPath);
+    if (existsSync(sheetAbs)) sheetBuffers.push(await readFile(sheetAbs));
+  }
+  const imgCtx: ImageGenContext = {
+    projectDir: ctx.projectDir,
+    imageProvider: ctx.imageProvider,
+    imageSize: size,
+    imageQuality: ctx.imageQuality,
+  };
+  const generated =
+    sheetBuffers.length > 0
+      ? await editKeyframeImage(keyframeCue, sheetBuffers, imgCtx, ratio)
+      : await generateBackdropImage(keyframeCue, imgCtx, ratio);
+  if (!generated.success) return { status: "failed", error: generated.error };
+
+  await mkdir(dirname(abs), { recursive: true });
+  await writeFile(abs, generated.buffer);
+  await mkdir(dirname(cacheAbs), { recursive: true });
+  await writeFile(cacheAbs, generated.buffer);
+  await writeAssetMetadata({
+    projectDir: ctx.projectDir,
+    kind: "keyframe",
+    beatId: beat.id,
+    cue: keyframeCue,
+    provider: ctx.imageProvider,
+    options: metadataOptions,
+    cacheKey: cache.key,
+    canonicalPath: rel,
+    cachePath: cache.path,
+  });
+  return { status: "generated", rel };
+}
+
 async function imageBufferFromResult(result: {
   success: boolean;
   error?: string;
@@ -1689,7 +1842,9 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
   const reference = assetReferenceForBeat(ctx.projectDir, "video", beat);
   if (reference) return referencePrimitiveOutcome("video", beat, ctx, reference);
 
-  const prompt = stringOrUndefined(beat.cues?.video);
+  const keyframeCue = stringOrUndefined(beat.cues?.keyframe);
+  // Motion prompt: explicit `video:` cue, else fall back to the keyframe prompt.
+  const prompt = stringOrUndefined(beat.cues?.video) ?? keyframeCue;
   if (!prompt) return { status: "no-cue" };
 
   // Resolve this beat's character sheets (generated up front by buildCharacters)
@@ -1707,7 +1862,10 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
     cue: prompt,
     provider: ctx.videoProvider,
     duration: normalizeVideoDuration(beat.duration),
-    characters: characterRefsRel,
+    // Keyframe mode keys the clip to the keyframe prompt; refs feed the keyframe,
+    // not the clip directly.
+    characters: keyframeCue ? undefined : characterRefsRel,
+    keyframe: keyframeCue,
   });
   const metadataPath = assetMetadataPath("video", beat.id);
   if (existsSync(abs) && !ctx.force) {
@@ -1764,6 +1922,22 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
   }
 
   loadSceneBuildEnv(ctx.projectDir);
+
+  // Keyframe → image-to-video: generate the still first, then animate it.
+  let keyframeStatus: PrimitiveStatus | undefined;
+  let keyframeRel: string | undefined;
+  let keyframeImageAbs: string | undefined;
+  if (keyframeCue) {
+    const kf = await ensureKeyframe(beat, ctx, keyframeCue, characterRefsRel);
+    if (kf.status === "failed") {
+      ctx.onProgress({ type: "video-failed", beatId: beat.id, error: kf.error });
+      return { status: "failed", error: kf.error };
+    }
+    keyframeStatus = kf.status;
+    keyframeRel = kf.rel;
+    keyframeImageAbs = join(ctx.projectDir, kf.rel);
+  }
+
   const result = await executeVideoGenerate({
     prompt,
     provider: ctx.videoProvider,
@@ -1771,7 +1945,14 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
     ratio: "16:9",
     output: abs,
     wait: false,
-    refImages: characterRefsAbs.length > 0 ? characterRefsAbs : undefined,
+    // Keyframe mode → single init frame (image-to-video); otherwise character
+    // reference-to-video.
+    image: keyframeImageAbs,
+    refImages: keyframeImageAbs
+      ? undefined
+      : characterRefsAbs.length > 0
+        ? characterRefsAbs
+        : undefined,
     apiKey: await apiKeyForVideoProvider(ctx.videoProvider, ctx.projectDir),
   });
   if (!result.success || !result.taskId) {
@@ -1808,6 +1989,8 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
       cacheKey: cache.key,
       metadataPath,
       freshness: "fresh",
+      keyframeStatus,
+      keyframePath: keyframeRel,
     };
   }
 
@@ -1815,7 +1998,7 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
     jobType: "generate-video",
     provider: result.provider ?? ctx.videoProvider,
     providerTaskId: result.taskId,
-    providerTaskType: "text2video",
+    providerTaskType: keyframeImageAbs ? "image2video" : "text2video",
     status: "running",
     projectDir: ctx.projectDir,
     workingDirectory: ctx.projectDir,
@@ -1841,6 +2024,8 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
     cachePath: cache.path,
     cacheKey: cache.key,
     metadataPath,
+    keyframeStatus,
+    keyframePath: keyframeRel,
   };
 }
 
@@ -2193,6 +2378,7 @@ function estimateActualAssetCost(
   for (const outcome of outcomes) {
     if (outcome.narrationStatus === "generated") cost += 0.05;
     if (outcome.backdropStatus === "generated") cost += backdropCostUsd(imageQuality);
+    if (outcome.keyframeStatus === "generated") cost += backdropCostUsd(imageQuality);
     if (outcome.videoStatus === "generated" || outcome.videoStatus === "pending") {
       cost +=
         outcome.videoProvider === "seedance" || outcome.videoProvider === "fal"

--- a/packages/cli/src/commands/_shared/storyboard-edit.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-edit.test.ts
@@ -184,3 +184,23 @@ describe("characters cue validation", () => {
     ]);
   });
 });
+
+describe("keyframe cue validation", () => {
+  const withKeyframe = (cue: string) =>
+    `## Beat hook - Hook\n\n\`\`\`yaml\n${cue}\n\`\`\`\n\nBody.\n`;
+
+  it("accepts a string keyframe cue", () => {
+    const result = validateStoryboardMarkdown(
+      withKeyframe(`keyframe: "nova walking down the pit lane, cinematic"`)
+    );
+    expect(result.ok).toBe(true);
+    expect(result.issues.map((i) => i.code)).not.toContain("UNKNOWN_CUE");
+  });
+
+  it("parses the keyframe cue into BeatCues", () => {
+    const md = withKeyframe(`keyframe: "nova on the grid"`);
+    expect(parseStoryboard(md).beats.find((b) => b.id === "hook")?.cues?.keyframe).toBe(
+      "nova on the grid"
+    );
+  });
+});

--- a/packages/cli/src/commands/_shared/storyboard-edit.ts
+++ b/packages/cli/src/commands/_shared/storyboard-edit.ts
@@ -13,6 +13,7 @@ export const STORYBOARD_CUE_KEYS = [
   "narration",
   "backdrop",
   "video",
+  "keyframe",
   "motion",
   "voice",
   "music",
@@ -64,7 +65,7 @@ interface BeatSection {
 const HEADING_RE = /^##\s+(.+?)\s*$/gm;
 const LEADING_CUE_RE = /^(\s*)```ya?ml\s*\n([\s\S]*?)\n```\s*(?:\n|$)/;
 const ALLOWED_CUE_KEYS = new Set<string>(STORYBOARD_CUE_KEYS);
-const STRING_CUE_KEYS = new Set<string>(["narration", "backdrop", "video", "motion", "voice", "music", "asset"]);
+const STRING_CUE_KEYS = new Set<string>(["narration", "backdrop", "video", "keyframe", "motion", "voice", "music", "asset"]);
 
 /** Beats beyond this render as static, overstuffed scenes. */
 export const MAX_RECOMMENDED_BEAT_SEC = 15;

--- a/packages/cli/src/commands/_shared/storyboard-parse.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.ts
@@ -141,6 +141,13 @@ export interface BeatCues {
    * reference-to-video generation. A single name or a list.
    */
   characters?: string | string[];
+  /**
+   * Keyframe still prompt. When set, the build generates a keyframe image for
+   * this beat (using the character sheet as an edit reference when `characters`
+   * is also present) and runs Seedance image-to-video on it. The `video` cue,
+   * if present, supplies the motion prompt; otherwise this text is used.
+   */
+  keyframe?: string;
   [key: string]: unknown;
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.2",
+  "version": "0.113.3",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.2",
+  "version": "0.113.3",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.2",
+  "version": "0.113.3",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Phase 0 of the keyframe workflow: per beat, generate a **keyframe still**, then
run Seedance **image-to-video** on that exact frame. Fulfills the roadmap
"improve image-to-video integration inside storyboard builds".

## What

A beat can declare a `keyframe:` cue:
- The keyframe prompt produces `assets/keyframe-<beatId>.png` — **edited from the
  beat's `characters` sheet** when present (character consistency), otherwise
  text-to-image.
- That frame is animated with Seedance **image-to-video**. The `video:` cue, if
  present, supplies the motion prompt; otherwise the keyframe prompt is reused.
- Composition is unchanged (path-based `<video>`).

```yaml
duration: 5
characters: [nova]
keyframe: "NOVA on the starting grid, low-angle hero shot, dramatic morning light"
video: "slow push-in as engines spool up"
```

## Scope

Deliberately **thin / single-beat**. Cross-beat consistency, keyframe approval
loops, off-model repair, and reference auto-routing are intentionally left for a
later layer.

## Implementation

- Reuses the existing image-to-video path: `executeVideoGenerate({ image })`
  (auto-uploads the local init frame to fal) and provider `editImage` for
  character-consistent keyframes — no new provider plumbing.
- New `keyframe` asset kind + `keyframeCacheDescriptor`; `videoCacheDescriptor`
  gains a `keyframe` discriminator (legacy clip keys unchanged).
- New `keyframe:` storyboard cue + validation.
- Dry-run + actual cost: keyframe still (one image gen) + image-to-video at
  **standard** Seedance pricing (no reference discount).

## Verification

- `pnpm build`, `pnpm lint`, typecheck, full suite green (1216 tests); the
  `storyboard set --describe` snapshot updated for the new cue key.
- New tests: keyframe cache descriptor + clip invalidation, keyframe cue
  validation/parse, build-plan keyframe-mode cost.
- Full `scripts/pre-push-validate.sh` exits 0. Patch bump to `0.113.3`.

Paid end-to-end (a real keyframe→i2v render) not run here — gated on spend
approval.