### PR TITLE
feat(scene): keyframe stills as a first-class asset (review before spend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.3] - 2026-06-18
+## [0.113.4] - 2026-06-19
+
+### Added
+
+- keyframe stills as a first-class asset (review before spend) *(scene)*
+
+### Documentation
+
+- add AI video prompting playbook (sheet → image storyboard → multi-scene i2v)
+
+## [0.113.3] - 2026-06-19
 
 ### Added
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.3",
+  "version": "0.113.4",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -240,6 +240,7 @@ Cost tier: _not tagged_
 - `skipNarration` _(boolean)_ — Don't dispatch TTS even when beats declare narration cues
 - `skipBackdrop` _(boolean)_ — Don't dispatch image-gen even when beats declare backdrop cues
 - `skipVideo` _(boolean)_ — Don't dispatch video generation even when beats declare video cues
+- `skipKeyframe` _(boolean)_ — Don't generate keyframe stills (review keyframes first with --skip-video, then build)
 - `skipMusic` _(boolean)_ — Don't dispatch music generation even when beats declare music cues
 - `skipRender` _(boolean)_ — Compose only — don't render to MP4
 - `tts` _(string)_ — TTS provider: auto|elevenlabs|openai|kokoro

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.3`
+> CLI version: `0.113.4`
 
 ## Mental model
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -132,6 +132,19 @@ Keyframe mode costs one extra image generation per beat plus the clip
 (image-to-video uses standard Seedance pricing, with no reference discount) —
 check `vibe build --dry-run` and gate with `--max-cost`.
 
+**Review the image storyboard before paying for video.** Keyframe stills are a
+first-class asset, so you can generate and review them before the expensive
+image-to-video step:
+
+```bash
+vibe build my-film --skip-video        # generate assets/keyframe-*.png only (cheap)
+# review the stills; regenerate a weak one and accept it:
+vibe build my-film --beat grid --stage assets --force --skip-video
+vibe build my-film --max-cost 6        # animate the approved keyframes
+```
+
+Use `--skip-keyframe` to opt a run out of keyframe generation entirely.
+
 ## Profiles
 
 `vibe init` supports three profiles:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.3",
+  "version": "0.113.4",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.3",
+  "version": "0.113.4",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.3",
+  "version": "0.113.4",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -585,6 +585,10 @@ exports[`CLI --describe schemas (drift detection) > vibe build --describe 1`] = 
         "description": "Don't dispatch image-gen even when beats declare backdrop cues",
         "type": "boolean",
       },
+      "skipKeyframe": {
+        "description": "Don't generate keyframe stills (review keyframes first with --skip-video, then build)",
+        "type": "boolean",
+      },
       "skipMusic": {
         "description": "Don't dispatch music generation even when beats declare music cues",
         "type": "boolean",

--- a/packages/cli/src/commands/_shared/build-plan.test.ts
+++ b/packages/cli/src/commands/_shared/build-plan.test.ts
@@ -122,7 +122,10 @@ describe("createBuildPlan", () => {
     );
 
     const plan = await createBuildPlan({ projectDir: dir, stage: "assets" });
-    // A keyframe cue produces a clip even without a `video:` cue.
+    // The keyframe is now a first-class asset, and a keyframe cue still produces
+    // a clip even without a `video:` cue.
+    expect(plan.beats[0].assets.keyframe?.willGenerate).toBe(true);
+    expect(plan.beats[0].assets.keyframe?.path).toBe("assets/keyframe-hook.png");
     expect(plan.beats[0].assets.video?.willGenerate).toBe(true);
     expect(plan.providers).toContain("seedance");
     expect(plan.providers).toContain("openai"); // keyframe image generation
@@ -133,6 +136,12 @@ describe("createBuildPlan", () => {
     });
     // total = keyframe still (hd image, 0.2) + image-to-video clip
     expect(plan.estimatedCostUsd).toBeCloseTo(0.2 + videoCost, 2);
+
+    // Review-before-spend: --skip-video plans the keyframe still but no clip.
+    const stills = await createBuildPlan({ projectDir: dir, stage: "assets", skipVideo: true });
+    expect(stills.beats[0].assets.keyframe?.willGenerate).toBe(true);
+    expect(stills.beats[0].assets.video).toBeNull();
+    expect(stills.estimatedCostUsd).toBeCloseTo(0.2, 2); // image only, no paid video
   });
 
   it("does not estimate cost for cached assets", async () => {

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -17,6 +17,7 @@ import {
   type BuildAssetKind,
   type CacheAssetDescriptor,
   imageRatioForSize,
+  keyframeCacheDescriptor,
   musicCacheDescriptor,
   narrationCacheDescriptor,
   normalizeVideoDuration,
@@ -62,6 +63,7 @@ export interface BuildPlanBeat {
   assets: {
     narration: AssetPlan | null;
     backdrop: AssetPlan | null;
+    keyframe: AssetPlan | null;
     video: AssetPlan | null;
     music: AssetPlan | null;
   };
@@ -145,6 +147,7 @@ export interface CreateBuildPlanOptions {
   skipNarration?: boolean;
   skipBackdrop?: boolean;
   skipVideo?: boolean;
+  skipKeyframe?: boolean;
   skipMusic?: boolean;
   ttsProvider?: string;
   voice?: string;
@@ -331,6 +334,16 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
             keyframe: keyframePrompt,
           })
         : null;
+    const keyframeCache = keyframePrompt
+      ? keyframeCacheDescriptor({
+          beatId: beat.id,
+          cue: keyframePrompt,
+          provider: resolved.image.resolved,
+          quality: imageQuality,
+          size: imageSize,
+          ratio: imageRatio,
+        })
+      : null;
     const musicCache =
       musicPrompt && !musicReference
         ? musicCacheDescriptor({
@@ -371,6 +384,22 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
             path: `assets/backdrop-${beat.id}.png`,
             cache: backdropCache,
             reference: backdropReference,
+            projectDir,
+            force: opts.force,
+            cost: backdropCostUsd(imageQuality),
+            active: includeAssets,
+          })
+        : null;
+    const keyframe =
+      keyframePrompt && !opts.skipKeyframe
+        ? assetPlan({
+            kind: "keyframe",
+            beatId: beat.id,
+            cue: keyframePrompt,
+            provider: resolved.image.resolved,
+            path: `assets/keyframe-${beat.id}.png`,
+            cache: keyframeCache,
+            reference: null,
             projectDir,
             force: opts.force,
             cost: backdropCostUsd(imageQuality),
@@ -419,7 +448,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
     const compositionPath = `compositions/scene-${beat.id}.html`;
     const compositionExists = existsSync(join(projectDir, compositionPath));
 
-    for (const asset of [narration, backdrop, video, music]) {
+    for (const asset of [narration, backdrop, keyframe, video, music]) {
       if (!asset) continue;
       if (asset.referenceError) {
         missing.add("assets");
@@ -444,15 +473,9 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
     if (narration?.willGenerate) noteProviderNeed(resolved.narration, "Narration");
     if (backdrop?.willGenerate && isSupportedBuildImageProvider(resolved.image.resolved))
       noteProviderNeed(resolved.image, "Backdrop generation");
+    if (keyframe?.willGenerate && isSupportedBuildImageProvider(resolved.image.resolved))
+      noteProviderNeed(resolved.image, "Keyframe generation");
     if (video?.willGenerate) noteProviderNeed(resolved.video, "Video generation");
-    // Keyframe → image-to-video: when the clip will generate, a keyframe still
-    // is produced first (one image generation per beat).
-    if (keyframePrompt && video?.willGenerate) {
-      estimatedCostUsd += backdropCostUsd(imageQuality);
-      providers.add(resolved.image.resolved);
-      if (isSupportedBuildImageProvider(resolved.image.resolved))
-        noteProviderNeed(resolved.image, "Keyframe generation");
-    }
     if (music?.willGenerate) noteProviderNeed(resolved.music, "Music generation");
     if (!compositionExists) missing.add("compositions");
     if (includeCompose && !compositionExists && mode !== "agent") {
@@ -466,7 +489,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
       heading: beat.heading,
       durationSec: beat.duration ?? null,
       cues: cue,
-      assets: { narration, backdrop, video, music },
+      assets: { narration, backdrop, keyframe, video, music },
       composition: {
         path: compositionPath,
         exists: compositionExists,
@@ -748,6 +771,7 @@ function providerResolutionsForPlan(
   return [
     includeAssets && !opts.skipNarration && needsProvider("narration") ? resolved.narration : null,
     includeAssets && !opts.skipBackdrop && needsProvider("backdrop") ? resolved.image : null,
+    includeAssets && !opts.skipKeyframe && needsProvider("keyframe") ? resolved.image : null,
     includeAssets && !opts.skipVideo && needsProvider("video") ? resolved.video : null,
     includeAssets && !opts.skipMusic && needsProvider("music") ? resolved.music : null,
     resolved.composer ?? null,

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -125,6 +125,10 @@ export type SceneBuildProgressEvent =
   | { type: "backdrop-generated"; beatId: string; path: string; provider: string }
   | { type: "backdrop-failed"; beatId: string; error: string }
   | { type: "backdrop-skipped"; beatId: string; reason: string }
+  | { type: "keyframe-cached"; beatId: string; path: string }
+  | { type: "keyframe-generated"; beatId: string; path: string; provider: string }
+  | { type: "keyframe-failed"; beatId: string; error: string }
+  | { type: "keyframe-skipped"; beatId: string; reason: string }
   | { type: "video-cached"; beatId: string; path: string }
   | { type: "video-generated"; beatId: string; path: string; provider: string }
   | { type: "video-pending"; beatId: string; jobId: string; provider: string }
@@ -251,6 +255,8 @@ export interface SceneBuildOptions {
   musicProvider?: BuildMusicProvider;
   /** Skip AI video generation even when beats declare video cues. */
   skipVideo?: boolean;
+  /** Skip keyframe-still generation even when beats declare keyframe cues. */
+  skipKeyframe?: boolean;
   /** Skip music generation even when beats declare music cues. */
   skipMusic?: boolean;
   /** OpenAI image quality — see `vibe generate image --quality`. */
@@ -391,6 +397,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     skipNarration: opts.skipNarration,
     skipBackdrop: opts.skipBackdrop,
     skipVideo: opts.skipVideo,
+    skipKeyframe: opts.skipKeyframe,
     skipMusic: opts.skipMusic,
     ttsProvider: opts.ttsProvider,
     voice: opts.voice,
@@ -606,6 +613,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
           skipNarration: opts.skipNarration ?? false,
           skipBackdrop: opts.skipBackdrop ?? false,
           skipVideo: opts.skipVideo ?? false,
+          skipKeyframe: opts.skipKeyframe ?? false,
           skipMusic: opts.skipMusic ?? false,
           force: opts.force ?? false,
           onProgress,
@@ -1038,6 +1046,7 @@ interface BeatDispatchContext {
   skipNarration: boolean;
   skipBackdrop: boolean;
   skipVideo: boolean;
+  skipKeyframe: boolean;
   skipMusic: boolean;
   force: boolean;
   onProgress: (e: SceneBuildProgressEvent) => void;
@@ -1054,6 +1063,12 @@ async function buildBeatPrimitives(
   beat: Beat,
   ctx: BeatDispatchContext
 ): Promise<BeatPrimitiveResult> {
+  // Keyframe is generated first as a first-class asset: the video step animates
+  // it (image-to-video), and `--skip-video` lets the keyframe storyboard be
+  // reviewed before any paid video is dispatched.
+  const keyframe = ctx.skipKeyframe
+    ? await skipped("keyframe", beat.id, "--skip-keyframe", ctx)
+    : await dispatchKeyframe(beat, ctx);
   const [narration, backdrop, video, music] = await Promise.all([
     ctx.skipNarration
       ? skipped("narration", beat.id, "--skip-narration", ctx)
@@ -1061,7 +1076,9 @@ async function buildBeatPrimitives(
     ctx.skipBackdrop
       ? skipped("backdrop", beat.id, "--skip-backdrop", ctx)
       : dispatchBackdrop(beat, ctx),
-    ctx.skipVideo ? skipped("video", beat.id, "--skip-video", ctx) : dispatchVideo(beat, ctx),
+    ctx.skipVideo
+      ? skipped("video", beat.id, "--skip-video", ctx)
+      : dispatchVideo(beat, ctx, keyframe),
     ctx.skipMusic ? skipped("music", beat.id, "--skip-music", ctx) : dispatchMusic(beat, ctx),
   ]);
   return {
@@ -1107,8 +1124,8 @@ async function buildBeatPrimitives(
       videoMetadataPath: video.metadataPath,
       videoFreshness: video.freshness,
       videoSourcePath: video.sourcePath,
-      keyframeStatus: video.keyframeStatus,
-      keyframePath: video.keyframePath,
+      keyframeStatus: keyframe.status,
+      keyframePath: keyframe.path,
       musicStatus: music.status,
       musicPath: music.path,
       musicJobId: music.job?.id,
@@ -1138,9 +1155,6 @@ interface PrimitiveOutcome {
   metadataPath?: string;
   freshness?: AssetFreshness;
   sourcePath?: string;
-  /** Set by dispatchVideo in keyframe mode — the still that drove image-to-video. */
-  keyframeStatus?: PrimitiveStatus;
-  keyframePath?: string;
 }
 
 async function referencePrimitiveOutcome(
@@ -1838,7 +1852,37 @@ function imageProviderKeyInfo(provider: BuildImageProvider): { configKey: string
   return { configKey: "openai", envVar: "OPENAI_API_KEY" };
 }
 
-async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<PrimitiveOutcome> {
+/**
+ * Generate (or reuse) this beat's keyframe still as a first-class asset, so it
+ * can be reviewed via `vibe build --skip-video` before any paid image-to-video.
+ * The video step consumes the result.
+ */
+async function dispatchKeyframe(beat: Beat, ctx: BeatDispatchContext): Promise<PrimitiveOutcome> {
+  const keyframeCue = stringOrUndefined(beat.cues?.keyframe);
+  if (!keyframeCue) return { status: "no-cue" };
+
+  const characterRefsRel = beatCharacterNames(beat.cues)
+    .map((name) => ctx.characterPaths?.get(name))
+    .filter((p): p is string => typeof p === "string");
+
+  const kf = await ensureKeyframe(beat, ctx, keyframeCue, characterRefsRel);
+  if (kf.status === "failed") {
+    ctx.onProgress({ type: "keyframe-failed", beatId: beat.id, error: kf.error });
+    return { status: "failed", error: kf.error };
+  }
+  ctx.onProgress(
+    kf.status === "cached"
+      ? { type: "keyframe-cached", beatId: beat.id, path: kf.rel }
+      : { type: "keyframe-generated", beatId: beat.id, path: kf.rel, provider: ctx.imageProvider }
+  );
+  return { status: kf.status, path: kf.rel, provider: ctx.imageProvider };
+}
+
+async function dispatchVideo(
+  beat: Beat,
+  ctx: BeatDispatchContext,
+  keyframe: PrimitiveOutcome
+): Promise<PrimitiveOutcome> {
   const reference = assetReferenceForBeat(ctx.projectDir, "video", beat);
   if (reference) return referencePrimitiveOutcome("video", beat, ctx, reference);
 
@@ -1921,23 +1965,24 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
     };
   }
 
-  loadSceneBuildEnv(ctx.projectDir);
-
-  // Keyframe → image-to-video: generate the still first, then animate it.
-  let keyframeStatus: PrimitiveStatus | undefined;
-  let keyframeRel: string | undefined;
-  let keyframeImageAbs: string | undefined;
-  if (keyframeCue) {
-    const kf = await ensureKeyframe(beat, ctx, keyframeCue, characterRefsRel);
-    if (kf.status === "failed") {
-      ctx.onProgress({ type: "video-failed", beatId: beat.id, error: kf.error });
-      return { status: "failed", error: kf.error };
-    }
-    keyframeStatus = kf.status;
-    keyframeRel = kf.rel;
-    keyframeImageAbs = join(ctx.projectDir, kf.rel);
+  // Keyframe → image-to-video: the still is produced up front by
+  // dispatchKeyframe. It must be ready to animate; if it was skipped
+  // (--skip-keyframe) or failed, we can't run image-to-video for this beat.
+  const keyframeImageRel =
+    keyframeCue && (keyframe.status === "generated" || keyframe.status === "cached")
+      ? keyframe.path
+      : undefined;
+  if (keyframeCue && !keyframeImageRel) {
+    const reason =
+      keyframe.status === "failed"
+        ? `keyframe unavailable: ${keyframe.error ?? "generation failed"}`
+        : "keyframe not generated (build without --skip-keyframe first)";
+    ctx.onProgress({ type: "video-skipped", beatId: beat.id, reason });
+    return { status: "skipped" };
   }
+  const keyframeImageAbs = keyframeImageRel ? join(ctx.projectDir, keyframeImageRel) : undefined;
 
+  loadSceneBuildEnv(ctx.projectDir);
   const result = await executeVideoGenerate({
     prompt,
     provider: ctx.videoProvider,
@@ -1989,8 +2034,6 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
       cacheKey: cache.key,
       metadataPath,
       freshness: "fresh",
-      keyframeStatus,
-      keyframePath: keyframeRel,
     };
   }
 
@@ -2024,8 +2067,6 @@ async function dispatchVideo(beat: Beat, ctx: BeatDispatchContext): Promise<Prim
     cachePath: cache.path,
     cacheKey: cache.key,
     metadataPath,
-    keyframeStatus,
-    keyframePath: keyframeRel,
   };
 }
 
@@ -2205,7 +2246,7 @@ function loadSceneBuildEnv(projectDir: string): void {
 }
 
 async function skipped(
-  kind: "narration" | "backdrop" | "video" | "music",
+  kind: "narration" | "backdrop" | "keyframe" | "video" | "music",
   beatId: string,
   reason: string,
   ctx: BeatDispatchContext

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -46,6 +46,10 @@ export const buildCommand = new Command("build")
   .option("--skip-narration", "Don't dispatch TTS even when beats declare narration cues")
   .option("--skip-backdrop", "Don't dispatch image-gen even when beats declare backdrop cues")
   .option("--skip-video", "Don't dispatch video generation even when beats declare video cues")
+  .option(
+    "--skip-keyframe",
+    "Don't generate keyframe stills (review keyframes first with --skip-video, then build)"
+  )
   .option("--skip-music", "Don't dispatch music generation even when beats declare music cues")
   .option("--skip-render", "Compose only — don't render to MP4")
   .option("--tts <provider>", "TTS provider: auto|elevenlabs|openai|kokoro")
@@ -119,6 +123,7 @@ Advanced equivalent: \`vibe scene build\`.`
       skipNarration: options.skipNarration ?? false,
       skipBackdrop: options.skipBackdrop ?? false,
       skipVideo: options.skipVideo ?? false,
+      skipKeyframe: options.skipKeyframe ?? false,
       skipMusic: options.skipMusic ?? false,
       skipRender: options.skipRender ?? false,
       ttsProvider: options.tts,
@@ -140,6 +145,7 @@ Advanced equivalent: \`vibe scene build\`.`
         skipNarration: options.skipNarration,
         skipBackdrop: options.skipBackdrop,
         skipVideo: options.skipVideo,
+        skipKeyframe: options.skipKeyframe,
         skipMusic: options.skipMusic,
         ttsProvider: options.tts,
         voice: options.voice,
@@ -231,6 +237,7 @@ Advanced equivalent: \`vibe scene build\`.`
       skipNarration: options.skipNarration,
       skipBackdrop: options.skipBackdrop,
       skipVideo: options.skipVideo,
+      skipKeyframe: options.skipKeyframe,
       skipMusic: options.skipMusic,
       skipRender: options.skipRender,
       ttsProvider: options.tts,
@@ -289,6 +296,7 @@ type BuildDryRunParams = {
   skipNarration: boolean;
   skipBackdrop: boolean;
   skipVideo: boolean;
+  skipKeyframe: boolean;
   skipMusic: boolean;
   skipRender: boolean;
   ttsProvider: unknown;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.3",
+  "version": "0.113.4",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.3",
+  "version": "0.113.4",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.3",
+  "version": "0.113.4",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Implements the research's #1 multi-scene principle — **lock the image storyboard
before paying for video** — as an OSS capability.

## What

Keyframe generation moves out of `dispatchVideo` into its own assets-stage
primitive (`dispatchKeyframe`). Keyframe stills are produced up front, so:

```bash
vibe build my-film --skip-video     # generate assets/keyframe-*.png only (image cost)
# review the stills; regenerate a weak one:
vibe build my-film --beat grid --stage assets --force --skip-video
vibe build my-film --max-cost 6     # animate the approved keyframes (paid i2v)
```

- New `dispatchKeyframe` + keyframe progress events; `dispatchVideo` consumes the
  pre-generated keyframe (skips the clip with a clear reason if it's missing).
- `build-plan`: keyframe is a **distinct asset line** (own cost + provider need);
  the clip is still planned for keyframe-only beats.
- New `--skip-keyframe` flag.

This is the OSS foundation of the review/approval loop; the intelligent
cross-scene orchestration (continuity carry-over, auto reference routing,
automated repair, managed execution) remains for a later layer.

## Verification

- `pnpm build`, lint, typecheck, full suite green (1216); `build-plan` test
  asserts the keyframe asset + the `--skip-video` (image-only) plan; the
  `build --describe` snapshot updated for `--skip-keyframe`.
- Dry-run confirms keyframe as a separate asset; `--skip-video` plans the still
  with no clip (image-only $0.20). Full pre-push gate exits 0.

Patch bump to **0.113.4**.