### PR TITLE
chore: gitignore keyframe-demo/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ archive/
 /demo-video/
 demo-output/
 /nova-demo/
+/keyframe-demo/
 test-results/
 
 # Test artifacts


### PR DESCRIPTION
Ignore the local `keyframe-demo/` demo media (paid e2e output), matching the existing `/nova-demo/` rule, so it can't be committed accidentally. gitignore-only; no version bump.