### PR TITLE
fix(scene): --skip-video produces a consistent keyframe storyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.113.5] - 2026-06-19
+
+### Fixed
+
+- --skip-video produces a consistent keyframe storyboard *(scene)*
+
+### Maintenance
+
+- gitignore keyframe-demo/ (local demo media)
+
 ## [0.113.4] - 2026-06-19
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.4",
+  "version": "0.113.5",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.4`
+> CLI version: `0.113.5`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.4",
+  "version": "0.113.5",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.4",
+  "version": "0.113.5",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.4",
+  "version": "0.113.5",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -382,10 +382,21 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   const projectDir = resolve(opts.projectDir);
   const onProgress = opts.onProgress ?? (() => {});
   const mode = resolveSceneBuildMode(opts);
-  const selectedStage = opts.stage ?? (opts.skipRender ? "sync" : "all");
+  let selectedStage = opts.stage ?? (opts.skipRender ? "sync" : "all");
+  // --skip-video produces keyframe stills (an image storyboard) for review, not
+  // a final video. The composition would reference <video> clips that were never
+  // generated, so capture can't run — stop at sync instead of failing render.
+  const skipVideoStopsRender =
+    (opts.skipVideo ?? false) && (selectedStage === "all" || selectedStage === "render");
+  if (skipVideoStopsRender) selectedStage = "sync";
   const stageReports = createEmptyStageReports();
   const warnings: string[] = [];
   const retryWith: string[] = [];
+  if (skipVideoStopsRender) {
+    warnings.push(
+      "--skip-video: skipped render (no clips to capture). Review assets/keyframe-*.png, then build without --skip-video to animate them."
+    );
+  }
   let sceneRepair = skippedSceneRepairSummary();
 
   const storyboardPath = join(projectDir, "STORYBOARD.md");
@@ -571,10 +582,12 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   if (shouldRunStage(selectedStage, "assets")) {
     onProgress({ type: "phase-start", phase: "primitives" });
 
-    // Generate the character sheets referenced by any video beat once, up front,
-    // so dispatchVideo can pass them as reference-to-video inputs.
+    // Generate the character sheets referenced by any beat once, up front, so
+    // both reference-to-video (dispatchVideo) and keyframe edits
+    // (dispatchKeyframe) can use them. Needed whenever video OR keyframe runs —
+    // only skip when both are skipped.
     const characterPaths = new Map<string, string>();
-    if (!(opts.skipVideo ?? false)) {
+    if (!((opts.skipVideo ?? false) && (opts.skipKeyframe ?? false))) {
       const referenced = new Set<string>();
       for (const beat of activeBeats) {
         for (const name of beatCharacterNames(beat.cues)) referenced.add(name);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.4",
+  "version": "0.113.5",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.4",
+  "version": "0.113.5",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.4",
+  "version": "0.113.5",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Fixes two defects in the review-before-spend flow (v0.113.4), surfaced by
dogfooding the flagship demo:

1. **Character sheets were gated by `!skipVideo`**, so `vibe build --skip-video`
   generated keyframe stills with **no character sheet** (text-only, not
   character-consistent) — defeating the point of reviewing the image
   storyboard. Now `buildCharacters` runs whenever video **or** keyframe will
   generate (skip only when both are skipped).
2. **Render failed under `--skip-video`** ("video metadata not ready") because
   the composition referenced clips that were never generated. `--skip-video` now
   caps the stage at `sync` (skips render) with a clear warning.

## Verification

- `vibe build showcase-demo --skip-video` → character sheet present, keyframes
  character-consistent (cache-hit), render **skipped** (not failed), exit 0, $0.
- `pnpm build`/lint/typecheck + scene-build/build-plan tests green; full gate
  exit 0.

Patch bump to **0.113.5**.