### PR TITLE
fix(scene): keyframe face consistency + --skip-video asset generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.113.6] - 2026-06-19
+
+### Documentation
+
+- lead README with the directed-video showcase
+
+### Fixed
+
+- keyframe face consistency + --skip-video asset generation *(scene)*
+
 ## [0.113.5] - 2026-06-19
 
 ### Fixed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.5",
+  "version": "0.113.6",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.5`
+> CLI version: `0.113.6`
 
 ## Mental model
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -145,6 +145,21 @@ vibe build my-film --max-cost 6        # animate the approved keyframes
 
 Use `--skip-keyframe` to opt a run out of keyframe generation entirely.
 
+### Provider quality tiers
+
+Provider choice drives perceived polish, especially for character-consistent
+work:
+
+- **Faces / character identity** — `--image-provider gemini` (Nano Banana) holds
+  the same face across scenes noticeably better than `gpt-image-2`, whose
+  identity tends to drift after a few scenes. Use it for character/keyframe-heavy
+  pieces. Keyframe edits already pin facial features with an identity-lock
+  instruction, but the model still matters.
+- **Narration** — `--tts kokoro` is free and local (draft quality); for a final
+  or shared cut use `--tts openai` (fast, ~$0.02/video) or `--tts elevenlabs`
+  (premium voices). Switching providers regenerates narration and updates the
+  render automatically.
+
 ## Profiles
 
 `vibe init` supports three profiles:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.5",
+  "version": "0.113.6",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.5",
+  "version": "0.113.6",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.5",
+  "version": "0.113.6",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -605,6 +605,21 @@ backdrop: "../outside.png"
     expect(report.stageReports!.render.status).toBe("skipped");
   });
 
+  it("--skip-video runs the assets stage (keyframe stills) but skips only render", async () => {
+    // Regression: --skip-video must NOT cap the stage to sync (which would skip
+    // asset generation entirely). Keyframe stills are produced in the assets
+    // stage for review; only render is skipped (no clips to capture).
+    const r = await executeSceneBuild({ projectDir, skipVideo: true });
+    expect(r.success).toBe(true);
+    expect(r.outputPath).toBeUndefined();
+    expect(executeSceneRender).not.toHaveBeenCalled();
+
+    const report = readBuildReport();
+    expect(report.stageReports!.assets.status).toBe("done");
+    expect(report.stageReports!.render.status).toBe("skipped");
+    expect(report.warnings.some((w) => w.includes("skip-video"))).toBe(true);
+  });
+
   it("writes a stable beat-only assets build-report contract", async () => {
     const r = await executeSceneBuild({
       projectDir,

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -20,7 +20,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 
 import { config as loadDotenv } from "dotenv";
@@ -382,13 +382,14 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   const projectDir = resolve(opts.projectDir);
   const onProgress = opts.onProgress ?? (() => {});
   const mode = resolveSceneBuildMode(opts);
-  let selectedStage = opts.stage ?? (opts.skipRender ? "sync" : "all");
+  const selectedStage = opts.stage ?? (opts.skipRender ? "sync" : "all");
   // --skip-video produces keyframe stills (an image storyboard) for review, not
   // a final video. The composition would reference <video> clips that were never
-  // generated, so capture can't run — stop at sync instead of failing render.
+  // generated, so capture can't run. Keep the full pipeline (assets → compose →
+  // sync) so the keyframes ARE generated, and skip ONLY the render stage.
   const skipVideoStopsRender =
     (opts.skipVideo ?? false) && (selectedStage === "all" || selectedStage === "render");
-  if (skipVideoStopsRender) selectedStage = "sync";
+  const effectiveSkipRender = (opts.skipRender ?? false) || skipVideoStopsRender;
   const stageReports = createEmptyStageReports();
   const warnings: string[] = [];
   const retryWith: string[] = [];
@@ -956,7 +957,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     }
   }
 
-  if (selectedStage === "sync" || opts.skipRender) {
+  if (selectedStage === "sync" || effectiveSkipRender) {
     return finishBuildResult({
       success: true,
       phase: "sync-only",
@@ -1341,6 +1342,13 @@ async function dispatchNarration(beat: Beat, ctx: BeatDispatchContext): Promise<
 
   await mkdir(dirname(abs), { recursive: true });
   await writeFile(abs, result.audioBuffer);
+  // Remove stale narration of the OTHER extension so a TTS-provider switch
+  // (e.g. kokoro .wav → openai .mp3) doesn't leave a file that shadows this one
+  // in the root composition and keeps the old voice in the render.
+  for (const otherExt of ["mp3", "wav"]) {
+    const sibling = join(ctx.projectDir, `assets/narration-${beat.id}.${otherExt}`);
+    if (sibling !== abs && existsSync(sibling)) await rm(sibling, { force: true });
+  }
   await mkdir(dirname(cacheAbs), { recursive: true });
   await writeFile(cacheAbs, result.audioBuffer);
   await writeAssetMetadata({
@@ -1379,14 +1387,17 @@ interface CharacterBuildResult {
   failures: string[];
 }
 
-/** Turnaround character-sheet prompt — the layout validated to hold identity. */
+/** Turnaround character-sheet prompt — leads with a frontal face close-up so
+ * downstream scene edits have a strong identity anchor (faces in a pure
+ * turnaround are too small to hold identity across scenes). */
 function characterSheetPrompt(name: string, description: string): string {
   return [
-    `Character turnaround reference sheet of an original fictional character named ${name}: ${description}.`,
-    "Show three full-body views side by side on one clean canvas — front view, side profile, and back view —",
-    "with identical outfit, hairstyle, hair color, and body proportions across all three views.",
+    `Character reference sheet of an original fictional character named ${name}: ${description}.`,
+    "Top row: ONE large, sharp, evenly-lit frontal close-up of the FACE (head and shoulders) as the primary identity anchor — clear eyes, nose, jawline, and skin detail.",
+    "Bottom row: three full-body views side by side — front, side profile, and back.",
+    "The face, facial features, hairstyle, hair color, outfit, and body proportions must be IDENTICAL across the close-up and all three views.",
     "Plain light-grey studio background, even neutral lighting, no props.",
-    "Photorealistic digital character, professional concept-art character sheet layout.",
+    "Photorealistic, professional concept-art character sheet layout.",
   ].join(" ");
 }
 
@@ -1815,9 +1826,14 @@ async function ensureKeyframe(
     imageSize: size,
     imageQuality: ctx.imageQuality,
   };
+  // Identity-lock prefix: editing a scene from the character sheet drifts the
+  // face unless we explicitly pin the facial features. Only applies when we have
+  // a character reference to edit from.
+  const identityLock =
+    "Keep the EXACT same person and face as the reference image(s): identical facial features (eyes, nose shape, jawline), skin tone and complexion, hairstyle, hair color, and wardrobe. Do not restyle or change the face. Change only the scene, pose, framing, and lighting. ";
   const generated =
     sheetBuffers.length > 0
-      ? await editKeyframeImage(keyframeCue, sheetBuffers, imgCtx, ratio)
+      ? await editKeyframeImage(`${identityLock}${keyframeCue}`, sheetBuffers, imgCtx, ratio)
       : await generateBackdropImage(keyframeCue, imgCtx, ratio);
   if (!generated.success) return { status: "failed", error: generated.error };
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.5",
+  "version": "0.113.6",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.5",
+  "version": "0.113.6",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.5",
+  "version": "0.113.6",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Quality fixes found while reviewing the showcase.

## 1. `--skip-video` regression (from 0.113.5) — keyframes weren't generated
0.113.5 capped `selectedStage` to `"sync"` when `--skip-video` was set, but stage
gating is exact-match, so that **skipped the entire assets stage** — keyframe
stills were never produced (it only appeared to work when they were already
cached). Now `--skip-video` keeps the full pipeline (assets → compose → sync) and
skips **only** the render stage. New regression test covers it.

## 2. Face consistency across scenes
- `characterSheetPrompt` now leads with a large frontal face close-up as the
  identity anchor (a pure turnaround has faces too small to hold identity).
- `ensureKeyframe` prepends an identity-lock instruction (same eyes/nose/jawline/
  skin/hair; change only scene/pose/framing/lighting).
- Verified: regenerating the showcase keyframes with `--image-provider gemini`
  (Nano Banana) + these changes produces a consistent face across all 4 scenes,
  vs the drift under gpt-image-2.

## 3. TTS provider switch reaches the render
`dispatchNarration` removes stale narration of the other extension, so switching
`--tts kokoro` (.wav) → `--tts openai` (.mp3) no longer leaves a shadow file that
the root composition keeps using (old voice in the render).

## Docs
`docs/projects.md`: provider quality tiers (gemini/Nano Banana for identity;
openai/elevenlabs for final narration).

Build/lint/typecheck + scene-build/build-plan/build-cache tests green; full gate
exit 0. Patch bump **0.113.6**.