### PR TITLE
fix(scene): disable Seedance audio generation for build clips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.6] - 2026-06-19
+## [0.113.7] - 2026-06-19
 
 ### Documentation
 
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- disable Seedance audio generation for build clips *(scene)*
 - keyframe face consistency + --skip-video asset generation *(scene)*
 
 ## [0.113.5] - 2026-06-19

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.6",
+  "version": "0.113.7",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.6`
+> CLI version: `0.113.7`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.6",
+  "version": "0.113.7",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.6",
+  "version": "0.113.7",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.6",
+  "version": "0.113.7",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -2027,6 +2027,10 @@ async function dispatchVideo(
       : characterRefsAbs.length > 0
         ? characterRefsAbs
         : undefined,
+    // Build clips are always muted in the composition (a separate narration/music
+    // track carries audio), so the model's generated audio is never used. Disable
+    // it: it's wasted, and Seedance's audio moderation can spuriously fail a beat.
+    generateAudio: false,
     apiKey: await apiKeyForVideoProvider(ctx.videoProvider, ctx.projectDir),
   });
   if (!result.success || !result.taskId) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.6",
+  "version": "0.113.7",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.6",
+  "version": "0.113.7",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.6",
+  "version": "0.113.7",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Build compositions always mute the video layer and carry audio on a separate
narration/music track, so Seedance's generated audio is never used in the render.

Pass `generateAudio: false` for the build's image-to-video / reference-to-video
dispatch. Two wins:
- Avoids wasted audio compute on every clip.
- Prevents a real failure mode: Seedance's audio moderation can spuriously fail
  a beat with `HTTP 422 — Output audio has sensitive content` (hit while
  regenerating the showcase grid clip).

`executeVideoGenerate` already supported `generateAudio`; this just sets it for
build clips. Build/lint/typecheck + scene-build tests green. Patch bump **0.113.7**.