### PR TITLE
feat(mcp-server): --help/--version + npm-name clarity (0.113.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.113.9] - 2026-06-20
+
+### Added
+
+- print usage on --help / --version *(mcp-server)*
+
+### Documentation
+
+- clarify npm package names in README install
+
 ## [0.113.8] - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -256,6 +256,13 @@ The installer places the CLI checkout under the XDG data directory
 directory or an ancestor, VibeFrame uses that project config in isolation and
 does not merge in user-scope keys.
 
+> **npm package names:** the CLI is published as
+> [`@vibeframe/cli`](https://www.npmjs.com/package/@vibeframe/cli) (binary
+> `vibe`) and the MCP server as
+> [`@vibeframe/mcp-server`](https://www.npmjs.com/package/@vibeframe/mcp-server).
+> There is no bare `vibeframe` npm package from this project — that name belongs
+> to an unrelated package, so `npx vibeframe` will not run this tool.
+
 For local development:
 
 ```bash

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.8",
+  "version": "0.113.9",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.8`
+> CLI version: `0.113.9`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.8",
+  "version": "0.113.9",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.8",
+  "version": "0.113.9",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.8",
+  "version": "0.113.9",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.8",
+  "version": "0.113.9",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.8",
+  "version": "0.113.9",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/cli-flags.test.ts
+++ b/packages/mcp-server/src/cli-flags.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { handleCliFlags } from "./cli-flags.js";
+
+describe("handleCliFlags", () => {
+  let log: MockInstance;
+
+  beforeEach(() => {
+    log = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    log.mockRestore();
+  });
+
+  it("prints usage and returns true for --help / -h", () => {
+    for (const flag of ["--help", "-h"]) {
+      log.mockClear();
+      expect(handleCliFlags([flag], "1.2.3")).toBe(true);
+      expect(log).toHaveBeenCalledOnce();
+      const out = String(log.mock.calls[0][0]);
+      expect(out).toContain("VibeFrame MCP Server v1.2.3");
+      expect(out).toContain("@vibeframe/mcp-server");
+    }
+  });
+
+  it("prints the bare version and returns true for --version / -V", () => {
+    for (const flag of ["--version", "-V"]) {
+      log.mockClear();
+      expect(handleCliFlags([flag], "1.2.3")).toBe(true);
+      expect(log).toHaveBeenCalledWith("1.2.3");
+    }
+  });
+
+  it("returns false and prints nothing for no args (server should boot)", () => {
+    expect(handleCliFlags([], "1.2.3")).toBe(false);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("returns false for unknown args so the server still boots", () => {
+    expect(handleCliFlags(["--workspace", "/tmp/x"], "1.2.3")).toBe(false);
+    expect(log).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/cli-flags.ts
+++ b/packages/mcp-server/src/cli-flags.ts
@@ -1,0 +1,54 @@
+/**
+ * Pre-flight CLI flag handling for the MCP server entry.
+ *
+ * The server normally speaks MCP over stdio and never reads argv, but a human
+ * probing the package (`npx -y @vibeframe/mcp-server --help`) reasonably
+ * expects `--help`/`--version` to print and exit instead of silently booting a
+ * stdio server. This lives in its own module so it stays unit-testable — the
+ * entry (`index.ts`) connects the transport at import time and is deliberately
+ * not imported by tests.
+ */
+
+function usage(version: string): string {
+  return [
+    `VibeFrame MCP Server v${version}`,
+    "",
+    "AI-native video editing exposed over the Model Context Protocol (stdio).",
+    "It is launched by an MCP client (Claude Desktop, Cursor, Claude Code), not",
+    "run directly — there is normally nothing to interact with on the terminal.",
+    "",
+    "Add it to your client config:",
+    "",
+    '  {',
+    '    "mcpServers": {',
+    '      "vibeframe": {',
+    '        "command": "npx",',
+    '        "args": ["-y", "@vibeframe/mcp-server"]',
+    '      }',
+    '    }',
+    '  }',
+    "",
+    "Options:",
+    "  -h, --help     Show this help and exit",
+    "  -V, --version  Print the version and exit",
+    "",
+    "Docs: https://github.com/vericontext/vibeframe#mcp-integration",
+  ].join("\n");
+}
+
+/**
+ * If argv requests help/version, print it and return true (caller should exit).
+ * Returns false for normal startup (including unknown args, so the server still
+ * boots and lets the MCP client drive it).
+ */
+export function handleCliFlags(argv: string[], version: string): boolean {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(usage(version));
+    return true;
+  }
+  if (argv.includes("--version") || argv.includes("-V")) {
+    console.log(version);
+    return true;
+  }
+  return false;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -19,6 +19,14 @@ import {
   scrubUnresolvedUserConfigEnv,
 } from "./instructions.js";
 import { makeElicitFn, type ElicitCapableServer } from "./elicit.js";
+import { handleCliFlags } from "./cli-flags.js";
+
+// Human probing the package (`npx @vibeframe/mcp-server --help/--version`)?
+// Print and exit before redirecting stdout or touching the environment, so the
+// output lands on real stdout and no startup side effects run.
+if (handleCliFlags(process.argv.slice(2), process.env.VIBE_MCP_SERVER_VERSION ?? "0.0.0-dev")) {
+  process.exit(0);
+}
 
 /**
  * VibeFrame MCP Server

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.8",
+  "version": "0.113.9",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Post-0.113.8 polish surfaced while re-verifying the release across hosts.

- **mcp-server `--help` / `--version`**: the stdio entry ignored argv and booted
  the server even when a human ran `npx @vibeframe/mcp-server --help`. Add a
  pure, testable `handleCliFlags()` helper (kept out of the booting entry so it
  stays unit-testable) that prints usage / the version to stdout and exits
  before any startup side effects. Unknown args still fall through to a normal
  boot.
- **README npm-name clarity**: note that the published packages are
  `@vibeframe/cli` (bin `vibe`) and `@vibeframe/mcp-server`, and that the bare
  `vibeframe` npm name is an unrelated third-party package, so `npx vibeframe`
  does not run this tool.
- **chore**: bump to 0.113.9 (+ CHANGELOG, cli-reference).

## Testing

- `pnpm -F @vibeframe/mcp-server test` — 73 passed (incl. 4 new `cli-flags` tests)
- Built artifact verified: `--version` → `0.113.9`, `--help` → usage on stdout,
  bare invocation still boots ("VibeFrame MCP Server started")
- `bash scripts/pre-push-validate.sh` → exit 0 (version sync, typecheck,
  gen:reference:check, agent-sync:check, CHANGELOG)
- Fresh-user quickstart re-verified end-to-end (init → storyboard validate →
  plan → build --dry-run, all exit 0; dry-run est. \$0.78, 0 validation errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)