### PR TITLE
Agent-workflow polish: PR-route policy, goal-loop example, SFX discipline (0.113.10)

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -108,8 +108,18 @@ git commit -m "chore: bump version to $NEW_VERSION" -m "Release-Type: minor: <wh
 
 Do not create a local tag. Do not push unless the user explicitly asks.
 
-Publishing is manual. After the version commit lands on `main` and CI passes,
-run the `Create release tag` workflow to create `vX.Y.Z`, then run
-`Publish to npm` manually with that tag. A human-created `git push origin
+11. The version commit reaches `main` **via a PR**, never a direct push (even
+    though `main` allows admin bypass). Put it on a `chore/release-$NEW_VERSION`
+    branch, open a PR, let CI go green, and merge:
+
+```bash
+git switch -c chore/release-$NEW_VERSION
+git push -u origin chore/release-$NEW_VERSION
+gh pr create --fill --base main
+```
+
+Publishing is manual. After the version commit lands on `main` (through the PR)
+and CI passes, run the `Create release tag` workflow to create `vX.Y.Z`, then
+run `Publish to npm` manually with that tag. A human-created `git push origin
 vX.Y.Z` tag also triggers `publish.yml`, but CI and the tag helper do not
 dispatch publishing automatically.

--- a/.claude/rules/versioning.md
+++ b/.claude/rules/versioning.md
@@ -67,11 +67,17 @@ pnpm gen:reference:check  # must pass before commit
 # Step 6: Commit (exclude test/temp files)
 git add package.json packages/*/package.json apps/*/package.json CHANGELOG.md docs/cli-reference.md
 git commit -m "chore: bump version to X.Y.Z"
+
+# Step 7: Land it on main via a PR — NOT a direct push (main allows admin
+# bypass, but the policy is PR-only for every commit, releases included).
+git switch -c chore/release-X.Y.Z
+git push -u origin chore/release-X.Y.Z
+gh pr create --fill --base main   # then wait for CI green and merge
 ```
 
 Do not create a local release tag in normal development. After the version
-commit lands on `main` and CI passes, manually run the `Create release tag`
-workflow. Then manually run `Publish to npm` with that tag. A human-created
+commit lands on `main` (through the PR) and CI passes, manually run the
+`Create release tag` workflow. Then manually run `Publish to npm` with that tag. A human-created
 `git push origin vX.Y.Z` tag also triggers publishing, but CI and the tag helper
 do not dispatch publishing automatically.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -112,8 +112,18 @@ git commit -m "chore: bump version to $NEW_VERSION" -m "Release-Type: minor: <wh
 
 Do not create a local tag. Do not push unless the user explicitly asks.
 
-Publishing is manual. After the version commit lands on `main` and CI passes,
-run the `Create release tag` workflow to create `vX.Y.Z`, then run
-`Publish to npm` manually with that tag. A human-created `git push origin
+11. The version commit reaches `main` **via a PR**, never a direct push (even
+    though `main` allows admin bypass). Put it on a `chore/release-$NEW_VERSION`
+    branch, open a PR, let CI go green, and merge:
+
+```bash
+git switch -c chore/release-$NEW_VERSION
+git push -u origin chore/release-$NEW_VERSION
+gh pr create --fill --base main
+```
+
+Publishing is manual. After the version commit lands on `main` (through the PR)
+and CI passes, run the `Create release tag` workflow to create `vX.Y.Z`, then
+run `Publish to npm` manually with that tag. A human-created `git push origin
 vX.Y.Z` tag also triggers `publish.yml`, but CI and the tag helper do not
 dispatch publishing automatically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,11 @@ General expectation:
 - Git & PR workflow: branch off `main` as `feat/<topic>`, `fix/<topic>`, or
   `chore/<topic>`. **One PR = one coherent scope** — do not stack unrelated
   commits onto an open PR branch. Rebase/split when scope drifts.
+- **Every commit reaches `main` via a PR — including `chore: bump version`
+  release commits.** Branch → PR → CI green → merge. Do **not** push directly to
+  `main`, even as a maintainer with admin bypass (`main` allows it, but the
+  policy does not). Release bumps go on a `chore/release-<version>` (or the
+  feature) branch and merge through the same gate as any other change.
 - Version bumps default to `patch` during `0.x`, including most ordinary
   `feat:` and `fix:` commits. **`patch` is the default; `minor` is rare.** Use
   `minor` only for new public CLI command namespaces, new MCP tool families,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.113.10] - 2026-06-20
+
+### Documentation
+
+- goal-loop recovery worked example + SFX cue note
+- require PR route for all commits including releases
+
+### Fixed
+
+- never invent fallback SFX in scene composition *(scene)*
+
 ## [0.113.9] - 2026-06-20
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.9",
+  "version": "0.113.10",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.9`
+> CLI version: `0.113.10`
 
 ## Mental model
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -48,6 +48,44 @@ and prefer `nextActions`: run only `safeToAutoRun:true` actions automatically,
 ask before `requiresConfirmation:true`, and use `retryWith` only as the
 compatibility fallback.
 
+Worked example — `vibe inspect project my-video --json` returns a review report
+whose `nextActions` are pre-classified so the host loop never has to guess:
+
+```jsonc
+{
+  "kind": "review", "status": "fail", "score": 17,
+  "nextActions": [
+    {
+      "kind": "command",
+      "command": "vibe build my-video --stage sync --json",
+      "fixOwner": "vibe",        // VibeFrame can fix this itself
+      "costTier": "free",
+      "safeToAutoRun": true,     // → run it without asking
+      "requiresConfirmation": false,
+      "reason": "The root composition is missing or could not be verified."
+    },
+    {
+      "kind": "command",
+      "command": "vibe generate video ... --json",
+      "fixOwner": "host-agent",  // the outer goal loop owns this
+      "costTier": "very-high",
+      "safeToAutoRun": false,
+      "requiresConfirmation": true,  // → ask the user before spending
+      "reason": "Regenerating the clip is a paid provider call."
+    }
+  ],
+  "retryWith": ["vibe build my-video --stage sync --json"]
+}
+```
+
+Host-loop logic: iterate `nextActions` → run every `safeToAutoRun:true` action
+as-is → for `requiresConfirmation:true` (or any `very-high`/`unknown` `costTier`)
+ask the user first → if a `command` is rejected by an older CLI, fall back to
+`retryWith`. Stop when a re-`inspect` returns `status:"pass"` and no
+`fixOwner:"host-agent"` issues remain. `fixOwner` tells you who acts:
+`"vibe"` actions are safe local repairs; `"host-agent"` actions are yours to run
+or escalate. Never invent commands when `nextActions` is present.
+
 Claude Desktop uses global MCP config, so anchor it to the workspace you want
 relative project names to resolve under. VibeFrame writes a shell wrapper
 because Claude Desktop may not preserve a raw `cwd` field:
@@ -65,7 +103,7 @@ Use the folders consistently:
 | Path            | Role                                                                                 |
 | --------------- | ------------------------------------------------------------------------------------ |
 | `brief.md`      | Optional rough input before `vibe init`; can live outside or beside the project.     |
-| `STORYBOARD.md` | Beats, narration, duration, and image/video/music cues.                              |
+| `STORYBOARD.md` | Beats, narration, duration, and image/video/music cues. Scene audio comes only from explicit `narration`/`music` cues — composition never invents ambient/foley SFX. |
 | `DESIGN.md`     | Palette, typography, layout, motion, transitions, and visual anti-patterns.          |
 | `media/`        | User-provided source files: photos, screenshots, logos, B-roll, voice recordings.    |
 | `assets/`       | Generated or canonical build assets such as narration, backdrops, music, and videos. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.9",
+  "version": "0.113.10",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.9",
+  "version": "0.113.10",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.9",
+  "version": "0.113.10",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
@@ -157,6 +157,13 @@ describe("buildUserPrompt", () => {
     expect(u).toContain("never with inner clip windows");
   });
 
+  it("forbids inventing sound effects in the visual-only fragment", () => {
+    const u = buildUserPrompt({ beat, storyboardGlobal: "" });
+    expect(u).toContain("Do NOT invent sound effects");
+    expect(u).toContain("visual-only");
+    expect(u).toContain("narration");
+  });
+
   it("changes the cache key when finalDurationSec changes", () => {
     const a = buildUserPrompt({ beat, storyboardGlobal: "", finalDurationSec: 6 });
     const b = buildUserPrompt({ beat, storyboardGlobal: "", finalDurationSec: 8.26 });

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.ts
@@ -308,6 +308,13 @@ ${finalDurationBullet}
 - If the beat cues include \`narration\`, do not embed an \`<audio>\` tag in the
   scene fragment. The root timeline wires \`assets/narration-${ctx.beat.id}.wav\`
   or \`assets/narration-${ctx.beat.id}.mp3\` separately.
+- Do NOT invent sound effects. This scene fragment is visual-only: never add
+  an \`<audio>\` tag, and never imply ambient/foley SFX (keyboard clicks, whoosh,
+  applause, room tone) that the beat did not explicitly request. Audio comes
+  only from the beat's explicit \`narration\` and \`music\` cues, wired by the
+  root timeline. If the beat declares an explicit \`sfx\` cue, treat it as intent
+  for the storyboard author — still do not embed it here — and only when it is
+  clearly tied to the beat's narration/motion; ignore orphaned or generic SFX.
 - **\`.clip\` elements get visibility control from the framework but NO
   sizing.** Always give \`.clip\` explicit fill via CSS:
   \`{ position: absolute; inset: 0; }\` (or equivalent

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.9",
+  "version": "0.113.10",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.9",
+  "version": "0.113.10",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.9",
+  "version": "0.113.10",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Post-0.113.9 follow-ups (Codex's deferred workflow items #3/#6/#7).

- **#3 — PR-route policy (docs):** every commit reaches `main` via a PR,
  including `chore: bump version` release commits. `main` allows admin bypass,
  but the policy is now PR-only. Aligned `AGENTS.md`, the `release` skill
  (+ synced `.claude/skills`), and `.claude/rules/versioning.md`. This PR
  dogfoods it — the bump lands through here, not a direct push.
- **#6 — goal-loop worked example (docs):** added a concrete review-report JSON
  example to `docs/projects.md` showing how `nextActions` / `fixOwner` /
  `safeToAutoRun` / `requiresConfirmation` / `retryWith` drive the outer host
  loop, plus the host-loop decision/termination logic. Field shapes match
  `review-report.ts`.
- **#7 — SFX discipline (fix):** the scene-composition prompt let the model
  imply ambient/foley SFX (e.g. keyboard typing) no beat requested. The
  fragment is now constrained visual-only — no `<audio>`, no inferred SFX;
  audio comes solely from explicit `narration`/`music` cues.

## Testing

- `pnpm -F @vibeframe/cli exec vitest run …/compose-scenes-skills.test.ts` — 46
  passed (incl. new "forbids inventing sound effects" test)
- `pnpm agent-sync:check` — in sync (release skill regenerated)
- `bash scripts/pre-push-validate.sh` — exit 0 (version sync, typecheck, lint,
  gen:reference:check, CHANGELOG, agent-sync)
- chore: bump to 0.113.10 (CHANGELOG + cli-reference regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)