### PR TITLE
feat(build): word-level transcript → per-beat compose prompt (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.113.11] - 2026-06-22
+
+### Added
+
+- pass word-level transcript into per-beat compose prompt *(build)*
+
+### Documentation
+
+- rewrite README for clarity and structure
+
 ## [0.113.10] - 2026-06-20
 
 ### Documentation

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.10",
+  "version": "0.113.11",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.10`
+> CLI version: `0.113.11`
 
 ## Mental model
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -242,6 +242,7 @@ Cost tier: _not tagged_
 - `skipVideo` _(boolean)_ — Don't dispatch video generation even when beats declare video cues
 - `skipKeyframe` _(boolean)_ — Don't generate keyframe stills (review keyframes first with --skip-video, then build)
 - `skipMusic` _(boolean)_ — Don't dispatch music generation even when beats declare music cues
+- `skipTranscript` _(boolean)_ — Don't transcribe narration for word-sync (default: transcribe when narration + OpenAI key exist)
 - `skipRender` _(boolean)_ — Compose only — don't render to MP4
 - `tts` _(string)_ — TTS provider: auto|elevenlabs|openai|kokoro
 - `voice` _(string)_ — Voice id

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.10",
+  "version": "0.113.11",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.10",
+  "version": "0.113.11",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.10",
+  "version": "0.113.11",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -602,6 +602,10 @@ exports[`CLI --describe schemas (drift detection) > vibe build --describe 1`] = 
         "description": "Compose only — don't render to MP4",
         "type": "boolean",
       },
+      "skipTranscript": {
+        "description": "Don't transcribe narration for word-sync (default: transcribe when narration + OpenAI key exist)",
+        "type": "boolean",
+      },
       "skipVideo": {
         "description": "Don't dispatch video generation even when beats declare video cues",
         "type": "boolean",

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -149,6 +149,13 @@ export interface CreateBuildPlanOptions {
   skipVideo?: boolean;
   skipKeyframe?: boolean;
   skipMusic?: boolean;
+  /**
+   * Skip Whisper word-level transcription of narration. Recorded for plan
+   * fidelity; transcription is a negligible-cost step (~$0.002/beat) that only
+   * runs when a beat has narration and an OpenAI key is configured, so it is
+   * not itemised as a separate cost line.
+   */
+  skipTranscript?: boolean;
   ttsProvider?: string;
   voice?: string;
   imageProvider?: string;

--- a/packages/cli/src/commands/_shared/compose-prompts.test.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.test.ts
@@ -163,4 +163,28 @@ describe("getComposePrompts", () => {
     const r = await getComposePrompts({ projectDir });
     expect(r.bundleVersion).toMatch(/^[0-9a-f]+-\d{4}-\d{2}-\d{2}$/);
   });
+
+  it("exposes transcriptPath + injects word timings when a beat transcript exists", async () => {
+    seed({ withSkill: true });
+    mkdirSync(join(projectDir, "assets"), { recursive: true });
+    writeFileSync(
+      join(projectDir, "assets/transcript-hook.json"),
+      JSON.stringify([
+        { text: "Ship", start: 0, end: 0.4 },
+        { text: "faster", start: 0.45, end: 0.9 },
+      ]),
+      "utf-8"
+    );
+
+    const r = await getComposePrompts({ projectDir });
+    const hook = r.beats.find((b) => b.id === "hook")!;
+    const outro = r.beats.find((b) => b.id === "outro")!;
+
+    expect(hook.transcriptPath).toBe("assets/transcript-hook.json");
+    expect(hook.userPrompt).toContain("Narration word timings");
+    expect(hook.userPrompt).toContain('[0, "Ship"]');
+    // Beat without a transcript file gets no path and no timing section.
+    expect(outro.transcriptPath).toBeUndefined();
+    expect(outro.userPrompt).not.toContain("Narration word timings");
+  });
 });

--- a/packages/cli/src/commands/_shared/compose-prompts.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.ts
@@ -40,6 +40,7 @@ import { parseStoryboard, type Beat } from "./storyboard-parse.js";
 import { buildUserPrompt } from "./compose-scenes-skills.js";
 import { resolveProjectBeatDurations } from "./root-sync.js";
 import { BUNDLE_VERSION } from "./hf-skill-bundle/bundle.js";
+import { readBeatTranscript, beatTranscriptRelPath } from "./transcribe-narration.js";
 
 export interface ComposePromptsBeat {
   /** Stable beat id from `parseStoryboard().deriveBeatId()`. */
@@ -67,6 +68,13 @@ export interface ComposePromptsBeat {
    * agentic and batch paths produce equivalent HTML.
    */
   userPrompt: string;
+  /**
+   * Project-relative path to the beat's Whisper word-level transcript
+   * (`assets/transcript-<id>.json`), present only when the asset stage
+   * transcribed this beat's narration. The host agent can read it for exact
+   * word timings; the same timings are already summarised in `userPrompt`.
+   */
+  transcriptPath?: string;
   /** True when `compositions/scene-<id>.html` already exists on disk. */
   exists: boolean;
 }
@@ -181,27 +189,35 @@ export async function getComposePrompts(opts: ComposePromptsOptions): Promise<Co
     // best-effort only
   }
 
-  const result: ComposePromptsBeat[] = beats.map((beat) => {
-    const outputPathAbs = join(compositionsDir, `scene-${beat.id}.html`);
-    const outputPathRel = relative(projectDir, outputPathAbs);
-    const finalDurationSec = finalDurations.get(beat.id);
-    const userPrompt = buildUserPrompt({
-      beat,
-      storyboardGlobal: parsed.global,
-      finalDurationSec,
-    });
-    return {
-      id: beat.id,
-      heading: beat.heading,
-      outputPath: outputPathRel,
-      duration: beat.duration,
-      finalDurationSec,
-      cues: beat.cues,
-      body: beat.body,
-      userPrompt,
-      exists: existsSync(outputPathAbs),
-    };
-  });
+  const result: ComposePromptsBeat[] = await Promise.all(
+    beats.map(async (beat) => {
+      const outputPathAbs = join(compositionsDir, `scene-${beat.id}.html`);
+      const outputPathRel = relative(projectDir, outputPathAbs);
+      const finalDurationSec = finalDurations.get(beat.id);
+      // Word-level timings, when the asset stage transcribed this beat's
+      // narration. Surfaced in the prompt AND exposed as a path for hosts
+      // that want the raw data. Missing → undefined → prompt omits timings.
+      const transcript = await readBeatTranscript(projectDir, beat.id);
+      const userPrompt = buildUserPrompt({
+        beat,
+        storyboardGlobal: parsed.global,
+        finalDurationSec,
+        transcript,
+      });
+      return {
+        id: beat.id,
+        heading: beat.heading,
+        outputPath: outputPathRel,
+        duration: beat.duration,
+        finalDurationSec,
+        cues: beat.cues,
+        body: beat.body,
+        userPrompt,
+        transcriptPath: transcript ? beatTranscriptRelPath(beat.id) : undefined,
+        exists: existsSync(outputPathAbs),
+      };
+    })
+  );
 
   const skillRef = existsSync(skillPath) ? "SKILL.md" : null;
   const instructions = buildInstructions({

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
@@ -13,7 +13,9 @@ import {
   executeComposeScenesWithSkills,
   extractHtml,
   formatLintFeedback,
+  formatTranscriptSection,
   lintBeatHtml,
+  TRANSCRIPT_PROMPT_MAX_WORDS,
   ComposeBeatError,
 } from "./compose-scenes-skills.js";
 
@@ -172,6 +174,86 @@ describe("buildUserPrompt", () => {
     ).not.toBe(
       computeCacheKey({ provider: "claude", systemPrompt: "S", userPrompt: b, model: "M" })
     );
+  });
+
+  it("omits the timing section when no transcript is supplied", () => {
+    const u = buildUserPrompt({ beat, storyboardGlobal: "" });
+    expect(u).not.toContain("Narration word timings");
+    expect(u).not.toContain("phrase-level");
+  });
+
+  it("injects word-level timings for a short transcript", () => {
+    const u = buildUserPrompt({
+      beat,
+      storyboardGlobal: "",
+      transcript: [
+        { text: "Ship", start: 0, end: 0.4 },
+        { text: "faster", start: 0.45, end: 0.9 },
+      ],
+    });
+    expect(u).toContain("Narration word timings (seconds)");
+    expect(u).toContain('[0, "Ship"]');
+    expect(u).toContain('[0.45, "faster"]');
+    // Visual-sync-only guard travels with the timings.
+    expect(u).toContain("VISUAL sync only");
+  });
+
+  it("changes the cache key when the transcript changes", () => {
+    const without = buildUserPrompt({ beat, storyboardGlobal: "" });
+    const withT = buildUserPrompt({
+      beat,
+      storyboardGlobal: "",
+      transcript: [{ text: "Hi", start: 0, end: 0.3 }],
+    });
+    expect(
+      computeCacheKey({ provider: "claude", systemPrompt: "S", userPrompt: without, model: "M" })
+    ).not.toBe(
+      computeCacheKey({ provider: "claude", systemPrompt: "S", userPrompt: withT, model: "M" })
+    );
+  });
+});
+
+describe("formatTranscriptSection", () => {
+  it("returns empty string for undefined / empty transcript", () => {
+    expect(formatTranscriptSection(undefined)).toBe("");
+    expect(formatTranscriptSection([])).toBe("");
+  });
+
+  it("emits a word-level table at or below the budget", () => {
+    const words = Array.from({ length: 10 }, (_, i) => ({
+      text: `w${i}`,
+      start: i * 0.5,
+      end: i * 0.5 + 0.4,
+    }));
+    const section = formatTranscriptSection(words);
+    expect(section).toContain("word-level");
+    expect(section).toContain('[0, "w0"]');
+    expect(section).not.toContain("approximate");
+  });
+
+  it("downgrades to approximate phrase-level anchors above the budget", () => {
+    const n = TRANSCRIPT_PROMPT_MAX_WORDS + 50;
+    const words = Array.from({ length: n }, (_, i) => ({
+      text: `w${i}`,
+      start: i * 0.3,
+      end: i * 0.3 + 0.25,
+    }));
+    const section = formatTranscriptSection(words);
+    expect(section).toContain("approximate, phrase-level");
+    expect(section).toContain(`${n} words`);
+    // Phrase anchors are far fewer than the raw word count.
+    const anchorCount = (section.match(/\], \[/g) ?? []).length + 1;
+    expect(anchorCount).toBeLessThanOrEqual(TRANSCRIPT_PROMPT_MAX_WORDS);
+    expect(anchorCount).toBeLessThan(n);
+  });
+
+  it("clamps negative start times to zero and rounds to 2dp", () => {
+    const section = formatTranscriptSection([
+      { text: "x", start: -0.2, end: 0.1 },
+      { text: "y", start: 1.23456, end: 1.5 },
+    ]);
+    expect(section).toContain('[0, "x"]');
+    expect(section).toContain('[1.23, "y"]');
   });
 });
 

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.ts
@@ -43,6 +43,8 @@ import { parseStoryboard, type Beat } from "./storyboard-parse.js";
 import { resolveProjectBeatDurations } from "./root-sync.js";
 import { type ComposerProvider, resolveComposer, composerEnvVar } from "./composer-resolve.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
+import { readBeatTranscript } from "./transcribe-narration.js";
+import type { SceneTranscriptWord } from "./scene-html-emit.js";
 
 /** Effort level → token caps. Model is per-provider (see MODEL_SETTINGS_BY_PROVIDER). */
 export type ComposeEffort = "low" | "medium" | "high";
@@ -124,6 +126,14 @@ export interface ComposeBeatContext {
    * duration is then only the minimum and is annotated as superseded.
    */
   finalDurationSec?: number;
+  /**
+   * Whisper word-level timings for this beat's narration audio, read from
+   * `assets/transcript-<id>.json` by the asset stage. When present,
+   * {@link buildUserPrompt} surfaces a compact timing table so the composer
+   * can sync caption / kinetic-type word reveals to speech. Folded into the
+   * user prompt, so the compose cache key invalidates when timings change.
+   */
+  transcript?: SceneTranscriptWord[];
 }
 
 export interface ComposeBeatResult {
@@ -203,11 +213,84 @@ function formatBeatCues(cues: Beat["cues"]): string {
   return lines.join("\n") + "\n";
 }
 
+/**
+ * Word-level timing entries above this count are downgraded to coarse,
+ * phrase-level anchors in the prompt. A token-budget guard: a 60s narration
+ * can exceed 150 words, and inlining every `[start, "word"]` pair bloats the
+ * prompt (and the cache key) for little composer benefit past a point.
+ */
+export const TRANSCRIPT_PROMPT_MAX_WORDS = 120;
+
+/**
+ * Render narration word timings as a compact, deterministic prompt section.
+ * Token-budget guard (the `oversized` case is the reason this is a function,
+ * not an inline template):
+ *   - no transcript → `""` (section omitted entirely; prompt unchanged).
+ *   - ≤ {@link TRANSCRIPT_PROMPT_MAX_WORDS} → full word-level `[start, "word"]`
+ *     table the composer can map 1:1 to GSAP reveals.
+ *   - more → group into ~`MAX/2` phrase anchors (start time of each phrase),
+ *     tagged "approximate" so the composer paces reveals across the beat
+ *     rather than over-trusting per-word truth.
+ * Pure and stable for a given input → the compose cache stays consistent.
+ */
+export function formatTranscriptSection(
+  transcript: SceneTranscriptWord[] | undefined,
+  maxWords = TRANSCRIPT_PROMPT_MAX_WORDS
+): string {
+  if (!transcript || transcript.length === 0) return "";
+  const round = (n: number): number => Number(Math.max(0, n).toFixed(2));
+  const noAudioRule =
+    "This is for VISUAL sync only — do NOT add an `<audio>` tag or invent SFX; " +
+    "the narration audio is wired separately by the root timeline. If this beat " +
+    "is visual-only (no on-screen text), you may ignore these timings.";
+
+  if (transcript.length <= maxWords) {
+    const pairs = transcript
+      .map((w) => `[${round(w.start)}, ${JSON.stringify(w.text)}]`)
+      .join(", ");
+    return `
+
+=== Narration word timings (seconds) ===
+
+Whisper word-level start times for this beat's narration. If you author captions
+or kinetic typography, reveal each word at its start time with absolute-time
+GSAP tweens, e.g.
+\`tl.fromTo('.caption .word[data-i="0"]', { opacity: 0, y: 10 }, { opacity: 1, y: 0, duration: 0.18 }, ${round(
+      transcript[0]!.start
+    )});\`
+${noAudioRule}
+
+word starts (word-level): ${pairs}`;
+  }
+
+  // Oversized → phrase-level anchors. Chunk so the table stays ~maxWords/2
+  // entries regardless of narration length.
+  const phraseCount = Math.max(1, Math.floor(maxWords / 2));
+  const chunkSize = Math.ceil(transcript.length / phraseCount);
+  const anchors: string[] = [];
+  for (let i = 0; i < transcript.length; i += chunkSize) {
+    const chunk = transcript.slice(i, i + chunkSize);
+    const text = chunk.map((w) => w.text).join(" ");
+    anchors.push(`[${round(chunk[0]!.start)}, ${JSON.stringify(text)}]`);
+  }
+  return `
+
+=== Narration timings (approximate, phrase-level) ===
+
+This beat's narration is long (${transcript.length} words), so timings are
+grouped into phrase-level anchors (start time of each phrase). Use them to PACE
+caption / kinetic-type reveals across the beat — they are approximate, not
+per-word truth.
+${noAudioRule}
+
+phrase starts (approximate): ${anchors.join(", ")}`;
+}
+
 /** Build the user prompt — instructions + storyboard global + beat body. */
 export function buildUserPrompt(
   ctx: Pick<
     ComposeBeatContext,
-    "beat" | "storyboardGlobal" | "retryFeedback" | "finalDurationSec"
+    "beat" | "storyboardGlobal" | "retryFeedback" | "finalDurationSec" | "transcript"
   >
 ): string {
   const compositionId = `scene-${ctx.beat.id}`;
@@ -380,7 +463,7 @@ ${ctx.storyboardGlobal || "(no global direction)"}
 
 ## ${ctx.beat.heading}
 ${formatBeatCues(ctx.beat.cues)}${cueDurationNote}
-${ctx.beat.body}
+${ctx.beat.body}${formatTranscriptSection(ctx.transcript)}
 
 === Output format ===
 
@@ -973,6 +1056,10 @@ export async function executeComposeScenesWithSkills(
     async (beat, beatIndex): Promise<FanoutOutcome> => {
       onProgress({ type: "beat-start", beatId: beat.id, beatIndex, totalBeats });
       try {
+        // Word-level timings (if the asset stage transcribed narration) let
+        // the composer sync caption / kinetic-type reveals to speech. Missing
+        // or unreadable → undefined → prompt simply omits the timing section.
+        const transcript = await readBeatTranscript(projectRoot, beat.id);
         const result = await composeBeatWithRetry(
           {
             beat,
@@ -984,6 +1071,7 @@ export async function executeComposeScenesWithSkills(
             effort: params.effort,
             cacheDir: params.cacheDir,
             finalDurationSec: finalDurations.get(beat.id),
+            transcript,
           },
           overrides
         );

--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -27,6 +27,13 @@ vi.mock("@vibeframe/ai-providers", async (importOriginal) => ({
   OpenAIImageProvider: vi.fn(),
 }));
 
+// Stub only the Whisper network call; keep the pure path/read helpers real so
+// dispatchTranscript's caching + file-write logic runs against the real fs.
+vi.mock("./transcribe-narration.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./transcribe-narration.js")>()),
+  transcribeNarrationWords: vi.fn(async () => []),
+}));
+
 vi.mock("./compose-scenes-skills.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./compose-scenes-skills.js")>();
   // Keep the real `buildUserPrompt` (and other pure helpers) so
@@ -52,6 +59,7 @@ vi.mock("../generate/music.js", () => ({
 
 import { resolveTtsProvider } from "./tts-resolve.js";
 import { GeminiProvider, GrokProvider, OpenAIImageProvider } from "@vibeframe/ai-providers";
+import { transcribeNarrationWords } from "./transcribe-narration.js";
 import { executeComposeScenesWithSkills } from "./compose-scenes-skills.js";
 import { executeSceneRender } from "./scene-render.js";
 import { executeVideoGenerate } from "../ai-video.js";
@@ -476,6 +484,41 @@ describe("executeSceneBuild", () => {
     expect(r.beats[0].backdropStatus).toBe("skipped");
     expect(resolveTtsProvider).not.toHaveBeenCalled();
     expect(OpenAIImageProvider).not.toHaveBeenCalled();
+  });
+
+  it("transcribes narration into assets/transcript-<beat>.json when word timings exist", async () => {
+    vi.mocked(transcribeNarrationWords).mockClear();
+    vi.mocked(transcribeNarrationWords).mockResolvedValue([
+      { text: "Type", start: 0, end: 0.3 },
+      { text: "a", start: 0.3, end: 0.4 },
+      { text: "YAML", start: 0.4, end: 0.9 },
+    ]);
+    try {
+      const r = await executeSceneBuild({ projectDir, stage: "assets" });
+      expect(r.success).toBe(true);
+      const transcriptPath = join(projectDir, "assets", "transcript-hook.json");
+      expect(existsSync(transcriptPath)).toBe(true);
+      expect(JSON.parse(readFileSync(transcriptPath, "utf-8"))).toEqual([
+        { text: "Type", start: 0, end: 0.3 },
+        { text: "a", start: 0.3, end: 0.4 },
+        { text: "YAML", start: 0.4, end: 0.9 },
+      ]);
+      expect(transcribeNarrationWords).toHaveBeenCalled();
+    } finally {
+      vi.mocked(transcribeNarrationWords).mockResolvedValue([]);
+    }
+  });
+
+  it("does not transcribe when --skip-transcript is set", async () => {
+    vi.mocked(transcribeNarrationWords).mockClear();
+    vi.mocked(transcribeNarrationWords).mockResolvedValue([{ text: "x", start: 0, end: 1 }]);
+    try {
+      await executeSceneBuild({ projectDir, stage: "assets", skipTranscript: true });
+      expect(existsSync(join(projectDir, "assets", "transcript-hook.json"))).toBe(false);
+      expect(transcribeNarrationWords).not.toHaveBeenCalled();
+    } finally {
+      vi.mocked(transcribeNarrationWords).mockResolvedValue([]);
+    }
   });
 
   it("uses referenced narration and backdrop assets without provider calls", async () => {

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -44,6 +44,8 @@ import {
 import type { ComposerProvider } from "./composer-resolve.js";
 import { getComposePrompts, type ComposePromptsBeat } from "./compose-prompts.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
+import { getConfiguredApiKey } from "../../utils/api-key.js";
+import { transcribeNarrationWords, beatTranscriptRelPath } from "./transcribe-narration.js";
 import { executeSceneRender, type SceneRenderResult } from "./scene-render.js";
 import {
   beatCharacterNames,
@@ -121,6 +123,9 @@ export type SceneBuildProgressEvent =
   | { type: "narration-generated"; beatId: string; path: string; provider: string }
   | { type: "narration-failed"; beatId: string; error: string }
   | { type: "narration-skipped"; beatId: string; reason: string }
+  | { type: "transcript-generated"; beatId: string; path: string; wordCount: number }
+  | { type: "transcript-cached"; beatId: string; path: string }
+  | { type: "transcript-skipped"; beatId: string; reason: string }
   | { type: "backdrop-cached"; beatId: string; path: string }
   | { type: "backdrop-generated"; beatId: string; path: string; provider: string }
   | { type: "backdrop-failed"; beatId: string; error: string }
@@ -259,6 +264,13 @@ export interface SceneBuildOptions {
   skipKeyframe?: boolean;
   /** Skip music generation even when beats declare music cues. */
   skipMusic?: boolean;
+  /**
+   * Skip Whisper word-level transcription of generated narration. Default is
+   * to transcribe whenever narration exists and an OpenAI key is configured,
+   * writing `assets/transcript-<beat>.json` so the composer can sync caption /
+   * kinetic-type reveals to speech. Pass true to opt out (no transcribe cost).
+   */
+  skipTranscript?: boolean;
   /** OpenAI image quality — see `vibe generate image --quality`. */
   imageQuality?: "standard" | "hd";
   /** OpenAI image size. Default 1536x1024 for cinematic 16:9-ish framing. */
@@ -629,6 +641,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
           skipVideo: opts.skipVideo ?? false,
           skipKeyframe: opts.skipKeyframe ?? false,
           skipMusic: opts.skipMusic ?? false,
+          skipTranscript: opts.skipTranscript ?? false,
           force: opts.force ?? false,
           onProgress,
           characterPaths,
@@ -1062,6 +1075,7 @@ interface BeatDispatchContext {
   skipVideo: boolean;
   skipKeyframe: boolean;
   skipMusic: boolean;
+  skipTranscript: boolean;
   force: boolean;
   onProgress: (e: SceneBuildProgressEvent) => void;
   /** name → relative path of generated/supplied character reference images. */
@@ -1095,6 +1109,12 @@ async function buildBeatPrimitives(
       : dispatchVideo(beat, ctx, keyframe),
     ctx.skipMusic ? skipped("music", beat.id, "--skip-music", ctx) : dispatchMusic(beat, ctx),
   ]);
+  // Word-level transcript depends on the narration audio, so it runs after the
+  // primitive fan-out (not inside it). Best-effort: a failure or missing key
+  // leaves the beat without word-sync timings but never fails the build.
+  if (!ctx.skipTranscript) {
+    await dispatchTranscript(beat, narration, ctx);
+  }
   return {
     outcome: {
       beatId: beat.id,
@@ -1378,6 +1398,62 @@ async function dispatchNarration(beat: Beat, ctx: BeatDispatchContext): Promise<
     metadataPath,
     freshness: "fresh",
   };
+}
+
+/**
+ * Whisper word-level transcription of a beat's generated narration. Writes
+ * `assets/transcript-<beat>.json` (the same shape `vibe scene add` produces),
+ * which the compose stage reads to drive word-synced caption / kinetic-type
+ * animations. Entirely best-effort:
+ *   - no narration → nothing to transcribe.
+ *   - no OpenAI key → skip with a hint (narration still plays).
+ *   - transcript exists + narration not freshly regenerated + not forced →
+ *     reuse the cached file (no re-transcribe cost).
+ *   - API failure / no words → skip; the composer just omits word-sync.
+ */
+async function dispatchTranscript(
+  beat: Beat,
+  narration: PrimitiveOutcome,
+  ctx: BeatDispatchContext
+): Promise<void> {
+  if (!narration.path) return;
+
+  const relPath = beatTranscriptRelPath(beat.id);
+  const abs = join(ctx.projectDir, relPath);
+  const narrationFresh = narration.status === "generated";
+  if (existsSync(abs) && !ctx.force && !narrationFresh) {
+    ctx.onProgress({ type: "transcript-cached", beatId: beat.id, path: relPath });
+    return;
+  }
+
+  const apiKey = await getConfiguredApiKey("OPENAI_API_KEY", undefined, { cwd: ctx.projectDir });
+  if (!apiKey) {
+    ctx.onProgress({
+      type: "transcript-skipped",
+      beatId: beat.id,
+      reason: "OPENAI_API_KEY not set — narration plays but word-sync timings unavailable",
+    });
+    return;
+  }
+
+  const words = await transcribeNarrationWords(join(ctx.projectDir, narration.path), { apiKey });
+  if (words.length === 0) {
+    ctx.onProgress({
+      type: "transcript-skipped",
+      beatId: beat.id,
+      reason: "transcription returned no word timings",
+    });
+    return;
+  }
+
+  await mkdir(dirname(abs), { recursive: true });
+  await writeFile(abs, JSON.stringify(words, null, 2), "utf-8");
+  ctx.onProgress({
+    type: "transcript-generated",
+    beatId: beat.id,
+    path: relPath,
+    wordCount: words.length,
+  });
 }
 
 interface CharacterBuildResult {

--- a/packages/cli/src/commands/_shared/transcribe-narration.test.ts
+++ b/packages/cli/src/commands/_shared/transcribe-narration.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  beatTranscriptRelPath,
+  readBeatTranscript,
+  transcribeNarrationWords,
+} from "./transcribe-narration.js";
+
+describe("beatTranscriptRelPath", () => {
+  it("maps a beat id to the canonical assets path", () => {
+    expect(beatTranscriptRelPath("hook")).toBe("assets/transcript-hook.json");
+  });
+});
+
+describe("readBeatTranscript", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "transcribe-narration-test-"));
+    mkdirSync(join(projectDir, "assets"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function seedTranscript(beatId: string, content: string): void {
+    writeFileSync(join(projectDir, beatTranscriptRelPath(beatId)), content, "utf-8");
+  }
+
+  it("returns undefined when the transcript file is missing", async () => {
+    expect(await readBeatTranscript(projectDir, "hook")).toBeUndefined();
+  });
+
+  it("reads a well-formed word-level transcript", async () => {
+    seedTranscript(
+      "hook",
+      JSON.stringify([
+        { text: "Ship", start: 0, end: 0.4 },
+        { text: "faster", start: 0.4, end: 0.9 },
+      ])
+    );
+    const words = await readBeatTranscript(projectDir, "hook");
+    expect(words).toEqual([
+      { text: "Ship", start: 0, end: 0.4 },
+      { text: "faster", start: 0.4, end: 0.9 },
+    ]);
+  });
+
+  it("drops malformed entries and keeps the valid ones", async () => {
+    seedTranscript(
+      "hook",
+      JSON.stringify([
+        { text: "ok", start: 0, end: 0.3 },
+        { text: "missing-times" },
+        { start: 1, end: 2 },
+        { text: "nan", start: Number.NaN, end: 1 },
+        { text: "good", start: 1, end: 1.5 },
+      ])
+    );
+    const words = await readBeatTranscript(projectDir, "hook");
+    expect(words).toEqual([
+      { text: "ok", start: 0, end: 0.3 },
+      { text: "good", start: 1, end: 1.5 },
+    ]);
+  });
+
+  it("returns undefined for non-array / malformed JSON", async () => {
+    seedTranscript("a", "{ not: valid json");
+    seedTranscript("b", JSON.stringify({ text: "x", start: 0, end: 1 }));
+    seedTranscript("c", JSON.stringify([]));
+    expect(await readBeatTranscript(projectDir, "a")).toBeUndefined();
+    expect(await readBeatTranscript(projectDir, "b")).toBeUndefined();
+    expect(await readBeatTranscript(projectDir, "c")).toBeUndefined();
+  });
+});
+
+describe("transcribeNarrationWords", () => {
+  it("returns [] (non-fatal) when the audio file cannot be read", async () => {
+    const words = await transcribeNarrationWords("/nonexistent/path/narration.wav", {
+      apiKey: "sk-test-unused",
+    });
+    expect(words).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/_shared/transcribe-narration.ts
+++ b/packages/cli/src/commands/_shared/transcribe-narration.ts
@@ -1,0 +1,91 @@
+/**
+ * @module _shared/transcribe-narration
+ *
+ * Shared narration → word-level transcript helpers, used by both
+ * `vibe scene add` (deterministic emit path) and `vibe build` (LLM compose
+ * path). Whisper transcription of the generated narration audio is the
+ * single, provider-agnostic source of word timings: every TTS provider
+ * (kokoro / openai / elevenlabs) writes a `.wav`/`.mp3`, and word timings let
+ * the composer sync captions / kinetic typography to speech.
+ *
+ * Failure is always non-fatal — narration still plays; callers treat the
+ * absence of timings as "no word-sync available", never as a build error.
+ */
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { WhisperProvider } from "@vibeframe/ai-providers";
+
+import type { SceneTranscriptWord } from "./scene-html-emit.js";
+
+export interface TranscribeNarrationOptions {
+  /** OpenAI API key for Whisper. */
+  apiKey: string;
+  /** Optional BCP-47 language hint passed to Whisper (auto-detect when unset). */
+  language?: string;
+}
+
+/**
+ * Transcribe a narration audio file to word-level timings. Returns an empty
+ * array on ANY failure (no words, API error, bad audio) so callers can treat
+ * the absence of timings as "no word-sync available" rather than abort.
+ */
+export async function transcribeNarrationWords(
+  audioAbsPath: string,
+  opts: TranscribeNarrationOptions
+): Promise<SceneTranscriptWord[]> {
+  try {
+    const whisper = new WhisperProvider();
+    await whisper.initialize({ apiKey: opts.apiKey });
+    const audioBytes = await readFile(audioAbsPath);
+    const audioBlob = new Blob([new Uint8Array(audioBytes)]);
+    const transcript = await whisper.transcribe(audioBlob, undefined, {
+      granularity: "word",
+      language: opts.language,
+    });
+    if (transcript.status === "completed" && transcript.words?.length) {
+      return transcript.words.map((w) => ({ text: w.text, start: w.start, end: w.end }));
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/** Canonical per-beat transcript path, relative to the project root. */
+export function beatTranscriptRelPath(beatId: string): string {
+  return `assets/transcript-${beatId}.json`;
+}
+
+/**
+ * Read a previously generated `assets/transcript-<beatId>.json` from disk.
+ * Returns `undefined` when the file is missing or malformed — compose then
+ * proceeds without word timings (identical to a project that never
+ * transcribed). Validates each entry's shape so a hand-edited or partial file
+ * can't inject `NaN`/`undefined` timings into the prompt.
+ */
+export async function readBeatTranscript(
+  projectDir: string,
+  beatId: string
+): Promise<SceneTranscriptWord[] | undefined> {
+  const abs = join(projectDir, beatTranscriptRelPath(beatId));
+  if (!existsSync(abs)) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(await readFile(abs, "utf-8"));
+    if (!Array.isArray(parsed)) return undefined;
+    const words = parsed
+      .filter(
+        (w): w is SceneTranscriptWord =>
+          typeof w === "object" &&
+          w !== null &&
+          typeof (w as SceneTranscriptWord).text === "string" &&
+          Number.isFinite((w as SceneTranscriptWord).start) &&
+          Number.isFinite((w as SceneTranscriptWord).end)
+      )
+      .map((w) => ({ text: w.text, start: w.start, end: w.end }));
+    return words.length > 0 ? words : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -51,6 +51,10 @@ export const buildCommand = new Command("build")
     "Don't generate keyframe stills (review keyframes first with --skip-video, then build)"
   )
   .option("--skip-music", "Don't dispatch music generation even when beats declare music cues")
+  .option(
+    "--skip-transcript",
+    "Don't transcribe narration for word-sync (default: transcribe when narration + OpenAI key exist)"
+  )
   .option("--skip-render", "Compose only — don't render to MP4")
   .option("--tts <provider>", "TTS provider: auto|elevenlabs|openai|kokoro")
   .option("--voice <id>", "Voice id")
@@ -125,6 +129,7 @@ Advanced equivalent: \`vibe scene build\`.`
       skipVideo: options.skipVideo ?? false,
       skipKeyframe: options.skipKeyframe ?? false,
       skipMusic: options.skipMusic ?? false,
+      skipTranscript: options.skipTranscript ?? false,
       skipRender: options.skipRender ?? false,
       ttsProvider: options.tts,
       voice: options.voice,
@@ -147,6 +152,7 @@ Advanced equivalent: \`vibe scene build\`.`
         skipVideo: options.skipVideo,
         skipKeyframe: options.skipKeyframe,
         skipMusic: options.skipMusic,
+        skipTranscript: options.skipTranscript,
         ttsProvider: options.tts,
         voice: options.voice,
         imageProvider,
@@ -239,6 +245,7 @@ Advanced equivalent: \`vibe scene build\`.`
       skipVideo: options.skipVideo,
       skipKeyframe: options.skipKeyframe,
       skipMusic: options.skipMusic,
+      skipTranscript: options.skipTranscript,
       skipRender: options.skipRender,
       ttsProvider: options.tts,
       voice: options.voice,
@@ -251,6 +258,8 @@ Advanced equivalent: \`vibe scene build\`.`
       onProgress: (e: SceneBuildProgressEvent) => {
         if (!spinner) return;
         if (e.type === "phase-start") spinner.text = `Phase: ${e.phase}...`;
+        else if (e.type === "transcript-generated")
+          spinner.text = `Transcribed narration: ${e.beatId} (${e.wordCount} words)`;
         else if (e.type === "render-done") spinner.text = `Rendered: ${e.outputPath}`;
       },
     });
@@ -298,6 +307,7 @@ type BuildDryRunParams = {
   skipVideo: boolean;
   skipKeyframe: boolean;
   skipMusic: boolean;
+  skipTranscript: boolean;
   skipRender: boolean;
   ttsProvider: unknown;
   voice: unknown;

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -23,7 +23,7 @@ import { mkdir, readFile, writeFile, access, copyFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import chalk from "chalk";
 import ora from "ora";
-import { GeminiProvider, OpenAIImageProvider, WhisperProvider } from "@vibeframe/ai-providers";
+import { GeminiProvider, OpenAIImageProvider } from "@vibeframe/ai-providers";
 import {
   resolveTtsProvider,
   TtsKeyMissingError,
@@ -64,6 +64,10 @@ import {
   type InstallSkillHost,
 } from "./_shared/install-skill.js";
 import { getComposePrompts } from "./_shared/compose-prompts.js";
+import {
+  transcribeNarrationWords,
+  beatTranscriptRelPath,
+} from "./_shared/transcribe-narration.js";
 import { executeSceneSubmit } from "./_shared/scene-submit.js";
 import { executeSceneRepair } from "./_shared/scene-repair.js";
 import {
@@ -963,31 +967,20 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
       );
     } else {
       opts.onProgress?.("Transcribing narration (Whisper word-level)...");
-      try {
-        const whisper = new WhisperProvider();
-        await whisper.initialize({ apiKey: whisperKey });
-        const audioBytes = await readFile(audioAbsPath);
-        const audioBlob = new Blob([new Uint8Array(audioBytes)]);
-        const transcript = await whisper.transcribe(audioBlob, undefined, {
-          granularity: "word",
-          language: opts.transcribeLanguage,
-        });
-        if (transcript.status === "completed" && transcript.words?.length) {
-          transcriptRelPath = `assets/transcript-${id}.json`;
-          const transcriptAbs = resolve(projectDir, transcriptRelPath);
-          await writeFile(transcriptAbs, JSON.stringify(transcript.words, null, 2), "utf-8");
-          transcriptWordCount = transcript.words.length;
-          transcriptWords = transcript.words.map((w) => ({
-            text: w.text,
-            start: w.start,
-            end: w.end,
-          }));
-        } else if (transcript.status === "failed") {
-          opts.onProgress?.(`Transcribe failed: ${transcript.error ?? "unknown error"}`);
-        }
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        opts.onProgress?.(`Transcribe failed: ${msg}`);
+      const words = await transcribeNarrationWords(audioAbsPath, {
+        apiKey: whisperKey,
+        language: opts.transcribeLanguage,
+      });
+      if (words.length > 0) {
+        transcriptRelPath = beatTranscriptRelPath(id);
+        const transcriptAbs = resolve(projectDir, transcriptRelPath);
+        await writeFile(transcriptAbs, JSON.stringify(words, null, 2), "utf-8");
+        transcriptWordCount = words.length;
+        transcriptWords = words;
+      } else {
+        opts.onProgress?.(
+          "Transcribe produced no word timings — narration plays without word-sync"
+        );
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.10",
+  "version": "0.113.11",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.10",
+  "version": "0.113.11",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.10",
+  "version": "0.113.11",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Closes the `vibe build` half of #204 — word-synced caption / kinetic-type animations.

## What
The LLM composer now receives Whisper **word-level narration timings** so it can sync word reveals to speech. The deterministic `vibe scene add` emit path already did this; `vibe build` did not.

## How
- **New `_shared/transcribe-narration.ts`** — `transcribeNarrationWords()` (provider-agnostic Whisper word-level transcription of generated narration), `readBeatTranscript()`, `beatTranscriptRelPath()`. The inline transcribe block in `vibe scene add` is refactored to reuse it (single source of truth).
- **Asset stage `dispatchTranscript()`** — after narration, transcribe to `assets/transcript-<beat>.json` when narration exists **and** an OpenAI key is configured. Cached (skipped when the file exists and narration wasn't freshly regenerated); best-effort (no key / no words → skip, never fails the build). Opt out with `--skip-transcript`.
- **Prompt injection (`formatTranscriptSection`)** — compact, deterministic timing section with a **token-budget guard**: word-level `[start, "word"]` table at/below 120 words; phrase-level *approximate* anchors above. Folded into the user prompt → the compose **cache key invalidates** when timings change. Carries the existing visual-sync-only guard (no `<audio>`/SFX).
- **Host-agent path (`compose-prompts`)** — exposes `transcriptPath` and feeds the same timings into its prompt.

## Behavior
- Default **on** when narration + OpenAI key exist; `--skip-transcript` opts out. No key → graceful skip (narration still plays, no word-sync). Transcription is `low`/negligible cost (~\$0.002/beat).

## Tests
- `formatTranscriptSection`: no / short / oversized transcript + clamping/rounding.
- `buildUserPrompt`: section omitted without transcript, word-level with, cache-key changes when transcript changes.
- asset stage: writes `transcript-<beat>.json` when words exist; `--skip-transcript` writes nothing.
- `readBeatTranscript` / path helper / non-fatal failure path.
- `vibe build --describe` schema snapshot updated for `--skip-transcript`.

## Notes / follow-ups
- Dry-run does not itemise the (~\$0.002/beat) transcription cost as a separate line — intentional, below plan rounding noise.
- LLM prompt-tuning for how aggressively it uses the timings is a separate quality pass.