### PR TITLE
docs: sync agent docs with current CLI/MCP surface

### DIFF
--- a/.agents/skills/vibe-scene/SKILL.md
+++ b/.agents/skills/vibe-scene/SKILL.md
@@ -94,10 +94,29 @@ vibe scene install-skill my-video --host auto
 vibe scene compose-prompts my-video --json
 vibe scene list-styles
 vibe scene add intro --project my-video --style announcement --headline "Hello"
+vibe scene add badge --project my-video --style simple --lottie assets/logo.lottie --lottie-position bottom-left
 vibe scene lint index.html --project my-video --json --fix
 ```
 
 Run `vibe schema scene.<subcommand>` before using less common flags.
+
+Overlay a Lottie animation (`.json`/`.lottie`) on a scene with `--lottie <path>`,
+tuned by `--lottie-position` (full|center|top-left|top-right|bottom-left|bottom-right),
+`--lottie-scale`, `--lottie-opacity`, and `--lottie-no-loop`. It renders as a
+`<dotlottie-wc>` overlay (no provider call — free).
+
+## Narration Word-Sync
+
+During `vibe build`, generated narration is transcribed at the word level
+(Whisper) to `assets/transcript-<beat>.json` whenever narration exists and an
+OpenAI key is configured. Those word timings are passed into each beat's compose
+prompt so captions / kinetic typography can be synced to speech.
+
+- On by default; pass `--skip-transcript` to opt out (no transcription cost).
+- No OpenAI key → silently skipped; narration still plays, just without
+  word-level animation timing.
+- Timings are advisory and visual-only — the composer never adds audio/SFX from
+  them. For long narration the prompt downgrades to coarse phrase-level anchors.
 
 ## STYLE And STORYBOARD Guidance
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -30,7 +30,8 @@ keeps them in sync — see `docs/agent-hosts.md`.
 │   ├── version-checker.md     # SSOT sync validation (haiku)
 │   ├── lint-fixer.md          # Fix ESLint errors (haiku)
 │   ├── e2e-tester.md          # Full E2E testing (sonnet, 60 turns)
-│   └── feature-tester.md      # Single-feature testing (haiku)
+│   ├── feature-tester.md      # Single-feature testing (sonnet, 30 turns)
+│   └── readme-writer.md       # Write/clean developer-facing docs (sonnet)
 └── skills/                    # Generated workflow skills (user-invocable)
     ├── test/SKILL.md          # /test — run tests
     ├── release/SKILL.md       # /release — version bump workflow
@@ -123,12 +124,15 @@ keeps them in sync — see `docs/agent-hosts.md`.
 
 Enabled in `settings.json` under `enabledPlugins`:
 
-| Plugin              | Provides                                           |
-| ------------------- | -------------------------------------------------- |
-| `claude-code-setup` | `claude-automation-recommender` skill              |
-| `code-review`       | `/code-review` skill for PR review                 |
-| `code-simplifier`   | `simplify` skill for review-and-fix                |
-| `security-guidance` | `/security-review` skill for branch security audit |
+| Plugin                | Provides                                           |
+| --------------------- | -------------------------------------------------- |
+| `claude-code-setup`   | `claude-automation-recommender` skill              |
+| `code-review`         | `/code-review` skill for PR review                 |
+| `code-simplifier`     | `simplify` skill for review-and-fix                |
+| `security-guidance`   | `/security-review` skill for branch security audit |
+| `playwright`          | Browser automation tools (MCP)                     |
+| `claude-md-management`| `/revise-claude-md` + CLAUDE.md audit skills       |
+| `typescript-lsp`      | TypeScript language-server tools                   |
 
 ## Adding New Components
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -25,9 +25,11 @@ paths:
 
 The canonical user-facing workflow commands are:
 
-- Project video flow: `init`, `build`, `render`
+- Project video flow: `init`, `plan`, `build`, `render` (edit beats with
+  `storyboard`, poll async work with `status`)
 - One-shot media: `generate`, `edit`, `inspect`, `audio`, `remix`
 - Automation: `run`, `agent`, `schema`, `context`, `guide`
+- Setup & hosts: `setup`, `doctor`, `host`
 - Lower-level operations: `scene`, `timeline`, `detect`, `batch`, `media`
 
 Do not introduce new docs or agent instructions that use removed namespaces such

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -83,6 +83,8 @@
     "code-review@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true
+    "playwright@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
   }
 }

--- a/.claude/skills/vibe-scene/SKILL.md
+++ b/.claude/skills/vibe-scene/SKILL.md
@@ -96,10 +96,29 @@ vibe scene install-skill my-video --host auto
 vibe scene compose-prompts my-video --json
 vibe scene list-styles
 vibe scene add intro --project my-video --style announcement --headline "Hello"
+vibe scene add badge --project my-video --style simple --lottie assets/logo.lottie --lottie-position bottom-left
 vibe scene lint index.html --project my-video --json --fix
 ```
 
 Run `vibe schema scene.<subcommand>` before using less common flags.
+
+Overlay a Lottie animation (`.json`/`.lottie`) on a scene with `--lottie <path>`,
+tuned by `--lottie-position` (full|center|top-left|top-right|bottom-left|bottom-right),
+`--lottie-scale`, `--lottie-opacity`, and `--lottie-no-loop`. It renders as a
+`<dotlottie-wc>` overlay (no provider call — free).
+
+## Narration Word-Sync
+
+During `vibe build`, generated narration is transcribed at the word level
+(Whisper) to `assets/transcript-<beat>.json` whenever narration exists and an
+OpenAI key is configured. Those word timings are passed into each beat's compose
+prompt so captions / kinetic typography can be synced to speech.
+
+- On by default; pass `--skip-transcript` to opt out (no transcription cost).
+- No OpenAI key → silently skipped; narration still plays, just without
+  word-level animation timing.
+- Timings are advisory and visual-only — the composer never adds audio/SFX from
+  them. For long narration the prompt downgrades to coarse phrase-level anchors.
 
 ## STYLE And STORYBOARD Guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,11 @@ CLI command availability and parameters.
 
 Canonical user-facing workflows:
 
-- Project video flow: `init`, `build`, `render`
+- Project video flow: `init`, `plan`, `build`, `render` (edit beats with
+  `storyboard`, poll async work with `status`)
 - One-shot media: `generate`, `edit`, `inspect`, `audio`, `remix`
 - Automation: `run`, `agent`, `schema`, `context`, `guide`
+- Setup & hosts: `setup`, `doctor`, `host`
 - Lower-level operations: `scene`, `timeline`, `detect`, `batch`, `media`
 
 Do not introduce docs, examples, or agent instructions that use removed


### PR DESCRIPTION
Bring AGENTS.md and .claude/ in line with what the CLI/MCP actually expose
after the word-sync (#204) and tooling changes this session.

- AGENTS.md + .claude/rules/architecture.md: complete the canonical CLI Shape
  list — add the public groups that were missing (`plan`, `storyboard`,
  `status`, `setup`, `doctor`, `host`). No listed command was wrong; the
  list was just incomplete. AGENTS.md stays lean (no feature lists; `vibe
  schema` remains the SSOT).
- .agents/skills/vibe-scene/SKILL.md (+ regenerated .claude copy via
  agent-sync): document the `--lottie` overlay flags on `vibe scene add` and
  the narration word-sync transcript (`--skip-transcript`,
  assets/transcript-<beat>.json) wired into per-beat compose prompts.
- .claude/README.md: add the readme-writer agent, fix the feature-tester model
  label (haiku -> sonnet/30), and refresh the Plugins table (playwright,
  claude-md-management, typescript-lsp).
- .claude/settings.json: enable the claude-md-management + typescript-lsp
  plugins installed this session.

agent-sync:check passes; every documented command/flag verified against the
built CLI.
