### PR TITLE
refactor: host-agnostic agent-loop language (drop invented /goal naming)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,11 +52,11 @@ namespaces such as `vibe ai`, `vibe project`, `vibe export`, or `vibe pipeline`.
 
 When invoking VibeFrame commands from an agent context:
 
-- Treat native Codex Goal mode, Claude Code `/goal`, Cursor agent loops, or
-  another host's equivalent as the outer loop for long-running video work.
+- Treat your host's agent loop (Claude Code, Codex, Cursor, or another
+  coding-agent host) as the outer loop for long-running video work.
   VibeFrame should provide video-specific commands, JSON reports, cost gates,
   deterministic repair, render inspection, and `nextActions`/`fixOwner`
-  recovery contracts, not a competing primary goal runner.
+  recovery contracts, not a competing primary agent loop.
 - Prefer `--json` for structured output.
 - Run `--dry-run` before paid or mutating operations when the command supports it.
 - When a review report includes `nextActions`, prefer it over inventing

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ vibe run promo.yaml --resume
 
 ## Agent Workflows
 
-The intended agent path: use the host's native goal mode as the outer loop,
+The intended agent path: use your host's agent loop as the outer loop,
 drive VibeFrame CLI commands with `--json`, and use `build-report.json` and
 `review-report.json` as loop state.
 
@@ -341,12 +341,13 @@ run `safeToAutoRun:true` actions automatically, ask before
 `fixOwner:"host-agent"` means the outer loop (or a human) must edit
 `STORYBOARD.md`, `DESIGN.md`, or compositions.
 
-### Goal mode prompts
+### Outer-loop agent prompts
 
-For Codex:
+Hand your coding agent a prompt like the following — these are plain prompts,
+not a built-in command. For Codex:
 
 ```text
-/goal Build launch/ into a reviewed VibeFrame MP4 from brief.md.
+Build launch/ into a reviewed VibeFrame MP4 from brief.md.
 Use vibe context/schema first when command details are unclear. Use --json for
 all vibe commands. Run --dry-run before paid operations and keep generated-asset
 spend under $5 with --max-cost 5 where supported. Read build-report.json and
@@ -366,8 +367,8 @@ intentionally accepted with a written reason, or reported as blocked.
 For Claude Code:
 
 ```text
-/goal Create the final VibeFrame project render for launch/ using the native
-Claude Code goal loop as the outer loop. Use vibe commands with --json, run
+Create the final VibeFrame project render for launch/ using your host's agent
+loop as the outer loop. Use vibe commands with --json, run
 dry-run before paid operations, cap build spend at $5 with --max-cost 5, and
 use build-report.json plus review-report.json as the loop state. Follow
 nextActions first, run only safeToAutoRun:true actions automatically, ask

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ vibe host setup all
 vibe host doctor all --json
 ```
 
-For long-running project builds, use the host's native goal mode as the outer
-loop. Codex `/goal` and Claude Code `/goal` should track the objective and stop
-conditions; VibeFrame provides `--json` commands, dry runs, budget caps,
+For long-running project builds, use your host's agent loop as the outer
+loop. The host agent (Claude Code, Codex, Cursor, or another coding-agent host)
+tracks the objective and stop conditions; VibeFrame provides `--json` commands, dry runs, budget caps,
 `build-report.json`, `review-report.json`, `retryWith`, `fixOwner`, repair
 commands, and render inspection.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -17,7 +17,8 @@ and `DESIGN.md` are the source of truth; generated files under
 `compositions/` are artifacts. Use `vibe storyboard revise --dry-run`
 for project-aware STORYBOARD.md rewrites, `vibe storyboard *` for narrow
 cue edits, and direct Markdown edits for larger DESIGN.md rewrites.
-Native Codex Goal mode and Claude Code `/goal` are the outer loop for
+Your host's agent loop (Claude Code, Codex, Cursor, or another coding-agent
+host) is the outer loop for
 long-running work. VibeFrame provides the video-specific command surface,
 machine reports, cost gates, deterministic repair, render inspection, and
 `retryWith` hints those hosts use to decide the next step and when to stop.
@@ -29,10 +30,10 @@ scene / timeline                                            ← lower-level auth
 run / agent / schema / context                              ← automation + agents
 ```
 
-Canonical native-goal loop:
+Canonical outer-loop:
 
 ```
-native host goal → vibe context/schema → plan dry-run → build with budget
+host agent loop → vibe context/schema → plan dry-run → build with budget
 → status polling → inspect project → render → inspect render
 → repair/edit using nextActions/fixOwner → repeat until stop rules pass
 ```
@@ -72,9 +73,9 @@ preferred agent contract: run only `safeToAutoRun:true` actions automatically,
 ask before `requiresConfirmation:true`, and use `retryWith` only as the
 compatibility fallback. Issue-level `fixOwner:"vibe"` means deterministic CLI
 recovery; `fixOwner:"host-agent"` means storyboard/design/composition edits
-should be handled by the host agent. A host-native goal should stop only after
+should be handled by the host agent. The outer loop should stop only after
 the final MP4 exists, duration and aspect ratio match the brief, render
-inspection has no errors, any AI review score meets the goal threshold when AI
+inspection has no errors, any AI review score meets the review threshold when AI
 review is requested, and every host-agent issue is fixed, accepted with
 rationale, or reported as blocked.
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -25,22 +25,22 @@ vibe build my-video --max-cost 5
 vibe render my-video -o renders/final.mp4
 ```
 
-## Native Host Goal Loop
+## Host Agent Loop
 
-Use Codex `/goal`, Claude Code `/goal`, Cursor, or another host-native goal
-feature as the outer loop for multi-step video builds. VibeFrame should not
+Use your host's agent loop (Claude Code, Codex, Cursor, or another coding-agent
+host) as the outer loop for multi-step video builds. VibeFrame should not
 compete with that loop. It should expose machine-readable state and recovery
 paths:
 
 ```text
-native host goal -> vibe context/schema -> plan dry-run -> build with budget
+host agent loop -> vibe context/schema -> plan dry-run -> build with budget
 -> status polling -> inspect project -> render -> inspect render
 -> repair/edit using nextActions/fixOwner -> repeat
 ```
 
-The goal should stop only when the final MP4 path exists, duration and aspect
+The outer loop should stop only when the final MP4 path exists, duration and aspect
 ratio match the brief, render inspection has no errors, any AI review score
-meets the goal threshold when AI review is requested, and unresolved
+meets the review threshold when AI review is requested, and unresolved
 `fixOwner:"host-agent"` issues are fixed,
 accepted with rationale, or reported as blocked. Agents should read
 `build-report.json` and `review-report.json` before choosing the next action
@@ -67,7 +67,7 @@ whose `nextActions` are pre-classified so the host loop never has to guess:
     {
       "kind": "command",
       "command": "vibe generate video ... --json",
-      "fixOwner": "host-agent",  // the outer goal loop owns this
+      "fixOwner": "host-agent",  // the outer agent loop owns this
       "costTier": "very-high",
       "safeToAutoRun": false,
       "requiresConfirmation": true,  // → ask the user before spending

--- a/packages/cli/CONTEXT.md
+++ b/packages/cli/CONTEXT.md
@@ -5,8 +5,9 @@
 VibeFrame CLI (`vibe`) is a CLI-first video toolkit. Every operation is
 a shell command. The same surface is exposed as MCP tools through
 [`@vibeframe/mcp-server`](https://www.npmjs.com/package/@vibeframe/mcp-server).
-For long-running video work, native Codex Goal mode and Claude Code `/goal`
-should own the outer loop: persistence, iteration, and stop decisions.
+For long-running video work, your host's agent loop (Claude Code, Codex,
+Cursor, or another coding-agent host) should own the outer loop: persistence,
+iteration, and stop decisions.
 VibeFrame owns the video-specific command surface, JSON reports, cost gates,
 deterministic repair, render inspection, and `retryWith` recovery hints.
 
@@ -15,21 +16,21 @@ For the full reference (every flag, default, enum), read
 from `vibe schema --list`. This file is the _agent quickstart_: rules,
 conventions, and discovery hooks.
 
-## Native host goal loop
+## Host agent loop
 
-Use the host's native goal feature rather than inventing a VibeFrame-owned
-goal runner. The canonical loop is:
+Use your host's agent loop as the outer loop rather than inventing a
+VibeFrame-owned loop. The canonical loop is:
 
 ```text
-native host goal -> vibe context/schema -> plan dry-run -> build with budget
+host agent loop -> vibe context/schema -> plan dry-run -> build with budget
 -> status polling -> inspect project -> render -> inspect render
 -> repair/edit using nextActions/fixOwner -> repeat until stop rules pass
 ```
 
-Copy-paste Codex goal:
+Copy-paste agent prompt (Codex) — a plain prompt, not a built-in command:
 
 ```text
-/goal Build my-video/ into a reviewed VibeFrame MP4. Use --json for every vibe
+Build my-video/ into a reviewed VibeFrame MP4. Use --json for every vibe
 command, run --dry-run before paid operations, cap generated-asset spend with
 --max-cost 5 where supported, and read build-report.json plus
 review-report.json before deciding the next action. Prefer nextActions: run
@@ -43,10 +44,10 @@ AI review score is >= 90 when AI review is requested, and unresolved host-agent 
 accepted with a written reason, or reported as blocked.
 ```
 
-Copy-paste Claude Code goal:
+Copy-paste agent prompt (Claude Code) — a plain prompt, not a built-in command:
 
 ```text
-/goal Finish the VibeFrame render for my-video/ using Claude Code goal mode as
+Finish the VibeFrame render for my-video/ using your host's agent loop as
 the outer loop. Use vibe context/schema when unsure, --json everywhere,
 dry-run before paid operations, --max-cost 5 for builds, nextActions before
 custom recovery, and build-report.json/review-report.json as loop state.
@@ -223,7 +224,7 @@ Review report contract:
 for storyboard/design/composition edits the host agent should make. Prefer
 `nextActions` first: run only `safeToAutoRun:true` actions automatically, ask
 before `requiresConfirmation:true`, and use `retryWith` only as the fallback.
-A host-native goal should not stop while `host-agent` issues remain unless
+The outer loop should not stop while `host-agent` issues remain unless
 they are fixed, intentionally accepted with a written reason, or reported as
 blocked.
 

--- a/packages/cli/src/commands/_shared/host-integration.ts
+++ b/packages/cli/src/commands/_shared/host-integration.ts
@@ -88,7 +88,7 @@ export function hostDefinitions(_projectDir = process.cwd()): HostDefinition[] {
       configKind: "codex-toml",
       notes: [
         "Codex reads AGENTS.md and can also load project-scoped .codex/config.toml after the project is trusted.",
-        "Use Codex /goal as the outer loop for long-running VibeFrame projects; vibe supplies JSON reports, nextActions classified by cost/safety (prefer these), retryWith as a compatibility fallback, and repair commands.",
+        "Use Codex's agent loop as the outer loop for long-running VibeFrame projects; vibe supplies JSON reports, nextActions classified by cost/safety (prefer these), retryWith as a compatibility fallback, and repair commands.",
         "Keep provider/auth keys in VibeFrame config or environment, not in project-local Codex config.",
       ],
     },
@@ -101,7 +101,7 @@ export function hostDefinitions(_projectDir = process.cwd()): HostDefinition[] {
       configKind: "mcp-json",
       notes: [
         "Claude Code can drive vibe directly through shell plus AGENTS.md/CLAUDE.md.",
-        "Use Claude Code /goal as the outer loop for long-running VibeFrame projects; vibe supplies JSON reports, nextActions classified by cost/safety (prefer these), retryWith as a compatibility fallback, and repair commands.",
+        "Use Claude Code's agent loop as the outer loop for long-running VibeFrame projects; vibe supplies JSON reports, nextActions classified by cost/safety (prefer these), retryWith as a compatibility fallback, and repair commands.",
         "The MCP entry is optional and gives Claude Code a typed tool surface.",
       ],
     },
@@ -435,14 +435,14 @@ function hostNextSteps(host: HostDefinition): string[] {
     return [
       "Trust the project in Codex so .codex/config.toml is loaded.",
       "Run /mcp in Codex to confirm the vibeframe server is connected.",
-      "Use /goal with the project AGENTS.md stop rules for long-running video builds.",
+      "Use Codex's agent loop with the project AGENTS.md stop rules for long-running video builds.",
     ];
   }
   if (host.id === "claude-code") {
     return [
       "Restart Claude Code or run /mcp to approve the project-scoped server.",
       "Use AGENTS.md/CLAUDE.md for shell-driven vibe workflows.",
-      "Use /goal with the project AGENTS.md stop rules for long-running video builds.",
+      "Use Claude Code's agent loop with the project AGENTS.md stop rules for long-running video builds.",
     ];
   }
   if (host.id === "claude-desktop") {

--- a/packages/cli/src/commands/_shared/init-templates.test.ts
+++ b/packages/cli/src/commands/_shared/init-templates.test.ts
@@ -31,10 +31,13 @@ describe("AGENTS_MD template", () => {
     expect(AGENTS_MD).toContain("--stdin");
   });
 
-  it("documents native host goal loops and strict stop rules", () => {
-    expect(AGENTS_MD).toContain("Native host goal loop");
-    expect(AGENTS_MD).toContain("Codex Goal mode");
-    expect(AGENTS_MD).toContain("Claude Code `/goal`");
+  it("documents the host agent loop and strict stop rules", () => {
+    expect(AGENTS_MD).toContain("Host agent loop");
+    expect(AGENTS_MD).toContain("your host's agent loop");
+    expect(AGENTS_MD).toContain("as the outer loop");
+    // No invented host-specific feature names (Claude Code has no `/goal`).
+    expect(AGENTS_MD).not.toContain("/goal");
+    expect(AGENTS_MD).not.toContain("Goal mode");
     expect(AGENTS_MD).toContain("build-report.json");
     expect(AGENTS_MD).toContain("review-report.json");
     expect(AGENTS_MD).toContain("nextActions");

--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -200,19 +200,19 @@ Default setup is snippet-only; use \`--write\` when you want VibeFrame to merge
 the generated config. Keep provider keys in \`.vibeframe/config.yaml\`, user
 config, or env files — not in app host config.
 
-## Native host goal loop
+## Host agent loop
 
-For long-running work, use Codex Goal mode, Claude Code \`/goal\`, Cursor, or
-another host-native goal feature as the outer loop. VibeFrame should not own a
-competing project-level goal runner. It provides \`--json\` commands, dry runs,
+For long-running work, use your host's agent loop (Claude Code, Codex, Cursor,
+or another coding-agent host) as the outer loop. VibeFrame should not own a
+competing project-level agent loop. It provides \`--json\` commands, dry runs,
 budget caps, \`build-report.json\`, \`review-report.json\`, \`nextActions\`,
 \`safeToAutoRun\`, \`requiresConfirmation\`, \`fixOwner\`, deterministic repair,
 and render inspection for the host agent to decide what to do next.
 
-Copy-paste Codex:
+Copy-paste agent prompt (Codex) — a plain prompt, not a built-in command:
 
 \`\`\`text
-/goal Build this VibeFrame project into renders/final.mp4. Use --json for every
+Build this VibeFrame project into renders/final.mp4. Use --json for every
 vibe command, run --dry-run before paid operations, use --max-cost 5 for builds
 unless the user gives another budget, read build-report.json and
 review-report.json before deciding the next action, prefer nextActions before
@@ -226,10 +226,10 @@ remaining host-agent issue is fixed, accepted with rationale, or reported as
 blocked.
 \`\`\`
 
-Copy-paste Claude Code:
+Copy-paste agent prompt (Claude Code) — a plain prompt, not a built-in command:
 
 \`\`\`text
-/goal Finish this VibeFrame render using Claude Code goal mode as the outer
+Finish this VibeFrame render using your host's agent loop as the outer
 loop. Use vibe context/schema when unsure, --json everywhere, dry-run before
 paid operations, budget cap via --max-cost 5, nextActions before guessing,
 build-report.json/review-report.json as loop state, and safeToAutoRun,

--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -149,11 +149,14 @@ describe("buildProjectAgentsMd", () => {
     expect(md).toContain("host agent's built-in image/audio generation tool");
   });
 
-  it("documents native host goal loop stop rules for generated projects", () => {
+  it("documents host agent loop stop rules for generated projects", () => {
     const md = buildProjectAgentsMd("my-promo");
-    expect(md).toContain("Native host goal loop");
-    expect(md).toContain("Codex Goal mode");
-    expect(md).toContain("Claude Code `/goal`");
+    expect(md).toContain("Host agent loop");
+    expect(md).toContain("your host's agent loop");
+    expect(md).toContain("as the outer loop");
+    // No invented host-specific feature names (Claude Code has no `/goal`).
+    expect(md).not.toContain("/goal");
+    expect(md).not.toContain("Goal mode");
     expect(md).toContain("build-report.json");
     expect(md).toContain("review-report.json");
     expect(md).toContain("nextActions");

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -422,19 +422,19 @@ vibe host setup all --write # write project/app config
 vibe host doctor all --json # verify readiness
 \`\`\`
 
-## Native host goal loop
+## Host agent loop
 
-For long-running work, use Codex Goal mode, Claude Code \`/goal\`, or the
-host's equivalent as the outer loop. VibeFrame should not run a competing
-project-level goal loop; it provides \`--json\` commands, dry runs, cost caps,
+For long-running work, use your host's agent loop (Claude Code, Codex, Cursor,
+or another coding-agent host) as the outer loop. VibeFrame should not run a competing
+project-level agent loop; it provides \`--json\` commands, dry runs, cost caps,
 \`build-report.json\`, \`review-report.json\`, \`nextActions\`, \`safeToAutoRun\`,
 \`requiresConfirmation\`, \`fixOwner\`, deterministic repair, and render
 inspection for the host agent to reason over.
 
-Copy-paste examples:
+Copy-paste agent prompts — plain prompts, not a built-in command:
 
 \`\`\`text
-/goal Build this VibeFrame project into renders/final.mp4. Use --json for every
+Build this VibeFrame project into renders/final.mp4. Use --json for every
 vibe command, run --dry-run before paid operations, use --max-cost 5 for builds
 unless the user sets another budget, read build-report.json and
 review-report.json before deciding the next action, prefer nextActions before
@@ -449,7 +449,7 @@ blocked.
 \`\`\`
 
 \`\`\`text
-/goal Finish this VibeFrame render using Claude Code goal mode as the outer
+Finish this VibeFrame render using your host's agent loop as the outer
 loop. Use vibe context/schema when unsure, --json everywhere, dry-run before
 paid operations, budget cap via --max-cost 5, nextActions before guessing,
 build-report.json/review-report.json as loop state, and safeToAutoRun,

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -39,7 +39,7 @@ export const contextCommand = new Command("context")
       product: "vibeframe",
       sourceOfTruth: ["STORYBOARD.md", "DESIGN.md", "vibe.config.json"],
       preferredFlow: [
-        "native Codex Goal mode or Claude Code /goal owns persistence, iteration, and stop decisions",
+        "the host agent loop owns persistence, iteration, and stop decisions",
         "vibe context/schema for command discovery",
         "storyboard revise after init when the brief changes",
         "storyboard validate",
@@ -55,18 +55,18 @@ export const contextCommand = new Command("context")
         "inspect render --ai when needed",
         "status project when async jobs are involved",
       ],
-      nativeGoalContract: {
+      hostLoopContract: {
         owner:
-          "host-native goal mode (Codex /goal, Claude Code /goal, Cursor or other host equivalent)",
+          "the host agent loop (Claude Code, Codex, Cursor, or another coding-agent host)",
         vibeRole:
           "video-specific commands, JSON reports, cost gates, deterministic repair, render inspection, nextActions, and retryWith compatibility hints",
         canonicalLoop:
-          "native host goal -> vibe context/schema -> plan dry-run -> build with budget -> status polling -> inspect project -> render -> inspect render -> repair/edit using nextActions/fixOwner -> repeat",
+          "host agent loop -> vibe context/schema -> plan dry-run -> build with budget -> status polling -> inspect project -> render -> inspect render -> repair/edit using nextActions/fixOwner -> repeat",
         stopRules: [
           "final MP4 exists at the requested output path",
           "duration and aspect ratio match the brief or explicitly accepted constraints",
           "inspect render --cheap reports no errors",
-          "any AI review score meets the goal threshold, commonly >= 90, when AI review is requested",
+          "any AI review score meets the review threshold, commonly >= 90, when AI review is requested",
           "all fixOwner:vibe issues have been repaired or are blocked with evidence",
           "all fixOwner:host-agent issues are fixed, intentionally accepted with a written reason, or reported as blocked",
         ],
@@ -234,8 +234,8 @@ Use 'vibe schema --list --surface public' for the small product surface.
 Use 'vibe schema <command> --json' to get parameter schemas.
 Use 'vibe doctor --json' to check configured API keys.
 Use '--dry-run --json' before any mutating/costly operation.
-Use native Codex Goal mode or Claude Code /goal as the outer loop; VibeFrame provides JSON reports, retryWith, fixOwner, cost gates, and render inspection for that host loop.
-Stop only when the final MP4 exists, target duration/aspect ratio are met, inspect render has no errors, any AI review score meets the goal threshold when AI review is requested, and every host-agent issue is fixed, accepted with rationale, or reported blocked.
+Use your host's agent loop (Claude Code, Codex, Cursor, or another coding-agent host) as the outer loop; VibeFrame provides JSON reports, retryWith, fixOwner, cost gates, and render inspection for that host loop.
+Stop only when the final MP4 exists, target duration/aspect ratio are met, inspect render has no errors, any AI review score meets the review threshold when AI review is requested, and every host-agent issue is fixed, accepted with rationale, or reported blocked.
 
 Cost tiers: Free (schema/context/doctor/detect/status/plan/storyboard validate/inspect project/render --cheap, deterministic edits) | Low (generate narration/sound-effect/music, audio transcribe, inspect media, optional AI review) | High (generate image/motion, edit image/reframe/grade/speed-ramp) | Very High (generate video, edit fill-gaps, remix highlights/auto-shorts, build with generated assets)
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,9 +6,9 @@ VibeFrame is CLI-first, not terminal-only. The CLI is the stable runtime; MCP is
 
 Confirmed MCP hosts today: **Claude Desktop**, **Cursor**, and **Claude Code**. Codex can drive `vibe` natively via shell + `AGENTS.md`, and can also load a project-scoped MCP server through `.codex/config.toml`. For other shell-capable hosts, use [`@vibeframe/cli`](https://www.npmjs.com/package/@vibeframe/cli) directly — same operations.
 
-For long-running video builds, use the host's native goal mode as the outer
-loop: Codex `/goal`, Claude Code `/goal`, Cursor's agent loop, or the host
-equivalent. VibeFrame's MCP tools provide the inner video runtime: JSON-style
+For long-running video builds, use your host's agent loop as the outer
+loop: Claude Code, Codex, Cursor, or another coding-agent host. VibeFrame's MCP
+tools provide the inner video runtime: JSON-style
 results, dry-run/cost gates, `build-report.json`, `review-report.json`,
 `retryWith`, `fixOwner`, deterministic repair, and render inspection.
 
@@ -20,9 +20,9 @@ results, dry-run/cost gates, `build-report.json`, `review-report.json`,
 | Shell / scripts (any agent host: Codex / Aider / Gemini CLI / etc.) | `@vibeframe/cli`                 | `vibe init my-video && vibe build my-video && vibe render my-video`                     |
 | Optional standalone agent REPL                                      | `@vibeframe/cli` (`vibe agent`)  | natural language -> CLI calls when you do not already use Claude Code/Codex/Cursor/etc. |
 
-Native goal stop rules should be explicit: final MP4 path exists, duration and
+Outer-loop stop rules should be explicit: final MP4 path exists, duration and
 aspect ratio match the brief, render inspection has no errors, any AI review score
-meets the goal threshold when AI review is requested, and every `fixOwner:"host-agent"` issue is fixed,
+meets the review threshold when AI review is requested, and every `fixOwner:"host-agent"` issue is fixed,
 accepted with rationale, or reported as blocked.
 
 The tool list below is what the MCP host sees. The same operations exist as `vibe <verb> <noun>` subcommands in the CLI — see `vibe --help`.

--- a/scripts/gen-cli-reference.mts
+++ b/scripts/gen-cli-reference.mts
@@ -103,7 +103,8 @@ and \`DESIGN.md\` are the source of truth; generated files under
 \`compositions/\` are artifacts. Use \`vibe storyboard revise --dry-run\`
 for project-aware STORYBOARD.md rewrites, \`vibe storyboard *\` for narrow
 cue edits, and direct Markdown edits for larger DESIGN.md rewrites.
-Native Codex Goal mode and Claude Code \`/goal\` are the outer loop for
+Your host's agent loop (Claude Code, Codex, Cursor, or another coding-agent
+host) is the outer loop for
 long-running work. VibeFrame provides the video-specific command surface,
 machine reports, cost gates, deterministic repair, render inspection, and
 \`retryWith\` hints those hosts use to decide the next step and when to stop.
@@ -115,10 +116,10 @@ scene / timeline                                            ← lower-level auth
 run / agent / schema / context                              ← automation + agents
 \`\`\`
 
-Canonical native-goal loop:
+Canonical outer-loop:
 
 \`\`\`
-native host goal → vibe context/schema → plan dry-run → build with budget
+host agent loop → vibe context/schema → plan dry-run → build with budget
 → status polling → inspect project → render → inspect render
 → repair/edit using nextActions/fixOwner → repeat until stop rules pass
 \`\`\`
@@ -158,9 +159,9 @@ preferred agent contract: run only \`safeToAutoRun:true\` actions automatically,
 ask before \`requiresConfirmation:true\`, and use \`retryWith\` only as the
 compatibility fallback. Issue-level \`fixOwner:"vibe"\` means deterministic CLI
 recovery; \`fixOwner:"host-agent"\` means storyboard/design/composition edits
-should be handled by the host agent. A host-native goal should stop only after
+should be handled by the host agent. The outer loop should stop only after
 the final MP4 exists, duration and aspect ratio match the brief, render
-inspection has no errors, any AI review score meets the goal threshold when AI
+inspection has no errors, any AI review score meets the review threshold when AI
 review is requested, and every host-agent issue is fixed, accepted with
 rationale, or reported as blocked.
 `;


### PR DESCRIPTION
## Why

The agent docs told users to drive long-running builds with **\`/goal\`** and "**Codex Goal mode**". Neither exists: Claude Code has no \`/goal\` slash command, and there is no "Goal mode" feature in Codex. The copy-paste \`/goal Build launch/ ...\` blocks did nothing when typed — exactly the kind of stale/invented host-feature drift the lean-docs policy is meant to prevent.

## What

Keep the **concept** (which is correct and is VibeFrame's real positioning) — the host's agent loop is the **outer** loop; VibeFrame is the **inner** video toolkit providing JSON reports, cost gates, \`nextActions\`/\`fixOwner\`, deterministic repair, and render inspection — but describe it **host-agnostically**.

- **Docs/prose:** \`AGENTS.md\`, \`README.md\`, \`docs/README.md\`, \`docs/projects.md\`, \`packages/mcp-server/README.md\`, \`packages/cli/CONTEXT.md\` — outer-loop language no longer names \`/goal\`/"Goal mode"; copy-paste blocks reframed as plain agent prompts.
- **CLI output:** \`vibe context\` renames the \`nativeGoalContract\` field → \`hostLoopContract\`; "goal threshold" → "review threshold".
- **Generated project templates:** the \`init\`/\`scene-project\` AGENTS.md templates use a "Host agent loop" section; their tests now **guard against \`/goal\`/"Goal mode" regressions**.
- **Generated reference:** updated the \`gen-cli-reference\` source and regenerated \`docs/cli-reference.md\`.

Plain-English uses of "goal" (e.g. \`## Non-Goals\`, "primary design goal", the setup wizard's "1. Goal" step) are intentionally left untouched.

## Verification

- \`pnpm -F @vibeframe/cli test\` — 1234 passed / 9 skipped (82 files).
- \`pnpm -F @vibeframe/cli lint\` — 0 errors.
- \`pnpm gen:reference\` regenerated; \`docs/cli-reference.md\` is clean of host-feature \`goal\` references.
- \`vibe context --format json\` confirmed emitting \`hostLoopContract\`.
- Pre-push gate passed (docs/refactor — no \`feat:\`/\`fix:\` since v0.113.11, so no version bump).