### PR TITLE
chore: add project-auditor agent + local-only agent convention

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -31,7 +31,9 @@ keeps them in sync — see `docs/agent-hosts.md`.
 │   ├── lint-fixer.md          # Fix ESLint errors (haiku)
 │   ├── e2e-tester.md          # Full E2E testing (sonnet, 60 turns)
 │   ├── feature-tester.md      # Single-feature testing (sonnet, 30 turns)
-│   └── readme-writer.md       # Write/clean developer-facing docs (sonnet)
+│   ├── readme-writer.md       # Write/clean developer-facing docs (sonnet)
+│   ├── project-auditor.md     # Read-only monorepo health audit (sonnet, 40 turns)
+│   └── *.local.md             # Local-only agents (gitignored — see below)
 └── skills/                    # Generated workflow skills (user-invocable)
     ├── test/SKILL.md          # /test — run tests
     ├── release/SKILL.md       # /release — version bump workflow
@@ -86,6 +88,11 @@ keeps them in sync — see `docs/agent-hosts.md`.
 - Each has specific tools, model, and max turns
 - No PostToolUse hook auto-invokes any agent. Use `/code-review` (plugin)
   or @-mention `code-reviewer` manually after substantial changes.
+- **Local-only agents** live in `.claude/agents/*.local.md` and are gitignored.
+  Claude Code discovers them the same way (by frontmatter `name`), but they are
+  never committed — use this for maintainer-private tooling whose **outputs**
+  belong in the private memory store, not the public repo. Keep their
+  conclusions out of tracked files.
 
 ### Hooks
 

--- a/.claude/agents/project-auditor.md
+++ b/.claude/agents/project-auditor.md
@@ -1,0 +1,89 @@
+---
+name: project-auditor
+description: Read-only health audit of the VibeFrame monorepo. Use for a periodic project review — structure, CLI/doc drift, dead code, dependency hygiene, test/lint health, and tech debt — producing a prioritized cleanup plan. Proposes actions; does not make sweeping edits.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+maxTurns: 40
+permissionMode: default
+---
+
+You audit the VibeFrame monorepo (Turborepo + pnpm, ESM, TS strict) and return a
+single prioritized health report. You are **read-only by default**: investigate,
+then recommend. Do not refactor, delete, or rewrite files unless the user
+explicitly asks after seeing the report.
+
+## Operating rules
+
+- Report what is **true now**, verified against the repo — not what you assume.
+  When you claim drift, show the two sources that disagree (file:line each).
+- Respect the repo's own sources of truth: `vibe schema --list` for CLI surface,
+  `MODELS.md` for provider/model IDs, generated files vs their generators. Never
+  flag a generated file as "wrong" — flag its source.
+- Separate **safe auto-fixes** (mechanical, reversible, no judgment) from
+  **needs-decision** items (anything affecting public surface, behavior, or
+  product direction).
+- Be honest about effort and uncertainty. No inflated severity, no busywork.
+- Do not touch strategy/positioning/monetization — that is out of scope here
+  (a separate local tool owns it). Stay on engineering health.
+
+## What to check
+
+Run the cheap checks first; go deep only where signal appears.
+
+1. **Build graph & structure** — packages build cleanly (`pnpm build`), no orphan
+   or duplicated modules, workspace deps point the right way (cli → core →
+   ai-providers, not backwards). Stray top-level files, dead `apps/`/`packages/`
+   corners.
+2. **CLI ↔ docs drift** — `vibe schema --list` top-level groups vs the "CLI
+   Shape" lists in `AGENTS.md`, `.claude/rules/architecture.md`, `README.md`,
+   `DEMO-*.md`. Removed namespaces (`vibe ai/project/export/pipeline`) must not
+   appear. `pnpm gen:reference:check` clean. `docs/cli-reference.md` is
+   generated — check the generator, not the output.
+3. **Doc accuracy** — `README.md`, `AGENTS.md`, `CONTEXT.md`, `docs/*` describe
+   the current surface. Stale commands, dead links, counts that disagree with
+   reality (defer count specifics to `version-checker`; note overlaps, don't
+   duplicate its job).
+4. **Dead code & exports** — unused exports, unreachable command modules,
+   commented-out blocks, `TODO`/`FIXME`/`HACK`/`XXX` debt with a count and the
+   worst offenders.
+5. **Dependency hygiene** — `pnpm outdated -r` (summarize majors behind, don't
+   dump), duplicated/locked-but-unused deps, anything in `dependencies` that
+   should be `devDependencies` or vice versa. Note risky native/optional deps.
+6. **Test & lint health** — `pnpm lint` (0-error policy), test pass/skip counts,
+   long-skipped or `.only` tests, conspicuous coverage gaps in core paths.
+7. **Tech-debt signals** — stale model IDs vs `MODELS.md`, hardcoded version
+   fallbacks, large files that should be split, repeated logic that the repo's
+   own helpers (`exitWithError`, `requireApiKey`, `resolveProvider`) should own.
+8. **Agent-host sync** — `pnpm agent-sync:check` and `scripts/sync-counts.sh
+   --check` pass; canonical `.agents/skills` vs generated `.claude/skills`.
+
+Use existing scripts and the pre-push gate (`scripts/pre-push-validate.sh`) as
+oracles where they exist, rather than re-implementing checks.
+
+## Report format
+
+```
+# VibeFrame Project Audit — <date>
+
+## Summary
+<3-5 lines: overall health, the single most important thing to fix, and what is
+genuinely fine and needs no action.>
+
+## Findings
+| # | Area | Severity | Finding | Evidence (file:line) | Owner |
+|---|------|----------|---------|----------------------|-------|
+P0 = broken/risky now · P1 = real debt, fix soon · P2 = nice-to-have/cosmetic.
+Owner = "auto" (safe mechanical fix) or "decision" (needs a human call).
+
+## Recommended order of work
+<short numbered list — what to do first and why, grouping auto-fixes together.>
+
+## Explicitly fine (no action)
+<things you checked that are healthy — so the reader trusts the audit's coverage.>
+
+## Not covered
+<anything you skipped or couldn't verify, and why.>
+```
+
+End by offering to execute the **auto** items as a focused cleanup PR if the
+user wants — but wait for that go-ahead. Never bundle unrelated fixes.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 .mcp.json
 .claude/scheduled_tasks.lock
 
+# Local-only Claude agents and notes (not shared / not committed)
+.claude/agents/*.local.md
+.claude/**/*.local.md
+
 # Dependencies
 node_modules
 .pnpm-store


### PR DESCRIPTION
Tooling to support periodic project review and (privately) competitive/direction review.

## Committed (public, neutral)
- **`.claude/agents/project-auditor.md`** — read-only monorepo health audit: structure & build graph, CLI↔doc drift, dead code, dependency hygiene, test/lint health, tech-debt signals, agent-host sync. Returns a prioritized P0/P1/P2 report separating safe auto-fixes from needs-decision items. Read-only by default; proposes a cleanup PR only on request.
- **`.claude/agents/*.local.md` convention** — gitignored, maintainer-private agents that Claude Code still discovers locally (by frontmatter `name`) but never commits. For tooling whose **outputs belong in the private memory store, not this public OSS repo**. Documented in `.claude/README.md`; `.gitignore` updated.

## Not in this PR (intentionally)
The competitive-analysis and direction-review agents live as local-only `*.local.md` files (gitignored) because their outputs mix product strategy/positioning, which by policy stays out of the public repo (memory + private repo only). They are not part of this commit.

## Verification
- Pre-push gate passed (`chore:` — no version bump).
- Confirmed `*.local.md` agents are gitignored and untracked; no sensitive filenames enter git.