### PR TITLE
fix: root-sync single source of clip/narration refs (no doubled audio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.113.12] - 2026-06-29
+
+### Changed
+
+- replace invented host goal-mode names with host-agnostic agent-loop language
+
+### Documentation
+
+- sync agent docs with current CLI/MCP surface
+
+### Fixed
+
+- make root-sync the single source of clip/narration refs (no doubled audio)
+
+### Maintenance
+
+- add project-auditor agent and local-only agent convention
+
 ## [0.113.11] - 2026-06-22
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.11",
+  "version": "0.113.12",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.11`
+> CLI version: `0.113.12`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.11",
+  "version": "0.113.12",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.11",
+  "version": "0.113.12",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.11",
+  "version": "0.113.12",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/root-sync.test.ts
+++ b/packages/cli/src/commands/_shared/root-sync.test.ts
@@ -1,6 +1,54 @@
 import { describe, expect, it } from "vitest";
-import { resolveSyncedBeatDuration } from "./root-sync.js";
+import { applyRootSyncHtml, resolveSyncedBeatDuration } from "./root-sync.js";
+import type { ExpectedRootSync } from "./root-sync.js";
 import { __setFfmpegToolsForTests, ffmpegToolsAvailable } from "./ffmpeg-gate.js";
+
+describe("applyRootSyncHtml — single managed source (no doubled narration)", () => {
+  const block = [
+    "      <!-- vibe-scene-build: clip refs (auto-generated; safe to re-run) -->",
+    '      <div class="clip" data-composition-id="scene-a" data-composition-src="compositions/scene-a.html" data-start="0" data-duration="6" data-track-index="0"></div>',
+    '      <audio id="narration-a" src="assets/narration-a.wav" data-start="0" data-duration="6" data-track-index="2"></audio>',
+    "      <!-- /vibe-scene-build -->",
+  ].join("\n");
+  const expected: ExpectedRootSync = { block, totalDurationSec: 6, audioRefs: [] };
+
+  const shell = (body: string) =>
+    `<!doctype html>\n<html>\n  <body>\n` +
+    `    <div id="root" data-composition-id="main" data-start="0" data-duration="6">\n` +
+    `${body}\n` +
+    `    </div>\n` +
+    `    <script>\n      window.__timelines = {};\n    </script>\n  </body>\n</html>\n`;
+
+  const count = (s: string, re: RegExp) => (s.match(re) ?? []).length;
+
+  it("does not double when the root already has stray narration/scene refs (the bug)", () => {
+    const html = shell(
+      [
+        '      <video id="bg-video" src="assets/bg.mp4" data-start="0" data-duration="6" data-track-index="0"></video>',
+        '      <div class="clip" data-composition-id="scene-a" data-composition-src="compositions/scene-a.html" data-start="0" data-duration="6" data-track-index="1"></div>',
+        '      <audio id="narration-a" src="assets/narration-a.wav" data-start="0" data-duration="6" data-track-index="2"></audio>',
+      ].join("\n")
+    );
+    const out = applyRootSyncHtml(html, expected);
+    expect(count(out, /id="narration-a"/g)).toBe(1);
+    expect(count(out, /data-composition-id="scene-a"/g)).toBe(1);
+    expect(count(out, /vibe-scene-build: clip refs/g)).toBe(1);
+    expect(out).toContain('id="bg-video"'); // custom (non-managed) element preserved
+  });
+
+  it("collapses an accidental second managed block", () => {
+    const out = applyRootSyncHtml(shell(`${block}\n${block}`), expected);
+    expect(count(out, /vibe-scene-build: clip refs/g)).toBe(1);
+    expect(count(out, /id="narration-a"/g)).toBe(1);
+  });
+
+  it("is idempotent for a clean single block", () => {
+    const once = applyRootSyncHtml(shell(block), expected);
+    const twice = applyRootSyncHtml(once, expected);
+    expect(twice).toBe(once);
+    expect(count(once, /id="narration-a"/g)).toBe(1);
+  });
+});
 
 describe("resolveSyncedBeatDuration", () => {
   const probe = (sec: number) => async () => sec;

--- a/packages/cli/src/commands/_shared/root-sync.ts
+++ b/packages/cli/src/commands/_shared/root-sync.ts
@@ -32,7 +32,7 @@ export interface RootSyncPlan {
   totalDurationSec?: number;
 }
 
-interface ExpectedRootSync {
+export interface ExpectedRootSync {
   block: string;
   totalDurationSec: number;
   audioRefs: Array<{
@@ -362,18 +362,62 @@ function rootSyncIssue(code: string, rootRel: string): ReviewIssue {
   };
 }
 
-function applyRootSyncHtml(html: string, expected: ExpectedRootSync): string {
+/** Stray managed-namespace refs (scene clip refs + narration/music audio) that
+ * live OUTSIDE a managed block — the source of the doubled-narration /
+ * duplicate-scene-ref bug class when index.html is hand-edited or a prior block
+ * was reformatted so its marker no longer matches. */
+const LOOSE_MANAGED_REF_RE =
+  /<audio\b[^>]*\bid="(?:narration|music)-|<div\b[^>]*\bdata-composition-id="scene-/i;
+
+function countManagedBlocks(html: string): number {
+  return (html.match(/<!-- vibe-scene-build: clip refs/g) ?? []).length;
+}
+
+function stripManagedBlocks(html: string): string {
+  // Global + dotall so EVERY block is removed (a non-greedy `.replace` left
+  // accidental duplicates behind).
+  return html.replace(/\n? *<!-- vibe-scene-build: clip refs[\s\S]*?<!-- \/vibe-scene-build -->/g, "");
+}
+
+function stripLooseManagedRefs(html: string): string {
+  let out = html.replace(
+    /[ \t]*<audio\b[^>]*\bid="(?:narration|music)-[^"]*"[^>]*>\s*<\/audio>[ \t]*\n?/gi,
+    ""
+  );
+  out = out.replace(
+    /[ \t]*<div\b[^>]*\bdata-composition-id="scene-[^"]*"[^>]*>\s*<\/div>[ \t]*\n?/gi,
+    ""
+  );
+  return out;
+}
+
+function insertManagedBlock(html: string, block: string): string {
+  const rootCloseRe = /(\n\s*<\/div>\s*\n\s*<script[^>]*>[\s\S]*window\.__timelines)/;
+  if (rootCloseRe.test(html)) return html.replace(rootCloseRe, `\n${block}\n    $1`);
+  if (/<\/body>/i.test(html)) return html.replace(/<\/body>/i, `${block}\n  </body>`);
+  return `${html}\n${block}`;
+}
+
+/**
+ * The managed `<!-- vibe-scene-build -->` block is the SINGLE source of scene
+ * clip refs + narration/music audio. Custom elements (e.g. a `bg-video`,
+ * overlay decorations) are left untouched.
+ *
+ * Fast path: one clean block and no stray managed refs → in-place replace (no
+ * churn). Otherwise (zero/duplicate blocks, or stray `scene-*`/`narration-*`/
+ * `music-*` refs from a hand-edited root) → strip every managed block AND every
+ * stray managed ref, then insert exactly one block. This makes the sync
+ * idempotent and structurally unable to double-wire narration audio.
+ */
+export function applyRootSyncHtml(html: string, expected: ExpectedRootSync): string {
+  const withoutBlocks = stripManagedBlocks(html);
+  const hasStray = LOOSE_MANAGED_REF_RE.test(withoutBlocks);
+
   let next: string;
-  const markerRe = rootSyncMarkerRe();
-  if (markerRe.test(html)) {
-    next = html.replace(markerRe, "\n" + expected.block);
+  if (countManagedBlocks(html) === 1 && !hasStray) {
+    next = html.replace(rootSyncMarkerRe(), "\n" + expected.block);
   } else {
-    const rootCloseRe = /(\n\s*<\/div>\s*\n\s*<script[^>]*>[\s\S]*window\.__timelines)/;
-    if (rootCloseRe.test(html)) {
-      next = html.replace(rootCloseRe, `\n${expected.block}\n    $1`);
-    } else {
-      next = html.replace(/<\/body>/i, `${expected.block}\n  </body>`);
-    }
+    next = insertManagedBlock(stripLooseManagedRefs(withoutBlocks), expected.block);
   }
   return setRootDuration(next, expected.totalDurationSec);
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.11",
+  "version": "0.113.12",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.11",
+  "version": "0.113.12",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.11",
+  "version": "0.113.12",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
**Phase 1 (reliability core) of the pipeline-redesign roadmap — PR 1/N.**

## Problem
While composing the ELARA flagship, the sync stage doubled the narration audio: the rendered video clipped at 0.0 dB with mean ~+5 dB vs a single clip. Root cause in `root-sync.ts applyRootSyncHtml`:
- it re-injected the managed `<!-- vibe-scene-build -->` block whenever `rootSyncMarkerRe()` didn't match an existing block, and
- its non-global `.replace` left an accidental *second* block behind,

so a hand-edited `index.html` (or a reformatted block) ended up with two `<audio id="narration-*">` sets + duplicate scene clip refs.

## Fix
The managed block is now the **single source** of scene clip refs + narration/music audio:
- strip *every* managed block (global) AND any stray `scene-*` / `narration-*` / `music-*` ref left outside a block, then insert exactly one block;
- a clean single block keeps the in-place fast path (no churn);
- custom, non-managed elements (e.g. a `bg-video`) are left untouched.

## Tests
New `applyRootSyncHtml` regression tests: stray-ref dedup (the bug), accidental-double-block collapse, idempotency. `root-sync.test.ts` 8/8 pass; related suites (scene-build, scene-project) green; build + lint clean.

Ref: memory `hyperframes-multiscene-video-render-gotchas`.