### PR TITLE
feat: bound LLM compose fan-out concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.13] - 2026-06-29
+## [0.113.14] - 2026-06-29
 
 ### Added
 
+- bound LLM compose fan-out concurrency (avoid provider rate limits)
 - deterministic AI-video composer (vibe build --composer template)
 
 ### Changed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.13",
+  "version": "0.113.14",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.13`
+> CLI version: `0.113.14`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.13",
+  "version": "0.113.14",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.13",
+  "version": "0.113.14",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.13",
+  "version": "0.113.14",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
@@ -9,6 +9,7 @@ import {
   composeBeatHtml,
   composeBeatWithRetry,
   computeCacheKey,
+  composeConcurrency,
   defaultCacheDir,
   executeComposeScenesWithSkills,
   extractHtml,
@@ -21,6 +22,28 @@ import {
 
 import type { Beat } from "./storyboard-parse.js";
 import type { LintFinding } from "./scene-lint.js";
+
+describe("composeConcurrency", () => {
+  const saved = process.env.VIBE_COMPOSE_CONCURRENCY;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.VIBE_COMPOSE_CONCURRENCY;
+    else process.env.VIBE_COMPOSE_CONCURRENCY = saved;
+  });
+
+  it("defaults to 4, clamped to the beat count", () => {
+    delete process.env.VIBE_COMPOSE_CONCURRENCY;
+    expect(composeConcurrency(10)).toBe(4);
+    expect(composeConcurrency(2)).toBe(2); // fewer beats than the cap
+    expect(composeConcurrency(0)).toBe(1); // never zero
+  });
+
+  it("honors a valid VIBE_COMPOSE_CONCURRENCY override", () => {
+    process.env.VIBE_COMPOSE_CONCURRENCY = "8";
+    expect(composeConcurrency(20)).toBe(8);
+    process.env.VIBE_COMPOSE_CONCURRENCY = "garbage";
+    expect(composeConcurrency(20)).toBe(4); // falls back to default
+  });
+});
 
 import { mkdirSync, writeFileSync, readFileSync as fsReadFileSync } from "node:fs";
 

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.ts
@@ -34,11 +34,22 @@ import { existsSync, mkdirSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { USER_CACHE_DIR } from "../../config/index.js";
+import { mapWithConcurrency } from "../../utils/concurrency.js";
 
 import { runHyperframeLint, type PreparedHyperframeLintInput } from "@hyperframes/producer";
 
 import { loadHyperframesSkillBundle } from "./hf-skill-bundle/bundle.js";
 import { filterSubCompFalsePositives, withVibeframeSubCompFindings, type LintFinding } from "./scene-lint.js";
+
+/** Default cap on concurrent per-beat LLM compose calls. */
+const DEFAULT_COMPOSE_CONCURRENCY = 4;
+
+/** Resolve the compose fan-out limit (env override, clamped to the beat count). */
+export function composeConcurrency(beatCount: number): number {
+  const env = Number.parseInt(process.env.VIBE_COMPOSE_CONCURRENCY ?? "", 10);
+  const limit = Number.isInteger(env) && env > 0 ? env : DEFAULT_COMPOSE_CONCURRENCY;
+  return Math.max(1, Math.min(limit, Math.max(1, beatCount)));
+}
 import { parseStoryboard, type Beat } from "./storyboard-parse.js";
 import { resolveProjectBeatDurations } from "./root-sync.js";
 import { type ComposerProvider, resolveComposer, composerEnvVar } from "./composer-resolve.js";
@@ -1052,7 +1063,13 @@ export async function executeComposeScenesWithSkills(
         error: string;
       };
 
-  const tasks: Array<Promise<FanoutOutcome>> = beats.map(
+  // Bound concurrent LLM compose calls so a many-beat video does not fire N
+  // provider requests at once and hit rate limits. The per-beat callback
+  // catches its own errors (returns a FanoutOutcome, never rejects), so the
+  // limiter only throttles — it never short-circuits the batch.
+  const outcomes = await mapWithConcurrency(
+    beats,
+    composeConcurrency(beats.length),
     async (beat, beatIndex): Promise<FanoutOutcome> => {
       onProgress({ type: "beat-start", beatId: beat.id, beatIndex, totalBeats });
       try {
@@ -1109,10 +1126,8 @@ export async function executeComposeScenesWithSkills(
     }
   );
 
-  const outcomes = await Promise.all(tasks);
-
   // Aggregate metadata in beat order. `outcomes` is already ordered by
-  // input position (Promise.all preserves order).
+  // input position (mapWithConcurrency preserves order).
   const written: ComposeScenesActionResult["data"] extends infer D
     ? D extends { written: infer W }
       ? W

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.13",
+  "version": "0.113.14",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.13",
+  "version": "0.113.14",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.13",
+  "version": "0.113.14",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
**Phase 1 (reliability core) wrap-up — PR 3/3.**

The batch composer fired one LLM request per beat with an unbounded `beats.map(...) + Promise.all`, so a flagship-length (many-beat) video hit provider rate limits all at once. Route the per-beat fan-out through the existing `mapWithConcurrency` limiter — default **4**, override via `VIBE_COMPOSE_CONCURRENCY`, clamped to the beat count. The per-beat callback already catches its own errors, so throttling only paces; it never short-circuits the batch.

Adds `composeConcurrency` + unit tests. Full CLI suite 1252 pass; lint/build clean. 0.113.14.

Completes Phase 1 (root-sync fix #241 + deterministic composer #242 + this).