### PR TITLE
feat: structured DESIGN.md parser (google-labs design.md standard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.14] - 2026-06-29
+## [0.113.15] - 2026-06-29
 
 ### Added
 
+- structured DESIGN.md parser (google-labs design.md standard)
 - bound LLM compose fan-out concurrency (avoid provider rate limits)
 - deterministic AI-video composer (vibe build --composer template)
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.14",
+  "version": "0.113.15",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.14`
+> CLI version: `0.113.15`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.14",
+  "version": "0.113.15",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.14",
+  "version": "0.113.15",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.14",
+  "version": "0.113.15",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/compose-aivideo.test.ts
+++ b/packages/cli/src/commands/_shared/compose-aivideo.test.ts
@@ -133,4 +133,12 @@ describe("extractDesignTokens", () => {
   it("falls back to defaults when fewer than 3 hexes are present", () => {
     expect(extractDesignTokens("no colors here")).toEqual(DEFAULT_AIVIDEO_TOKENS);
   });
+
+  it("maps named front-matter color tokens by role", () => {
+    const md = '---\ncolors:\n  ground: "#101418"\n  primary: "#F4E9D8"\n  accent: "#E8A23C"\n---\n# Design\n';
+    const t = extractDesignTokens(md);
+    expect(t.ground).toBe("#101418");
+    expect(t.primary).toBe("#F4E9D8");
+    expect(t.accent).toBe("#E8A23C");
+  });
 });

--- a/packages/cli/src/commands/_shared/compose-aivideo.ts
+++ b/packages/cli/src/commands/_shared/compose-aivideo.ts
@@ -23,6 +23,7 @@ import { join, resolve } from "node:path";
 
 import { commandExists, execSafe } from "../../utils/exec-safe.js";
 import { parseStoryboard, type Beat } from "./storyboard-parse.js";
+import { parseDesign } from "./design-parse.js";
 
 /**
  * Dedicated root track for the single background video. The managed root-sync
@@ -427,18 +428,41 @@ async function loadProjectTokens(projectDir: string): Promise<AiVideoDesignToken
   }
 }
 
+/**
+ * Map a DESIGN.md to background-video tokens. Named color tokens (front-matter
+ * `colors: { primary, ground, accent }` or descriptive keys) win; otherwise the
+ * palette is read by luminance (darkest → ground, lightest → primary) and the
+ * most-saturated remaining color becomes the accent.
+ */
 export function extractDesignTokens(designMd: string): AiVideoDesignTokens {
-  const hexes = Array.from(designMd.matchAll(/#[0-9a-fA-F]{6}\b/g)).map((m) => m[0]);
-  const unique = Array.from(new Set(hexes.map((h) => h.toUpperCase())));
-  if (unique.length < 3) return DEFAULT_AIVIDEO_TOKENS;
+  const colors = Object.values(parseDesign(designMd).colors)
+    .map((c) => c.toUpperCase())
+    .filter((c) => /^#[0-9A-F]{6}$/.test(c));
+  const named = parseDesign(designMd).colors;
+  const byName = (needles: string[]): string | undefined => {
+    const hit = Object.entries(named).find(([k]) =>
+      needles.some((n) => k.toLowerCase().includes(n))
+    )?.[1];
+    return hit && /^#[0-9a-fA-F]{6}$/.test(hit) ? hit.toUpperCase() : undefined;
+  };
+
+  const unique = Array.from(new Set(colors));
+  if (unique.length < 3 && Object.keys(named).length === 0) return DEFAULT_AIVIDEO_TOKENS;
+  if (unique.length < 3) {
+    return {
+      ...DEFAULT_AIVIDEO_TOKENS,
+      ground: byName(["ground", "background", "bg", "surface", "base"]) ?? DEFAULT_AIVIDEO_TOKENS.ground,
+      primary: byName(["primary", "text", "foreground", "ink"]) ?? DEFAULT_AIVIDEO_TOKENS.primary,
+      accent: byName(["accent", "brand", "highlight"]) ?? DEFAULT_AIVIDEO_TOKENS.accent,
+    };
+  }
   const sorted = [...unique].sort((a, b) => luminance(a) - luminance(b));
-  const ground = sorted[0]; // darkest
-  const primary = sorted[sorted.length - 1]; // lightest
-  // accent = most saturated of the remaining
+  const ground = byName(["ground", "background", "bg", "surface", "base"]) ?? sorted[0];
+  const primary = byName(["primary", "text", "foreground", "ink"]) ?? sorted[sorted.length - 1];
   const accent =
-    unique
-      .filter((h) => h !== ground && h !== primary)
-      .sort((a, b) => saturation(b) - saturation(a))[0] ?? DEFAULT_AIVIDEO_TOKENS.accent;
+    byName(["accent", "brand", "highlight"]) ??
+    unique.filter((h) => h !== ground && h !== primary).sort((a, b) => saturation(b) - saturation(a))[0] ??
+    DEFAULT_AIVIDEO_TOKENS.accent;
   return { ...DEFAULT_AIVIDEO_TOKENS, primary, ground, accent };
 }
 

--- a/packages/cli/src/commands/_shared/design-parse.test.ts
+++ b/packages/cli/src/commands/_shared/design-parse.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { parseDesign, validateDesignMarkdown } from "./design-parse.js";
+
+describe("parseDesign", () => {
+  it("reads google-labs-style YAML token front-matter + prose sections", () => {
+    const md = [
+      "---",
+      "name: Alpine",
+      "colors:",
+      '  primary: "#EAF2F7"',
+      '  ground: "#0E1A24"',
+      '  accent: "#E2683C"',
+      "typography:",
+      "  headline:",
+      '    fontFamily: "Archivo"',
+      "---",
+      "",
+      "## Overview",
+      "Cold and steadfast.",
+      "",
+      "## Motion",
+      "Slow, precise.",
+    ].join("\n");
+    const d = parseDesign(md);
+    expect(d.name).toBe("Alpine");
+    expect(d.colors).toEqual({ primary: "#EAF2F7", ground: "#0E1A24", accent: "#E2683C" });
+    expect((d.typography.headline as Record<string, unknown>).fontFamily).toBe("Archivo");
+    expect(d.sections.Overview).toBe("Cold and steadfast.");
+    expect(d.sections.Motion).toBe("Slow, precise.");
+  });
+
+  it("recovers a palette from prose hexes when there is no front-matter", () => {
+    const md = "## Palette\n- `#0E1A24` ground\n- `#EAF2F7` text\n";
+    const d = parseDesign(md);
+    expect(d.frontmatter).toEqual({});
+    expect(Object.values(d.colors).sort()).toEqual(["#0E1A24", "#EAF2F7"]);
+  });
+
+  it("degrades gracefully on invalid front-matter YAML", () => {
+    const md = "---\ncolors: [unclosed\n---\n## Style\nx\n";
+    const d = parseDesign(md);
+    expect(d.frontmatter).toEqual({});
+    // body (with the broken front-matter still in raw) parses sections best-effort
+    expect(d.raw).toContain("unclosed");
+  });
+});
+
+describe("validateDesignMarkdown", () => {
+  it("passes a well-formed token DESIGN.md", () => {
+    const md = '---\nname: X\ncolors:\n  primary: "#fff"\n  ground: "#000"\n---\n## Overview\nMood.\n';
+    expect(validateDesignMarkdown(md).filter((i) => i.severity === "error")).toEqual([]);
+  });
+
+  it("flags an empty palette and missing mood", () => {
+    const codes = validateDesignMarkdown("# Design\nnothing here\n").map((i) => i.code);
+    expect(codes).toContain("DESIGN_NO_PALETTE");
+    expect(codes).toContain("DESIGN_NO_MOOD");
+  });
+
+  it("errors on invalid front-matter YAML", () => {
+    const issues = validateDesignMarkdown("---\ncolors: [bad\n---\nbody\n");
+    expect(issues.some((i) => i.code === "DESIGN_FRONTMATTER_INVALID" && i.severity === "error")).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/_shared/design-parse.ts
+++ b/packages/cli/src/commands/_shared/design-parse.ts
@@ -1,0 +1,163 @@
+/**
+ * @module _shared/design-parse
+ *
+ * Tolerant parser for DESIGN.md, aligned with the emerging google-labs
+ * `design.md` convention: optional YAML front-matter carrying machine-readable
+ * design tokens (`name`, `colors`, `typography`, …) plus `## ` prose sections.
+ *
+ * It degrades gracefully — invalid/absent front-matter yields `{}` and the
+ * palette is recovered from hex literals in the prose, so a freeform DESIGN.md
+ * (today's format) and a dropped-in `awesome-design-md` file both parse. The
+ * parser only READS; it never rewrites the file.
+ */
+import { parse as parseYaml } from "yaml";
+
+export interface ParsedDesign {
+  /** `name:` from front-matter, if present. */
+  name?: string;
+  /** Color tokens — front-matter `colors:` map, else extracted from prose hexes. */
+  colors: Record<string, string>;
+  /** Typography tokens from front-matter `typography:` (shape left to the spec). */
+  typography: Record<string, unknown>;
+  /** `## ` section title → prose body (trimmed). */
+  sections: Record<string, string>;
+  /** Raw parsed front-matter object (`{}` when absent/invalid). */
+  frontmatter: Record<string, unknown>;
+  /** Original document. */
+  raw: string;
+}
+
+const DESIGN_FRONTMATTER_RE = /^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/;
+const SECTION_RE = /^##\s+(.+?)\s*$/gm;
+const HEX_RE = /#[0-9a-fA-F]{6}\b/g;
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Pull a `Record<string,string>` of color tokens from a front-matter value. */
+function colorTokens(value: unknown): Record<string, string> {
+  if (!isPlainObject(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === "string" && v.trim()) out[k] = v.trim();
+  }
+  return out;
+}
+
+export function parseDesign(md: string): ParsedDesign {
+  const raw = md.replace(/\r\n/g, "\n");
+
+  let frontmatter: Record<string, unknown> = {};
+  let body = raw;
+  const fm = raw.match(DESIGN_FRONTMATTER_RE);
+  if (fm) {
+    try {
+      const parsed = parseYaml(fm[1]);
+      if (isPlainObject(parsed)) {
+        frontmatter = parsed;
+        body = raw.slice(fm[0].length);
+      }
+    } catch {
+      // Invalid YAML → treat as freeform; leave body intact.
+    }
+  }
+
+  // Sections: split the body on `## ` headings.
+  const sections: Record<string, string> = {};
+  const headings: Array<{ title: string; start: number; end: number }> = [];
+  SECTION_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SECTION_RE.exec(body)) !== null) {
+    headings.push({ title: m[1].trim(), start: m.index + m[0].length, end: body.length });
+  }
+  for (let i = 0; i < headings.length; i++) {
+    if (i + 1 < headings.length) headings[i].end = headings[i + 1].start - 1;
+    const h = headings[i];
+    sections[h.title] = body.slice(h.start, h.end).replace(/^##\s+.+$/m, "").trim();
+  }
+
+  // Colors: front-matter `colors:` map wins; else recover hexes from the
+  // Colors/Palette section (or whole body) as ordered tokens color-1..N.
+  const colors = colorTokens(frontmatter.colors);
+  if (Object.keys(colors).length === 0) {
+    const source = sections.Colors ?? sections.Palette ?? body;
+    const hexes = Array.from(new Set((source.match(HEX_RE) ?? []).map((h) => h.toUpperCase())));
+    hexes.forEach((hex, i) => {
+      colors[`color-${i + 1}`] = hex;
+    });
+  }
+
+  return {
+    name: typeof frontmatter.name === "string" ? frontmatter.name : undefined,
+    colors,
+    typography: isPlainObject(frontmatter.typography) ? frontmatter.typography : {},
+    sections,
+    frontmatter,
+    raw,
+  };
+}
+
+export interface DesignValidationIssue {
+  severity: "error" | "warning" | "info";
+  code: string;
+  message: string;
+}
+
+/**
+ * Lint a DESIGN.md for the soft contract: parseable front-matter, at least a
+ * couple of palette colors, and the core prose sections. Warnings/infos only —
+ * a thin DESIGN.md is valid, just less useful to the composer.
+ */
+export function validateDesignMarkdown(md: string): DesignValidationIssue[] {
+  const issues: DesignValidationIssue[] = [];
+  const raw = md.replace(/\r\n/g, "\n");
+
+  const fm = raw.match(DESIGN_FRONTMATTER_RE);
+  if (fm) {
+    try {
+      const parsed = parseYaml(fm[1]);
+      if (!isPlainObject(parsed)) {
+        issues.push({
+          severity: "warning",
+          code: "DESIGN_FRONTMATTER_NOT_MAP",
+          message: "DESIGN.md front-matter is not a key/value map; ignoring it.",
+        });
+      }
+    } catch (err) {
+      issues.push({
+        severity: "error",
+        code: "DESIGN_FRONTMATTER_INVALID",
+        message: `DESIGN.md front-matter is not valid YAML: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+
+  const design = parseDesign(raw);
+  const colorCount = Object.keys(design.colors).length;
+  if (colorCount === 0) {
+    issues.push({
+      severity: "warning",
+      code: "DESIGN_NO_PALETTE",
+      message:
+        "DESIGN.md declares no colors (front-matter `colors:` or hex values in the Colors/Palette section). The composer will fall back to default tokens.",
+    });
+  } else if (colorCount < 2) {
+    issues.push({
+      severity: "info",
+      code: "DESIGN_THIN_PALETTE",
+      message: "DESIGN.md declares only one color; 2–3 (primary/ground/accent) read best on video.",
+    });
+  }
+
+  const hasMood = "Overview" in design.sections || "Style" in design.sections;
+  if (!hasMood) {
+    issues.push({
+      severity: "info",
+      code: "DESIGN_NO_MOOD",
+      message: "DESIGN.md has no `## Overview` or `## Style` section describing the mood/feel.",
+    });
+  }
+
+  return issues;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.14",
+  "version": "0.113.15",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.14",
+  "version": "0.113.15",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.14",
+  "version": "0.113.15",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
**Phase 2 (structured formats) — PR 1.**

DESIGN.md was only ever a freeform prompt blob + an existence gate; nothing read it as data. This adds a tolerant parser aligned with the emerging [google-labs `design.md`](https://github.com/google-labs-code/design.md) convention (40k★ [awesome-design-md](https://github.com/voltagent/awesome-design-md) ecosystem): optional YAML token front-matter (`name`, `colors`, `typography`) + `## ` prose sections, with graceful fallback (no/invalid front-matter → recover the palette from prose hexes). Today's freeform DESIGN.md **and** a dropped-in awesome-design-md file both parse.

- `parseDesign(md)` → `{ name, colors, typography, sections, frontmatter, raw }`
- `validateDesignMarkdown(md)` → soft issues (invalid front-matter, empty palette, missing mood)
- the deterministic AI-video composer now derives tokens via `parseDesign` with **role-aware named-color mapping** (primary/ground/accent), falling back to the luminance heuristic for unnamed palettes.

Tests: new `design-parse` suite + composer named-color case; full CLI suite **1259 pass**; lint/build clean. 0.113.15.

Follow-ups (this phase): emit the token front-matter from the DESIGN.md scaffold; add the `vibe design validate` command; then STORYBOARD `--kind` + SCRIPT.md/CHARACTERS.