### PR TITLE
feat: project --kind drives pipeline stages + default composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.16] - 2026-06-29
+## [0.113.17] - 2026-06-29
 
 ### Added
 
+- project --kind drives pipeline stages + default composer
 - vibe design validate + DESIGN.md google-labs token front-matter
 - structured DESIGN.md parser (google-labs design.md standard)
 - bound LLM compose fan-out concurrency (avoid provider rate limits)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.16",
+  "version": "0.113.17",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.16`
+> CLI version: `0.113.17`
 
 ## Mental model
 
@@ -347,6 +347,7 @@ Cost tier: _not tagged_
 - `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1 \| 4:5)_ _(default: `"16:9"`)_ — Scene aspect ratio: 16:9, 9:16, 1:1, 4:5
 - `duration` _(number)_ _(default: `10`)_ — Default scene/root duration in seconds
 - `visualStyle` _(string)_ — Seed scene DESIGN.md from a named style
+- `kind` _(string)_ _(default: `"cinema"`)_ — Project kind: cinema | story | aivideo | product | motion (drives pipeline stages + default composer)
 - `agent` _(string)_ _(default: `"auto"`)_ — Agent target: claude-code | codex | cursor | aider | gemini-cli | opencode | all | auto
 - `mcp` _(boolean)_ — Also write project-scoped MCP config for Codex/Claude Code/Cursor
 - `force` _(boolean)_ — Overwrite existing files instead of skipping

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.16",
+  "version": "0.113.17",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.16",
+  "version": "0.113.17",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.16",
+  "version": "0.113.17",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -696,6 +696,25 @@ exports[`CLI --describe schemas (drift detection) > vibe demo --describe 1`] = `
 }
 `;
 
+exports[`CLI --describe schemas (drift detection) > vibe design validate --describe 1`] = `
+{
+  "cost": "free",
+  "description": "Validate DESIGN.md front-matter tokens and sections",
+  "name": "design.validate",
+  "note": "Validate the DESIGN.md visual contract.",
+  "parameters": {
+    "properties": {
+      "project-dir": {
+        "description": "Project directory",
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+  "surface": "public",
+}
+`;
+
 exports[`CLI --describe schemas (drift detection) > vibe detect beats --describe 1`] = `
 {
   "cost": "free",
@@ -2622,6 +2641,11 @@ exports[`CLI --describe schemas (drift detection) > vibe init --describe 1`] = `
       },
       "from": {
         "description": "Draft STORYBOARD.md and DESIGN.md from a brief string or text/markdown file",
+        "type": "string",
+      },
+      "kind": {
+        "default": "cinema",
+        "description": "Project kind: cinema | story | aivideo | product | motion (drives pipeline stages + default composer)",
         "type": "string",
       },
       "mcp": {

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -38,6 +38,7 @@ import {
   type ParsedStoryboard,
 } from "./storyboard-parse.js";
 import { readProjectConfig, type LoadedProjectConfig } from "./project-config.js";
+import { kindAssetPolicy } from "./scene-project.js";
 import { validateStoryboardMarkdown, type StoryboardValidationIssue } from "./storyboard-edit.js";
 
 export type BuildStage = "assets" | "compose" | "sync" | "render" | "all";
@@ -191,6 +192,13 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
   loadPlanEnv(projectDir);
   const stage = opts.stage ?? "all";
   const config = await readProjectConfig(projectDir);
+  // Project kind forces per-kind asset skips (e.g. product/motion have no i2v),
+  // OR'd with the explicit `--skip-*` flags. Applied here so the dry-run plan +
+  // cost estimate match what the build actually runs.
+  const kindPolicy = kindAssetPolicy(config.config.kind);
+  const skipBackdrop = opts.skipBackdrop ?? kindPolicy.skipBackdrop ?? false;
+  const skipKeyframe = opts.skipKeyframe ?? kindPolicy.skipKeyframe ?? false;
+  const skipVideo = opts.skipVideo ?? kindPolicy.skipVideo ?? false;
   const storyboardPath = join(projectDir, "STORYBOARD.md");
   const warnings: string[] = [];
   const retryWith: string[] = [];
@@ -382,7 +390,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
           })
         : null;
     const backdrop =
-      backdropCue && !opts.skipBackdrop
+      backdropCue && !skipBackdrop
         ? assetPlan({
             kind: "backdrop",
             beatId: beat.id,
@@ -398,7 +406,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
           })
         : null;
     const keyframe =
-      keyframePrompt && !opts.skipKeyframe
+      keyframePrompt && !skipKeyframe
         ? assetPlan({
             kind: "keyframe",
             beatId: beat.id,
@@ -414,7 +422,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
           })
         : null;
     const video =
-      videoCue && !opts.skipVideo
+      videoCue && !skipVideo
         ? assetPlan({
             kind: "video",
             beatId: beat.id,
@@ -507,7 +515,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
 
   if (
     includeAssets &&
-    !opts.skipBackdrop &&
+    !skipBackdrop &&
     !isSupportedBuildImageProvider(resolved.image.resolved)
   ) {
     const unsupportedBackdropBeats = beats.filter((beat) =>
@@ -549,7 +557,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
     );
   }
 
-  if (validationOk && includeAssets && !opts.skipBackdrop) {
+  if (validationOk && includeAssets && !skipBackdrop) {
     const generatedBackdrops = beats
       .map((beat) => beat.assets.backdrop)
       .filter((asset): asset is AssetPlan => Boolean(asset?.willGenerate));
@@ -567,7 +575,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
   // Character sheets are generated once per build (project-level), before
   // per-beat video. Estimate cost for referenced, prompt-based characters that
   // are not already on disk so `--max-cost` gates them.
-  if (validationOk && includeAssets && !opts.skipVideo) {
+  if (validationOk && includeAssets && !skipVideo) {
     const referenced = new Set<string>();
     for (const beat of sourceBeats) {
       for (const name of beatCharacterNames(beat.cues)) referenced.add(name);

--- a/packages/cli/src/commands/_shared/project-config.ts
+++ b/packages/cli/src/commands/_shared/project-config.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 
-import type { SceneAspect, VibeProjectConfig as LegacyVibeProjectConfig } from "./scene-project.js";
+import type { SceneAspect, SceneKind, VibeProjectConfig as LegacyVibeProjectConfig } from "./scene-project.js";
 
 export const VIBE_CONFIG_FILENAME = "vibe.config.json";
 export const LEGACY_VIBE_PROJECT_FILENAME = "vibe.project.yaml";
@@ -19,6 +19,8 @@ export interface VibeProjectConfigV1 {
   schemaVersion: "1";
   name: string;
   aspect: SceneAspect;
+  /** Project kind — drives which pipeline stages run + the default composer. */
+  kind: SceneKind;
   defaults: {
     sceneDurationSec: number;
     narrationPaddingSec: number;
@@ -59,12 +61,14 @@ export interface LoadedProjectConfig {
 export function defaultProjectConfig(opts: {
   name: string;
   aspect?: SceneAspect;
+  kind?: SceneKind;
   sceneDurationSec?: number;
 }): VibeProjectConfigV1 {
   return {
     schemaVersion: "1",
     name: opts.name,
     aspect: opts.aspect ?? "16:9",
+    kind: opts.kind ?? "cinema", // DEFAULT_SCENE_KIND (literal to avoid an import cycle)
     defaults: {
       sceneDurationSec: opts.sceneDurationSec ?? 5,
       narrationPaddingSec: 0.5,
@@ -114,6 +118,7 @@ export function mergeProjectConfig(
 export function projectConfigJson(opts: {
   name: string;
   aspect?: SceneAspect;
+  kind?: SceneKind;
   sceneDurationSec?: number;
 }): string {
   return JSON.stringify(defaultProjectConfig(opts), null, 2) + "\n";
@@ -132,6 +137,7 @@ export async function readProjectConfig(projectDir: string): Promise<LoadedProje
       const fallback = defaultProjectConfig({
         name,
         aspect: parsed.aspect,
+        kind: parsed.kind,
         sceneDurationSec: parsed.defaults?.sceneDurationSec,
       });
       return {

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -42,6 +42,12 @@ import {
   type ComposeScenesActionResult,
 } from "./compose-scenes-skills.js";
 import { composeAiVideo } from "./compose-aivideo.js";
+import {
+  composerDefaultForKind,
+  isSceneKind,
+  kindAssetPolicy,
+  type SceneKind,
+} from "./scene-project.js";
 import type { ComposerProvider } from "./composer-resolve.js";
 import { getComposePrompts, type ComposePromptsBeat } from "./compose-prompts.js";
 import { getApiKeyFromConfig } from "../../config/index.js";
@@ -390,13 +396,38 @@ export interface SceneBuildResult {
 
 // ── Driver ───────────────────────────────────────────────────────────────
 
+/** Read the persisted project kind from vibe.config.json (default `cinema`). */
+function readProjectKindSync(projectDir: string): SceneKind {
+  try {
+    const raw = readFileSync(join(projectDir, "vibe.config.json"), "utf-8");
+    const k = (JSON.parse(raw) as { kind?: unknown }).kind;
+    return typeof k === "string" && isSceneKind(k) ? k : "cinema";
+  } catch {
+    return "cinema";
+  }
+}
+
 export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneBuildResult> {
   const startedAt = Date.now();
   const projectDir = resolve(opts.projectDir);
   const onProgress = opts.onProgress ?? (() => {});
+
+  // Project kind drives the default composer and per-kind asset skips. Explicit
+  // `--composer`/`--skip-*` flags always win over the kind defaults.
+  const projectKind = readProjectKindSync(projectDir);
+  const kindPolicy = kindAssetPolicy(projectKind);
+  const composer = opts.composer ?? composerDefaultForKind(projectKind);
+  const skipBackdrop = opts.skipBackdrop ?? kindPolicy.skipBackdrop ?? false;
+  const skipKeyframe = opts.skipKeyframe ?? kindPolicy.skipKeyframe ?? false;
+  // Asset-stage video skip (don't generate i2v clips). Distinct from the
+  // explicit `--skip-video` render-stop below: a `product`/`motion` kind has no
+  // i2v but still RENDERS (backdrops / graphics), so only the explicit flag
+  // stops the render.
+  const skipVideoAssets = opts.skipVideo ?? kindPolicy.skipVideo ?? false;
+
   // The deterministic template composer is a batch (CLI-authored) path — it must
   // not route to agent/needs-author even when an agent host is detected.
-  const mode = opts.composer === "template" ? "batch" : resolveSceneBuildMode(opts);
+  const mode = composer === "template" ? "batch" : resolveSceneBuildMode(opts);
   const selectedStage = opts.stage ?? (opts.skipRender ? "sync" : "all");
   // --skip-video produces keyframe stills (an image storyboard) for review, not
   // a final video. The composition would reference <video> clips that were never
@@ -422,9 +453,9 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     beat: opts.beatId,
     mode,
     skipNarration: opts.skipNarration,
-    skipBackdrop: opts.skipBackdrop,
-    skipVideo: opts.skipVideo,
-    skipKeyframe: opts.skipKeyframe,
+    skipBackdrop,
+    skipVideo: skipVideoAssets,
+    skipKeyframe,
     skipMusic: opts.skipMusic,
     ttsProvider: opts.ttsProvider,
     voice: opts.voice,
@@ -433,7 +464,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     imageSize: opts.imageSize,
     videoProvider: opts.videoProvider,
     musicProvider: opts.musicProvider,
-    composer: opts.composer,
+    composer,
     force: opts.force,
   });
   warnings.push(...buildPlan.warnings);
@@ -603,7 +634,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     // (dispatchKeyframe) can use them. Needed whenever video OR keyframe runs —
     // only skip when both are skipped.
     const characterPaths = new Map<string, string>();
-    if (!((opts.skipVideo ?? false) && (opts.skipKeyframe ?? false))) {
+    if (!(skipVideoAssets && skipKeyframe)) {
       const referenced = new Set<string>();
       for (const beat of activeBeats) {
         for (const name of beatCharacterNames(beat.cues)) referenced.add(name);
@@ -640,9 +671,9 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
           imageQuality: opts.imageQuality ?? "hd",
           imageSize: opts.imageSize ?? "1536x1024",
           skipNarration: opts.skipNarration ?? false,
-          skipBackdrop: opts.skipBackdrop ?? false,
-          skipVideo: opts.skipVideo ?? false,
-          skipKeyframe: opts.skipKeyframe ?? false,
+          skipBackdrop,
+          skipVideo: skipVideoAssets,
+          skipKeyframe,
           skipMusic: opts.skipMusic ?? false,
           skipTranscript: opts.skipTranscript ?? false,
           force: opts.force ?? false,
@@ -791,7 +822,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
       // All compositions present — fall through to render (no compose call).
       onProgress({ type: "phase-start", phase: "compose" });
       stageReports.compose.status = "done";
-    } else if (opts.composer === "template") {
+    } else if (composer === "template") {
       // Deterministic AI-video composer: concat clips → one bg video +
       // transparent lower-third overlays. No LLM, no multi-video render race.
       onProgress({ type: "phase-start", phase: "compose" });
@@ -832,7 +863,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
         {
           project: ".",
           effort: opts.effort,
-          composer: opts.composer,
+          composer,
           cacheDir: opts.cacheDir,
           onProgress: (e) => onProgress(e),
         },
@@ -886,7 +917,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     // LLM-authored HTML) and offer a targeted recompose. The deterministic
     // template composer intentionally references one concatenated bg video
     // (not per-beat clips), so this check does not apply there.
-    for (const beat of opts.composer === "template" ? [] : activeBeats) {
+    for (const beat of composer === "template" ? [] : activeBeats) {
       const videoRel = `assets/video-${beat.id}.mp4`;
       const compositionAbs = join(projectDir, "compositions", `scene-${beat.id}.html`);
       if (!existsSync(join(projectDir, videoRel)) || !existsSync(compositionAbs)) continue;

--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -14,12 +14,43 @@ import {
   buildProjectClaudeMd,
   buildStoryboardMd,
   buildSceneGitignore,
+  composerDefaultForKind,
   defaultVibeProjectConfig,
+  isSceneKind,
+  kindAssetPolicy,
   mergeHyperframesConfig,
   scaffoldSceneProject,
+  VALID_SCENE_KINDS,
   type HyperframesConfig,
 } from "./scene-project.js";
 import { getVisualStyle } from "./visual-styles.js";
+
+describe("SceneKind", () => {
+  it("recognizes the five kinds and rejects others", () => {
+    for (const k of VALID_SCENE_KINDS) expect(isSceneKind(k)).toBe(true);
+    expect(isSceneKind("nonsense")).toBe(false);
+    expect(VALID_SCENE_KINDS).toEqual(["cinema", "product", "aivideo", "story", "motion"]);
+  });
+
+  it("kindAssetPolicy: product skips i2v, motion skips all AI assets, others add none", () => {
+    expect(kindAssetPolicy("product")).toEqual({ skipKeyframe: true, skipVideo: true });
+    expect(kindAssetPolicy("motion")).toEqual({
+      skipKeyframe: true,
+      skipVideo: true,
+      skipBackdrop: true,
+    });
+    expect(kindAssetPolicy("cinema")).toEqual({});
+    expect(kindAssetPolicy("story")).toEqual({});
+    expect(kindAssetPolicy("aivideo")).toEqual({});
+  });
+
+  it("composerDefaultForKind: only aivideo defaults to the template composer", () => {
+    expect(composerDefaultForKind("aivideo")).toBe("template");
+    for (const k of ["cinema", "product", "story", "motion"] as const) {
+      expect(composerDefaultForKind(k)).toBeUndefined();
+    }
+  });
+});
 
 async function makeTmp(label = "vibe-scene-test-"): Promise<string> {
   return mkdtemp(join(tmpdir(), label));

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -22,6 +22,55 @@ import { projectConfigJson, VIBE_CONFIG_FILENAME } from "./project-config.js";
 export type SceneAspect = "16:9" | "9:16" | "1:1" | "4:5";
 export type SceneScaffoldProfile = "minimal" | "agent" | "full";
 
+/**
+ * Project KIND — orthogonal to {@link SceneScaffoldProfile} (which decides which
+ * files exist). Kind decides which pipeline STAGES run and which composer is the
+ * default:
+ * - `cinema` / `story` — directed, character-driven; keyframe→i2v, LLM composer.
+ * - `aivideo` — character + i2v, the deterministic `template` composer.
+ * - `product` — backdrop/asset-centric (no i2v keyframes).
+ * - `motion` — pure HTML/CSS/GSAP graphics (no AI image/video assets).
+ */
+export type SceneKind = "cinema" | "product" | "aivideo" | "story" | "motion";
+
+export const VALID_SCENE_KINDS: readonly SceneKind[] = [
+  "cinema",
+  "product",
+  "aivideo",
+  "story",
+  "motion",
+];
+
+/** Default kind preserves today's behavior (LLM composer, cue-driven assets). */
+export const DEFAULT_SCENE_KIND: SceneKind = "cinema";
+
+export function isSceneKind(value: string): value is SceneKind {
+  return (VALID_SCENE_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * Per-kind default asset skips, OR'd with the explicit `--skip-*` flags. Returns
+ * only the skips a kind forces; `cinema`/`story`/`aivideo` add none (assets run
+ * from their cues).
+ */
+export function kindAssetPolicy(
+  kind: SceneKind
+): { skipKeyframe?: boolean; skipVideo?: boolean; skipBackdrop?: boolean } {
+  switch (kind) {
+    case "product":
+      return { skipKeyframe: true, skipVideo: true }; // backdrop-centric, no i2v
+    case "motion":
+      return { skipKeyframe: true, skipVideo: true, skipBackdrop: true }; // pure graphics
+    default:
+      return {};
+  }
+}
+
+/** The composer a kind defaults to when `--composer` is not given. */
+export function composerDefaultForKind(kind: SceneKind): "template" | undefined {
+  return kind === "aivideo" ? "template" : undefined;
+}
+
 const ASPECT_DIMS: Record<SceneAspect, { width: number; height: number }> = {
   "16:9": { width: 1920, height: 1080 },
   "9:16": { width: 1080, height: 1920 },
@@ -615,6 +664,8 @@ export interface ScaffoldOptions {
   visualStyle?: VisualStyle;
   /** Scaffold shape. Defaults to "full" for backward-compatible programmatic use. */
   profile?: SceneScaffoldProfile;
+  /** Project kind — drives which pipeline stages run + the default composer. */
+  kind?: SceneKind;
 }
 
 export interface ScaffoldResult {
@@ -700,6 +751,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
   const duration = opts.duration ?? 10;
   const now = opts.now ?? new Date();
   const profile = opts.profile ?? "full";
+  const kind = opts.kind ?? DEFAULT_SCENE_KIND;
 
   await mkdir(dir, { recursive: true });
   if (profile === "full") {
@@ -755,7 +807,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
   if (await pathExists(vibeConfigJsonPath)) {
     skipped.push(vibeConfigJsonPath);
   } else {
-    await writeFile(vibeConfigJsonPath, projectConfigJson({ name, aspect }), "utf-8");
+    await writeFile(vibeConfigJsonPath, projectConfigJson({ name, aspect, kind }), "utf-8");
     created.push(vibeConfigJsonPath);
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -31,7 +31,9 @@ import { detectedAgentHosts, type AgentHostId } from "../utils/agent-host-detect
 import {
   describeSceneScaffold,
   isSceneScaffoldProfile,
+  isSceneKind,
   scaffoldSceneProject,
+  VALID_SCENE_KINDS,
   type SceneAspect,
 } from "./_shared/scene-project.js";
 import { getVisualStyle, visualStyleNames } from "./_shared/visual-styles.js";
@@ -89,6 +91,11 @@ export const initCommand = new Command("init")
   .option("-r, --ratio <ratio>", "Scene aspect ratio: 16:9, 9:16, 1:1, 4:5", "16:9")
   .option("-d, --duration <sec>", "Default scene/root duration in seconds", "10")
   .option("--visual-style <name>", "Seed scene DESIGN.md from a named style")
+  .option(
+    "--kind <kind>",
+    "Project kind: cinema | story | aivideo | product | motion (drives pipeline stages + default composer)",
+    "cinema"
+  )
   .option("--agent <id>", `Agent target: ${VALID_AGENTS.join(" | ")}`, "auto")
   .option("--mcp", "Also write project-scoped MCP config for Codex/Claude Code/Cursor")
   .option("--force", "Overwrite existing files instead of skipping")
@@ -304,6 +311,14 @@ async function runSceneInit(
     );
   }
 
+  const kind = String(options.kind ?? "cinema");
+  if (!isSceneKind(kind)) {
+    exitWithError(
+      usageError(`Invalid --kind: ${kind}`, `Must be one of: ${VALID_SCENE_KINDS.join(", ")}`)
+    );
+    return;
+  }
+
   const duration = Number.parseFloat(String(options.duration ?? "10"));
   if (!Number.isFinite(duration) || duration <= 0 || duration > 3600) {
     exitWithError(
@@ -355,6 +370,7 @@ async function runSceneInit(
         projectDir,
         name: projectName,
         profile,
+        kind,
         aspect,
         duration,
         visualStyle: visualStyle?.name ?? null,
@@ -372,6 +388,7 @@ async function runSceneInit(
     duration,
     visualStyle,
     profile,
+    kind,
   });
   const draftWarnings: string[] = [];
   if (fromBrief) {
@@ -419,6 +436,7 @@ async function runSceneInit(
         projectDir,
         name: projectName,
         profile,
+        kind,
         aspect,
         duration,
         visualStyle: visualStyle?.name ?? null,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.16",
+  "version": "0.113.17",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.16",
+  "version": "0.113.17",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.16",
+  "version": "0.113.17",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
**Phase 2 (structured formats) — PR 2B.**

Adds a `SceneKind` (cinema | story | aivideo | product | motion) orthogonal to the scaffold profile. `vibe init --kind <k>` persists it to `vibe.config.json`; the build pipeline gates on it.

## What
- **`kindAssetPolicy(kind)`** forces per-kind asset skips, OR'd with explicit `--skip-*`:
  - `product` → no i2v (backdrop-centric)
  - `motion` → no AI image/video (pure HTML/CSS/GSAP graphics)
  - `cinema` / `story` / `aivideo` → cue-driven (no extra skips)
  Applied inside `createBuildPlan` so the **dry-run plan + cost estimate match** the real build.
- **`composerDefaultForKind`**: `aivideo` defaults to the deterministic `--composer template` path (#242); other kinds keep the LLM composer. Explicit `--composer` always wins.
- Default kind = `cinema` → **preserves today's behavior exactly**. The asset-stage video skip is kept distinct from the explicit `--skip-video` render-stop (product/motion still render).

## Verified (free, dry-run on one storyboard)
| kind | keyframe | video | backdrop | est cost |
|---|---|---|---|---|
| product | 0 | 0 | 1 | \$0.31 |
| motion | 0 | 0 | 0 | \$0.11 |
| aivideo / cinema | 1 | 1 | 1 | \$2.22 |

`--kind nonsense` errors; kind persists + reads back. SceneKind unit tests + persisted on `VibeProjectConfigV1`. Full CLI suite **1274 pass / 9 skip**; mcp-server **73 pass**; lint/build clean; sync-counts in sync. 0.113.17.

Next: PR 2C (SCRIPT.md/CHARACTERS scaffolds + overlay cues).