### PR TITLE
feat: SCRIPT.md (always) + CHARACTERS.md (kind-gated) + overlay cues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.17] - 2026-06-29
+## [0.113.18] - 2026-06-29
 
 ### Added
 
+- SCRIPT.md (always) + CHARACTERS.md (kind-gated) + overlay cues
 - project --kind drives pipeline stages + default composer
 - vibe design validate + DESIGN.md google-labs token front-matter
 - structured DESIGN.md parser (google-labs design.md standard)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.17",
+  "version": "0.113.18",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.17`
+> CLI version: `0.113.18`
 
 ## Mental model
 
@@ -1936,7 +1936,7 @@ Cost tier: `free`
 
 - `project-dir` _(string)_ **required** — Project directory
 - `beat` _(string)_ **required** — Beat id
-- `key` _(string)_ **required** — Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters
+- `key` _(string)_ **required** — Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters | eyebrow | title | caption | kicker | sub
 - `value` _(array)_ — Cue value. Use --json-value to pass a JSON scalar/object.
 - `jsonValue` _(boolean)_ — Parse value as JSON instead of a string
 - `unset` _(boolean)_ — Remove the cue key from the beat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.17",
+  "version": "0.113.18",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.17",
+  "version": "0.113.18",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.17",
+  "version": "0.113.18",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -4081,7 +4081,7 @@ exports[`CLI --describe schemas (drift detection) > vibe storyboard set --descri
         "type": "boolean",
       },
       "key": {
-        "description": "Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters",
+        "description": "Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters | eyebrow | title | caption | kicker | sub",
         "type": "string",
       },
       "project-dir": {

--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -13,11 +13,15 @@ import {
   buildProjectAgentsMd,
   buildProjectClaudeMd,
   buildStoryboardMd,
+  buildCharactersMd,
   buildSceneGitignore,
+  buildScriptMd,
   composerDefaultForKind,
   defaultVibeProjectConfig,
+  describeSceneScaffold,
   isSceneKind,
   kindAssetPolicy,
+  kindHasCast,
   mergeHyperframesConfig,
   scaffoldSceneProject,
   VALID_SCENE_KINDS,
@@ -49,6 +53,54 @@ describe("SceneKind", () => {
     for (const k of ["cinema", "product", "story", "motion"] as const) {
       expect(composerDefaultForKind(k)).toBeUndefined();
     }
+  });
+
+  it("kindHasCast: only character-driven kinds have a cast", () => {
+    expect(kindHasCast("cinema")).toBe(true);
+    expect(kindHasCast("story")).toBe(true);
+    expect(kindHasCast("aivideo")).toBe(true);
+    expect(kindHasCast("product")).toBe(false);
+    expect(kindHasCast("motion")).toBe(false);
+  });
+
+  it("buildScriptMd is always emittable and names the project", () => {
+    expect(buildScriptMd("my-film", "cinema")).toContain("# my-film — Script");
+    expect(buildScriptMd("promo", "product")).toContain("Product walkthrough");
+    expect(buildScriptMd("loop", "motion")).toContain("Motion piece");
+  });
+
+  it("buildCharactersMd seeds a cast block with a reference sheet", () => {
+    const md = buildCharactersMd("my-film");
+    expect(md).toContain("# my-film — Characters");
+    expect(md).toContain("assets/characters/hero.png");
+  });
+
+  it("describeSceneScaffold lists SCRIPT.md always; CHARACTERS.md only for cast kinds", () => {
+    const cinema = describeSceneScaffold({ dir: "/x", kind: "cinema" }).authoring.join("|");
+    expect(cinema).toContain("SCRIPT.md");
+    expect(cinema).toContain("CHARACTERS.md");
+    const product = describeSceneScaffold({ dir: "/x", kind: "product" }).authoring.join("|");
+    expect(product).toContain("SCRIPT.md");
+    expect(product).not.toContain("CHARACTERS.md");
+  });
+});
+
+describe("scaffoldSceneProject kind-gated artifacts", () => {
+  it("writes SCRIPT.md always but CHARACTERS.md only for cast kinds", async () => {
+    const castDir = await makeTmp();
+    await scaffoldSceneProject({ dir: castDir, name: "cast", kind: "aivideo", profile: "minimal" });
+    expect(await pathExists(resolve(castDir, "SCRIPT.md"))).toBe(true);
+    expect(await pathExists(resolve(castDir, "CHARACTERS.md"))).toBe(true);
+
+    const castlessDir = await makeTmp();
+    await scaffoldSceneProject({
+      dir: castlessDir,
+      name: "promo",
+      kind: "product",
+      profile: "minimal",
+    });
+    expect(await pathExists(resolve(castlessDir, "SCRIPT.md"))).toBe(true);
+    expect(await pathExists(resolve(castlessDir, "CHARACTERS.md"))).toBe(false);
   });
 });
 
@@ -337,6 +389,8 @@ describe("scaffoldSceneProject", () => {
       "CLAUDE.md",
       "DESIGN.md",
       "STORYBOARD.md",
+      "SCRIPT.md",
+      "CHARACTERS.md",
       ".gitignore",
     ];
     for (const f of expected) {

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -71,6 +71,14 @@ export function composerDefaultForKind(kind: SceneKind): "template" | undefined 
   return kind === "aivideo" ? "template" : undefined;
 }
 
+/**
+ * Whether a kind has a recurring cast worth a `CHARACTERS.md` bible. Character-
+ * driven kinds (cinema/story/aivideo) do; product/motion do not.
+ */
+export function kindHasCast(kind: SceneKind): boolean {
+  return kind === "cinema" || kind === "story" || kind === "aivideo";
+}
+
 const ASPECT_DIMS: Record<SceneAspect, { width: number; height: number }> = {
   "16:9": { width: 1920, height: 1080 },
   "9:16": { width: 1080, height: 1920 },
@@ -343,6 +351,75 @@ ${avoid}
 
 _Browse other named styles: \`vibe scene list-styles\`_
 ${style ? `_This file was seeded by \`vibe scene init --visual-style "${style.name}"\`._` : `_Seed this file from a named style: \`vibe scene init <dir> --visual-style "<name>"\`._`}
+`;
+}
+
+/**
+ * Always-on `SCRIPT.md` — the narrative spine authored before the beat-level
+ * STORYBOARD.md. Kind tailors the guidance (a `motion`/`product` script is a
+ * shot/asset list; a `story`/`cinema` script is a scene-by-scene narrative).
+ */
+export function buildScriptMd(name: string, kind: SceneKind = DEFAULT_SCENE_KIND): string {
+  const intent =
+    kind === "product"
+      ? "Product walkthrough — what each section demonstrates, in order."
+      : kind === "motion"
+        ? "Motion piece — the message and the beats of on-screen text/graphics."
+        : kind === "aivideo"
+          ? "AI-video script — the spoken/voiced narrative the generated shots illustrate."
+          : "Narrative script — scene-by-scene story, dialogue, and voiceover.";
+  return `# ${name} — Script
+
+> **Authoring order:** SCRIPT.md (this file) → STORYBOARD.md (beats + cues)${
+    kindHasCast(kind) ? " → CHARACTERS.md (cast bible)" : ""
+  }.
+> ${intent}
+
+## Logline
+
+One or two sentences: who/what this is for and the single takeaway.
+
+## Script
+
+Write the spoken/voiceover line and the on-screen intent for each moment. Each
+\`##\`-level section below maps to one STORYBOARD beat.
+
+### 1. Open
+
+Voiceover / on-screen: …
+
+### 2. Develop
+
+Voiceover / on-screen: …
+
+### 3. Close
+
+Voiceover / on-screen: …
+`;
+}
+
+/**
+ * Kind-gated `CHARACTERS.md` — the cast bible. Promotes today's STORYBOARD
+ * \`characters:\` frontmatter into first-class identity blocks (reference sheet
+ * path + an identity-lock description used to keep keyframes/i2v on-model).
+ */
+export function buildCharactersMd(name: string): string {
+  return `# ${name} — Characters
+
+> Each character is referenced from STORYBOARD beats via the \`characters:\` cue.
+> The reference sheet + identity block keep keyframes and image-to-video on-model
+> across scenes (the Director continuity contract).
+
+## hero
+
+- **Reference sheet:** \`assets/characters/hero.png\` (a clean, front-lit full-body
+  or portrait sheet — the identity anchor for keyframe edits).
+- **Identity:** one paragraph of fixed, on-model traits — age, build, hair,
+  wardrobe, palette. Keep this stable across every beat.
+- **Range:** expressions / poses this character should hit.
+
+<!-- Add one ## block per recurring character. Delete this file for kinds with
+     no recurring cast. -->
 `;
 }
 
@@ -692,13 +769,17 @@ export function isSceneScaffoldProfile(value: string): value is SceneScaffoldPro
 export function describeSceneScaffold(opts: {
   dir: string;
   profile?: SceneScaffoldProfile;
+  kind?: SceneKind;
 }): SceneScaffoldGroups {
   const dir = resolve(opts.dir);
   const profile = opts.profile ?? "full";
+  const kind = opts.kind ?? DEFAULT_SCENE_KIND;
   const groups: SceneScaffoldGroups = {
     authoring: [
+      resolve(dir, "SCRIPT.md"),
       resolve(dir, "STORYBOARD.md"),
       resolve(dir, "DESIGN.md"),
+      ...(kindHasCast(kind) ? [resolve(dir, "CHARACTERS.md")] : []),
       resolve(dir, VIBE_CONFIG_FILENAME),
       resolve(dir, "vibe.project.yaml"),
       resolve(dir, ".gitignore"),
@@ -867,6 +948,26 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
   } else {
     await writeFile(storyboardPath, buildStoryboardMd(name, duration), "utf-8");
     created.push(storyboardPath);
+  }
+
+  // SCRIPT.md — always-on narrative spine (authored before STORYBOARD beats).
+  const scriptPath = resolve(dir, "SCRIPT.md");
+  if (await pathExists(scriptPath)) {
+    skipped.push(scriptPath);
+  } else {
+    await writeFile(scriptPath, buildScriptMd(name, kind), "utf-8");
+    created.push(scriptPath);
+  }
+
+  // CHARACTERS.md — only for kinds with a recurring cast (cinema/story/aivideo).
+  if (kindHasCast(kind)) {
+    const charactersPath = resolve(dir, "CHARACTERS.md");
+    if (await pathExists(charactersPath)) {
+      skipped.push(charactersPath);
+    } else {
+      await writeFile(charactersPath, buildCharactersMd(name), "utf-8");
+      created.push(charactersPath);
+    }
   }
 
   // .gitignore — preserve existing.

--- a/packages/cli/src/commands/_shared/storyboard-edit.ts
+++ b/packages/cli/src/commands/_shared/storyboard-edit.ts
@@ -19,6 +19,11 @@ export const STORYBOARD_CUE_KEYS = [
   "music",
   "asset",
   "characters",
+  "eyebrow",
+  "title",
+  "caption",
+  "kicker",
+  "sub",
 ] as const;
 
 export type StoryboardCueKey = (typeof STORYBOARD_CUE_KEYS)[number];
@@ -65,7 +70,7 @@ interface BeatSection {
 const HEADING_RE = /^##\s+(.+?)\s*$/gm;
 const LEADING_CUE_RE = /^(\s*)```ya?ml\s*\n([\s\S]*?)\n```\s*(?:\n|$)/;
 const ALLOWED_CUE_KEYS = new Set<string>(STORYBOARD_CUE_KEYS);
-const STRING_CUE_KEYS = new Set<string>(["narration", "backdrop", "video", "keyframe", "motion", "voice", "music", "asset"]);
+const STRING_CUE_KEYS = new Set<string>(["narration", "backdrop", "video", "keyframe", "motion", "voice", "music", "asset", "eyebrow", "title", "caption", "kicker", "sub"]);
 
 /** Beats beyond this render as static, overstuffed scenes. */
 export const MAX_RECOMMENDED_BEAT_SEC = 15;

--- a/packages/cli/src/commands/_shared/storyboard-parse.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.test.ts
@@ -267,6 +267,23 @@ Cold open.
     expect(r.body).not.toContain("narration:");
   });
 
+  it("preserves lower-third overlay cues (eyebrow/title/caption)", () => {
+    const body = `\`\`\`yaml
+eyebrow: "CHAPTER ONE"
+title: "The Summit"
+caption: "4,300m"
+\`\`\`
+
+### Concept
+`;
+    const r = extractBeatCues(body);
+    expect(r.cues).toMatchObject({
+      eyebrow: "CHAPTER ONE",
+      title: "The Summit",
+      caption: "4,300m",
+    });
+  });
+
   it("does NOT strip a yaml block deeper in the body (only leading block is metadata)", () => {
     const body = `### Concept
 

--- a/packages/cli/src/commands/_shared/storyboard-parse.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.ts
@@ -148,6 +148,12 @@ export interface BeatCues {
    * if present, supplies the motion prompt; otherwise this text is used.
    */
   keyframe?: string;
+  /** Lower-third overlay eyebrow/kicker (read by the deterministic composer). */
+  eyebrow?: string;
+  /** Lower-third headline; falls back to the beat heading when absent. */
+  title?: string;
+  /** Lower-third sub-line / caption. */
+  caption?: string;
   [key: string]: unknown;
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -341,7 +341,7 @@ async function runSceneInit(
 
   const projectDir = resolve(projectDirArg);
   const projectName = basename(projectDir);
-  const groups = describeSceneScaffold({ dir: projectDir, profile });
+  const groups = describeSceneScaffold({ dir: projectDir, profile, kind });
   const fromBrief =
     typeof options.from === "string" && options.from.trim()
       ? await readBriefOrLiteral(String(options.from), process.cwd())

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.17",
+  "version": "0.113.18",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.17",
+  "version": "0.113.18",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.17",
+  "version": "0.113.18",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
**Phase 2 (structured formats) — PR 2C.** Completes the authoring artifacts the redesigned pipeline (`SCRIPT → STORYBOARD → CHARACTERS → assets → compose`) was missing.

## What
- **`SCRIPT.md` (always)** — the narrative spine authored before STORYBOARD beats. Kind-tailored guidance (product = walkthrough, motion = on-screen beats, story/cinema = scene-by-scene, aivideo = voiced narrative).
- **`CHARACTERS.md` (kind-gated)** — a cast bible (reference sheet + identity-lock block) scaffolded **only for character-driven kinds** (cinema/story/aivideo) via `kindHasCast`. product/motion get no cast file. `describeSceneScaffold` lists both (dry-run + JSON reflect it).
- **Overlay cues** — `eyebrow`/`title`/`caption` (+ `kicker`/`sub` aliases) are now first-class storyboard cue keys: parsed, validated, round-tripped. The deterministic `template` composer's `beatOverlayText` already reads them, so an aivideo author can title each beat from STORYBOARD.

## Verified
- Scaffold: `SCRIPT=y` for all kinds; `CHARACTERS=y` only for cinema/aivideo (n for product/motion).
- Overlay cues: `storyboard validate` accepts them (no unknown-cue warning); `storyboard list` round-trips `{eyebrow, title, caption}`.
- Builders + parser get focused tests. Full CLI suite **1271 pass / 9 skip**; lint/build clean; gen:reference + agent-sync in sync.

This is the **last Phase-2 PR**. Next: Phase 3 (COMPOSITION.md → transcript stage → `vibe preview` → assemble). 0.113.18.