### PR TITLE
feat: COMPOSITION.md structural compose-contract (PR 3A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.18] - 2026-06-29
+## [0.113.19] - 2026-06-30
 
 ### Added
 
+- COMPOSITION.md structural compose-contract (hard-gate parallel to DESIGN.md)
 - SCRIPT.md (always) + CHARACTERS.md (kind-gated) + overlay cues
 - project --kind drives pipeline stages + default composer
 - vibe design validate + DESIGN.md google-labs token front-matter

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.18",
+  "version": "0.113.19",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.18`
+> CLI version: `0.113.19`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.18",
+  "version": "0.113.19",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.18",
+  "version": "0.113.19",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.18",
+  "version": "0.113.19",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/compose-prompts.test.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.test.ts
@@ -16,7 +16,9 @@ describe("getComposePrompts", () => {
     rmSync(projectDir, { recursive: true, force: true });
   });
 
-  function seed(opts: { storyboard?: string; design?: string; withSkill?: boolean } = {}): void {
+  function seed(
+    opts: { storyboard?: string; design?: string; withSkill?: boolean; composition?: string } = {},
+  ): void {
     writeFileSync(
       join(projectDir, "DESIGN.md"),
       opts.design ?? "# Design\n\n## Palette\n- `#000000`\n",
@@ -34,6 +36,9 @@ describe("getComposePrompts", () => {
         "---\nname: hyperframes\n---\nFRAMEWORK RULES",
         "utf-8",
       );
+    }
+    if (opts.composition !== undefined) {
+      writeFileSync(join(projectDir, "COMPOSITION.md"), opts.composition, "utf-8");
     }
   }
 
@@ -112,6 +117,32 @@ describe("getComposePrompts", () => {
     expect(r.instructions[0]).toContain("SKILL.md");
     expect(r.instructions.some((l) => l.includes("scene lint"))).toBe(true);
     expect(r.instructions.some((l) => l.includes("vibe render"))).toBe(true);
+  });
+
+  it("compositionReference is null + no 2b instruction when COMPOSITION.md is absent", async () => {
+    seed({ withSkill: true });
+    const r = await getComposePrompts({ projectDir });
+    expect(r.success).toBe(true);
+    expect(r.compositionReference).toBeNull();
+    expect(r.instructions.some((l) => l.includes("COMPOSITION.md"))).toBe(false);
+  });
+
+  it("surfaces COMPOSITION.md as a hard-gate reference + 2b instruction when present", async () => {
+    seed({ withSkill: true, composition: "# Composition\n\n## Layout\n- 12-col grid\n" });
+    const r = await getComposePrompts({ projectDir });
+    expect(r.success).toBe(true);
+    expect(r.compositionReference).toBe("COMPOSITION.md");
+    const step = r.instructions.find((l) => l.includes("COMPOSITION.md"));
+    expect(step).toBeDefined();
+    expect(step).toContain("STRUCTURAL");
+    expect(step).toContain("HARD-GATE");
+  });
+
+  it("carries compositionReference through the failure (baseError) path", async () => {
+    seed({ withSkill: true, composition: "# Composition\n" });
+    const r = await getComposePrompts({ projectDir, beatId: "nope" });
+    expect(r.success).toBe(false);
+    expect(r.compositionReference).toBe("COMPOSITION.md");
   });
 
   it("returns failure when DESIGN.md is missing", async () => {

--- a/packages/cli/src/commands/_shared/compose-prompts.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.ts
@@ -85,6 +85,14 @@ export interface ComposePromptsResult {
   projectDir: string;
   /** Project-root-relative path to DESIGN.md (always "DESIGN.md"). */
   designReference: string;
+  /**
+   * Project-root-relative path to the optional COMPOSITION.md structural
+   * contract (`"COMPOSITION.md"`), or `null` when the project doesn't have one.
+   * Parallel to {@link designReference}: DESIGN.md is the visual hard-gate,
+   * COMPOSITION.md is the structural hard-gate (layout system, GSAP timeline
+   * conventions, element/track rules). The host agent must honor it when present.
+   */
+  compositionReference: string | null;
   /** Project-root-relative path to STORYBOARD.md (always "STORYBOARD.md"). */
   storyboardReference: string;
   /**
@@ -125,15 +133,21 @@ export interface ComposePromptsOptions {
 export async function getComposePrompts(opts: ComposePromptsOptions): Promise<ComposePromptsResult> {
   const projectDir = resolve(opts.projectDir);
   const designPath = join(projectDir, "DESIGN.md");
+  const compositionPath = join(projectDir, "COMPOSITION.md");
   const storyboardPath = join(projectDir, "STORYBOARD.md");
   const skillPath = join(projectDir, "SKILL.md");
   const compositionsDir = join(projectDir, "compositions");
+
+  // The optional structural contract — surfaced as a hard-gate reference only
+  // when the project actually carries one (COMPOSITION.md is bespoke, never scaffolded).
+  const compositionReference = existsSync(compositionPath) ? "COMPOSITION.md" : null;
 
   const warnings: string[] = [];
   const baseError = (msg: string): ComposePromptsResult => ({
     success: false,
     projectDir,
     designReference: "DESIGN.md",
+    compositionReference,
     storyboardReference: "STORYBOARD.md",
     skillReference: existsSync(skillPath) ? "SKILL.md" : null,
     compositionsDir: "compositions",
@@ -222,6 +236,7 @@ export async function getComposePrompts(opts: ComposePromptsOptions): Promise<Co
   const skillRef = existsSync(skillPath) ? "SKILL.md" : null;
   const instructions = buildInstructions({
     skillRef,
+    compositionRef: compositionReference,
     beatCount: result.length,
     filtered: opts.beatId !== undefined,
   });
@@ -230,6 +245,7 @@ export async function getComposePrompts(opts: ComposePromptsOptions): Promise<Co
     success: true,
     projectDir,
     designReference: "DESIGN.md",
+    compositionReference,
     storyboardReference: "STORYBOARD.md",
     skillReference: skillRef,
     compositionsDir: "compositions",
@@ -242,6 +258,7 @@ export async function getComposePrompts(opts: ComposePromptsOptions): Promise<Co
 
 function buildInstructions(args: {
   skillRef: string | null;
+  compositionRef: string | null;
   beatCount: number;
   filtered: boolean;
 }): string[] {
@@ -252,6 +269,9 @@ function buildInstructions(args: {
     lines.push(`1. Run \`vibe scene install-skill\` to install \`SKILL.md\` (Hyperframes rules) into this project, then re-read it.`);
   }
   lines.push(`2. Read \`DESIGN.md\` for project-specific palette, typography, motion signature.`);
+  if (args.compositionRef) {
+    lines.push(`2b. Read \`${args.compositionRef}\` for the project STRUCTURAL contract (layout system, GSAP timeline conventions, element/track rules) — a HARD-GATE parallel to DESIGN.md; every composition must satisfy it.`);
+  }
   lines.push(`3. For each beat in the \`beats\` array below, author HTML at \`outputPath\` matching the \`userPrompt\`. The beat \`body\` carries the narrative + visual + animation intent; \`cues\` carries machine-readable per-beat overrides (narration, duration, backdrop, voice).`);
   lines.push(`3b. Use each beat's \`finalDurationSec\` (narration-synced) for \`data-duration\` and timeline anchors when present — NOT the storyboard \`duration\`, which is only the minimum. Scenes composed at the storyboard duration end early and render black tails.`);
   lines.push(`3c. Never give inner \`.clip\` elements a non-zero \`data-start\` — the renderer does not toggle internal clip visibility inside sub-compositions, so phased clips render all phases at once (overlapping text). Use full-window clips and GSAP autoAlpha phase transitions instead. Also keep beats 6-15s; split anything longer in the storyboard first.`);

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.test.ts
@@ -98,6 +98,26 @@ describe("buildSystemPrompt", () => {
     expect(sys).toContain("Palette");
     expect(sys).toContain("HARD-GATE");
   });
+
+  it("omits the COMPOSITION.md block when no compositionMd is provided", () => {
+    const sys = buildSystemPrompt({ skillBundle, designMd });
+    expect(sys).not.toContain("COMPOSITION.md");
+  });
+
+  it("omits the COMPOSITION.md block when compositionMd is blank/whitespace", () => {
+    const sys = buildSystemPrompt({ skillBundle, designMd, compositionMd: "   \n  " });
+    expect(sys).not.toContain("COMPOSITION.md");
+  });
+
+  it("injects COMPOSITION.md as a parallel structural hard-gate after DESIGN.md when present", () => {
+    const compositionMd = "# Composition\n\n## Layout\n- 12-col grid\n";
+    const sys = buildSystemPrompt({ skillBundle, designMd, compositionMd });
+    expect(sys).toContain("COMPOSITION.md");
+    expect(sys).toContain("STRUCTURAL");
+    expect(sys).toContain("12-col grid");
+    // Structural gate must come AFTER the visual DESIGN.md gate.
+    expect(sys.indexOf("COMPOSITION.md")).toBeGreaterThan(sys.indexOf("DESIGN.md"));
+  });
 });
 
 describe("buildUserPrompt", () => {

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.ts
@@ -103,6 +103,13 @@ export interface ComposeBeatContext {
   beat: Beat;
   /** Project's `DESIGN.md` content (visual identity hard-gate). */
   designMd: string;
+  /**
+   * Optional `COMPOSITION.md` content — the per-project STRUCTURAL contract
+   * (layout system, GSAP timeline conventions, element/track rules), parallel
+   * to DESIGN.md's visual contract. Injected into the system prompt as a
+   * hard-gate when present.
+   */
+  compositionMd?: string;
   /** Storyboard's global direction (everything before the first `## Beat`). */
   storyboardGlobal: string;
   /** Hyperframes skill bundle content + hash, from `loadHyperframesSkillBundle()`. */
@@ -170,10 +177,17 @@ export interface ComposeBeatResult {
 
 // ── Prompt construction (pure) ──────────────────────────────────────────
 
-/** Build the system prompt — skill bundle + DESIGN.md hard-gate. */
+/** Build the system prompt — skill bundle + DESIGN.md hard-gate (+ optional COMPOSITION.md). */
 export function buildSystemPrompt(
-  ctx: Pick<ComposeBeatContext, "skillBundle" | "designMd">
+  ctx: Pick<ComposeBeatContext, "skillBundle" | "designMd" | "compositionMd">
 ): string {
+  const composition = ctx.compositionMd?.trim()
+    ? `
+
+=== COMPOSITION.md (project-specific STRUCTURAL contract — HARD-GATE, layout/timeline/element rules) ===
+
+${ctx.compositionMd.trim()}`
+    : "";
   return `You are a Hyperframes composition author. The skill content below
 defines the framework rules, motion principles, and quality standards.
 Read it thoroughly before writing any HTML.
@@ -182,7 +196,7 @@ ${ctx.skillBundle.content}
 
 === DESIGN.md (project-specific visual identity — HARD-GATE, every decision must trace back) ===
 
-${ctx.designMd}`;
+${ctx.designMd}${composition}`;
 }
 
 /**
@@ -906,6 +920,11 @@ export type ComposeProgressEvent =
 export interface ComposeScenesParams {
   /** Path to DESIGN.md, relative to project root. */
   design?: string;
+  /**
+   * Path to the optional COMPOSITION.md structural contract, relative to project
+   * root. Defaults to `COMPOSITION.md`; silently ignored when absent.
+   */
+  composition?: string;
   /** Path to STORYBOARD.md, relative to project root. */
   storyboard?: string;
   /** Scene project root, relative to outputDir. Defaults to outputDir. */
@@ -986,6 +1005,7 @@ export async function executeComposeScenesWithSkills(
 ): Promise<ComposeScenesActionResult> {
   const projectRoot = params.project ? resolve(outputDir, params.project) : resolve(outputDir);
   const designPath = resolve(projectRoot, params.design ?? "DESIGN.md");
+  const compositionPath = resolve(projectRoot, params.composition ?? "COMPOSITION.md");
   const storyboardPath = resolve(projectRoot, params.storyboard ?? "STORYBOARD.md");
 
   if (!existsSync(designPath)) {
@@ -996,6 +1016,10 @@ export async function executeComposeScenesWithSkills(
   }
 
   const designMd = await readFile(designPath, "utf-8");
+  // COMPOSITION.md is the OPTIONAL structural contract — read it when present.
+  const compositionMd = existsSync(compositionPath)
+    ? await readFile(compositionPath, "utf-8")
+    : undefined;
   const storyboardMd = await readFile(storyboardPath, "utf-8");
 
   const { global: storyboardGlobal, beats } = parseStoryboard(storyboardMd);
@@ -1081,6 +1105,7 @@ export async function executeComposeScenesWithSkills(
           {
             beat,
             designMd,
+            compositionMd,
             storyboardGlobal,
             skillBundle,
             provider,

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -371,6 +371,7 @@ export interface SceneBuildResult {
   composePrompts?: {
     skillReference: string | null;
     designReference: string;
+    compositionReference: string | null;
     storyboardReference: string;
     compositionsDir: string;
     instructions: string[];
@@ -800,6 +801,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
             ? {
                 skillReference: plan.skillReference,
                 designReference: plan.designReference,
+                compositionReference: plan.compositionReference,
                 storyboardReference: plan.storyboardReference,
                 compositionsDir: plan.compositionsDir,
                 instructions: plan.instructions,

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -273,6 +273,9 @@ sceneCommand
     console.log(chalk.dim(`Project:    ${projectDir}`));
     console.log(chalk.dim(`Skill ref:  ${result.skillReference ?? chalk.yellow("not installed")}`));
     console.log(chalk.dim(`Design ref: ${result.designReference}`));
+    if (result.compositionReference) {
+      console.log(chalk.dim(`Compose ref: ${result.compositionReference}`));
+    }
     console.log(
       chalk.dim(`Beats:      ${result.beats.length}${options.beat ? " (filtered)" : ""}`)
     );

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -894,6 +894,7 @@ export const sceneComposePromptsTool = defineTool({
       data: {
         projectDir: relative(ctx.workingDirectory, result.projectDir) || ".",
         designReference: result.designReference,
+        compositionReference: result.compositionReference,
         storyboardReference: result.storyboardReference,
         skillReference: result.skillReference,
         compositionsDir: result.compositionsDir,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.18",
+  "version": "0.113.19",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.18",
+  "version": "0.113.19",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.18",
+  "version": "0.113.19",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Phase 3 — PR 3A: COMPOSITION.md compose-contract

Adds an **optional `COMPOSITION.md`** — the per-project *structural* contract
(layout system, GSAP timeline conventions, element/track rules), a HARD-GATE
parallel to `DESIGN.md`'s visual contract. Read-only when present; never scaffolded
(bespoke by design).

### LLM-composer path (`compose-scenes-skills.ts`)
- `compositionMd?` on `ComposeBeatContext`; `buildSystemPrompt` injects it as a
  parallel structural hard-gate *after* the DESIGN.md gate (only when non-blank).
- `composition?` on `ComposeScenesParams` (defaults `COMPOSITION.md`, silently
  ignored when absent); optional read in `executeComposeScenesWithSkills`, threaded
  into the beat ctx. Cache auto-invalidates (systemPrompt is hashed by `computeCacheKey`).

### Agent-mode parity (`compose-prompts.ts`)
- `compositionReference: string | null` on `ComposePromptsResult` (`"COMPOSITION.md"`
  when present, else `null`) — set in both the success and `baseError` paths.
- `buildInstructions` emits a `2b.` step pointing the host agent at the structural
  contract, only when present.
- Surfaced through `scene_compose_prompts` (MCP tool), `vibe scene compose-prompts`
  (CLI human + JSON), and the build needs-author `composePrompts` payload.

### Tests
- `buildSystemPrompt` injects/omits the COMPOSITION block (present / absent / blank);
  structural gate ordered after the visual gate.
- `getComposePrompts` `compositionReference` is `"COMPOSITION.md"` / `null` and the
  `2b` instruction appears only when present, including the failure path.

No new CLI surface → no tool-count / schema drift. `vibe preview` + `vibe assemble`
(later Phase 3 PRs) stay CLI-only.

Bump 0.113.18 → 0.113.19.