### PR TITLE
feat: transcript first-class build stage (PR 3B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.19] - 2026-06-30
+## [0.113.20] - 2026-06-30
 
 ### Added
 
+- promote transcript to a first-class build stage (--stage transcript)
 - COMPOSITION.md structural compose-contract (hard-gate parallel to DESIGN.md)
 - SCRIPT.md (always) + CHARACTERS.md (kind-gated) + overlay cues
 - project --kind drives pipeline stages + default composer

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.19",
+  "version": "0.113.20",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -232,7 +232,7 @@ Cost tier: _not tagged_
 **Parameters:**
 
 - `project-dir` _(string)_ — Video project directory
-- `stage` _(string)_ _(default: `"all"`)_ — Build stage: assets|compose|sync|render|all
+- `stage` _(string)_ _(default: `"all"`)_ — Build stage: assets|transcript|compose|sync|render|all
 - `beat` _(string)_ — Restrict asset/compose work to one beat id
 - `mode` _(string)_ _(default: `"auto"`)_ — Build mode: agent|batch|auto
 - `effort` _(string)_ _(default: `"medium"`)_ — Compose effort tier (batch mode only): low|medium|high
@@ -365,7 +365,7 @@ Cost tier: _not tagged_
 **Parameters:**
 
 - `project-dir` _(string)_ — Video project directory
-- `stage` _(string)_ _(default: `"all"`)_ — Stage to plan: assets|compose|sync|render|all
+- `stage` _(string)_ _(default: `"all"`)_ — Stage to plan: assets|transcript|compose|sync|render|all
 - `beat` _(string)_ — Restrict the plan to one beat
 - `mode` _(string)_ _(default: `"auto"`)_ — Build mode: agent|batch|auto
 - `skipNarration` _(boolean)_ — Don't include narration generation in the plan

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.19`
+> CLI version: `0.113.20`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.19",
+  "version": "0.113.20",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.19",
+  "version": "0.113.20",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.19",
+  "version": "0.113.20",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -612,7 +612,7 @@ exports[`CLI --describe schemas (drift detection) > vibe build --describe 1`] = 
       },
       "stage": {
         "default": "all",
-        "description": "Build stage: assets|compose|sync|render|all",
+        "description": "Build stage: assets|transcript|compose|sync|render|all",
         "type": "string",
       },
       "tts": {
@@ -3099,7 +3099,7 @@ exports[`CLI --describe schemas (drift detection) > vibe plan --describe 1`] = `
       },
       "stage": {
         "default": "all",
-        "description": "Stage to plan: assets|compose|sync|render|all",
+        "description": "Stage to plan: assets|transcript|compose|sync|render|all",
         "type": "string",
       },
       "tts": {

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -41,7 +41,7 @@ import { readProjectConfig, type LoadedProjectConfig } from "./project-config.js
 import { kindAssetPolicy } from "./scene-project.js";
 import { validateStoryboardMarkdown, type StoryboardValidationIssue } from "./storyboard-edit.js";
 
-export type BuildStage = "assets" | "compose" | "sync" | "render" | "all";
+export type BuildStage = "assets" | "transcript" | "compose" | "sync" | "render" | "all";
 export type BuildPlanStatus = "ready" | "invalid";
 export type AssetPlanReason =
   | "canonical-exists"
@@ -184,6 +184,8 @@ const MUSIC_COST_USD = 0.5;
 const ELEVENLABS_NARRATION_COST_USD = 0.05;
 /** gpt-4o-mini-tts is ~$0.015/min of audio; a beat is ~10–20s. Includes retry headroom. */
 const OPENAI_NARRATION_COST_USD = 0.01;
+/** Whisper word-level transcription is ~$0.006/min; a beat is ~10–20s. */
+const TRANSCRIPT_COST_USD = 0.002;
 const COMPOSE_COST_USD = 0.06;
 const SUPPORTED_BUILD_IMAGE_PROVIDERS = ["openai", "gemini", "grok"] as const;
 
@@ -256,6 +258,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
   const missing = new Set<string>();
   let estimatedCostUsd = 0;
   const includeAssets = stage === "all" || stage === "assets";
+  const includeTranscript = stage === "all" || stage === "transcript";
   const includeCompose = stage === "all" || stage === "compose";
   const mode = opts.mode ?? config.config.build.mode;
   const imageQuality = opts.imageQuality ?? config.config.build.imageQuality ?? "hd";
@@ -511,6 +514,13 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
       },
     };
   });
+  // Transcript stage: Whisper word-timings for each narrated beat. Nearly free
+  // but modeled so `--stage transcript` reports a non-zero, faithful estimate.
+  if (includeTranscript && !opts.skipNarration) {
+    const narratedBeats = beats.filter((beat) => beat.assets.narration != null).length;
+    estimatedCostUsd += narratedBeats * TRANSCRIPT_COST_USD;
+  }
+
   providerResolution.push(...providerResolutionsForPlan(resolved, beats, opts, includeAssets));
 
   if (

--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -486,7 +486,10 @@ describe("executeSceneBuild", () => {
     expect(OpenAIImageProvider).not.toHaveBeenCalled();
   });
 
-  it("transcribes narration into assets/transcript-<beat>.json when word timings exist", async () => {
+  it("runs `--stage transcript` standalone over on-disk narration and reports `transcript-only`", async () => {
+    // Standalone stage: narration already exists on disk, assets stage does NOT run.
+    mkdirSync(join(projectDir, "assets"), { recursive: true });
+    writeFileSync(join(projectDir, "assets", "narration-hook.wav"), Buffer.from([1]));
     vi.mocked(transcribeNarrationWords).mockClear();
     vi.mocked(transcribeNarrationWords).mockResolvedValue([
       { text: "Type", start: 0, end: 0.3 },
@@ -494,8 +497,11 @@ describe("executeSceneBuild", () => {
       { text: "YAML", start: 0.4, end: 0.9 },
     ]);
     try {
-      const r = await executeSceneBuild({ projectDir, stage: "assets" });
+      const r = await executeSceneBuild({ projectDir, stage: "transcript" });
       expect(r.success).toBe(true);
+      expect(r.phase).toBe("transcript-only");
+      expect(r.stageReports?.transcript.status).toBe("done");
+      expect(r.stageReports?.assets.status).toBe("skipped");
       const transcriptPath = join(projectDir, "assets", "transcript-hook.json");
       expect(existsSync(transcriptPath)).toBe(true);
       expect(JSON.parse(readFileSync(transcriptPath, "utf-8"))).toEqual([
@@ -510,16 +516,34 @@ describe("executeSceneBuild", () => {
   });
 
   it("does not transcribe when --skip-transcript is set", async () => {
+    mkdirSync(join(projectDir, "assets"), { recursive: true });
+    writeFileSync(join(projectDir, "assets", "narration-hook.wav"), Buffer.from([1]));
     vi.mocked(transcribeNarrationWords).mockClear();
     vi.mocked(transcribeNarrationWords).mockResolvedValue([{ text: "x", start: 0, end: 1 }]);
     try {
-      await executeSceneBuild({ projectDir, stage: "assets", skipTranscript: true });
+      const r = await executeSceneBuild({ projectDir, stage: "transcript", skipTranscript: true });
       expect(existsSync(join(projectDir, "assets", "transcript-hook.json"))).toBe(false);
       expect(transcribeNarrationWords).not.toHaveBeenCalled();
+      expect(r.stageReports?.transcript.status).toBe("skipped");
     } finally {
       vi.mocked(transcribeNarrationWords).mockResolvedValue([]);
     }
   });
+
+  it("`--stage all` (default build) still transcribes after generating narration", async () => {
+    vi.mocked(transcribeNarrationWords).mockClear();
+    vi.mocked(transcribeNarrationWords).mockResolvedValue([{ text: "Hi", start: 0, end: 0.5 }]);
+    try {
+      const r = await executeSceneBuild({ projectDir, stage: "all" });
+      expect(r.success).toBe(true);
+      expect(r.stageReports?.transcript.status).toBe("done");
+      expect(existsSync(join(projectDir, "assets", "transcript-hook.json"))).toBe(true);
+      expect(transcribeNarrationWords).toHaveBeenCalled();
+    } finally {
+      vi.mocked(transcribeNarrationWords).mockResolvedValue([]);
+    }
+  });
+
 
   it("uses referenced narration and backdrop assets without provider calls", async () => {
     mkdirSync(join(projectDir, "assets"), { recursive: true });

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -310,6 +310,7 @@ export interface SceneBuildOptions {
 export type SceneBuildPhase =
   | "done"
   | "assets-only"
+  | "transcript-only"
   | "pending-jobs"
   | "compose-only"
   | "sync-only"
@@ -317,7 +318,7 @@ export type SceneBuildPhase =
   | "needs-author"
   | "failed";
 export type BuildWorkflowStatus = "done" | "running" | "needs-author" | "failed" | "ready";
-export type BuildCurrentStage = "assets" | "compose" | "sync" | "render" | "done";
+export type BuildCurrentStage = "assets" | "transcript" | "compose" | "sync" | "render" | "done";
 
 export interface BuildBeatSummary {
   total: number;
@@ -385,7 +386,7 @@ export interface SceneBuildResult {
   beatSummary?: BuildBeatSummary;
   estimatedCostUsd?: number;
   costUsd?: number;
-  stageReports?: Record<"assets" | "compose" | "sync" | "render", StageReport>;
+  stageReports?: Record<"assets" | "transcript" | "compose" | "sync" | "render", StageReport>;
   sceneRepair?: BuildSceneRepairSummary;
   jobs?: JobRecord[];
   warnings?: string[];
@@ -676,7 +677,6 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
           skipVideo: skipVideoAssets,
           skipKeyframe,
           skipMusic: opts.skipMusic ?? false,
-          skipTranscript: opts.skipTranscript ?? false,
           force: opts.force ?? false,
           onProgress,
           characterPaths,
@@ -766,6 +766,41 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
       beats: beatOutcomes,
       estimatedCostUsd: buildPlan.estimatedCostUsd,
       costUsd: stageReports.assets.costUsd,
+      stageReports,
+      jobs: pendingJobs,
+      warnings,
+      retryWith,
+      totalLatencyMs: Date.now() - startedAt,
+    });
+  }
+
+  // ── Phase 1.5: transcript ─────────────────────────────────────────────
+  // Word-level narration timings feed caption / kinetic-type sync in compose.
+  // Best-effort: a missing key or no words leaves a beat without timings but
+  // never fails the build. Narration paths/freshness come from `beatOutcomes`
+  // (fresh asset run OR `collectExistingBeatOutcomes` on disk), so this works
+  // standalone via `--stage transcript`.
+  if (shouldRunStage(selectedStage, "transcript") && !(opts.skipTranscript ?? false)) {
+    const { statuses } = await runTranscriptStage(activeBeats, beatOutcomes, {
+      projectDir,
+      force: opts.force ?? false,
+      onProgress,
+    });
+    const produced = statuses.some((s) => s === "generated" || s === "cached");
+    stageReports.transcript.status = produced ? "done" : "skipped";
+  } else {
+    stageReports.transcript.status = "skipped";
+  }
+
+  if (selectedStage === "transcript") {
+    return finishBuildResult({
+      success: true,
+      phase: "transcript-only",
+      mode,
+      selectedStage,
+      beats: beatOutcomes,
+      estimatedCostUsd: buildPlan.estimatedCostUsd,
+      costUsd: stageReports.assets.costUsd + stageReports.transcript.costUsd,
       stageReports,
       jobs: pendingJobs,
       warnings,
@@ -1147,7 +1182,6 @@ interface BeatDispatchContext {
   skipVideo: boolean;
   skipKeyframe: boolean;
   skipMusic: boolean;
-  skipTranscript: boolean;
   force: boolean;
   onProgress: (e: SceneBuildProgressEvent) => void;
   /** name → relative path of generated/supplied character reference images. */
@@ -1181,12 +1215,8 @@ async function buildBeatPrimitives(
       : dispatchVideo(beat, ctx, keyframe),
     ctx.skipMusic ? skipped("music", beat.id, "--skip-music", ctx) : dispatchMusic(beat, ctx),
   ]);
-  // Word-level transcript depends on the narration audio, so it runs after the
-  // primitive fan-out (not inside it). Best-effort: a failure or missing key
-  // leaves the beat without word-sync timings but never fails the build.
-  if (!ctx.skipTranscript) {
-    await dispatchTranscript(beat, narration, ctx);
-  }
+  // Word-level transcript runs as its own stage (`--stage transcript`) after
+  // the asset fan-out — see `runTranscriptStage` in `executeSceneBuild`.
   return {
     outcome: {
       beatId: beat.id,
@@ -1472,30 +1502,45 @@ async function dispatchNarration(beat: Beat, ctx: BeatDispatchContext): Promise<
   };
 }
 
+/** Per-beat outcome of {@link dispatchTranscript}. */
+type TranscriptStatus = "generated" | "cached" | "skipped" | "failed";
+
+/** Minimal context the transcript stage needs (a slice of {@link BeatDispatchContext}). */
+interface TranscriptDispatchContext {
+  projectDir: string;
+  force: boolean;
+  onProgress: (e: SceneBuildProgressEvent) => void;
+}
+
 /**
- * Whisper word-level transcription of a beat's generated narration. Writes
+ * Whisper word-level transcription of a beat's narration. Writes
  * `assets/transcript-<beat>.json` (the same shape `vibe scene add` produces),
  * which the compose stage reads to drive word-synced caption / kinetic-type
- * animations. Entirely best-effort:
- *   - no narration → nothing to transcribe.
- *   - no OpenAI key → skip with a hint (narration still plays).
+ * animations. Entirely best-effort — it never fails the build:
+ *   - no narration audio → nothing to transcribe (`skipped`).
+ *   - no OpenAI key → skip with a hint (`skipped`); narration still plays.
  *   - transcript exists + narration not freshly regenerated + not forced →
- *     reuse the cached file (no re-transcribe cost).
- *   - API failure / no words → skip; the composer just omits word-sync.
+ *     reuse the cached file (`cached`, no re-transcribe cost).
+ *   - API failure / no words → `skipped`; the composer just omits word-sync.
+ *   - write error → `failed` (surfaced as a warning, still non-fatal).
+ *
+ * Takes the narration audio path + a freshness hint rather than the in-memory
+ * `PrimitiveOutcome`, so it works both inline after the asset fan-out AND as a
+ * standalone `--stage transcript` pass that re-resolves narration from disk.
  */
 async function dispatchTranscript(
   beat: Beat,
-  narration: PrimitiveOutcome,
-  ctx: BeatDispatchContext
-): Promise<void> {
-  if (!narration.path) return;
+  narrationPath: string | undefined,
+  narrationFresh: boolean,
+  ctx: TranscriptDispatchContext
+): Promise<TranscriptStatus> {
+  if (!narrationPath) return "skipped";
 
   const relPath = beatTranscriptRelPath(beat.id);
   const abs = join(ctx.projectDir, relPath);
-  const narrationFresh = narration.status === "generated";
   if (existsSync(abs) && !ctx.force && !narrationFresh) {
     ctx.onProgress({ type: "transcript-cached", beatId: beat.id, path: relPath });
-    return;
+    return "cached";
   }
 
   const apiKey = await getConfiguredApiKey("OPENAI_API_KEY", undefined, { cwd: ctx.projectDir });
@@ -1505,27 +1550,62 @@ async function dispatchTranscript(
       beatId: beat.id,
       reason: "OPENAI_API_KEY not set — narration plays but word-sync timings unavailable",
     });
-    return;
+    return "skipped";
   }
 
-  const words = await transcribeNarrationWords(join(ctx.projectDir, narration.path), { apiKey });
+  const words = await transcribeNarrationWords(join(ctx.projectDir, narrationPath), { apiKey });
   if (words.length === 0) {
     ctx.onProgress({
       type: "transcript-skipped",
       beatId: beat.id,
       reason: "transcription returned no word timings",
     });
-    return;
+    return "skipped";
   }
 
-  await mkdir(dirname(abs), { recursive: true });
-  await writeFile(abs, JSON.stringify(words, null, 2), "utf-8");
+  try {
+    await mkdir(dirname(abs), { recursive: true });
+    await writeFile(abs, JSON.stringify(words, null, 2), "utf-8");
+  } catch (err) {
+    ctx.onProgress({
+      type: "transcript-skipped",
+      beatId: beat.id,
+      reason: `failed to write transcript: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return "failed";
+  }
   ctx.onProgress({
     type: "transcript-generated",
     beatId: beat.id,
     path: relPath,
     wordCount: words.length,
   });
+  return "generated";
+}
+
+/**
+ * Run the transcript stage across all active beats. Resolves each beat's
+ * narration audio path + freshness from its build outcome (which is populated
+ * either by a fresh asset run or {@link collectExistingBeatOutcomes} on disk),
+ * then transcribes concurrently. Best-effort: aggregates statuses for the stage
+ * report but never throws.
+ */
+async function runTranscriptStage(
+  beats: Beat[],
+  outcomes: BeatBuildOutcome[],
+  ctx: TranscriptDispatchContext
+): Promise<{ statuses: TranscriptStatus[] }> {
+  const byId = new Map(outcomes.map((o) => [o.beatId, o]));
+  const statuses = await mapWithConcurrency(beats, BEAT_PRIMITIVES_CONCURRENCY, (beat) => {
+    const outcome = byId.get(beat.id);
+    return dispatchTranscript(
+      beat,
+      outcome?.narrationPath,
+      outcome?.narrationStatus === "generated",
+      ctx
+    );
+  });
+  return { statuses };
 }
 
 interface CharacterBuildResult {
@@ -2436,9 +2516,13 @@ async function skipped(
   return { status: "skipped" };
 }
 
-function createEmptyStageReports(): Record<"assets" | "compose" | "sync" | "render", StageReport> {
+function createEmptyStageReports(): Record<
+  "assets" | "transcript" | "compose" | "sync" | "render",
+  StageReport
+> {
   return {
     assets: { status: "pending", costUsd: 0, warnings: [], retryWith: [] },
+    transcript: { status: "pending", costUsd: 0, warnings: [], retryWith: [] },
     compose: { status: "pending", costUsd: 0, warnings: [], retryWith: [] },
     sync: { status: "pending", costUsd: 0, warnings: [], retryWith: [] },
     render: { status: "pending", costUsd: 0, warnings: [], retryWith: [] },
@@ -3008,6 +3092,8 @@ function buildCurrentStage(result: SceneBuildResult): BuildCurrentStage {
     case "pending-jobs":
       return "assets";
     case "assets-only":
+      return "transcript";
+    case "transcript-only":
     case "needs-author":
       return "compose";
     case "compose-only":

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -29,7 +29,7 @@ import {
 } from "./output.js";
 
 const VALID_MODES: SceneBuildMode[] = ["agent", "batch", "auto"];
-const VALID_STAGES: BuildStage[] = ["assets", "compose", "sync", "render", "all"];
+const VALID_STAGES: BuildStage[] = ["assets", "transcript", "compose", "sync", "render", "all"];
 const VALID_IMAGE_PROVIDERS = ["openai", "gemini", "grok"] as const;
 const VALID_VIDEO_PROVIDERS: BuildVideoProvider[] = ["seedance", "grok", "kling", "runway", "veo"];
 const VALID_MUSIC_PROVIDERS: BuildMusicProvider[] = ["elevenlabs", "replicate"];

--- a/packages/cli/src/commands/plan.ts
+++ b/packages/cli/src/commands/plan.ts
@@ -5,7 +5,7 @@ import { resolve } from "node:path";
 import { createBuildPlan, type BuildPlanResult, type BuildStage } from "./_shared/build-plan.js";
 import { exitWithError, isJsonMode, outputSuccess, usageError } from "./output.js";
 
-const VALID_STAGES: BuildStage[] = ["assets", "compose", "sync", "render", "all"];
+const VALID_STAGES: BuildStage[] = ["assets", "transcript", "compose", "sync", "render", "all"];
 const VALID_MODES = ["agent", "batch", "auto"] as const;
 const VALID_TTS_PROVIDERS = ["auto", "elevenlabs", "openai", "kokoro"] as const;
 const VALID_IMAGE_PROVIDERS = ["openai", "gemini", "grok"] as const;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.19",
+  "version": "0.113.20",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.19",
+  "version": "0.113.20",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.19",
+  "version": "0.113.20",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Phase 3 — PR 3B: transcript first-class stage

Promotes Whisper word-level transcription from a buried per-beat sub-step inside
the **assets** stage to its own first-class build stage between **assets** and
**compose**, runnable in isolation with `--stage transcript`.

### What changed
- **`BuildStage`** gains `"transcript"` (`build-plan.ts`); `VALID_STAGES` in
  `build.ts` + `plan.ts` updated → `--stage transcript` is a valid, plannable stage.
- **`stageReports.transcript`** added (record type + `createEmptyStageReports`);
  `SceneBuildPhase` gains `"transcript-only"`, `BuildCurrentStage` gains `"transcript"`.
- **`dispatchTranscript`** refactored to take a narration **path + freshness hint**
  (re-resolved from `beatOutcomes`, which `collectExistingBeatOutcomes` fills from
  disk) instead of the in-memory `PrimitiveOutcome`, and to **return a status**
  (`generated|cached|skipped|failed`). New `runTranscriptStage` fans out over beats
  with the existing `mapWithConcurrency` pool.
- Inline transcript call removed from `buildBeatPrimitives`; new stage block + a
  `transcript-only` early-return inserted in `executeSceneBuild`.
- **`createBuildPlan`** models a small `TRANSCRIPT_COST_USD` (~\$0.002/narrated beat)
  under `--stage all`/`--stage transcript`, so `vibe plan --stage transcript`
  reports a faithful estimate.

### Behavior
- Default `vibe build` / `--stage all` **still transcribes** (unchanged user-visible
  behavior) — transcript just runs as its own stage now.
- `vibe build --stage transcript` runs it standalone over on-disk narration.
- `--stage assets` **no longer transcribes** (explicit, documented split).
- Best-effort throughout: missing key / no words / write error never fails the build.

### Verification
- New tests: standalone `--stage transcript` writes `assets/transcript-<id>.json` +
  reports `transcript-only` / `stageReports.transcript.status`; `--stage all` still
  transcribes; `--skip-transcript` suppresses it.
- Functional smoke: `vibe plan --stage transcript` → est \$0.01 / status ready;
  `vibe build --stage transcript` (no narration) → `transcript-only`, transcript skipped.
- Full CLI + MCP suites green; `gen:reference`, `agent-sync:check`, `sync-counts` clean.
  Envelope snapshots refreshed for the `--stage` enum.

CLI-only stage; no new agent/MCP tools. Bump 0.113.19 → 0.113.20.