### PR TITLE
refactor: HF-lean lazy bundle load (PR 4A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.22] - 2026-06-30
+## [0.113.23] - 2026-06-30
 
 ### Added
 
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- lazy-load vendored Hyperframes skill content (HF-lean)
 - replace invented host goal-mode names with host-agnostic agent-loop language
 
 ### Documentation

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.22",
+  "version": "0.113.23",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.22`
+> CLI version: `0.113.23`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.22",
+  "version": "0.113.23",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.22",
+  "version": "0.113.23",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.22",
+  "version": "0.113.23",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/cli/src/commands/_shared/compose-scenes-skills.ts
+++ b/packages/cli/src/commands/_shared/compose-scenes-skills.ts
@@ -1030,7 +1030,7 @@ export async function executeComposeScenesWithSkills(
     };
   }
 
-  const skillBundleLoaded = loadHyperframesSkillBundle();
+  const skillBundleLoaded = await loadHyperframesSkillBundle();
   const skillBundle = { content: skillBundleLoaded.content, hash: skillBundleLoaded.hash };
 
   // Resolve the composer provider + key. Cache hits are still allowed when

--- a/packages/cli/src/commands/_shared/hf-skill-bundle/bundle.test.ts
+++ b/packages/cli/src/commands/_shared/hf-skill-bundle/bundle.test.ts
@@ -6,17 +6,17 @@ import {
 } from "./bundle.js";
 
 describe("loadHyperframesSkillBundle", () => {
-  it("returns a non-empty bundle from one of the two sources", () => {
-    const r = loadHyperframesSkillBundle();
+  it("returns a non-empty bundle from one of the two sources", async () => {
+    const r = await loadHyperframesSkillBundle();
     expect(["installed", "vendored"]).toContain(r.source);
     expect(r.content.length).toBeGreaterThan(10_000); // 5 markdown files concatenated
     expect(r.hash).toMatch(/^[0-9a-f]{64}$/); // sha256 hex
   });
 
-  it("bundle includes all 5 files in fixed order", () => {
+  it("bundle includes all 5 files in fixed order", async () => {
     // Order is baked into bundle.ts so we just check the section markers
     // appear in the right sequence — applies to installed and vendored.
-    const r = loadHyperframesSkillBundle();
+    const r = await loadHyperframesSkillBundle();
     const indices = [
       "hyperframes/SKILL.md",
       "hyperframes/house-style.md",
@@ -30,9 +30,9 @@ describe("loadHyperframesSkillBundle", () => {
     }
   });
 
-  it("hash is stable within a session (cache-key contract)", () => {
-    const a = loadHyperframesSkillBundle();
-    const b = loadHyperframesSkillBundle();
+  it("hash is stable within a session (cache-key contract)", async () => {
+    const a = await loadHyperframesSkillBundle();
+    const b = await loadHyperframesSkillBundle();
     expect(a.hash).toBe(b.hash);
     expect(a.content).toBe(b.content);
   });
@@ -41,8 +41,8 @@ describe("loadHyperframesSkillBundle", () => {
     expect(BUNDLE_VERSION).toMatch(/^[0-9a-f]{7,40}-\d{4}-\d{2}-\d{2}$/);
   });
 
-  it("hint string surfaces source clearly", () => {
-    const r = loadHyperframesSkillBundle();
+  it("hint string surfaces source clearly", async () => {
+    const r = await loadHyperframesSkillBundle();
     if (r.source === "vendored") {
       expect(r.hint).toContain("vendored");
       expect(r.hint).toContain(BUNDLE_VERSION);

--- a/packages/cli/src/commands/_shared/hf-skill-bundle/bundle.ts
+++ b/packages/cli/src/commands/_shared/hf-skill-bundle/bundle.ts
@@ -33,18 +33,15 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 
-// Vendored skill content as TS template-literal constants, auto-generated
-// from the sibling .md files by `scripts/refresh-hf-bundle.sh`. Kept as a
-// regular TS module (not bundler-magic .md imports) so any package whose
-// tsc traverses this file (mcp-server via workspace dep) compiles without
-// needing extra ambient declarations or sibling .d.ts files.
-import {
-  SKILL_MD,
-  HOUSE_STYLE_MD,
-  MOTION_PRINCIPLES_MD,
-  TYPOGRAPHY_MD,
-  TRANSITIONS_MD,
-} from "./bundle-content.js";
+// The vendored skill content (~52KB of TS template-literal constants in
+// `./bundle-content.ts`, auto-generated from the sibling .md files by
+// `scripts/refresh-hf-bundle.sh`) is loaded via a LAZY `await import` inside
+// `buildVendored()` — NOT a top-level import. That keeps `BUNDLE_VERSION` (and
+// any path that only needs it, e.g. the agent-mode `getComposePrompts`) free of
+// the heavy content: only the batch LLM composer that actually calls
+// `loadHyperframesSkillBundle()` pays to evaluate it. (esbuild bundles it inline
+// but wraps a dynamically-imported local module in a lazy initializer, so the
+// string allocation defers until first await.)
 
 /**
  * Snapshot identifier. Bump on every refresh of the vendored MD files.
@@ -56,17 +53,6 @@ import {
  * bump this constant. `scripts/refresh-hf-bundle.sh` does this automatically.
  */
 export const BUNDLE_VERSION = "970367f-2026-04-25";
-
-/**
- * Files included in the bundle, in concatenation order.
- */
-const VENDORED_SECTIONS: ReadonlyArray<{ label: string; content: string }> = [
-  { label: "hyperframes/SKILL.md",             content: SKILL_MD             },
-  { label: "hyperframes/house-style.md",       content: HOUSE_STYLE_MD       },
-  { label: "hyperframes/motion-principles.md", content: MOTION_PRINCIPLES_MD },
-  { label: "hyperframes/typography.md",        content: TYPOGRAPHY_MD        },
-  { label: "hyperframes/transitions.md",       content: TRANSITIONS_MD       },
-];
 
 /** Path to the user-installed Hyperframes skill, if present. */
 function installedSkillPath(): string | null {
@@ -82,9 +68,20 @@ function joinSections(sections: ReadonlyArray<{ label: string; content: string }
     .join("\n");
 }
 
-function buildVendored(): { content: string; hint: string } {
+async function buildVendored(): Promise<{ content: string; hint: string }> {
+  // Lazily pull the heavy ~52KB content only when the vendored snapshot is
+  // actually needed (no installed skill, batch composer running).
+  const { SKILL_MD, HOUSE_STYLE_MD, MOTION_PRINCIPLES_MD, TYPOGRAPHY_MD, TRANSITIONS_MD } =
+    await import("./bundle-content.js");
+  const sections: ReadonlyArray<{ label: string; content: string }> = [
+    { label: "hyperframes/SKILL.md",             content: SKILL_MD             },
+    { label: "hyperframes/house-style.md",       content: HOUSE_STYLE_MD       },
+    { label: "hyperframes/motion-principles.md", content: MOTION_PRINCIPLES_MD },
+    { label: "hyperframes/typography.md",        content: TYPOGRAPHY_MD        },
+    { label: "hyperframes/transitions.md",       content: TRANSITIONS_MD       },
+  ];
   return {
-    content: joinSections(VENDORED_SECTIONS),
+    content: joinSections(sections),
     hint:
       `[skill] using vendored Hyperframes snapshot ${BUNDLE_VERSION}. ` +
       `For latest, run \`npx skills add heygen-com/hyperframes\`.`,
@@ -120,8 +117,14 @@ function buildInstalled(skillRoot: string): { content: string; hint: string } | 
  *
  * Side-effect free except for the optional `~/.claude/skills/hyperframes/`
  * filesystem read.
+ *
+ * Async because the vendored snapshot content is loaded via a lazy
+ * `await import("./bundle-content.js")` (see {@link buildVendored}) so paths
+ * that never need it (agent-mode, template composer) don't pay to evaluate the
+ * ~52KB string. When an installed skill is present, the vendored content module
+ * is never imported at all.
  */
-export function loadHyperframesSkillBundle(): {
+export async function loadHyperframesSkillBundle(): Promise<{
   content: string;
   /** "installed" (user has ~/.claude/skills/hyperframes/) or "vendored" (esbuild-inlined snapshot). */
   source: "installed" | "vendored";
@@ -129,7 +132,7 @@ export function loadHyperframesSkillBundle(): {
   hint: string;
   /** Stable hash of (BUNDLE_VERSION + content). Used as cache-key input. */
   hash: string;
-} {
+}> {
   const installedRoot = installedSkillPath();
   if (installedRoot) {
     const r = buildInstalled(installedRoot);
@@ -142,7 +145,7 @@ export function loadHyperframesSkillBundle(): {
       };
     }
   }
-  const v = buildVendored();
+  const v = await buildVendored();
   return {
     content: v.content,
     source: "vendored",

--- a/packages/cli/src/commands/_shared/install-skill.ts
+++ b/packages/cli/src/commands/_shared/install-skill.ts
@@ -36,15 +36,23 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 
-import {
-  HOUSE_STYLE_MD,
-  MOTION_PRINCIPLES_MD,
-  SKILL_MD,
-  TRANSITIONS_MD,
-  TYPOGRAPHY_MD,
-} from "./hf-skill-bundle/bundle-content.js";
 import { BUNDLE_VERSION } from "./hf-skill-bundle/bundle.js";
 import type { AgentHostId } from "../../utils/agent-host-detect.js";
+
+/**
+ * The vendored skill content. Loaded via a lazy `await import` in
+ * {@link installHyperframesSkill} (not a top-level import) so loading this
+ * module at CLI startup — it's reachable from the `scene` command group —
+ * doesn't eagerly evaluate the ~52KB content. `BUNDLE_VERSION` stays a cheap
+ * static import.
+ */
+interface HfBundleContent {
+  SKILL_MD: string;
+  HOUSE_STYLE_MD: string;
+  MOTION_PRINCIPLES_MD: string;
+  TYPOGRAPHY_MD: string;
+  TRANSITIONS_MD: string;
+}
 
 /** Hosts the install-skill command knows file layouts for. */
 export type InstallSkillHost = "claude-code" | "cursor" | "all";
@@ -93,13 +101,13 @@ interface SkillFile {
  * AGENTS.md `@SKILL.md` references and what Codex / Aider / generic
  * agents discover by walking the project tree.
  */
-function universalFiles(): SkillFile[] {
+function universalFiles(c: HfBundleContent): SkillFile[] {
   return [
-    { relPath: "SKILL.md", content: SKILL_MD },
-    { relPath: "references/house-style.md", content: HOUSE_STYLE_MD },
-    { relPath: "references/motion-principles.md", content: MOTION_PRINCIPLES_MD },
-    { relPath: "references/typography.md", content: TYPOGRAPHY_MD },
-    { relPath: "references/transitions.md", content: TRANSITIONS_MD },
+    { relPath: "SKILL.md", content: c.SKILL_MD },
+    { relPath: "references/house-style.md", content: c.HOUSE_STYLE_MD },
+    { relPath: "references/motion-principles.md", content: c.MOTION_PRINCIPLES_MD },
+    { relPath: "references/typography.md", content: c.TYPOGRAPHY_MD },
+    { relPath: "references/transitions.md", content: c.TRANSITIONS_MD },
   ];
 }
 
@@ -108,14 +116,14 @@ function universalFiles(): SkillFile[] {
  * under `.claude/skills/hyperframes/` so Claude Code's skill loader
  * picks it up automatically.
  */
-function claudeCodeFiles(): SkillFile[] {
+function claudeCodeFiles(c: HfBundleContent): SkillFile[] {
   const base = ".claude/skills/hyperframes";
   return [
-    { relPath: `${base}/SKILL.md`, content: SKILL_MD },
-    { relPath: `${base}/references/house-style.md`, content: HOUSE_STYLE_MD },
-    { relPath: `${base}/references/motion-principles.md`, content: MOTION_PRINCIPLES_MD },
-    { relPath: `${base}/references/typography.md`, content: TYPOGRAPHY_MD },
-    { relPath: `${base}/references/transitions.md`, content: TRANSITIONS_MD },
+    { relPath: `${base}/SKILL.md`, content: c.SKILL_MD },
+    { relPath: `${base}/references/house-style.md`, content: c.HOUSE_STYLE_MD },
+    { relPath: `${base}/references/motion-principles.md`, content: c.MOTION_PRINCIPLES_MD },
+    { relPath: `${base}/references/typography.md`, content: c.TYPOGRAPHY_MD },
+    { relPath: `${base}/references/transitions.md`, content: c.TRANSITIONS_MD },
   ];
 }
 
@@ -125,13 +133,13 @@ function claudeCodeFiles(): SkillFile[] {
  * The body concatenates SKILL.md + references so a single file is enough
  * (Cursor doesn't traverse a directory the way Claude Code does).
  */
-function cursorFiles(): SkillFile[] {
+function cursorFiles(c: HfBundleContent): SkillFile[] {
   const body = [
-    SKILL_MD,
-    "\n\n## Reference: house-style.md\n\n" + HOUSE_STYLE_MD,
-    "\n\n## Reference: motion-principles.md\n\n" + MOTION_PRINCIPLES_MD,
-    "\n\n## Reference: typography.md\n\n" + TYPOGRAPHY_MD,
-    "\n\n## Reference: transitions.md\n\n" + TRANSITIONS_MD,
+    c.SKILL_MD,
+    "\n\n## Reference: house-style.md\n\n" + c.HOUSE_STYLE_MD,
+    "\n\n## Reference: motion-principles.md\n\n" + c.MOTION_PRINCIPLES_MD,
+    "\n\n## Reference: typography.md\n\n" + c.TYPOGRAPHY_MD,
+    "\n\n## Reference: transitions.md\n\n" + c.TRANSITIONS_MD,
   ].join("");
 
   // Strip upstream Hyperframes frontmatter (Cursor uses its own shape) and
@@ -153,13 +161,13 @@ alwaysApply: false
 }
 
 /** Resolve which host-specific layouts to install based on `hosts`. */
-function selectHostFiles(hosts: InstallSkillHost[]): SkillFile[] {
+function selectHostFiles(hosts: InstallSkillHost[], c: HfBundleContent): SkillFile[] {
   const wantsAll = hosts.includes("all");
   const wantsClaude = wantsAll || hosts.includes("claude-code");
   const wantsCursor = wantsAll || hosts.includes("cursor");
   const out: SkillFile[] = [];
-  if (wantsClaude) out.push(...claudeCodeFiles());
-  if (wantsCursor) out.push(...cursorFiles());
+  if (wantsClaude) out.push(...claudeCodeFiles(c));
+  if (wantsCursor) out.push(...cursorFiles(c));
   return out;
 }
 
@@ -175,7 +183,9 @@ export async function installHyperframesSkill(opts: InstallSkillOptions): Promis
   const force = opts.force ?? false;
   const dryRun = opts.dryRun ?? false;
 
-  const files = [...universalFiles(), ...selectHostFiles(opts.hosts)];
+  // Lazily pull the ~52KB vendored content only when actually installing.
+  const content: HfBundleContent = await import("./hf-skill-bundle/bundle-content.js");
+  const files = [...universalFiles(content), ...selectHostFiles(opts.hosts, content)];
   const actions: InstallSkillFileAction[] = [];
 
   if (!dryRun && !existsSync(projectDir)) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.22",
+  "version": "0.113.23",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.22",
+  "version": "0.113.23",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.22",
+  "version": "0.113.23",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Phase 4 — PR 4A: HF-lean

Stops eagerly evaluating the vendored ~52KB Hyperframes skill prompt on paths that
don't need it. Today `hf-skill-bundle/bundle.ts` statically imports the heavy `*_MD`
content, so importing even the cheap `BUNDLE_VERSION` transitively pulls 52KB into
memory — paid by the agent-mode compose path (`getComposePrompts`, needs only the
version) and at CLI startup (via the `scene` command group → `install-skill.ts`). Only
the **batch LLM composer** (sole real caller `compose-scenes-skills.ts`) needs the content.

### What changed
- **`bundle.ts`**: dropped the top-level `import { SKILL_MD, … } from "./bundle-content.js"`
  and the module-level `VENDORED_SECTIONS`. `buildVendored()` now does a lazy
  `await import("./bundle-content.js")`; `loadHyperframesSkillBundle()` is now **async**.
  `BUNDLE_VERSION` stays a cheap top-level export — no longer drags content. When an
  installed skill is present, the vendored content module is never imported at all.
- **`install-skill.ts`**: the other static importer (loaded at startup). Dropped the
  top-level `*_MD` import; `installHyperframesSkill()` does one
  `await import(".../bundle-content.js")` and threads the constants into the file builders.
- **`compose-scenes-skills.ts`**: `await loadHyperframesSkillBundle()` (already async ctx).
- **`bundle.test.ts`**: the 5 loader calls became `await`; all assertions unchanged.

### Benefit (honest scope)
`build.js` is `bundle: true` + single `outfile`, **no `splitting`** — the 52KB literal
stays in `dist/index.js` (bundle size unchanged). The win is **deferred runtime
evaluation**: esbuild wraps a dynamically-imported local module in a lazy initializer, so
the string allocation + `joinSections` only run when the batch composer (or explicit
`scene install-skill`) first awaits it. Plus a real source-level decoupling — the
"HF skill is optional" story is now true; non-batch paths no longer depend on the content.

### Verification
- `tsc --noEmit` (CLI) + MCP build (tsc-traverses `bundle.ts` via workspace dep) clean.
- Focused: `bundle`, `compose-scenes-skills`, `compose-prompts`, `install-skill` — all green.
- Full CLI + MCP suites green; `gen:reference:check`, `agent-sync:check`, `sync-counts`
  clean (pure internal refactor — no CLI surface / tool-count change).
- Smoke: `vibe scene install-skill` still writes 11 files + correct `bundleVersion`.

Engine, audio mux, chrome discovery untouched. Bump 0.113.22 → 0.113.23.