### PR TITLE
chore: ignore flagship-nightshift output and commit attribution config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "permissions": {
     "allow": [
       "Bash(git status:*)",

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,10 @@ demo-output/
 /nova-demo/
 /keyframe-demo/
 /showcase-demo/
+/elara-demo/
+/elara-veo/
+/flagship-2/
+/flagship-nightshift/
 test-results/
 
 # Test artifacts


### PR DESCRIPTION
Working-tree hygiene from the 2026-07-01 project audit.

- Add `/flagship-nightshift/` to `.gitignore` so the untracked flagship render project (scenes, renders, reports) no longer lands in `git add .`. Also lands the pending `/elara-demo/`, `/elara-veo/`, `/flagship-2/` ignore rules.
- Commit the empty `attribution` block in `.claude/settings.json` (clean-commit config) to clear it from every `git status`.

No source changes.