### PR TITLE
docs: document vibe preview and assemble in CLI surface

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -25,12 +25,13 @@ paths:
 
 The canonical user-facing workflow commands are:
 
-- Project video flow: `init`, `plan`, `build`, `render` (edit beats with
-  `storyboard`, poll async work with `status`)
+- Project video flow: `init`, `plan`, `build`, `preview`, `render` (edit beats
+  with `storyboard`, poll async work with `status`)
 - One-shot media: `generate`, `edit`, `inspect`, `audio`, `remix`
 - Automation: `run`, `agent`, `schema`, `context`, `guide`
 - Setup & hosts: `setup`, `doctor`, `host`
-- Lower-level operations: `scene`, `timeline`, `detect`, `batch`, `media`
+- Lower-level operations: `scene`, `design`, `timeline`, `detect`, `batch`,
+  `media`, `assemble`
 
 Do not introduce new docs or agent instructions that use removed namespaces such
 as `vibe ai`, `vibe project`, `vibe export`, or `vibe pipeline`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,12 +38,13 @@ CLI command availability and parameters.
 
 Canonical user-facing workflows:
 
-- Project video flow: `init`, `plan`, `build`, `render` (edit beats with
-  `storyboard`, poll async work with `status`)
+- Project video flow: `init`, `plan`, `build`, `preview`, `render` (edit beats
+  with `storyboard`, poll async work with `status`)
 - One-shot media: `generate`, `edit`, `inspect`, `audio`, `remix`
 - Automation: `run`, `agent`, `schema`, `context`, `guide`
 - Setup & hosts: `setup`, `doctor`, `host`
-- Lower-level operations: `scene`, `timeline`, `detect`, `batch`, `media`
+- Lower-level operations: `scene`, `design`, `timeline`, `detect`, `batch`,
+  `media`, `assemble`
 
 Do not introduce docs, examples, or agent instructions that use removed
 namespaces such as `vibe ai`, `vibe project`, `vibe export`, or `vibe pipeline`.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ vibe build my-video --dry-run --max-cost 5 --json
 vibe build my-video --max-cost 5 --json
 vibe status project my-video --refresh --json
 vibe inspect project my-video --json
+vibe preview my-video --json
 vibe render my-video -o renders/final.mp4 --json
 vibe inspect render my-video --cheap --json
 vibe scene repair my-video --json
@@ -273,7 +274,7 @@ Use the highest-level lane that fits the job:
 
 | Lane             | Use it when...                                       | Commands                                               |
 | ---------------- | ---------------------------------------------------- | ------------------------------------------------------ |
-| **BUILD**        | You want a complete video from a written brief       | `init`, `storyboard`, `plan`, `build`, `render`, `inspect` |
+| **BUILD**        | You want a complete video from a written brief       | `init`, `storyboard`, `plan`, `build`, `preview`, `render`, `inspect` |
 | **GENERATE/ASSET** | You need one standalone image, clip, voice, or music | `generate image/video/narration/music/motion`          |
 | **EDIT/REMIX**   | You already have media and want to change or reuse it | `edit`, `remix`, `audio`, `detect`                     |
 


### PR DESCRIPTION
From the 2026-07-01 project audit (findings 4, 5).

`vibe preview` and `vibe assemble` shipped in 0.113.23 but were absent from the human-readable CLI surface (only the generated `docs/cli-reference.md` had them). Also documents the `design` namespace.

- `AGENTS.md` CLI Shape: add `preview` to the project video flow; add `design` + `assemble` to lower-level operations.
- `README.md`: add `vibe preview` to Project Flow and the BUILD lane.
- `.claude/rules/architecture.md`: mirror the same list (Claude-only, not synced).

Verified: `agent-sync:check` and `gen:reference:check` pass.