### PR TITLE
refactor: keep scene scaffolds lean by skipping redundant skill copies

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1453,7 +1453,7 @@ Cost tier: `free`
 
 #### `vibe scene install-skill`
 
-Install the Hyperframes skill into a scene project so the host agent can read it (Phase H1)
+Eject editable Hyperframes skill copies into a scene project (SKILL.md + references/). vibe init skips these when the skill is installed globally; run this to customize them per project.
 
 Product surface: `internal`
 Note: Build/init installs the host-agent composition skill when needed.

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -3810,7 +3810,7 @@ exports[`CLI --describe schemas (drift detection) > vibe scene compose-prompts -
 exports[`CLI --describe schemas (drift detection) > vibe scene install-skill --describe 1`] = `
 {
   "cost": "free",
-  "description": "Install the Hyperframes skill into a scene project so the host agent can read it (Phase H1)",
+  "description": "Eject editable Hyperframes skill copies into a scene project (SKILL.md + references/). vibe init skips these when the skill is installed globally; run this to customize them per project.",
   "name": "scene.install-skill",
   "note": "Build/init installs the host-agent composition skill when needed.",
   "parameters": {

--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -241,24 +241,29 @@ no unresolved unacknowledged host-agent issues.
 
 ### Composition rules (scene HTML)
 
-\`vibe init\` installs local composition rules into your project. The
-universal copy lives at \`SKILL.md\` (with \`references/*.md\`), and
-host-specific copies are placed where each agent expects them
-(\`.claude/skills/hyperframes/\` for Claude Code, \`.cursor/rules/hyperframes.mdc\`
-for Cursor). **Read \`SKILL.md\` before authoring any scene composition HTML
-under \`compositions/\`** — it defines the framework rules, motion
-principles, type system, and visual-identity hard-gate. The same skill
-governs \`vibe scene lint\` so your authored HTML and the linter stay in
+Composition rules live in the **Hyperframes skill** — framework rules, motion
+principles, type system, and visual-identity hard-gate. **Load that skill
+before authoring any scene composition HTML under \`compositions/\`.** The same
+rules govern \`vibe scene lint\`, so your authored HTML and the linter stay in
 agreement.
+
+Where the skill comes from depends on your setup:
+
+- If the \`hyperframes\` skill is installed globally (e.g. Claude Code), your
+  agent already has it — \`vibe init\` does **not** copy it into the project.
+- Otherwise \`vibe init\` writes a local copy: universal \`SKILL.md\` (with
+  \`references/*.md\`) at the project root, plus host layouts
+  (\`.claude/skills/hyperframes/\`, \`.cursor/rules/hyperframes.mdc\`).
+
+To get editable per-project copies on demand, run
+\`vibe scene install-skill [--host all]\` (these copies are gitignored by
+default — see \`.gitignore\`).
 
 For render-stable text, do not apply continuous \`scale\`, \`x\`, \`y\`,
 \`filter\`, or other transform tweens to \`.scene-content\` or any ancestor
 containing live text/cards. Put ambient zoom/parallax on background or media
 layers only; text should enter briefly and then hold still at its final CSS
 position.
-
-To retro-install on a project scaffolded before this command existed, run
-\`vibe scene install-skill [--host all]\`.
 
 ### Scene composer (batch / non-agent fallback)
 
@@ -418,6 +423,13 @@ renders/
 .pipeline-state.yaml
 *.vibe.json
 .vibeframe/
+
+# Vendored Hyperframes skill copies — regenerable via 'vibe scene install-skill'.
+# Delete these lines if you eject and want to commit per-project customizations.
+/SKILL.md
+/references/
+/.claude/skills/hyperframes/
+/.cursor/rules/hyperframes.mdc
 `;
 
 /**

--- a/packages/cli/src/commands/_shared/install-skill.test.ts
+++ b/packages/cli/src/commands/_shared/install-skill.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import {
   deriveInstallHosts,
+  deriveRootReaderPresent,
   installHyperframesSkill,
 } from "./install-skill.js";
 
@@ -138,6 +139,104 @@ describe("installHyperframesSkill", () => {
     const r = await installHyperframesSkill({ projectDir, hosts: [] });
     // Format is `<sha>-<YYYY-MM-DD>` per BUNDLE_VERSION docstring.
     expect(r.bundleVersion).toMatch(/^[0-9a-f]+-\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("installHyperframesSkill — lean redundancy gating", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "install-skill-lean-"));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("lean + global skill present: writes nothing for a Claude-only project", async () => {
+    const r = await installHyperframesSkill({
+      projectDir,
+      hosts: ["claude-code"],
+      lean: true,
+      hasGlobalSkill: true,
+    });
+
+    expect(r.files).toHaveLength(0);
+    expect(existsSync(join(projectDir, "SKILL.md"))).toBe(false);
+    expect(existsSync(join(projectDir, "references"))).toBe(false);
+    expect(existsSync(join(projectDir, ".claude/skills/hyperframes"))).toBe(false);
+  });
+
+  it("lean + global skill present: still writes Cursor rules (no global mechanism)", async () => {
+    const r = await installHyperframesSkill({
+      projectDir,
+      hosts: ["cursor"],
+      lean: true,
+      hasGlobalSkill: true,
+    });
+
+    // Cursor rule only — no root universal, no claude copy.
+    expect(existsSync(join(projectDir, ".cursor/rules/hyperframes.mdc"))).toBe(true);
+    expect(existsSync(join(projectDir, "SKILL.md"))).toBe(false);
+    expect(r.files.map((f) => f.path)).toEqual([".cursor/rules/hyperframes.mdc"]);
+  });
+
+  it("lean + global skill present + root-reading host: writes root SKILL.md, skips claude copy", async () => {
+    const r = await installHyperframesSkill({
+      projectDir,
+      hosts: ["claude-code"],
+      lean: true,
+      hasGlobalSkill: true,
+      rootReaderHostPresent: true,
+    });
+
+    // Root files for codex/aider present; the redundant claude copy is skipped.
+    expect(existsSync(join(projectDir, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(projectDir, "references/house-style.md"))).toBe(true);
+    expect(existsSync(join(projectDir, ".claude/skills/hyperframes"))).toBe(false);
+    expect(r.files.some((f) => f.path.startsWith(".claude/"))).toBe(false);
+  });
+
+  it("lean + no global skill: writes everything (fallback so nothing is lost)", async () => {
+    await installHyperframesSkill({
+      projectDir,
+      hosts: ["claude-code"],
+      lean: true,
+      hasGlobalSkill: false,
+    });
+
+    expect(existsSync(join(projectDir, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(projectDir, ".claude/skills/hyperframes/SKILL.md"))).toBe(true);
+  });
+
+  it("not lean (eject): writes everything even when a global skill exists", async () => {
+    const r = await installHyperframesSkill({
+      projectDir,
+      hosts: ["all"],
+      // no `lean` — the explicit install path; hasGlobalSkill is ignored
+      hasGlobalSkill: true,
+    });
+
+    expect(r.files).toHaveLength(11);
+    expect(existsSync(join(projectDir, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(projectDir, ".claude/skills/hyperframes/SKILL.md"))).toBe(true);
+    expect(existsSync(join(projectDir, ".cursor/rules/hyperframes.mdc"))).toBe(true);
+  });
+});
+
+describe("deriveRootReaderPresent", () => {
+  it("true when a non-Claude/non-Cursor host is present", () => {
+    expect(deriveRootReaderPresent(["codex"])).toBe(true);
+    expect(deriveRootReaderPresent(["aider"])).toBe(true);
+    expect(deriveRootReaderPresent(["gemini-cli"])).toBe(true);
+    expect(deriveRootReaderPresent(["claude-code", "codex"])).toBe(true);
+  });
+
+  it("false for Claude/Cursor-only or empty", () => {
+    expect(deriveRootReaderPresent(["claude-code"])).toBe(false);
+    expect(deriveRootReaderPresent(["cursor"])).toBe(false);
+    expect(deriveRootReaderPresent(["claude-code", "cursor"])).toBe(false);
+    expect(deriveRootReaderPresent([])).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/_shared/install-skill.ts
+++ b/packages/cli/src/commands/_shared/install-skill.ts
@@ -22,22 +22,42 @@
  *       references/{house-style,...}.md
  *     .cursor/rules/hyperframes.mdc         # if hosts includes "cursor"
  *
- * Codex + Aider are AGENTS.md-driven hosts; they read the project root
- * SKILL.md via an `@SKILL.md` reference in AGENTS.md (handled by the
- * init-templates AGENTS_MD section, not here).
+ * Codex + Aider are AGENTS.md-driven hosts; they discover the project-root
+ * SKILL.md because AGENTS.md points at it in prose (the init-templates
+ * AGENTS_MD "Composition rules" section, not an `@`-import).
  *
  * The content is byte-identical to what `loadHyperframesSkillBundle()`
- * uses — same vendored files, same `BUNDLE_VERSION`. After install, the
- * agentic compose path (Phase H2) reads these files instead of the
- * vendored TS string constants, so users can edit them per project.
+ * uses — same vendored files, same `BUNDLE_VERSION`. Build/render never read
+ * these project files (they use the vendored bundle); they exist only so host
+ * agents can read the rules and so users can edit them per project.
+ *
+ * Lean scaffolds: the automatic `vibe init` path passes `lean: true`, so when
+ * the Hyperframes skill is already installed globally
+ * (`hasGlobalHyperframesSkill()`) it skips the redundant copies — the
+ * `.claude/skills/hyperframes/` copy always, and the root `SKILL.md` +
+ * `references/` unless a root-reading host (codex/aider/gemini/opencode) needs
+ * them. Explicit `vibe scene install-skill` omits `lean`, fully materializing
+ * editable copies regardless (the "eject").
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 
 import { BUNDLE_VERSION } from "./hf-skill-bundle/bundle.js";
 import type { AgentHostId } from "../../utils/agent-host-detect.js";
+
+/**
+ * True when the Hyperframes skill is installed at the user's global Claude
+ * skills dir (`~/.claude/skills/hyperframes/`). When present, materializing the
+ * skill into a project is redundant — the host agent already loads it globally —
+ * so `vibe init` keeps the scaffold lean and skips the copies. Explicit
+ * `vibe scene install-skill` ignores this (it's the opt-in "eject" path).
+ */
+export function hasGlobalHyperframesSkill(): boolean {
+  return existsSync(join(homedir(), ".claude", "skills", "hyperframes", "SKILL.md"));
+}
 
 /**
  * The vendored skill content. Loaded via a lazy `await import` in
@@ -70,6 +90,24 @@ export interface InstallSkillOptions {
   force?: boolean;
   /** Don't write — just describe what would happen. */
   dryRun?: boolean;
+  /**
+   * Opt into redundancy gating: skip copies the globally-installed Hyperframes
+   * skill already provides. The automatic `vibe init` path sets this so the
+   * scaffold stays lean; the explicit `vibe scene install-skill` path leaves it
+   * false to fully materialize editable copies (the "eject"). Default false.
+   */
+  lean?: boolean;
+  /**
+   * Caller signals a root-reading host (codex / aider / gemini / opencode) is
+   * present, so the root `SKILL.md` + `references/` must be written even when
+   * the global Claude skill exists. Default false. Only consulted when `lean`.
+   */
+  rootReaderHostPresent?: boolean;
+  /**
+   * Override the global-skill probe (testing seam). Defaults to
+   * {@link hasGlobalHyperframesSkill}. Only consulted when `lean`.
+   */
+  hasGlobalSkill?: boolean;
 }
 
 export type InstallSkillFileStatus =
@@ -160,15 +198,49 @@ alwaysApply: false
   ];
 }
 
-/** Resolve which host-specific layouts to install based on `hosts`. */
-function selectHostFiles(hosts: InstallSkillHost[], c: HfBundleContent): SkillFile[] {
+/**
+ * Resolve which files to write given the requested hosts and redundancy state.
+ *
+ * - Root universal files (`SKILL.md` + `references/`) serve root-reading hosts
+ *   (codex / aider / gemini / opencode) and per-project editing. Skipped only
+ *   when the global skill covers them and no root-reader needs them.
+ * - The Claude host copy pure-duplicates the global skill — skipped when the
+ *   global skill is present.
+ * - Cursor's rule file has no global mechanism — always written when requested.
+ *
+ * `globalPresent` is only true under lean gating; otherwise everything the
+ * hosts request is written (the explicit install / eject path).
+ */
+function selectFiles(
+  hosts: InstallSkillHost[],
+  c: HfBundleContent,
+  opts: { globalPresent: boolean; rootReaderPresent: boolean },
+): SkillFile[] {
   const wantsAll = hosts.includes("all");
   const wantsClaude = wantsAll || hosts.includes("claude-code");
   const wantsCursor = wantsAll || hosts.includes("cursor");
+
   const out: SkillFile[] = [];
-  if (wantsClaude) out.push(...claudeCodeFiles(c));
-  if (wantsCursor) out.push(...cursorFiles(c));
+  if (!opts.globalPresent || opts.rootReaderPresent) {
+    out.push(...universalFiles(c));
+  }
+  if (wantsClaude && !opts.globalPresent) {
+    out.push(...claudeCodeFiles(c));
+  }
+  if (wantsCursor) {
+    out.push(...cursorFiles(c));
+  }
   return out;
+}
+
+/**
+ * Map an `AgentHostId[]` to whether a root-reading host is present. Codex,
+ * Aider, Gemini, and OpenCode read the project-root `SKILL.md` via AGENTS.md
+ * prose — they have no global-skill mechanism, so the root files must be
+ * written for them even when the global Claude skill exists.
+ */
+export function deriveRootReaderPresent(detected: AgentHostId[]): boolean {
+  return detected.some((id) => id !== "claude-code" && id !== "cursor");
 }
 
 /**
@@ -185,7 +257,15 @@ export async function installHyperframesSkill(opts: InstallSkillOptions): Promis
 
   // Lazily pull the ~52KB vendored content only when actually installing.
   const content: HfBundleContent = await import("./hf-skill-bundle/bundle-content.js");
-  const files = [...universalFiles(content), ...selectHostFiles(opts.hosts, content)];
+  const lean = opts.lean ?? false;
+  const globalPresent = lean
+    ? (opts.hasGlobalSkill ?? hasGlobalHyperframesSkill())
+    : false;
+  const rootReaderPresent = opts.rootReaderHostPresent ?? false;
+  const files = selectFiles(opts.hosts, content, {
+    globalPresent,
+    rootReaderPresent,
+  });
   const actions: InstallSkillFileAction[] = [];
 
   if (!dryRun && !existsSync(projectDir)) {

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -618,7 +618,11 @@ no unresolved unacknowledged host-agent issues.
 
 ## Skills — USE THESE FIRST
 
-@SKILL.md
+**Load the \`hyperframes\` skill before authoring scenes** — it encodes the
+composition rules, motion principles, type system, and visual-identity gate.
+If your agent has it installed globally it is already available; otherwise run
+\`vibe scene install-skill\` to eject a local, editable copy (\`SKILL.md\` +
+\`references/\`, gitignored by default) and read \`SKILL.md\`.
 
 **Always invoke the relevant skill before authoring scenes.** Skills encode
 framework-specific patterns (GSAP timeline registration, data-attribute
@@ -648,7 +652,7 @@ the framework-level minimum, not the cinematic craft layer.
 - \`index.html\` — root composition (timeline)
 - \`compositions/scene-*.html\` — per-scene HTML authored by you or the agent
 - \`assets/\` — generated/canonical build media (narration audio, images, video)
-- \`references/\` — composition rule docs installed by VibeFrame, not user media
+- \`references/\` — composition rule docs, only when ejected via \`vibe scene install-skill\` (not user media)
 - \`transcript.json\` — Whisper word-level transcript (if narration exists)
 - \`hyperframes.json\` — HF registry config (speak to both toolchains)
 - \`vibe.config.json\` — canonical VibeFrame config (providers, budget)
@@ -716,6 +720,13 @@ export function buildSceneGitignore(): string {
 # Render outputs
 renders/*.mp4
 tmp/
+
+# Vendored Hyperframes skill copies — regenerable via 'vibe scene install-skill'.
+# Delete these lines if you eject and want to commit per-project customizations.
+/SKILL.md
+/references/
+/.claude/skills/hyperframes/
+/.cursor/rules/hyperframes.mdc
 
 # OS / editor
 .DS_Store

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -39,7 +39,7 @@ import {
 import { getVisualStyle, visualStyleNames } from "./_shared/visual-styles.js";
 import { draftStoryboardFromBrief } from "./_shared/storyboard-draft.js";
 import { projectConfigJson, VIBE_CONFIG_FILENAME } from "./_shared/project-config.js";
-import { deriveInstallHosts, installHyperframesSkill } from "./_shared/install-skill.js";
+import { deriveInstallHosts, deriveRootReaderPresent, installHyperframesSkill } from "./_shared/install-skill.js";
 import { hostDefinitions, planHostSetup, type HostSetupId } from "./_shared/host-integration.js";
 import {
   AGENTS_MD,
@@ -417,6 +417,10 @@ async function runSceneInit(
       ? await installHyperframesSkill({
           projectDir,
           hosts: deriveInstallHosts(detectedIds),
+          // Automatic path stays lean: skip copies the global skill already
+          // provides, but keep root files if a root-reading host needs them.
+          lean: true,
+          rootReaderHostPresent: deriveRootReaderPresent(detectedIds),
         })
       : { success: true, files: [], bundleVersion: "not-installed" };
   const mcpActions =

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -137,7 +137,7 @@ type InstallSkillHostFlag = (typeof VALID_INSTALL_SKILL_HOSTS)[number];
 sceneCommand
   .command("install-skill")
   .description(
-    "Install the Hyperframes skill into a scene project so the host agent can read it (Phase H1)"
+    "Eject editable Hyperframes skill copies into a scene project (SKILL.md + references/). vibe init skips these when the skill is installed globally; run this to customize them per project."
   )
   .argument("[project-dir]", "Project directory containing STORYBOARD.md / DESIGN.md", ".")
   .option("--host <id>", `Host layout target: ${VALID_INSTALL_SKILL_HOSTS.join(" | ")}`, "auto")
@@ -166,6 +166,8 @@ sceneCommand
       hosts,
       force: options.force ?? false,
       dryRun: options.dryRun ?? false,
+      // Explicit install is the opt-in "eject": omit `lean` so the editable
+      // copies are materialized in full, even when a global skill exists.
     });
 
     if (isJsonMode()) {

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -815,7 +815,7 @@ export const sceneInstallSkillTool = defineTool({
   title: "Install Hyperframes Skill",
   annotations: { readOnly: false, idempotent: true, openWorld: false },
   description:
-    "Install the vendored Hyperframes skill bundle into a scene project so the host agent (Claude Code, Cursor, Codex, Aider) can read framework rules + house style directly. Writes a universal SKILL.md + references/ at the project root, plus per-host layouts (.claude/skills/hyperframes/ for Claude Code, .cursor/rules/hyperframes.mdc for Cursor) when those hosts are detected. Phase H1 of the agentic-native composer plan — once installed, the host agent itself can author scene HTML using the rules instead of relying on vibe's internal LLM call.",
+    "Eject editable copies of the vendored Hyperframes skill bundle into a scene project so you can customize the framework rules + house style per project. Writes a universal SKILL.md + references/ at the project root, plus per-host layouts (.claude/skills/hyperframes/ for Claude Code, .cursor/rules/hyperframes.mdc for Cursor) when those hosts are detected. Note: vibe init already skips these copies when the Hyperframes skill is installed globally (the host agent loads it from there); run this only to get editable per-project copies. Build/render read the vendored bundle, not these files.",
   schema: sceneInstallSkillSchema,
   async execute(args, ctx) {
     const projectDir = resolve(ctx.workingDirectory, args.projectDir);
@@ -834,6 +834,8 @@ export const sceneInstallSkillTool = defineTool({
       hosts,
       force: args.force ?? false,
       dryRun: args.dryRun ?? false,
+      // Explicit install is the opt-in "eject": omit `lean` so copies are
+      // materialized in full even when a global skill exists.
     });
 
     return {


### PR DESCRIPTION
First step of the scene-workspace declutter (agentic CLI UX). Approved plan phase A.

## Problem
`vibe init --type scene` materialized `SKILL.md` + `references/*.md` + a byte-identical `.claude/skills/hyperframes/` copy into every project — duplicating the globally-installed `hyperframes` skill. Build/render read the **vendored** bundle, not these files, so the copies were pure clutter for a Claude Code user.

## Change
- `hasGlobalHyperframesSkill()` probe + a `lean` gate in `installHyperframesSkill`: when lean and the global skill is present, skip the `.claude` copy always, and the root `SKILL.md`/`references` unless a root-reading host (codex/aider/gemini/opencode) needs them. Cursor rules always written (no global mechanism).
- `vibe init` passes `lean:true`; explicit `vibe scene install-skill` omits it = full materialization (the eject).
- Always gitignore the regenerable copies (both gitignore templates).
- AGENTS.md prose points at the skill (global/vendored); dropped the dangling `@SKILL.md`; fixed a stale header comment.

## Verify
Build clean, lint 0, full suite 1297 passing (+6 gating tests). E2E on a machine with the global skill: `vibe init` writes no `.claude/skills/hyperframes/`; `vibe scene install-skill --host all` still materializes all 11 files. `gen:reference:check` + `agent-sync:check` + pre-push gate green.

No build/render behavior change (vendored bundle path untouched).