### PR TITLE
refactor: stop scaffolding legacy vibe.project.yaml; fix budget salvage

### DIFF
--- a/packages/cli/src/agent/tools/scene.test.ts
+++ b/packages/cli/src/agent/tools/scene.test.ts
@@ -81,7 +81,7 @@ describe("init handler", () => {
     expect(result.success).toBe(true);
     expect(result.output).toContain("Scene project scaffolded at promo");
     expect(await pathExists(resolve(cwd, "promo/index.html"))).toBe(true);
-    expect(await pathExists(resolve(cwd, "promo/vibe.project.yaml"))).toBe(true);
+    expect(await pathExists(resolve(cwd, "promo/vibe.config.json"))).toBe(true);
     expect(await pathExists(resolve(cwd, "promo/compositions"))).toBe(true);
   });
 });

--- a/packages/cli/src/commands/_shared/project-config.test.ts
+++ b/packages/cli/src/commands/_shared/project-config.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readProjectConfig } from "./project-config.js";
+
+describe("readProjectConfig — legacy vibe.project.yaml back-compat", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "project-config-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads a legacy project.yaml when no vibe.config.json exists", async () => {
+    writeFileSync(
+      join(dir, "vibe.project.yaml"),
+      "name: legacy-proj\naspect: '9:16'\ndefaultSceneDuration: 8\nproviders:\n  image: openai\n  tts: kokoro\n",
+      "utf-8",
+    );
+
+    const loaded = await readProjectConfig(dir);
+    expect(loaded.legacy).toBe(true);
+    expect(loaded.source).toBe("vibe.project.yaml");
+    expect(loaded.config.name).toBe("legacy-proj");
+    expect(loaded.config.aspect).toBe("9:16");
+    expect(loaded.config.providers.image).toBe("openai");
+    expect(loaded.config.providers.narration).toBe("kokoro");
+  });
+
+  it("salvages a real budget cap (budget.maxUsd) into build.maxCostUsd", async () => {
+    writeFileSync(
+      join(dir, "vibe.project.yaml"),
+      "name: capped\nbudget:\n  maxUsd: 7\n",
+      "utf-8",
+    );
+
+    const loaded = await readProjectConfig(dir);
+    expect(loaded.config.build.maxCostUsd).toBe(7);
+  });
+
+  it("does not turn the scaffold's maxUsd:0 into a $0 cap (keeps the no-cap default)", async () => {
+    writeFileSync(
+      join(dir, "vibe.project.yaml"),
+      "name: uncapped\nbudget:\n  maxUsd: 0\n",
+      "utf-8",
+    );
+
+    const loaded = await readProjectConfig(dir);
+    // 0 is the scaffold default meaning "no explicit cap" — must not become a
+    // hard $0 gate; the V1 default (null = no cap) stands.
+    expect(loaded.config.build.maxCostUsd).toBeNull();
+  });
+
+  it("prefers vibe.config.json over the legacy yaml when both exist", async () => {
+    writeFileSync(
+      join(dir, "vibe.config.json"),
+      JSON.stringify({ schemaVersion: "1", name: "canonical" }),
+      "utf-8",
+    );
+    writeFileSync(join(dir, "vibe.project.yaml"), "name: legacy\n", "utf-8");
+
+    const loaded = await readProjectConfig(dir);
+    expect(loaded.legacy).toBe(false);
+    expect(loaded.source).toBe("vibe.config.json");
+    expect(loaded.config.name).toBe("canonical");
+  });
+});

--- a/packages/cli/src/commands/_shared/project-config.ts
+++ b/packages/cli/src/commands/_shared/project-config.ts
@@ -166,6 +166,12 @@ export async function readProjectConfig(projectDir: string): Promise<LoadedProje
       config.providers.narration = legacy?.providers?.tts ?? null;
       config.composition.engine = legacy?.composition?.engine ?? "hyperframes";
       config.composition.entry = legacy?.composition?.entry ?? "index.html";
+      // Salvage a real budget cap the user set in the legacy file (previously
+      // dropped on load). Ignore the scaffold's `maxUsd: 0` default so we don't
+      // turn "no cap" (V1 null) into "cap everything at $0".
+      if (typeof legacy?.budget?.maxUsd === "number" && legacy.budget.maxUsd > 0) {
+        config.build.maxCostUsd = legacy.budget.maxUsd;
+      }
       return {
         config,
         source: LEGACY_VIBE_PROJECT_FILENAME,

--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import { mkdtemp, readFile, writeFile, mkdir, access } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { parse as yamlParse } from "yaml";
 
 import {
   aspectToDims,
@@ -384,7 +383,6 @@ describe("scaffoldSceneProject", () => {
       "meta.json",
       "index.html",
       "vibe.config.json",
-      "vibe.project.yaml",
       "AGENTS.md",
       "CLAUDE.md",
       "DESIGN.md",
@@ -448,19 +446,6 @@ describe("scaffoldSceneProject", () => {
     const after = await readFile(storyboardPath, "utf-8");
     expect(after).toBe("# Custom storyboard\n\n## Beat x — X\n");
     expect(second.skipped.some((p) => p.endsWith("STORYBOARD.md"))).toBe(true);
-  });
-
-  it("vibe.project.yaml parses as valid YAML and carries the chosen aspect", async () => {
-    const dir = await makeTmp();
-    await scaffoldSceneProject({ dir, name: "fixture", aspect: "9:16", duration: 10 });
-    const raw = await readFile(resolve(dir, "vibe.project.yaml"), "utf-8");
-    const parsed = yamlParse(raw);
-    expect(parsed).toMatchObject({
-      name: "fixture",
-      aspect: "9:16",
-      defaultSceneDuration: 5,
-      providers: { image: null, tts: null, transcribe: null },
-    });
   });
 
   it("vibe.config.json parses as the canonical project contract", async () => {
@@ -563,7 +548,8 @@ describe("scaffoldSceneProject", () => {
     expect(await pathExists(resolve(dir, "STORYBOARD.md"))).toBe(true);
     expect(await pathExists(resolve(dir, "DESIGN.md"))).toBe(true);
     expect(await pathExists(resolve(dir, "vibe.config.json"))).toBe(true);
-    expect(await pathExists(resolve(dir, "vibe.project.yaml"))).toBe(true);
+    // Legacy YAML is no longer scaffolded.
+    expect(await pathExists(resolve(dir, "vibe.project.yaml"))).toBe(false);
     expect(await pathExists(resolve(dir, "index.html"))).toBe(false);
     expect(await pathExists(resolve(dir, "hyperframes.json"))).toBe(false);
     expect(await pathExists(resolve(dir, "CLAUDE.md"))).toBe(false);

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -2,7 +2,7 @@
  * @module _shared/scene-project
  *
  * Helpers for scaffolding a "scene project" — a directory that works as both
- * a VibeFrame project (via `vibe.project.yaml`) AND a HeyGen Hyperframes
+ * a VibeFrame project (via `vibe.config.json`) AND a HeyGen Hyperframes
  * project (via `hyperframes.json` + `meta.json` + `index.html`). Either
  * toolchain can be run inside the directory.
  *
@@ -13,7 +13,6 @@
 
 import { mkdir, readFile, writeFile, access } from "node:fs/promises";
 import { resolve, basename } from "node:path";
-import { stringify as yamlStringify } from "yaml";
 
 import type { VisualStyle } from "./visual-styles.js";
 import { projectConfigJson, VIBE_CONFIG_FILENAME } from "./project-config.js";
@@ -652,7 +651,6 @@ the framework-level minimum, not the cinematic craft layer.
 - \`transcript.json\` — Whisper word-level transcript (if narration exists)
 - \`hyperframes.json\` — HF registry config (speak to both toolchains)
 - \`vibe.config.json\` — canonical VibeFrame config (providers, budget)
-- \`vibe.project.yaml\` — legacy compatibility config
 - \`renders/\` — output MP4s
 
 ## Commands
@@ -781,7 +779,6 @@ export function describeSceneScaffold(opts: {
       resolve(dir, "DESIGN.md"),
       ...(kindHasCast(kind) ? [resolve(dir, "CHARACTERS.md")] : []),
       resolve(dir, VIBE_CONFIG_FILENAME),
-      resolve(dir, "vibe.project.yaml"),
       resolve(dir, ".gitignore"),
     ],
     render: [],
@@ -890,18 +887,6 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
   } else {
     await writeFile(vibeConfigJsonPath, projectConfigJson({ name, aspect, kind }), "utf-8");
     created.push(vibeConfigJsonPath);
-  }
-
-  // vibe.project.yaml — legacy compatibility. New code reads
-  // vibe.config.json first, but we still write the legacy file during the
-  // transition so older render/build paths and external scripts keep working.
-  const vibePath = resolve(dir, "vibe.project.yaml");
-  if (await pathExists(vibePath)) {
-    skipped.push(vibePath);
-  } else {
-    const cfg = { ...defaultVibeProjectConfig(name), aspect };
-    await writeFile(vibePath, yamlStringify(cfg), "utf-8");
-    created.push(vibePath);
   }
 
   if (profile === "agent" || profile === "full") {

--- a/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
+++ b/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
@@ -62,7 +62,7 @@ narration / backdrop intent.
 
 1. \`vibe init my-promo --visual-style "Swiss Pulse"\` — seeds
    \`DESIGN.md\` (palette, typography, motion, transitions) plus the
-   \`vibe.project.yaml\` / \`hyperframes.json\` / \`index.html\` scaffold.
+   \`vibe.config.json\` / \`hyperframes.json\` / \`index.html\` scaffold.
    In Plan H this **also installs local composition rules** at the
    right place for your host (\`.claude/skills/hyperframes/\` for Claude
    Code, \`.cursor/rules/hyperframes.mdc\` for Cursor, universal
@@ -169,7 +169,7 @@ integration on top of Hyperframes' rendering primitives.
 - [ ] \`vibe scene lint\` exits 0 (or only warnings)
 - [ ] \`vibe doctor\` confirms a usable Chrome (required for render)
 - [ ] Root \`data-duration\` matches the sum of clip durations
-- [ ] Aspect ratio in \`vibe.project.yaml\` matches the destination platform
+- [ ] Aspect ratio in \`vibe.config.json\` matches the destination platform
 `;
 
 const PIPELINE_WALKTHROUGH = `# YAML pipelines (Video as Code)

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -69,14 +69,16 @@ describe("vibe init (black-box)", () => {
     expect(existsSync(join(projectDir, ".env.example"))).toBe(true);
     expect(existsSync(join(projectDir, ".gitignore"))).toBe(true);
     expect(existsSync(join(projectDir, "vibe.config.json"))).toBe(true);
-    expect(existsSync(join(projectDir, "vibe.project.yaml"))).toBe(true);
+    // The legacy vibe.project.yaml is no longer scaffolded (config.json is the
+    // canonical contract; the YAML is only read for back-compat).
+    expect(existsSync(join(projectDir, "vibe.project.yaml"))).toBe(false);
 
     // CLAUDE.md imports AGENTS.md so they stay single-sourced.
     expect(readFileSync(join(projectDir, "CLAUDE.md"), "utf-8")).toContain("@AGENTS.md");
 
-    // vibe.project.yaml uses the directory basename as the project name.
-    const yaml = readFileSync(join(projectDir, "vibe.project.yaml"), "utf-8");
-    expect(yaml).toMatch(/^name: vibe-init-test-/m);
+    // vibe.config.json uses the directory basename as the project name.
+    const config = JSON.parse(readFileSync(join(projectDir, "vibe.config.json"), "utf-8"));
+    expect(config.name).toMatch(/^vibe-init-test-/);
   });
 
   it("is idempotent — second run skips existing files (--force overwrites)", () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -7,7 +7,7 @@
  * machine-wide config (`~/.vibeframe/config.yaml`), init writes
  * project-local files: `AGENTS.md` (cross-tool), `CLAUDE.md` (Claude
  * Code, imports `@AGENTS.md`), `.env.example`, `.gitignore` additions,
- * and an optional `vibe.project.yaml`.
+ * and `vibe.config.json` (the canonical project contract).
  *
  * Scaffolding decision tree:
  *   - Always: `.gitignore` additions, `.env.example`
@@ -47,7 +47,6 @@ import {
   GEMINI_MD,
   GITIGNORE_ADDITIONS,
   renderEnvExample,
-  renderProjectYaml,
 } from "./_shared/init-templates.js";
 import { exitWithError, isJsonMode, outputSuccess, usageError } from "./output.js";
 
@@ -206,16 +205,6 @@ export const initCommand = new Command("init")
       await writeIfMissing(
         resolve(projectDir, VIBE_CONFIG_FILENAME),
         projectConfigJson({ name: projectName }),
-        options.force,
-        options.dryRun
-      )
-    );
-
-    // ── vibe.project.yaml (legacy, only when missing) ──────────────────
-    actions.push(
-      await writeIfMissing(
-        resolve(projectDir, "vibe.project.yaml"),
-        renderProjectYaml({ name: projectName }),
         options.force,
         options.dryRun
       )


### PR DESCRIPTION
Second step of the scene-workspace declutter (agentic CLI UX). Approved plan phase B.

## Problem
Every scaffold wrote **both** `vibe.config.json` (the authoritative V1 contract) and a legacy `vibe.project.yaml`, duplicating config in every project root. `vibe.config.json` is a strict superset, so the YAML is pure clutter. Separately, a legacy `budget.maxUsd` cap was silently **dropped** on load.

## Change
- Stop writing `vibe.project.yaml` in `scaffoldSceneProject` and `vibe init`. `readProjectConfig` still **reads** it (back-compat for existing projects).
- Fix the salvage: map legacy `budget.maxUsd` → `build.maxCostUsd` (consumed), ignoring the scaffold's `maxUsd:0` default so 'no cap' doesn't become a $0 gate.
- Update scaffold prose/file-lists + walkthroughs to name `vibe.config.json`; update tests to assert the YAML is no longer created; add `project-config` tests for the legacy read + salvage.

## Verify
Build clean, lint 0, full suite green. E2E: `vibe init --type scene` writes `vibe.config.json`, no `vibe.project.yaml`; a legacy project with `budget.maxUsd: 7` surfaces `build.maxCostUsd === 7`; scene detection still works via `vibe.config.json`. pre-push gate green.

No reader removed — legacy projects keep loading.