### PR TITLE
chore: bump version to 0.113.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.23] - 2026-06-30
+## [0.113.24] - 2026-07-01
 
 ### Added
 
@@ -22,11 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- remove orphaned exportCommand and dead helpers
+- keep scene scaffolds lean by skipping redundant skill copies
+- stop scaffolding legacy vibe.project.yaml; fix budget salvage
 - lazy-load vendored Hyperframes skill content (HF-lean)
 - replace invented host goal-mode names with host-agnostic agent-loop language
 
 ### Documentation
 
+- document vibe preview and assemble in CLI surface
+- retire stale FUNCTIONS.md, FUNCTIONS-TOBE.md, and DEMO-*.md
 - sync agent docs with current CLI/MCP surface
 
 ### Fixed
@@ -35,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Maintenance
 
+- ignore flagship-nightshift output and commit attribution config
 - add project-auditor agent and local-only agent convention
 
 ## [0.113.11] - 2026-06-22

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.23",
+  "version": "0.113.24",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.23`
+> CLI version: `0.113.24`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.23",
+  "version": "0.113.24",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.23",
+  "version": "0.113.24",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.23",
+  "version": "0.113.24",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.23",
+  "version": "0.113.24",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.23",
+  "version": "0.113.24",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.23",
+  "version": "0.113.24",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Patch release rolling up the changes merged since 0.113.23:

- #257 lean skill scaffolds (skip redundant hyperframes copies)
- #258 retire legacy vibe.project.yaml + budget salvage
- #256 document vibe preview / assemble
- #255 remove orphaned exportCommand
- #254 worktree hygiene (flagship-nightshift gitignore)

All packages set to 0.113.24; CHANGELOG + cli-reference regenerated. Build, lint, tests (1300 passing), and the pre-push gate are green locally. Publishing stays manual (create tag + run publish workflow after this lands).