### PR TITLE
feat(web): feature the aurora flagship on the site; fix dead .tape demo refs

### DIFF
--- a/apps/web/app/demo/page.tsx
+++ b/apps/web/app/demo/page.tsx
@@ -166,31 +166,22 @@ export default function DemoPage() {
             </h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto mb-12 animate-fade-in-up delay-100">
               Plain CLI, optional built-in agent, or a host agent — same project files and command
-              contracts. Each surface below ships a VHS tape; install{" "}
-              <a
-                href="https://github.com/charmbracelet/vhs"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline hover:text-foreground"
-              >
-                vhs
-              </a>{" "}
-              and run it to see the recording.
+              contracts. Each surface below is the exact command sequence you run.
             </p>
           </div>
 
           <div className="grid md:grid-cols-2 gap-6 animate-fade-in-up delay-200">
             <TapeCard
               badge="1 · Media primitives"
-              title="DEMO-quickstart"
+              title="One-shot media"
               note="Host agent drives image generation, video generation, inspection, and overlay editing"
-              command="vhs assets/demos/quickstart-claude-code.tape"
+              command="vibe generate image '...' -o frame.png && vibe generate video '...' -i frame.png -o clip.mp4 && vibe inspect media clip.mp4"
             />
             <TapeCard
               badge="2 · Storyboard dogfood"
-              title="DEMO-dogfood"
+              title="Storyboard build"
               note="Host agent runs the fuller storyboard build, report, render, and YAML workflow"
-              command="vhs assets/demos/dogfood-claude-code.tape"
+              command="vibe init launch --from brief.md && vibe build launch --max-cost 5 && vibe render launch && vibe run workflow.yaml"
             />
           </div>
 

--- a/apps/web/components/demo-showcase.tsx
+++ b/apps/web/components/demo-showcase.tsx
@@ -5,27 +5,68 @@ const RAW_ASSET_BASE = "https://raw.githubusercontent.com/vericontext/vibeframe/
 const LOCAL_ASSET_BASE = "/demo-media";
 const DEMO_ASSET_BASE = process.env.NODE_ENV === "development" ? LOCAL_ASSET_BASE : RAW_ASSET_BASE;
 
+export const FLAGSHIP_VIDEO =
+  "https://github.com/vericontext/vibeframe/releases/download/v0.113.11/vibeframe-showcase.mp4";
 export const PROCESS_HIGHLIGHT_VIDEO = `${DEMO_ASSET_BASE}/process-highlights/demo-process-highlight-bgm.mp4`;
 export const RESULT_VIDEO = `${DEMO_ASSET_BASE}/demo-result.mp4`;
 
 export function DemoShowcase() {
   return (
-    <div className="grid lg:grid-cols-2 gap-5">
-      <DemoVideoCard
-        eyebrow="Process highlight"
-        title="Agent loop in under a minute"
-        description="From rough brief and optional media inputs through setup, research, storyboard/design updates, image cues, build, render, and review."
-        src={PROCESS_HIGHLIGHT_VIDEO}
-        icon={<Terminal className="w-4 h-4" />}
-      />
-      <DemoVideoCard
-        eyebrow="Final result"
-        title="The rendered MP4"
-        description="The shareable MP4 from the storyboard-driven build path, without exposing the whole process."
-        src={RESULT_VIDEO}
-        icon={<Film className="w-4 h-4" />}
-      />
+    <div className="space-y-5">
+      <FlagshipCard />
+      <div className="grid lg:grid-cols-2 gap-5">
+        <DemoVideoCard
+          eyebrow="Process highlight"
+          title="Agent loop in under a minute"
+          description="From rough brief and optional media inputs through setup, research, storyboard/design updates, image cues, build, render, and review."
+          src={PROCESS_HIGHLIGHT_VIDEO}
+          icon={<Terminal className="w-4 h-4" />}
+        />
+        <DemoVideoCard
+          eyebrow="Final result"
+          title="The rendered MP4"
+          description="The shareable MP4 from the storyboard-driven build path, without exposing the whole process."
+          src={RESULT_VIDEO}
+          icon={<Film className="w-4 h-4" />}
+        />
+      </div>
     </div>
+  );
+}
+
+function FlagshipCard() {
+  return (
+    <article className="overflow-hidden rounded-xl border border-border/60 bg-secondary/35 shadow-xl">
+      <div className="relative bg-black">
+        <video
+          src={FLAGSHIP_VIDEO}
+          controls
+          muted
+          loop
+          playsInline
+          preload="metadata"
+          className="aspect-video w-full bg-black object-contain"
+        />
+        <div className="pointer-events-none absolute left-3 top-3 flex items-center gap-2 rounded-full border border-white/15 bg-black/55 px-3 py-1 text-xs font-medium text-white/85 backdrop-blur">
+          <Film className="w-3.5 h-3.5" />
+          Directed AI video
+        </div>
+      </div>
+      <div className="p-5">
+        <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+          <PlayCircle className="w-4 h-4" />
+          Flagship render — one character, many scenes
+        </div>
+        <h3 className="text-xl font-semibold text-foreground">
+          Chasing Light — one photographer across a single arctic night
+        </h3>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          Trek, first aurora, the whole sky, dawn — the same character throughout. Character sheet →
+          image storyboard → image-to-video → composed render, generated end-to-end by{" "}
+          <code>vibe build</code>.
+        </p>
+      </div>
+    </article>
   );
 }
 


### PR DESCRIPTION
Consistency-audit follow-up (vibeframe.ai vs README).

- **Flagship on site:** homepage demo section previously showed only generic demo clips and never the flagship render the README leads with. Add a 'Chasing Light' showcase card playing the v0.113.11 release render (`vibeframe-showcase.mp4`).
- **Dead demo refs:** `/demo` instructed users to run `vhs assets/demos/quickstart-claude-code.tape` and `dogfood-claude-code.tape` — files that don't exist in the repo. Replace with the real vibe command sequences and drop the inaccurate VHS-tape framing.

Verified: `pnpm -F @vibeframe/web lint` clean, `pnpm -F @vibeframe/web build` succeeds.