### PR TITLE
fix(web): drop fictional /goal 'goal mode'; sync stale hero/provider copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.113.25] - 2026-07-01
+
+### Fixed
+
+- drop fictional /goal 'goal mode'; sync stale hero/provider copy *(web)*
+
 ## [0.113.24] - 2026-07-01
 
 ### Added
 
+- feature the aurora flagship on the site; fix dead .tape demo refs *(web)*
 - extract audio mux into a standalone assemble stage (vibe assemble, render --silent)
 - add `vibe preview` cheap draft render command
 - promote transcript to a first-class build stage (--stage transcript)
@@ -30,16 +37,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- migrate character-consistency examples from Nova to the aurora showcase
+- rename showcase GIF to bust GitHub camo image cache
+- upgrade showcase to the research-driven v3 render
+- replace README showcase with the new aurora render
+- declutter README hero; clarify host-sync scope in AGENTS.md
 - document vibe preview and assemble in CLI surface
 - retire stale FUNCTIONS.md, FUNCTIONS-TOBE.md, and DEMO-*.md
 - sync agent docs with current CLI/MCP surface
 
 ### Fixed
 
+- remove remaining VHS-tape wording from the demo page *(web)*
 - make root-sync the single source of clip/narration refs (no doubled audio)
 
 ### Maintenance
 
+- untrack showcase-aurora render project (committed by mistake)
 - ignore flagship-nightshift output and commit attribution config
 - add project-auditor agent and local-only agent convention
 

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 
 export const runtime = "edge";
-export const alt = "VibeFrame - AI-Native Video Editing";
+export const alt = "VibeFrame — Storyboard-first video CLI for coding agents";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -190,7 +190,7 @@ export default async function Image() {
         >
           <span>Open source video CLI</span>
           <span>•</span>
-          <span>Open Source</span>
+          <span>MIT</span>
           <span>•</span>
           <span>vibeframe.ai</span>
         </div>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -88,10 +88,8 @@ export default function LandingPage() {
               DESIGN.md
             </code>{" "}
             and then routes asset generation, scene composition, build reports, render inspection,
-            and final MP4 export through commands any bash-capable coding agent can run. Codex Goal
-            mode and Claude Code{" "}
-            <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-sm">/goal</code>{" "}
-            stay the outer loop; VibeFrame supplies the video runtime.
+            and the final rendered MP4 through commands any bash-capable coding agent can run. Your
+            coding agent&apos;s own loop stays the outer loop; VibeFrame supplies the video runtime.
           </p>
 
           <div className="grid lg:grid-cols-[1.35fr_0.65fr] gap-4 max-w-5xl mx-auto mb-10 text-left animate-fade-in-up delay-150">
@@ -654,12 +652,9 @@ export default function LandingPage() {
             <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
               Claude Code, Codex, Cursor, and other coding agents can drive{" "}
               <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">vibe</code> directly
-              through shell commands and project guidance files. Use native goal modes such as Codex{" "}
-              <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">/goal</code> and
-              Claude Code{" "}
-              <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">/goal</code> for
-              long-running loops, then let VibeFrame provide reports, retry hints, and repair
-              commands. Run{" "}
+              through shell commands and project guidance files. Use your host&apos;s own
+              long-running agent loop for multi-step builds, then let VibeFrame provide reports,
+              retry hints, and repair commands. Run{" "}
               <code className="text-primary bg-primary/10 px-2 py-0.5 rounded">vibe agent</code>{" "}
               only when you want a standalone natural-language session inside the CLI.
             </p>
@@ -688,13 +683,13 @@ export default function LandingPage() {
               <FeatureItem
                 icon={<Zap className="w-5 h-5" />}
                 title={`${process.env.NEXT_PUBLIC_LLM_PROVIDERS} LLM Providers`}
-                description="OpenAI, Claude, Gemini, xAI Grok, OpenRouter, Ollama — swap with -p flag"
+                description="OpenAI, Claude, Gemini, xAI Grok, OpenRouter, Ollama, Evolink — swap with -p flag"
                 gradient="from-yellow-500 to-orange-500"
               />
               <FeatureItem
                 icon={<Sparkles className="w-5 h-5" />}
                 title={`${process.env.NEXT_PUBLIC_AGENT_TOOLS} Tools`}
-                description="Project files, build reports, generation, media, export, filesystem"
+                description="Project files, build reports, generation, media, render, filesystem"
                 gradient="from-purple-500 to-pink-500"
               />
               <FeatureItem

--- a/apps/web/app/twitter-image.tsx
+++ b/apps/web/app/twitter-image.tsx
@@ -1,6 +1,6 @@
 export { default } from "./opengraph-image";
 
 export const runtime = "edge";
-export const alt = "VibeFrame - AI-Native Video Editing";
+export const alt = "VibeFrame — Storyboard-first video CLI for coding agents";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.24",
+  "version": "0.113.25",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.24`
+> CLI version: `0.113.25`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.24",
+  "version": "0.113.25",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.24",
+  "version": "0.113.25",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.24",
+  "version": "0.113.25",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.24",
+  "version": "0.113.25",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.24",
+  "version": "0.113.25",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.24",
+  "version": "0.113.25",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Site↔code drift fix (the reported 'goal' issue).

- Remove the fictional Codex 'Goal mode' + Claude Code `/goal` from the hero and agent-mode section — refer to the host's own agent loop generically.
- Fix LLM-provider mismatch: derived count renders 7 but prose listed 6 → add the missing Evolink.
- Retire 'export' wording (no export command) → rendered MP4 / render.
- Refresh social-image alt to the storyboard-first positioning; de-dup the 'Open Source' footer chip → MIT.
- chore: bump version to 0.113.25 (required after the v0.113.24 tag).

Verified: web lint + build pass. Merge → Vercel redeploys.