### PR TITLE
feat: OKF-aligned frontmatter standard for docs + workflow files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: "VibeFrame Docs"
+description: "Index of VibeFrame documentation — project flow, CLI reference, AI-video prompting, and agent hosts."
+tags: [docs, index]
+---
+
 # VibeFrame Docs
 
 This directory is intentionally small. Exact CLI behavior should come from the

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: "Agent Hosts & Sync"
+description: "How VibeFrame configures Claude Code, Codex, and Cursor from one canonical source."
+tags: [agents, hosts, sync]
+---
+
 # Agent Hosts & Sync
 
 VibeFrame ships agent configuration for three hosts — Claude Code, OpenAI

--- a/docs/ai-video-prompting.md
+++ b/docs/ai-video-prompting.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: "AI Video Prompting Playbook"
+description: "Character sheet to image storyboard to multi-scene image-to-video prompting for consistent, directed AI video."
+tags: [video, prompting, characters]
+---
+
 # AI video prompting playbook — character sheet → image storyboard → multi-scene video
 
 A practical, copy-paste guide for the workflow that produces consistent,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: "VibeFrame CLI Reference"
+description: "Auto-generated reference for every VibeFrame CLI command, argument, and option."
+tags: [cli, reference, generated]
+---
+
 # VibeFrame CLI Reference
 
 > **Auto-generated** from `vibe schema --list`. Do not edit by hand —

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "VibeFrame",
+  "description": "Storyboard-first, agent-friendly video CLI.",
+  "colors": {
+    "primary": "#2563eb",
+    "light": "#60a5fa",
+    "dark": "#1d4ed8"
+  },
+  "navigation": {
+    "groups": [
+      {
+        "group": "Overview",
+        "pages": ["README"]
+      },
+      {
+        "group": "Guides",
+        "pages": ["projects", "recipes", "ai-video-prompting"]
+      },
+      {
+        "group": "Reference",
+        "pages": ["cli-reference", "agent-hosts", "hyperframes"]
+      },
+      {
+        "group": "Meta",
+        "pages": ["okf", "extension-directory-submission"]
+      }
+    ]
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/vericontext/vibeframe"
+    }
+  }
+}

--- a/docs/extension-directory-submission.md
+++ b/docs/extension-directory-submission.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: "Claude Extension Directory Submission"
+description: "Submission notes for the VibeFrame MCP desktop extension."
+tags: [mcp, extension]
+---
+
 # Claude Extension Directory Submission — VibeFrame
 
 Working notes + reviewer guide for submitting the VibeFrame Desktop Extension

--- a/docs/hyperframes.md
+++ b/docs/hyperframes.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: "Composition Engine Boundary"
+description: "Where VibeFrame ends and the Hyperframes composition engine begins."
+tags: [architecture, hyperframes]
+---
+
 # Composition Engine Boundary
 
 VibeFrame is the workflow layer around composition engines. It does not try to

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# VibeFrame docs
+
+Open Knowledge Format (OKF) bundle listing. Each entry is a concept document
+with `type` frontmatter; agents can route by `type` and follow the links.
+
+- [VibeFrame Docs](/docs/README.md) — `Reference` — docs index and orientation.
+- [Project Files And Flow](/docs/projects.md) — `Reference` — project file roles and the init → build → render flow.
+- [VibeFrame Recipes](/docs/recipes.md) — `Reference` — copy-paste command recipes.
+- [AI Video Prompting Playbook](/docs/ai-video-prompting.md) — `Reference` — character sheet → image storyboard → image-to-video.
+- [VibeFrame CLI Reference](/docs/cli-reference.md) — `Reference` — every command, argument, and option (generated).
+- [Agent Hosts & Sync](/docs/agent-hosts.md) — `Reference` — Claude Code / Codex / Cursor configuration.
+- [Composition Engine Boundary](/docs/hyperframes.md) — `Reference` — where VibeFrame ends and Hyperframes begins.
+- [Open Knowledge Format in VibeFrame](/docs/okf.md) — `Reference` — how VibeFrame files map to OKF.
+- [Claude Extension Directory Submission](/docs/extension-directory-submission.md) — `Reference` — MCP desktop extension notes.

--- a/docs/okf.md
+++ b/docs/okf.md
@@ -1,0 +1,71 @@
+---
+type: Reference
+title: "Open Knowledge Format in VibeFrame"
+description: "How VibeFrame's project and docs files map onto Google's Open Knowledge Format (OKF), and how the build workflow flows with it."
+tags: [okf, format, frontmatter, agents]
+---
+
+# Open Knowledge Format in VibeFrame
+
+[Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+is Google Cloud's vendor-neutral spec (Apache-2.0, announced 2026-06-12) for
+storing knowledge as a **directory of markdown files, each with YAML frontmatter
+on top and a free-form markdown body below**. One required field — `type` — plus
+recommended `title`, `description`, `resource`, `tags`, `timestamp`. Custom keys
+are allowed; consumers preserve unknown fields. `index.md` is the bundle listing;
+links are plain markdown.
+
+That is exactly the shape VibeFrame already uses, just made explicit.
+
+## Why it fits VibeFrame
+
+A VibeFrame project **is** a curated knowledge bundle for the coding agent that
+builds the video. The agent doesn't hold the whole film in its head — it reads
+the project's files as context, then acts:
+
+| File | OKF `type` | What the agent reads it for |
+| --- | --- | --- |
+| `STORYBOARD.md` | `Storyboard` | beats, narration, character/keyframe/video cues |
+| `DESIGN.md` | `Design` | palette, typography, motion, transition rules |
+| `CHARACTERS.md` | `Characters` | the recurring cast + identity anchors |
+| `SCRIPT.md` | `Script` | the spoken/narration script |
+| `COMPOSITION.md` | `Composition` | the structural compose contract |
+| `docs/*.md` | `Reference` | the product/CLI knowledge base |
+
+Frontmatter + body was already the pattern (`storyboard-parse.ts`,
+`design-parse.ts`), previously with three independent parsers. This is now
+consolidated behind one `extractFrontmatter()` helper
+(`packages/cli/src/commands/_shared/frontmatter.ts`), and the scaffolded
+`STORYBOARD.md` / `DESIGN.md` carry an OKF `type`.
+
+## How the workflow flows with it
+
+```text
+vibe init  → scaffolds an OKF bundle (typed STORYBOARD/DESIGN + docs)
+             ↓ the agent reads by type, not by guessing filenames
+edit       → STORYBOARD/DESIGN stay human- and agent-editable markdown
+vibe build → parsers read the same frontmatter; unknown OKF keys pass through
+             ↓
+render     → the bundle is portable: `git clone` ships it, `cat` reads it
+```
+
+Practical wins:
+- **Routing by `type`** — an OKF-aware agent (or a future `vibe` command) can
+  pick up "the `Design` doc" or "all `Storyboard` docs" without hardcoded paths.
+- **Portability** — no database or SDK; the project directory is the knowledge.
+- **Interop** — any OKF-consuming tool can read a VibeFrame project, and
+  VibeFrame docs render directly in Mintlify (OKF's `title`/`description` are the
+  fields Mintlify needs — see `docs/docs.json`).
+
+## Current status & what's deliberately left
+
+- **Done:** shared frontmatter helper; `type` on scaffolded `STORYBOARD.md` /
+  `DESIGN.md`; OKF frontmatter on all `docs/*.md`; an OKF `index.md` listing.
+- **Assessed, not yet adopted:** `type` on the prose files (`CHARACTERS.md`,
+  `SCRIPT.md`, `COMPOSITION.md`) — additive and safe, but those files aren't
+  parsed today, so it buys OKF-conformance without changing behavior; worth doing
+  when there's an OKF consumer to justify it. Routing helpers (`vibe` reading a
+  bundle by `type`) are a natural follow-up, not a requirement.
+
+OKF changes nothing about how VibeFrame runs — it just names a pattern the
+project already followed, which makes the whole project legible to agents.

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: "Project Files And Flow"
+description: "VibeFrame project file roles (STORYBOARD, DESIGN, characters) and the init to build to render flow."
+tags: [projects, workflow]
+---
+
 # Project Files And Flow
 
 VibeFrame has two main flows:

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: "VibeFrame Recipes"
+description: "Copy-paste command recipes for common VibeFrame video tasks."
+tags: [recipes, cli]
+---
+
 # VibeFrame Recipes
 
 Verified recipes for common VibeFrame workflows.

--- a/packages/cli/src/commands/_shared/design-parse.ts
+++ b/packages/cli/src/commands/_shared/design-parse.ts
@@ -11,6 +11,7 @@
  * parser only READS; it never rewrites the file.
  */
 import { parse as parseYaml } from "yaml";
+import { extractFrontmatter } from "./frontmatter.js";
 
 export interface ParsedDesign {
   /** `name:` from front-matter, if present. */
@@ -46,22 +47,8 @@ function colorTokens(value: unknown): Record<string, string> {
 }
 
 export function parseDesign(md: string): ParsedDesign {
-  const raw = md.replace(/\r\n/g, "\n");
-
-  let frontmatter: Record<string, unknown> = {};
-  let body = raw;
-  const fm = raw.match(DESIGN_FRONTMATTER_RE);
-  if (fm) {
-    try {
-      const parsed = parseYaml(fm[1]);
-      if (isPlainObject(parsed)) {
-        frontmatter = parsed;
-        body = raw.slice(fm[0].length);
-      }
-    } catch {
-      // Invalid YAML → treat as freeform; leave body intact.
-    }
-  }
+  const { data, body, raw } = extractFrontmatter(md);
+  const frontmatter: Record<string, unknown> = data ?? {};
 
   // Sections: split the body on `## ` headings.
   const sections: Record<string, string> = {};

--- a/packages/cli/src/commands/_shared/frontmatter.ts
+++ b/packages/cli/src/commands/_shared/frontmatter.ts
@@ -1,0 +1,49 @@
+/**
+ * @module _shared/frontmatter
+ *
+ * One canonical "YAML frontmatter + markdown body" splitter for all VibeFrame
+ * `.md` files. Previously each consumer (storyboard, design, install-skill)
+ * declared its own `/^---\n…\n---/` regex + `yaml.parse` — this consolidates
+ * them.
+ *
+ * The shape matches Google's Open Knowledge Format (OKF) and Mintlify: a leading
+ * `---` YAML block, then a free-form markdown body. VibeFrame project files
+ * (STORYBOARD.md, DESIGN.md, CHARACTERS.md, …) are OKF concept documents; docs/
+ * pages carry OKF/Mintlify frontmatter (`type`, `title`, `description`, `tags`).
+ */
+
+import { parse as parseYaml } from "yaml";
+
+/** Leading `---\n…\n---` block. Anchored to the start of the (normalized) text. */
+export const FRONTMATTER_RE = /^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/;
+
+export interface ExtractedFrontmatter {
+  /** Parsed frontmatter map, or `null` when absent / invalid / not a map. */
+  data: Record<string, unknown> | null;
+  /** Markdown body after the frontmatter block (or the whole doc when absent). */
+  body: string;
+  /** The full document, CRLF-normalized to LF. */
+  raw: string;
+}
+
+/**
+ * Split a leading YAML frontmatter block from the markdown body. CRLF is
+ * normalized to LF. Returns `data: null` (freeform) when there is no leading
+ * block, the YAML is invalid, or it is not a plain object — callers decide
+ * whether that means `undefined` or `{}`.
+ */
+export function extractFrontmatter(md: string): ExtractedFrontmatter {
+  const raw = md.replace(/\r\n/g, "\n");
+  const match = raw.match(FRONTMATTER_RE);
+  if (match) {
+    try {
+      const parsed = parseYaml(match[1]);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return { data: parsed as Record<string, unknown>, body: raw.slice(match[0].length), raw };
+      }
+    } catch {
+      // Invalid YAML → treat the whole doc as freeform body.
+    }
+  }
+  return { data: null, body: raw, raw };
+}

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -264,6 +264,7 @@ export function buildDesignMd(opts: { name: string; style?: VisualStyle }): stri
   const { name, style } = opts;
   const roles = designColorRoles(style);
   const frontmatter = `---
+type: Design
 name: ${name}
 colors:
   primary: "${roles.primary}"
@@ -425,6 +426,7 @@ export function buildCharactersMd(name: string): string {
 /** Starter `STORYBOARD.md` for the one-shot `vibe build` flow. */
 export function buildStoryboardMd(name: string, duration = 12): string {
   return `---
+type: Storyboard
 title: ${name}
 duration: ${duration}
 aspect: 16:9

--- a/packages/cli/src/commands/_shared/storyboard-draft.ts
+++ b/packages/cli/src/commands/_shared/storyboard-draft.ts
@@ -27,6 +27,7 @@ export function draftStoryboardFromBrief(opts: {
     : threeBeatDraft({ product, brief, theme, durations: beatDurations });
 
   const storyboardMd = `---
+type: Storyboard
 title: ${JSON.stringify(product)}
 duration: ${total}
 aspect: ${opts.aspect ?? "16:9"}

--- a/packages/cli/src/commands/_shared/storyboard-parse.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.ts
@@ -24,6 +24,7 @@
  */
 
 import { parse as parseYaml } from "yaml";
+import { extractFrontmatter } from "./frontmatter.js";
 
 export interface ParsedStoryboard {
   /**
@@ -211,9 +212,6 @@ const BEAT_PREFIX_RE = /^Beat\s+(.+?)\s+(?:—|:|-)\s+(.+)$/i;
 const DURATION_SUBSECTION_RE = /###\s+Beat\s+duration\s*\n([\s\S]*?)(?=\n###\s|\n##\s|$)/i;
 // Capture optional minus so a "-3" body doesn't sneak in as 3.
 const DURATION_VALUE_RE = /(-?\d+(?:\.\d+)?)\s*(?:s|sec|seconds?)?/i;
-// Top-of-file YAML frontmatter, standard markdown convention. Closing fence
-// must start at column 0 to avoid eating fenced ```yaml inside a beat.
-const FRONTMATTER_RE = /^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/;
 // First ```yaml fenced block inside a beat body. Anchored to the start of the
 // body so we only treat a leading cue block as machine metadata; ```yaml
 // blocks deeper in the body are left as illustrative content.
@@ -295,21 +293,11 @@ export function extractProjectFrontmatter(md: string): {
   frontmatter: ProjectFrontmatter | undefined;
   remaining: string;
 } {
-  const match = md.match(FRONTMATTER_RE);
-  if (!match) return { frontmatter: undefined, remaining: md };
-  let parsed: unknown;
-  try {
-    parsed = parseYaml(match[1]);
-  } catch {
-    return { frontmatter: undefined, remaining: md };
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { frontmatter: undefined, remaining: md };
-  }
-  return {
-    frontmatter: parsed as ProjectFrontmatter,
-    remaining: md.slice(match[0].length),
-  };
+  const { data, body } = extractFrontmatter(md);
+  // Preserve prior semantics: no/invalid frontmatter → undefined + the original
+  // (already-normalized) doc; valid → the parsed map + the post-block body.
+  if (!data) return { frontmatter: undefined, remaining: md };
+  return { frontmatter: data as ProjectFrontmatter, remaining: body };
 }
 
 /**

--- a/scripts/gen-cli-reference.mts
+++ b/scripts/gen-cli-reference.mts
@@ -85,7 +85,14 @@ function getSchema(path: string): ToolSchema {
 
 // ── Static content blocks ────────────────────────────────────────────────────
 
-const HEADER = `# VibeFrame CLI Reference
+const HEADER = `---
+type: Reference
+title: "VibeFrame CLI Reference"
+description: "Auto-generated reference for every VibeFrame CLI command, argument, and option."
+tags: [cli, reference, generated]
+---
+
+# VibeFrame CLI Reference
 
 > **Auto-generated** from \`vibe schema --list\`. Do not edit by hand —
 > run \`pnpm gen:reference\` after any flag/command change.


### PR DESCRIPTION
Adopt Google's Open Knowledge Format (OKF) — frontmatter (`type` + title/description/tags) over a markdown body — so a VibeFrame project reads as an agent-consumable knowledge bundle, and docs/ becomes Mintlify-ready in the same move (OKF title/description = what Mintlify needs).

- **Shared parser:** new `extractFrontmatter()` (frontmatter.ts) consolidates the storyboard + design frontmatter extraction (previously 3 duplicated regexes). DESIGN validation keeps its own parse (needs invalid-vs-not-map error codes). Behavior-preserving — full CLI suite green (1300 tests).
- **Workflow files:** scaffolded STORYBOARD.md/DESIGN.md carry OKF `type`.
- **docs/:** OKF frontmatter on all pages (generated cli-reference via the HEADER, deterministic); new `docs.json` (Mintlify nav), `index.md` (OKF listing), `okf.md` (the assessment / 파악 deliverable).

Verified: build, lint, full test, gen:reference:check, agent-sync:check all green; scaffold smoke confirms type + parse.