### PR TITLE
feat: add experimental Gemini Omni video provider (-p omni)

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -167,7 +167,7 @@ Grok Imagine supports 14 aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:
 
 ---
 
-## Text-to-Video (5)
+## Text-to-Video (5 stable + 1 experimental)
 
 > Models marked **Audio: Yes** generate synchronized sound (dialogue, SFX, ambient). Silent models need separate `vibe generate speech` / `vibe generate sound-effect`.
 
@@ -185,8 +185,11 @@ Grok Imagine supports 14 aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:
 | Veo | `veo-3.0-generate-preview` | 5-8 sec | Yes | `GOOGLE_API_KEY` | `-p veo --veo-model 3.0` | Native audio |
 | Runway | `gen4.5` | 2-10 sec | No | `RUNWAY_API_SECRET` | `-p runway` | Flagship, text+image-to-video (12 credits/sec) |
 | Runway | `gen4_turbo` | 5-10 sec | No | `RUNWAY_API_SECRET` | `-p runway --runway-model gen4_turbo` | Legacy, **image-to-video only** |
+| Gemini Omni ⚠️ | `gemini-omni-flash-preview` | preview | Yes | `GOOGLE_API_KEY` | `-p omni` | **Experimental**, opt-in only. New `/v1beta/interactions` endpoint. Never auto-selected. See below. |
 
 > `-p fal` is a deprecated v0.x alias for `-p seedance` and will be removed at the 1.0 cut. Use `-p seedance` in new scripts.
+
+> ⚠️ **Gemini Omni is experimental.** It is not wired into default provider resolution — you must pass `-p omni` explicitly. The preview interactions schema may change; treat it as unstable.
 
 ### Veo Advanced Options
 
@@ -211,10 +214,38 @@ All text-to-video providers also support image-to-video. Key differences per pro
 | Veo | all models | Yes | base64 (first frame) | Supports `--last-frame` for frame interpolation |
 | Runway | `gen4.5` | Yes | URL or data URI | Text+image-to-video |
 | Runway | `gen4_turbo` | **I2V only** | URL or data URI | Cannot do text-only generation |
+| Gemini Omni ⚠️ | `gemini-omni-flash-preview` | Yes (experimental) | base64 (first frame) | Sends `video_config.task: image_to_video`; opt-in `-p omni` only |
 
-### Gemini Omni Watchlist
+### Gemini Omni (experimental)
 
-Google has started surfacing Gemini Omni Flash in consumer/editorial video products, but the Gemini API model docs do not currently list a stable API model ID for Omni video generation. Do not add `-p omni` or an Omni setup provider until Google publishes a Gemini API or Vertex AI endpoint with model ID, pricing, input/output schema, and region/safety constraints.
+Google Gemini Omni (`gemini-omni-flash-preview`) is a **preview** video
+generation/editing model on the Generative Language API. VibeFrame ships an
+opt-in, experimental client for it — `vibe generate video -p omni`. It is **not**
+part of default provider resolution (Seedance / Veo / Kling / Runway / Grok
+remain the stable path), and the preview request/response schema may change.
+
+Reference: <https://ai.google.dev/gemini-api/docs/omni>
+
+| Property | Value |
+|----------|-------|
+| Model ID | `gemini-omni-flash-preview` |
+| Endpoint | `POST /v1beta/interactions` (new stateful endpoint — **not** Veo's `:predictLongRunning`) |
+| Auth | `GOOGLE_API_KEY` (same key as Gemini / Veo — no new credential) |
+| Tasks | `text_to_video`, `image_to_video`, `reference_to_video`, `edit` via `generation_config.video_config.task` |
+| Aspect ratios | `16:9`, `9:16` |
+| Watermark | SynthID |
+
+**Preview limits** (per Google's docs, subject to change):
+
+- Audio-reference upload is **not** supported.
+- Video references are limited to ≤3 seconds.
+- Editing uploaded video is restricted in the EEA, Switzerland, and the UK.
+- English-tested only; no system-instruction or temperature controls.
+- Large (>4MB) videos may be returned via an async `delivery: uri` reference.
+
+VibeFrame's Omni client (`packages/ai-providers/src/gemini/gemini-omni.ts`)
+parses the interactions response defensively for the video URL, since the
+preview schema is not yet stable.
 
 ---
 
@@ -271,6 +302,7 @@ export REPLICATE_API_TOKEN="..."      # Replicate (music)
 | `vibe generate video -p kling` | `KLING_API_KEY` | Kling v2.5-turbo |
 | `vibe generate image -p grok` | `XAI_API_KEY` | Grok Imagine |
 | `vibe generate video -p veo` | `GOOGLE_API_KEY` | Veo 3.1 |
+| `vibe generate video -p omni` | `GOOGLE_API_KEY` | Gemini Omni (experimental) |
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -702,7 +702,7 @@ Cost tier: `free`
 
 #### `vibe generate video`
 
-Generate video using AI (Seedance, Grok, Kling, Runway, or Veo)
+Generate video using AI (Seedance, Grok, Kling, Runway, Veo, or Gemini Omni)
 
 Product surface: `public`
 
@@ -711,7 +711,7 @@ Cost tier: `very-high`
 **Parameters:**
 
 - `prompt` _(string)_ — Text prompt describing the video (interactive if omitted)
-- `provider` _(string)_ — Provider: seedance (ByteDance Seedance 2.0 via fal.ai), grok, kling, runway, veo. `fal` is a deprecated v0.x alias for seedance and will be removed in 1.0.
+- `provider` _(string)_ — Provider: seedance (ByteDance Seedance 2.0 via fal.ai), grok, kling, runway, veo, omni (Gemini Omni, experimental). `fal` is a deprecated v0.x alias for seedance and will be removed in 1.0.
 - `apiKey` _(string)_ — API key (or set FAL_API_KEY / XAI_API_KEY / RUNWAY_API_SECRET / KLING_API_KEY / GOOGLE_API_KEY env)
 - `output` _(string)_ — Output file path (downloads video)
 - `image` _(string)_ — Reference image for image-to-video

--- a/packages/ai-providers/src/gemini/gemini-omni.ts
+++ b/packages/ai-providers/src/gemini/gemini-omni.ts
@@ -1,0 +1,142 @@
+/**
+ * @module gemini/gemini-omni
+ *
+ * EXPERIMENTAL — Google Gemini Omni (`gemini-omni-flash-preview`) image-to-video.
+ *
+ * Omni is a preview video model on the Generative Language API. Unlike Veo
+ * (`:predictLongRunning` on `/models`), Omni uses the new stateful
+ * `POST /v1beta/interactions` endpoint with a `generation_config.video_config`
+ * block (`task: text_to_video | image_to_video | reference_to_video | edit`).
+ * It reuses the SAME `GOOGLE_API_KEY` as Gemini/Veo — no new credential.
+ *
+ * The interactions request/response schema is preview and may shift; this client
+ * follows https://ai.google.dev/gemini-api/docs/omni and parses the video URL
+ * defensively. Marked experimental and opt-in (`-p omni`); it is NOT wired into
+ * the default video-provider resolution.
+ *
+ * Known preview limits: audio-reference upload unsupported, video refs ≤3s,
+ * EEA/CH/UK restrictions on editing uploaded video, English-tested only.
+ */
+
+import type { GenerateOptions, VideoResult } from "../interface/types.js";
+import type { ProviderConfig } from "../interface/index.js";
+
+const OMNI_MODEL = "gemini-omni-flash-preview";
+const INTERACTIONS_URL = "https://generativelanguage.googleapis.com/v1beta/interactions";
+
+type OmniTask = "text_to_video" | "image_to_video" | "reference_to_video";
+
+/** Pull an inline base64 image + mime out of `referenceImage` / `referenceImages`. */
+function firstReferenceImage(
+  options: GenerateOptions
+): { base64: string; mimeType: string } | undefined {
+  const refs = options.referenceImages;
+  if (refs && refs.length > 0 && refs[0].base64) return refs[0];
+  const ref = options.referenceImage;
+  if (typeof ref === "string" && ref) {
+    // data URI or raw base64
+    const m = ref.match(/^data:(.+?);base64,(.*)$/);
+    if (m) return { mimeType: m[1], base64: m[2] };
+    return { mimeType: "image/png", base64: ref };
+  }
+  return undefined;
+}
+
+/** Best-effort walk of an unknown response object for a video URL/uri. */
+function findVideoUrl(obj: unknown): string | undefined {
+  if (!obj || typeof obj !== "object") return undefined;
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    if (typeof v === "string" && /^https?:\/\//.test(v) && /(uri|url|video)/i.test(k)) return v;
+    if (typeof v === "object") {
+      const nested = findVideoUrl(v);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Minimal Gemini Omni video client. Mirrors the shape the CLI expects from
+ * other video providers (`initialize` + `generateVideo` → {@link VideoResult}).
+ */
+export class OmniProvider {
+  id = "omni";
+  label = "Gemini Omni (experimental)";
+  private apiKey?: string;
+
+  async initialize(config: ProviderConfig): Promise<void> {
+    this.apiKey = config.apiKey;
+  }
+
+  isConfigured(): boolean {
+    return !!this.apiKey;
+  }
+
+  async generateVideo(prompt: string, options?: GenerateOptions): Promise<VideoResult> {
+    if (!this.apiKey) {
+      return { id: "", status: "failed", error: "GOOGLE_API_KEY not configured for Gemini Omni" };
+    }
+    const opts = options ?? ({ prompt } as GenerateOptions);
+    const image = firstReferenceImage(opts);
+    const task: OmniTask = image ? "image_to_video" : "text_to_video";
+    const aspectRatio = opts.aspectRatio === "9:16" ? "9:16" : "16:9";
+
+    // Preview interactions request. `inputs` carries the text prompt and, for
+    // image_to_video, the anchor frame inline.
+    const inputs: Array<Record<string, unknown>> = [{ text: prompt }];
+    if (image) {
+      inputs.push({ inline_data: { mime_type: image.mimeType, data: image.base64 } });
+    }
+    const body = {
+      model: OMNI_MODEL,
+      inputs,
+      generation_config: {
+        video_config: { task, aspect_ratio: aspectRatio },
+      },
+    };
+
+    try {
+      const res = await fetch(INTERACTIONS_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-goog-api-key": this.apiKey },
+        body: JSON.stringify(body),
+      });
+      const text = await res.text();
+      if (!res.ok) {
+        return {
+          id: "",
+          status: "failed",
+          error: `Gemini Omni (experimental) request failed: HTTP ${res.status} — ${text.slice(0, 300)}`,
+        };
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        return { id: "", status: "failed", error: "Gemini Omni returned a non-JSON response" };
+      }
+      const videoUrl = findVideoUrl(parsed);
+      const id =
+        (parsed as { interaction_id?: string; name?: string })?.interaction_id ??
+        (parsed as { name?: string })?.name ??
+        "";
+      if (!videoUrl) {
+        return {
+          id,
+          status: "failed",
+          error:
+            "Gemini Omni response contained no video URL (the preview interactions schema may have changed).",
+        };
+      }
+      return { id, status: "completed", videoUrl };
+    } catch (err) {
+      return {
+        id: "",
+        status: "failed",
+        error: `Gemini Omni (experimental) error: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+}
+
+export const omniProvider = new OmniProvider();

--- a/packages/ai-providers/src/gemini/index.ts
+++ b/packages/ai-providers/src/gemini/index.ts
@@ -1,6 +1,7 @@
 export * from "./GeminiProvider.js";
 export * from "./gemini-motion.js";
 export * from "./gemini-models.js";
+export * from "./gemini-omni.js";
 
 import { defineProvider } from "../define-provider.js";
 
@@ -29,4 +30,14 @@ defineProvider({
   kinds: ["video"],
   resolverPriority: { video: 3 },
   commandsUnlocked: ["generate video -p veo"],
+});
+
+// Gemini Omni — experimental preview video model on the same GOOGLE_API_KEY.
+// No resolverPriority: opt-in only (`-p omni`), never auto-selected as default.
+defineProvider({
+  id: "omni",
+  label: "Gemini Omni (experimental)",
+  apiKey: "google",
+  kinds: ["video"],
+  commandsUnlocked: ["generate video -p omni"],
 });

--- a/packages/ai-providers/src/index.ts
+++ b/packages/ai-providers/src/index.ts
@@ -45,6 +45,8 @@ export {
   GEMINI_TEXT_MODEL_HELP,
   GeminiProvider,
   geminiProvider,
+  OmniProvider,
+  omniProvider,
   isGeminiTextModelAlias,
   resolveGeminiTextModel,
   type GeminiTextModel,

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -2296,7 +2296,7 @@ exports[`CLI --describe schemas (drift detection) > vibe generate thumbnail --de
 exports[`CLI --describe schemas (drift detection) > vibe generate video --describe 1`] = `
 {
   "cost": "very-high",
-  "description": "Generate video using AI (Seedance, Grok, Kling, Runway, or Veo)",
+  "description": "Generate video using AI (Seedance, Grok, Kling, Runway, Veo, or Gemini Omni)",
   "name": "generate.video",
   "parameters": {
     "properties": {
@@ -2355,7 +2355,7 @@ exports[`CLI --describe schemas (drift detection) > vibe generate video --descri
         "type": "string",
       },
       "provider": {
-        "description": "Provider: seedance (ByteDance Seedance 2.0 via fal.ai), grok, kling, runway, veo. \`fal\` is a deprecated v0.x alias for seedance and will be removed in 1.0.",
+        "description": "Provider: seedance (ByteDance Seedance 2.0 via fal.ai), grok, kling, runway, veo, omni (Gemini Omni, experimental). \`fal\` is a deprecated v0.x alias for seedance and will be removed in 1.0.",
         "type": "string",
       },
       "ratio": {

--- a/packages/cli/src/commands/ai-video.ts
+++ b/packages/cli/src/commands/ai-video.ts
@@ -20,6 +20,7 @@ import {
   GeminiProvider,
   GrokProvider,
   KlingProvider,
+  OmniProvider,
   RunwayProvider,
   type MediaReference,
 } from "@vibeframe/ai-providers";
@@ -33,7 +34,7 @@ import { getConfiguredApiKey } from "../utils/api-key.js";
 
 export interface VideoGenerateOptions {
   prompt: string;
-  provider?: "grok" | "runway" | "kling" | "veo" | "seedance" | "fal";
+  provider?: "grok" | "runway" | "kling" | "veo" | "seedance" | "fal" | "omni";
   image?: string;
   refImages?: string[];
   refVideos?: string[];
@@ -94,6 +95,7 @@ export async function executeVideoGenerate(
       runway: "RUNWAY_API_SECRET",
       kling: "KLING_API_KEY",
       veo: "GOOGLE_API_KEY",
+      omni: "GOOGLE_API_KEY",
       seedance: "FAL_API_KEY",
       fal: "FAL_API_KEY",
     };
@@ -345,6 +347,32 @@ export async function executeVideoGenerate(
         duration: finalResult.duration,
         outputPath,
         provider: "grok",
+      };
+    } else if (provider === "omni") {
+      // EXPERIMENTAL — Gemini Omni preview (interactions endpoint), same GOOGLE_API_KEY.
+      const omni = new OmniProvider();
+      await omni.initialize({ apiKey: key });
+      const result = await omni.generateVideo(prompt, {
+        prompt,
+        referenceImage,
+        aspectRatio: ratio as "16:9" | "9:16" | "1:1",
+      });
+      if (result.status !== "completed" || !result.videoUrl) {
+        return { success: false, error: result.error || "Gemini Omni generation failed" };
+      }
+      let outputPath: string | undefined;
+      if (output) {
+        const buffer = await downloadVideo(result.videoUrl, key);
+        outputPath = resolve(process.cwd(), output);
+        await writeFile(outputPath, buffer);
+      }
+      return {
+        success: true,
+        taskId: result.id,
+        status: "completed",
+        videoUrl: result.videoUrl,
+        outputPath,
+        provider: "omni",
       };
     }
 

--- a/packages/cli/src/commands/generate/video.ts
+++ b/packages/cli/src/commands/generate/video.ts
@@ -1,7 +1,8 @@
 /**
  * @module generate/video
  * @description `vibe generate video` (alias `vid`) — multi-provider video
- * generation. fal.ai (Seedance 2.0), Grok, Veo (Gemini), Kling, Runway.
+ * generation. fal.ai (Seedance 2.0), Grok, Veo (Gemini), Kling, Runway,
+ * plus experimental Gemini Omni (`-p omni`).
  * Split out of `generate.ts` in v0.69 (Plan G Phase 2).
  */
 
@@ -17,6 +18,7 @@ import {
   KlingProvider,
   RunwayProvider,
   FalProvider,
+  OmniProvider,
   estimateSeedanceVideoCostUsd,
   type MediaReference,
 } from "@vibeframe/ai-providers";
@@ -41,11 +43,11 @@ export function registerVideoCommand(parent: Command): void {
   parent
     .command("video")
     .alias("vid")
-    .description("Generate video using AI (Seedance, Grok, Kling, Runway, or Veo)")
+    .description("Generate video using AI (Seedance, Grok, Kling, Runway, Veo, or Gemini Omni)")
     .argument("[prompt]", "Text prompt describing the video (interactive if omitted)")
     .option(
       "-p, --provider <provider>",
-      "Provider: seedance (ByteDance Seedance 2.0 via fal.ai), grok, kling, runway, veo. `fal` is a deprecated v0.x alias for seedance and will be removed in 1.0."
+      "Provider: seedance (ByteDance Seedance 2.0 via fal.ai), grok, kling, runway, veo, omni (Gemini Omni, experimental). `fal` is a deprecated v0.x alias for seedance and will be removed in 1.0."
     )
     .option(
       "-k, --api-key <key>",
@@ -147,10 +149,11 @@ Examples:
         // get the deprecation warning (below) instead of "Invalid provider".
         // It is NOT in videoEnvMap because the warning translates to seedance
         // before any map lookup runs.
-        const validProviders = ["runway", "kling", "veo", "grok", "seedance", "fal"];
+        const validProviders = ["runway", "kling", "veo", "grok", "seedance", "fal", "omni"];
         const videoEnvMap: Record<string, string> = {
           grok: "XAI_API_KEY",
           veo: "GOOGLE_API_KEY",
+          omni: "GOOGLE_API_KEY",
           kling: "KLING_API_KEY",
           runway: "RUNWAY_API_SECRET",
           seedance: "FAL_API_KEY",
@@ -162,7 +165,7 @@ Examples:
             exitWithError(
               usageError(
                 `Invalid provider: ${provider}`,
-                "Available providers: seedance, grok, kling, runway, veo. `fal` is a deprecated alias for seedance."
+                "Available providers: seedance, grok, kling, runway, veo, omni (experimental). `fal` is a deprecated alias for seedance."
               )
             );
           }
@@ -290,6 +293,7 @@ Examples:
           runway: "RUNWAY_API_SECRET",
           kling: "KLING_API_KEY",
           veo: "GOOGLE_API_KEY",
+          omni: "GOOGLE_API_KEY",
           grok: "XAI_API_KEY",
           seedance: "FAL_API_KEY",
         };
@@ -297,6 +301,7 @@ Examples:
           runway: "Runway",
           kling: "Kling",
           veo: "Veo",
+          omni: "Gemini Omni (experimental)",
           grok: "Grok",
           seedance: "Seedance 2.0 via fal.ai",
         };
@@ -684,6 +689,20 @@ Examples:
             resolution: options.resolution,
             generateAudio: options.generateAudio,
             lastFrame: seedanceEndImage,
+          });
+          finalResult = result;
+        } else if (provider === "omni") {
+          // Gemini Omni (experimental) — preview `/v1beta/interactions`
+          // endpoint. Opt-in only (`-p omni`), never auto-resolved. The
+          // interactions call returns a final video URL synchronously, so
+          // there is no separate poll/wait loop.
+          const omni = new OmniProvider();
+          await omni.initialize({ apiKey });
+          spinner.text = "Generating video with Gemini Omni (experimental)...";
+          result = await omni.generateVideo(prompt, {
+            prompt,
+            referenceImage,
+            aspectRatio: options.ratio as "16:9" | "9:16" | "1:1",
           });
           finalResult = result;
         }

--- a/packages/cli/src/tools/manifest.test.ts
+++ b/packages/cli/src/tools/manifest.test.ts
@@ -113,7 +113,7 @@ describe("tool manifest invariants", () => {
     expect(tool.description).toContain("FAL_API_KEY");
 
     const provider = tool.inputSchema.properties?.provider as { enum?: string[] } | undefined;
-    expect(provider?.enum).toEqual(["seedance", "grok", "kling", "runway", "veo"]);
+    expect(provider?.enum).toEqual(["seedance", "grok", "kling", "runway", "veo", "omni"]);
     expect(tool.inputSchema.properties).toHaveProperty("seedanceModel");
   });
 

--- a/packages/cli/src/tools/manifest/generate.ts
+++ b/packages/cli/src/tools/manifest/generate.ts
@@ -407,10 +407,10 @@ export const generateVideoTool = defineTool({
   schema: z.object({
     prompt: z.string().describe("Text prompt describing the video"),
     provider: z
-      .enum(["seedance", "grok", "kling", "runway", "veo"])
+      .enum(["seedance", "grok", "kling", "runway", "veo", "omni"])
       .optional()
       .describe(
-        "Video provider (default: seedance when FAL_API_KEY is configured, otherwise first configured provider)"
+        "Video provider (default: seedance when FAL_API_KEY is configured, otherwise first configured provider). `omni` = Gemini Omni, experimental/opt-in, uses GOOGLE_API_KEY."
       ),
     image: z.string().optional().describe("Reference image path for image-to-video"),
     endImage: z.string().optional().describe("Ending frame image path for Seedance image-to-video"),

--- a/packages/cli/src/utils/provider-resolver.test.ts
+++ b/packages/cli/src/utils/provider-resolver.test.ts
@@ -42,6 +42,10 @@ describe("provider registry — derived shapes match v0.67 hardcoded arrays", ()
       { name: "veo", envVar: "GOOGLE_API_KEY", label: "Veo" },
       { name: "kling", envVar: "KLING_API_KEY", label: "Kling" },
       { name: "runway", envVar: "RUNWAY_API_SECRET", label: "Runway" },
+      // Gemini Omni (experimental) registers as a video provider but declares
+      // no resolverPriority, so it sorts last and is never auto-selected —
+      // opt-in via `-p omni` only. veo always wins GOOGLE_API_KEY resolution.
+      { name: "omni", envVar: "GOOGLE_API_KEY", label: "Gemini Omni (experimental)" },
     ]);
   });
 
@@ -85,6 +89,7 @@ describe("provider registry — derived shapes match v0.67 hardcoded arrays", ()
       GOOGLE_API_KEY: [
         "generate image",
         "generate video -p veo",
+        "generate video -p omni",
         "edit image",
         "analyze media",
         "analyze video",


### PR DESCRIPTION
Add an opt-in, experimental client for Google's Gemini Omni preview video
model (`gemini-omni-flash-preview`). Omni uses the new stateful
`POST /v1beta/interactions` endpoint (not Veo's `:predictLongRunning`) with a
`generation_config.video_config.task` block, and reuses the existing
GOOGLE_API_KEY — no new credential.

- New `OmniProvider` in ai-providers (defensive parse of the preview
  interactions schema), registered via `defineProvider` with NO resolverPriority
  so it sorts last and is never auto-selected — `-p omni` only.
- Wire `omni` into both video paths: the `vibe generate video` CLI command and
  the `executeVideoGenerate` executor (pipeline / scene-build / MCP tool).
- Expose `omni` in the generate_video agent/MCP schema, flagged experimental.
- Document the model id, endpoint, tasks, and preview/EEA/audio-ref limits in
  MODELS.md (replaces the old "watchlist" note).
- Update the provider-surface guard tests + CLI reference to include omni.

Experimental and opt-in: the stable video path (seedance/veo/kling/runway/grok)
is unchanged.
