### PR TITLE
fix(release): detect version bumps that do not cover HEAD

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -5,11 +5,27 @@ description: Bump VibeFrame versions, regenerate release artifacts, run verifica
 
 # Release
 
-Use this skill when the user asks Codex to run a VibeFrame release bump or fix a
-missing version bump after `feat:` / `fix:` commits.
+Use this skill when the user asks Codex to cut a VibeFrame release.
 
 The bump is one of `patch`, `minor`, or `major`. **Default to `patch`** when
 no bump is specified or when there is any doubt.
+
+## When Bumps Happen
+
+**Once per release, not once per PR.** Ordinary `feat:` / `fix:` PRs merge to
+`main` without a version bump. This skill runs when you decide to release, and
+the single bump it produces must cover *every* commit since the last tag -
+`git-cliff` handles that automatically in step 7.
+
+Check what the release will cover before starting:
+
+```bash
+bash scripts/release-status.sh
+```
+
+That script is the single source of truth for release state. The push gate, the
+tag workflow, and the daily drift check all call it, so its answer is the same
+one CI will give.
 
 ## Version Policy
 
@@ -118,8 +134,18 @@ git push -u origin chore/release-$NEW_VERSION
 gh pr create --fill --base main
 ```
 
-Publishing is manual. After the version commit lands on `main` (through the PR)
-and CI passes, run the `Create release tag` workflow to create `vX.Y.Z`, then
-run `Publish to npm` manually with that tag. A human-created `git push origin
-vX.Y.Z` tag also triggers `publish.yml`, but CI and the tag helper do not
-dispatch publishing automatically.
+12. Tagging is automatic. Once the version commit lands on `main` and CI passes,
+    the `Create release tag` workflow creates `vX.Y.Z` on its own. Before
+    tagging it re-runs `scripts/release-status.sh` and **refuses** if `feat:` /
+    `fix:` commits landed after the bump, or if `CHANGELOG.md` has no
+    `## [X.Y.Z]` entry. Do not create the tag by hand.
+
+13. Publishing stays manual. Run the `Publish to npm` workflow with the new tag.
+
+    Tags pushed by a workflow cannot trigger another workflow, so the automatic
+    tag never dispatches `publish.yml` - that is what keeps the "CI never
+    publishes" policy intact. A human-created `git push origin vX.Y.Z` *does*
+    trigger `publish.yml`, so do not push release tags manually.
+
+If publishing is forgotten, the daily `Release drift check` workflow opens an
+issue comparing `main`, the latest tag, and the published npm versions.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -9,11 +9,27 @@ disable-model-invocation: true
 
 # Release
 
-Use this skill when the user asks Codex to run a VibeFrame release bump or fix a
-missing version bump after `feat:` / `fix:` commits.
+Use this skill when the user asks Codex to cut a VibeFrame release.
 
 The bump is one of `patch`, `minor`, or `major`. **Default to `patch`** when
 no bump is specified or when there is any doubt.
+
+## When Bumps Happen
+
+**Once per release, not once per PR.** Ordinary `feat:` / `fix:` PRs merge to
+`main` without a version bump. This skill runs when you decide to release, and
+the single bump it produces must cover *every* commit since the last tag -
+`git-cliff` handles that automatically in step 7.
+
+Check what the release will cover before starting:
+
+```bash
+bash scripts/release-status.sh
+```
+
+That script is the single source of truth for release state. The push gate, the
+tag workflow, and the daily drift check all call it, so its answer is the same
+one CI will give.
 
 ## Version Policy
 
@@ -122,8 +138,18 @@ git push -u origin chore/release-$NEW_VERSION
 gh pr create --fill --base main
 ```
 
-Publishing is manual. After the version commit lands on `main` (through the PR)
-and CI passes, run the `Create release tag` workflow to create `vX.Y.Z`, then
-run `Publish to npm` manually with that tag. A human-created `git push origin
-vX.Y.Z` tag also triggers `publish.yml`, but CI and the tag helper do not
-dispatch publishing automatically.
+12. Tagging is automatic. Once the version commit lands on `main` and CI passes,
+    the `Create release tag` workflow creates `vX.Y.Z` on its own. Before
+    tagging it re-runs `scripts/release-status.sh` and **refuses** if `feat:` /
+    `fix:` commits landed after the bump, or if `CHANGELOG.md` has no
+    `## [X.Y.Z]` entry. Do not create the tag by hand.
+
+13. Publishing stays manual. Run the `Publish to npm` workflow with the new tag.
+
+    Tags pushed by a workflow cannot trigger another workflow, so the automatic
+    tag never dispatches `publish.yml` - that is what keeps the "CI never
+    publishes" policy intact. A human-created `git push origin vX.Y.Z` *does*
+    trigger `publish.yml`, so do not push release tags manually.
+
+If publishing is forgotten, the daily `Release drift check` workflow opens an
+issue comparing `main`, the latest tag, and the published npm versions.

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,0 +1,124 @@
+name: Release drift check
+
+# Backstop for the one manual step left in the release flow.
+#
+# release-tag.yml now tags automatically, so bump -> tag cannot be forgotten.
+# tag -> npm publish is still deliberately manual (AGENTS.md: "CI never
+# publishes npm packages"), and a manual step with no detector is exactly how
+# v0.113.25 sat unpublished for three weeks. This job watches that gap.
+#
+# It reports; it never publishes.
+
+on:
+  schedule:
+    # Daily at 09:00 UTC.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # Ignore drift younger than this. A release is tagged and published minutes
+  # apart by a human, so a fresh tag awaiting publish is normal, not drift.
+  GRACE_HOURS: 6
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Compare main, latest tag, and npm
+        id: check
+        run: |
+          ROOT_VERSION=$(node -p "require('./package.json').version")
+          LATEST_TAG=$(git tag --list 'v*' --sort=v:refname | tail -1)
+          TAG_VERSION="${LATEST_TAG#v}"
+          CLI_NPM=$(npm view @vibeframe/cli version 2>/dev/null || echo "unknown")
+          MCP_NPM=$(npm view @vibeframe/mcp-server version 2>/dev/null || echo "unknown")
+
+          echo "main package.json:      $ROOT_VERSION"
+          echo "latest tag:             $LATEST_TAG"
+          echo "npm @vibeframe/cli:         $CLI_NPM"
+          echo "npm @vibeframe/mcp-server:  $MCP_NPM"
+
+          TAG_EPOCH=$(git log -1 --format=%ct "$LATEST_TAG" 2>/dev/null || echo 0)
+          NOW_EPOCH=$(date -u +%s)
+          AGE_HOURS=$(( (NOW_EPOCH - TAG_EPOCH) / 3600 ))
+          echo "tag age: ${AGE_HOURS}h (grace ${GRACE_HOURS}h)"
+
+          REASONS=""
+          if [ "$ROOT_VERSION" != "$TAG_VERSION" ]; then
+            REASONS="${REASONS}- main is at \`$ROOT_VERSION\` but the latest tag is \`$LATEST_TAG\`. Auto-tagging should have handled this - check the **Create release tag** workflow for a failure.\n"
+          fi
+          if [ "$CLI_NPM" != "$TAG_VERSION" ]; then
+            REASONS="${REASONS}- npm \`@vibeframe/cli\` is at \`$CLI_NPM\`, tag is \`$TAG_VERSION\`. Run **Publish to npm** with \`$LATEST_TAG\`.\n"
+          fi
+          if [ "$MCP_NPM" != "$TAG_VERSION" ]; then
+            REASONS="${REASONS}- npm \`@vibeframe/mcp-server\` is at \`$MCP_NPM\`, tag is \`$TAG_VERSION\`. Run **Publish to npm** with \`$LATEST_TAG\`.\n"
+          fi
+
+          if [ -z "$REASONS" ]; then
+            echo "In sync."
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$AGE_HOURS" -lt "$GRACE_HOURS" ]; then
+            echo "Drift detected but tag is only ${AGE_HOURS}h old - within grace, not reporting."
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "drifted=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "The published state has drifted from the repository state for over ${AGE_HOURS}h."
+            echo ""
+            printf '%b' "$REASONS"
+            echo ""
+            echo "| where | version |"
+            echo "| --- | --- |"
+            echo "| \`main\` package.json | \`$ROOT_VERSION\` |"
+            echo "| latest git tag | \`$LATEST_TAG\` |"
+            echo "| npm \`@vibeframe/cli\` | \`$CLI_NPM\` |"
+            echo "| npm \`@vibeframe/mcp-server\` | \`$MCP_NPM\` |"
+            echo ""
+            echo "This issue closes itself once the versions line up again."
+          } > /tmp/drift-body.md
+
+          cat /tmp/drift-body.md
+
+      - name: Open or update the drift issue
+        if: steps.check.outputs.drifted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "Release drift: published version is behind the repository"
+        run: |
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file /tmp/drift-body.md
+            echo "Updated issue #$EXISTING"
+          else
+            gh issue create --title "$TITLE" --body-file /tmp/drift-body.md
+          fi
+
+      - name: Close the drift issue once back in sync
+        if: steps.check.outputs.drifted == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "Release drift: published version is behind the repository"
+        run: |
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "Versions are back in sync."
+            echo "Closed issue #$EXISTING"
+          fi

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,11 +1,23 @@
 name: Create release tag
 
-# Manual helper for creating the release tag that matches the root
-# package.json version. CI remains validation-only; this workflow never
-# dispatches npm publishing.
+# Creates the release tag matching the root package.json version.
+#
+# Runs automatically once CI passes on `main`, and is idempotent: when the
+# version is already tagged (the normal state for every non-release push) it
+# skips immediately. A version bump merging into main is therefore tagged
+# without a human remembering to do it - that forgotten manual step is what
+# stranded v0.113.25 untagged and unpublished for three weeks.
+#
+# npm publishing stays manual. Tags pushed with GITHUB_TOKEN cannot trigger
+# other workflows, so publish.yml is NOT dispatched by the tag created here.
+# That preserves the "CI never publishes npm packages" policy in AGENTS.md.
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -13,9 +25,15 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    # Never tag off a red CI run. workflow_dispatch is trusted to the operator.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
         with:
+          # Tag the exact commit CI validated, not whatever main has drifted to.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -36,15 +54,60 @@ jobs:
             echo "Tag $TAG already exists; nothing to do."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Tag $TAG missing; will create."
+            echo "Tag $TAG missing; will validate then create."
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # The enforcement point. The push gate only warns about unreleased work,
+      # so this is where a version that does not describe HEAD gets stopped.
+      # Every release passes through here, and unlike a local hook it cannot be
+      # skipped with --no-verify or bypassed by pushing from another host.
+      - name: Verify the version covers HEAD
+        if: steps.check.outputs.skip == 'false'
+        env:
+          TAG: ${{ steps.check.outputs.tag }}
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          set +e
+          bash scripts/release-status.sh
+          STATUS=$?
+          set -e
+
+          case "$STATUS" in
+            0)
+              echo "Version $VERSION covers HEAD."
+              ;;
+            1)
+              echo "::error::Refusing to tag $TAG: feat/fix commits landed after the last version bump, so this version does not describe them. Run /release patch to bump and regenerate CHANGELOG.md, then let this workflow tag the result."
+              exit 1
+              ;;
+            2)
+              echo "::error::Refusing to tag $TAG: CHANGELOG.md has no '## [$VERSION]' entry. publish.yml extracts the GitHub Release body from that section, so tagging now would ship an empty release. Fix: git-cliff --tag $TAG -o CHANGELOG.md"
+              exit 1
+              ;;
+            *)
+              echo "::error::release-status.sh failed with exit $STATUS"
+              exit 1
+              ;;
+          esac
+
       - name: Create and push tag
         if: steps.check.outputs.skip == 'false'
+        env:
+          TAG: ${{ steps.check.outputs.tag }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.check.outputs.tag }}" \
-            -m "Release ${{ steps.check.outputs.tag }}"
-          git push origin "${{ steps.check.outputs.tag }}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+      - name: Summary
+        if: steps.check.outputs.skip == 'false'
+        env:
+          TAG: ${{ steps.check.outputs.tag }}
+        run: |
+          {
+            echo "Created tag \`$TAG\`."
+            echo ""
+            echo "Next step is manual: run **Publish to npm** with tag \`$TAG\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,20 +127,30 @@ General expectation:
   `main`, even as a maintainer with admin bypass (`main` allows it, but the
   policy does not). Release bumps go on a `chore/release-<version>` (or the
   feature) branch and merge through the same gate as any other change.
-- Version bumps default to `patch` during `0.x`, including most ordinary
-  `feat:` and `fix:` commits. **`patch` is the default; `minor` is rare.** Use
-  `minor` only for new public CLI command namespaces, new MCP tool families,
-  public API contract additions, or large product milestones; reserve `major`
-  for breaking changes or the 1.0 milestone. The shared push gate
+- **Bump at release time, not per PR.** `feat:`/`fix:` PRs merge without a
+  version bump. When you decide to release, `/release` bumps once and
+  regenerates `CHANGELOG.md` so the new version covers every commit since the
+  last tag. The push gate **warns** about unreleased work but never blocks on
+  it; the blocking check lives in `.github/workflows/release-tag.yml`, which
+  refuses to tag a version that does not describe `HEAD`.
+- Version bumps default to `patch` during `0.x`. **`patch` is the default;
+  `minor` is rare.** Use `minor` only for new public CLI command namespaces, new
+  MCP tool families, public API contract additions, or large product milestones;
+  reserve `major` for breaking changes or the 1.0 milestone. The shared push gate
   (`scripts/pre-push-validate.sh`) **blocks** a `minor`/`major` bump unless the
   `chore: bump version` commit carries a `Release-Type: minor: <reason>` (or
   `major`) trailer, or `VIBE_ALLOW_MINOR=1` is set.
 - API keys belong in local config or `.env`-style files, never committed.
 - See `MODELS.md` for provider details.
 - `CHANGELOG.md` is generated with `git-cliff --tag vX.Y.Z -o CHANGELOG.md`.
-- CI never publishes npm packages. After a version commit lands on `main` and
-  CI passes, manually create the release tag and manually run the publish
-  workflow for that tag.
+- CI never publishes npm packages. Once the version commit lands on `main` and
+  CI passes, the release tag is created **automatically** by the `Create release
+  tag` workflow. Publishing stays manual: run the `Publish to npm` workflow with
+  that tag. (Tags pushed by a workflow cannot trigger another workflow, so
+  auto-tagging never reaches `publish.yml`.)
+- Release state is computed in one place - `scripts/release-status.sh`. The push
+  gate, the tag workflow, and the daily drift check all call it. Do not
+  reimplement version/tag comparisons anywhere else.
 
 ## Verification
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,18 @@ demos, packaging, or contributor maintenance.
 - `print-env-example.mts` - regenerates `.env.example` from provider metadata.
 - `sync-counts.sh` - drift checker for provider/count-related metadata.
 
+## Release
+
+- `release-status.sh` - single source of truth for release state: whether the
+  current version covers every `feat:`/`fix:` commit on `HEAD`, whether it is
+  tagged, and whether `CHANGELOG.md` documents it. Called by
+  `pre-push-validate.sh`, `.github/workflows/release-tag.yml`, and
+  `.github/workflows/release-drift.yml`. **Do not reimplement version/tag
+  comparisons elsewhere** - divergent copies of this logic are what let
+  v0.113.25 ship untagged.
+- `pre-push-validate.sh` - shared push gate for Claude Code, Codex, and plain
+  Git (`.claude/hooks/` and `.githooks/` both delegate here).
+
 ## Contributor Helpers
 
 - `dev-setup-wizard.mts` - runs setup against an isolated debug home.

--- a/scripts/pre-push-validate.sh
+++ b/scripts/pre-push-validate.sh
@@ -8,6 +8,7 @@ if [ -z "$PROJECT_DIR" ]; then
 fi
 
 ERRORS=()
+WARNINGS=()
 
 # 1. Version sync — all package.json files must have the same version.
 ROOT_VERSION=$(jq -r '.version' "$PROJECT_DIR/package.json")
@@ -18,38 +19,35 @@ for pkg in packages/cli packages/core packages/ai-providers packages/mcp-server 
   fi
 done
 
-# 2. Version bump check — feat:/fix: commits since last tag should have a bump commit.
-# Prefer the newest remote v* tag when available. GitHub Actions creates
-# release tags after version commits land on main, so a developer clone can
-# otherwise have stale local tags and miss a required bump on the next push.
-remote_latest_tag() {
-  cd "$PROJECT_DIR" || return 1
-  git ls-remote --tags origin 'refs/tags/v*' 2>/dev/null \
-    | awk '{print $2}' \
-    | sed 's#refs/tags/##; s#\^{}##' \
-    | sort -Vu \
-    | tail -1
-}
+# 2. Release coverage - delegated to scripts/release-status.sh so this gate, the
+# tag workflow, and the drift detector all judge release state identically. Two
+# copies of this logic drifting apart is the bug class that stranded v0.113.25.
+#
+# Under the release-time-bump policy, unreleased feat:/fix: work on main is
+# NORMAL and does not block a push. It is surfaced as a warning so it never goes
+# unnoticed. The blocking enforcement lives in release-tag.yml, which refuses to
+# tag a version that does not cover HEAD.
+LATEST_TAG=""
+TAG_VERSION=""
+CHANGELOG_HAS_VERSION="true"
+RELEASE_JSON=$(cd "$PROJECT_DIR" && bash scripts/release-status.sh --json 2>/dev/null || true)
 
-local_latest_tag() {
-  cd "$PROJECT_DIR" || return 1
-  git tag --list 'v*' --sort=v:refname 2>/dev/null | tail -1
-}
+if [ -n "$RELEASE_JSON" ]; then
+  LATEST_TAG=$(echo "$RELEASE_JSON" | jq -r '.latestTag')
+  TAG_VERSION=$(echo "$RELEASE_JSON" | jq -r '.tagVersion')
+  CHANGELOG_HAS_VERSION=$(echo "$RELEASE_JSON" | jq -r '.changelogHasVersion')
+  UNCOVERED_COUNT=$(echo "$RELEASE_JSON" | jq -r '.uncoveredCount')
 
-LATEST_TAG=$(remote_latest_tag)
-if [ -z "$LATEST_TAG" ]; then
-  LATEST_TAG=$(local_latest_tag)
-fi
-
-if [ -n "$LATEST_TAG" ]; then
-  if ! (cd "$PROJECT_DIR" && git rev-parse -q --verify "refs/tags/$LATEST_TAG" >/dev/null); then
-    (cd "$PROJECT_DIR" && git fetch --quiet origin "refs/tags/$LATEST_TAG:refs/tags/$LATEST_TAG" 2>/dev/null) || true
+  if [ "$UNCOVERED_COUNT" -gt 0 ]; then
+    UNCOVERED_LIST=$(echo "$RELEASE_JSON" | jq -r '.uncovered[]' | sed 's/^/      /')
+    WARNINGS+=("$UNCOVERED_COUNT unreleased feat:/fix: commit(s) since ${LATEST_TAG}. Release with /release patch when ready.
+$UNCOVERED_LIST")
   fi
-  TAG_VERSION="${LATEST_TAG#v}"
-  FEAT_FIX=$(cd "$PROJECT_DIR" && git log "$LATEST_TAG"..HEAD --oneline -E --grep="^(feat|fix)(\(.+\))?:" --format="%s" 2>/dev/null || true)
-  if [ -n "$FEAT_FIX" ] && [ "$ROOT_VERSION" = "$TAG_VERSION" ]; then
-    ERRORS+=("feat:/fix: commits found since $LATEST_TAG but version is still $ROOT_VERSION. Fix: /release patch by default; use /release minor only for public command/API milestones")
-  fi
+else
+  # Checks 2b and 7 below key off LATEST_TAG. If release state could not be
+  # computed they would silently pass - a blocking guard vanishing without a
+  # sound is the failure mode this whole change exists to remove. Fail loudly.
+  ERRORS+=("Could not compute release state. Fix: bash scripts/release-status.sh --json")
 fi
 
 # 2b. Non-patch bump guard — during 0.x, patch is the default. A minor/major
@@ -92,11 +90,11 @@ if ! (cd "$PROJECT_DIR" && pnpm agent-sync:check > /dev/null 2>&1); then
   ERRORS+=("Agent host config drift. Run 'pnpm agent-sync'. $SYNC_MSG")
 fi
 
-# 7. CHANGELOG sync — if version changed since last tag, CHANGELOG must contain it.
-if [ -n "$LATEST_TAG" ] && [ "$ROOT_VERSION" != "$TAG_VERSION" ]; then
-  if ! grep -q "\[$ROOT_VERSION\]" "$PROJECT_DIR/CHANGELOG.md" 2>/dev/null; then
-    ERRORS+=("CHANGELOG.md missing entry for v$ROOT_VERSION. Fix: git-cliff --tag v$ROOT_VERSION -o CHANGELOG.md")
-  fi
+# 7. CHANGELOG sync - if version changed since last tag, CHANGELOG must contain
+# it. release-status.sh anchors the match the same way publish.yml extracts
+# release notes, so passing here guarantees a non-empty GitHub Release body.
+if [ -n "$LATEST_TAG" ] && [ "$ROOT_VERSION" != "$TAG_VERSION" ] && [ "$CHANGELOG_HAS_VERSION" != "true" ]; then
+  ERRORS+=("CHANGELOG.md missing entry for v$ROOT_VERSION. Fix: git-cliff --tag v$ROOT_VERSION -o CHANGELOG.md")
 fi
 
 # Run a checked command, capturing combined output. On failure, attach the
@@ -131,6 +129,14 @@ gated_check "docs/cli-reference.md is stale" \
 
 # 12. Package export/package smoke.
 gated_check "Package smoke" "pnpm build && pnpm package:check" pnpm package:check
+
+if [ ${#WARNINGS[@]} -gt 0 ]; then
+  echo "Pre-push warnings (not blocking):" >&2
+  for warn in "${WARNINGS[@]}"; do
+    echo "  - $warn" >&2
+  done
+  echo "" >&2
+fi
 
 if [ ${#ERRORS[@]} -gt 0 ]; then
   echo "Pre-push validation failed:" >&2

--- a/scripts/release-status.sh
+++ b/scripts/release-status.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Single source of truth for VibeFrame release state.
+#
+# Callers:
+#   - scripts/pre-push-validate.sh          non-blocking warning about unreleased work
+#   - .github/workflows/release-tag.yml     blocks tagging a version that does not cover HEAD
+#   - .github/workflows/release-drift.yml   daily tag-vs-npm backstop
+#
+# Keeping the computation here - rather than reimplementing it in the bash gate
+# and again in workflow YAML - is deliberate. Two copies of this logic drifting
+# apart is the exact bug class this script exists to prevent.
+#
+# The question that matters is NOT "has anyone bumped since the last tag?" but
+# "does the current version cover every feat/fix on HEAD?". A bump that landed
+# before further feat/fix commits leaves those commits unreleased and
+# undocumented, which is invisible to a naive version-vs-tag comparison.
+#
+# Usage:
+#   bash scripts/release-status.sh           human-readable summary
+#   bash scripts/release-status.sh --json    machine-readable
+#
+# Exit codes:
+#   0  clean - the current version covers HEAD
+#   1  uncovered feat/fix commits exist after the last version bump
+#   2  release metadata drift (CHANGELOG has no entry for the current version)
+
+set -uo pipefail
+
+PROJECT_DIR="${VIBEFRAME_PROJECT_DIR:-${CLAUDE_PROJECT_DIR:-}}"
+if [ -z "$PROJECT_DIR" ]; then
+  PROJECT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+fi
+cd "$PROJECT_DIR" || exit 2
+
+JSON=0
+if [ "${1:-}" = "--json" ]; then
+  JSON=1
+fi
+
+# Prefer the newest remote v* tag. Release tags are created by CI after version
+# commits land on main, so a developer clone can otherwise hold a stale local
+# tag and misjudge the range.
+remote_latest_tag() {
+  git ls-remote --tags origin 'refs/tags/v*' 2>/dev/null \
+    | awk '{print $2}' \
+    | sed 's#refs/tags/##; s#\^{}##' \
+    | sort -Vu \
+    | tail -1
+}
+
+local_latest_tag() {
+  git tag --list 'v*' --sort=v:refname 2>/dev/null | tail -1
+}
+
+ROOT_VERSION=$(jq -r '.version' package.json)
+
+LATEST_TAG=$(remote_latest_tag)
+if [ -z "$LATEST_TAG" ]; then
+  LATEST_TAG=$(local_latest_tag)
+fi
+
+# The range computations below need the tag object present locally.
+if [ -n "$LATEST_TAG" ] && ! git rev-parse -q --verify "refs/tags/$LATEST_TAG" >/dev/null; then
+  git fetch --quiet origin "refs/tags/$LATEST_TAG:refs/tags/$LATEST_TAG" 2>/dev/null || true
+fi
+
+TAG_VERSION="${LATEST_TAG#v}"
+
+# Subject-only matching. `git log --grep` searches the whole commit message,
+# so a merge commit whose body quotes the PR title double-counts the commit it
+# merged. Formatting the subject and grepping it keeps each commit counted once.
+subjects_since() {
+  git log "$1..HEAD" --no-merges --format='%h %s' 2>/dev/null
+}
+
+# The most recent version bump reachable from HEAD. Everything after it is work
+# the current version does not describe.
+LAST_BUMP=""
+if [ -n "$LATEST_TAG" ]; then
+  LAST_BUMP=$(subjects_since "$LATEST_TAG" \
+    | grep -E '^[0-9a-f]+ chore: bump version' \
+    | head -1 \
+    | awk '{print $1}')
+fi
+
+RANGE_START="${LAST_BUMP:-$LATEST_TAG}"
+
+UNCOVERED=""
+if [ -n "$RANGE_START" ]; then
+  UNCOVERED=$(subjects_since "$RANGE_START" \
+    | grep -E '^[0-9a-f]+ (feat|fix)(\(.+\))?:' || true)
+fi
+
+UNCOVERED_COUNT=0
+if [ -n "$UNCOVERED" ]; then
+  UNCOVERED_COUNT=$(printf '%s\n' "$UNCOVERED" | wc -l | tr -d ' ')
+fi
+
+TAG_EXISTS=false
+if git rev-parse -q --verify "refs/tags/v$ROOT_VERSION" >/dev/null 2>&1; then
+  TAG_EXISTS=true
+elif [ -n "$(git ls-remote --tags origin "refs/tags/v$ROOT_VERSION" 2>/dev/null)" ]; then
+  TAG_EXISTS=true
+fi
+
+# publish.yml extracts release notes by matching `## [VERSION]` at line start.
+# Anchor identically here so a passing check guarantees a non-empty release body.
+CHANGELOG_HAS_VERSION=false
+if grep -q "^## \[$ROOT_VERSION\]" CHANGELOG.md 2>/dev/null; then
+  CHANGELOG_HAS_VERSION=true
+fi
+
+STATUS=0
+if [ "$UNCOVERED_COUNT" -gt 0 ]; then
+  STATUS=1
+elif [ "$CHANGELOG_HAS_VERSION" = false ]; then
+  STATUS=2
+fi
+
+if [ "$JSON" -eq 1 ]; then
+  jq -n \
+    --arg rootVersion "$ROOT_VERSION" \
+    --arg latestTag "$LATEST_TAG" \
+    --arg tagVersion "$TAG_VERSION" \
+    --arg lastBump "$LAST_BUMP" \
+    --arg uncoveredList "$UNCOVERED" \
+    --argjson uncoveredCount "$UNCOVERED_COUNT" \
+    --argjson tagExists "$TAG_EXISTS" \
+    --argjson changelogHasVersion "$CHANGELOG_HAS_VERSION" \
+    --argjson status "$STATUS" \
+    '{
+      rootVersion: $rootVersion,
+      latestTag: $latestTag,
+      tagVersion: $tagVersion,
+      lastBump: $lastBump,
+      uncoveredCount: $uncoveredCount,
+      uncovered: ($uncoveredList | if length > 0 then split("\n") else [] end),
+      tagExists: $tagExists,
+      changelogHasVersion: $changelogHasVersion,
+      status: $status
+    }'
+else
+  echo "Release status"
+  echo "  root version:  $ROOT_VERSION"
+  echo "  latest tag:    ${LATEST_TAG:-<none>}"
+  echo "  last bump:     ${LAST_BUMP:-<none since tag>}"
+  echo "  v$ROOT_VERSION tagged: $TAG_EXISTS"
+  echo "  CHANGELOG has [$ROOT_VERSION]: $CHANGELOG_HAS_VERSION"
+  echo "  uncovered feat/fix: $UNCOVERED_COUNT"
+  if [ -n "$UNCOVERED" ]; then
+    printf '%s\n' "$UNCOVERED" | sed 's/^/    /'
+  fi
+fi
+
+exit "$STATUS"


### PR DESCRIPTION
## Problem

`main` has been at `0.113.25` since 2026-07-01 while the latest tag and npm are both `v0.113.24`. Seven commits, including two `feat:`, are unreleased. npm users cannot get the Gemini Omni provider (#268) or the OKF frontmatter work (#267).

This was not a host-switching issue. `.githooks/pre-push` and `.claude/hooks/pre-push-validate.sh` both `exec` the same `scripts/pre-push-validate.sh`, and `core.hooksPath` is set correctly. **Running the gate against the broken state exits 0.** It passes.

The bug is the condition itself:

```bash
if [ -n "$FEAT_FIX" ] && [ "$ROOT_VERSION" = "$TAG_VERSION" ]; then
```

That asks "has anyone bumped since the last tag?". The question that matters is "does the current version cover every `feat:`/`fix:` on `HEAD`?". The moment one bump landed (`0.113.24` -> `0.113.25`), `ROOT != TAG` disarmed the check until the next tag existed, and #267 and #268 pushed clean.

A second hole: tag creation and npm publish were both manual, with nothing watching either. A pre-push gate only runs when someone pushes, and this failure is a state that persisted on `main` while nobody pushed.

## Approach

**One implementation of release state.** `scripts/release-status.sh` is now the single source of truth, called by the push gate, the tag workflow, and the drift check. The gate is already host-agnostic because three entry points delegate to one script; the same property is applied here. Two copies of this logic drifting apart is precisely the bug being fixed.

It also fixes a counting bug: the old `--grep` matched merge-commit bodies, so each merged commit was counted twice. `--no-merges` plus subject-only matching reports 2 commits where the old logic reported 6.

**Bumps move to release time, not per PR.** `feat:`/`fix:` PRs merge without a bump. The gate now *warns* about unreleased work rather than blocking, and enforcement moves to the tag workflow - the one gate every release must pass and which, unlike a local hook, cannot be skipped with `--no-verify` or bypassed from another host.

**Tagging is automatic.** `release-tag.yml` runs on green CI for `main` and is idempotent: already-tagged versions skip immediately. Before tagging it refuses if `feat:`/`fix:` commits landed after the last bump, or if `CHANGELOG.md` has no `## [X.Y.Z]` entry (`publish.yml` extracts the release body from that section, so tagging without it ships an empty release).

Publishing stays manual. Tags pushed with `GITHUB_TOKEN` cannot trigger another workflow, so auto-tagging never reaches `publish.yml` - the "CI never publishes npm packages" policy is intact.

**`release-drift.yml`** backstops the remaining manual step, comparing `main`, the latest tag, and published npm versions daily, with a 6h grace so an in-progress release does not alarm.

## Verification

The guard was tested against the state that actually shipped:

```
$ bash scripts/release-status.sh
  uncovered feat/fix: 2
    c8c59973 feat: add experimental Gemini Omni video provider (-p omni)
    19944f01 feat: OKF-aligned frontmatter standard for docs + workflow files
exit 1

$ # tag guard simulation at current HEAD
REFUSED: feat/fix commits landed after the last version bump
```

Today's incident is the regression test, and the new guard rejects it.

- Full `scripts/pre-push-validate.sh`: exit 0 with the warning surfaced (previously silent)
- `pnpm lint` 0 errors, `pnpm build`, `pnpm typecheck`, `pnpm gen:reference:check`, `pnpm package:check`, `pnpm agent-sync:check` all pass
- `pnpm test`: 1300 passed, 9 skipped
- Both workflow files parse as valid YAML with the expected triggers

`.claude/skills/release/SKILL.md` is generated - regenerated via `pnpm agent-sync`.

## Follow-up

This PR carries no version bump, per the new policy. The recovery release `0.113.26` follows in a separate PR and will exercise the auto-tag path.

https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp