### PR TITLE
chore: bump version to 0.113.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.113.25] - 2026-07-01
+## [0.113.26] - 2026-07-22
+
+### Added
+
+- add experimental Gemini Omni video provider (-p omni)
+- OKF-aligned frontmatter standard for docs + workflow files
 
 ### Fixed
 
+- detect version bumps that do not cover HEAD *(release)*
 - drop fictional /goal 'goal mode'; sync stale hero/provider copy *(web)*
 
 ## [0.113.24] - 2026-07-01

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.113.25",
+  "version": "0.113.26",
   "description": "VibeFrame Web - landing and demo site for the storyboard-first agentic video CLI",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,7 +15,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.113.25`
+> CLI version: `0.113.26`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.113.25",
+  "version": "0.113.26",
   "description": "Agentic video workflow layer. CLI-first, MCP-ready.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.113.25",
+  "version": "0.113.26",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.113.25",
+  "version": "0.113.26",
   "description": "VibeFrame CLI - agentic video workflow runtime",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.113.25",
+  "version": "0.113.26",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.113.25",
+  "version": "0.113.26",
   "description": "VibeFrame MCP Server - AI-native video editing via Model Context Protocol",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.113.25",
+  "version": "0.113.26",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Why

Recovers the release stranded on 2026-07-01. `main` sat at `0.113.25` with no matching tag while npm stayed on `0.113.24`, so the Gemini Omni provider (#268) and the OKF frontmatter work (#267) were never published. The gate hole that allowed this is fixed in #269.

## Changelog

Regenerating with `git-cliff --tag v0.113.26` drops the orphaned `[0.113.25]` section. That entry was generated at bump time and listed only the web copy fix, documenting neither feat that landed after it. `0.113.26` now covers all four commits since `v0.113.24`:

```
## [0.113.26] - 2026-07-22

### Added
- add experimental Gemini Omni video provider (-p omni)
- OKF-aligned frontmatter standard for docs + workflow files

### Fixed
- detect version bumps that do not cover HEAD (release)
- drop fictional /goal 'goal mode'; sync stale hero/provider copy (web)
```

## This PR exercises the new auto-tag path

#269 already proved itself on `main`: the `workflow_run` trigger fired on green CI and **refused** to tag, correctly, because `0.113.25` did not describe the commits that followed it ([run 29938658073](https://github.com/vericontext/vibeframe/actions/runs/29938658073)).

```
Tag v0.113.25 missing; will validate then create.
  uncovered feat/fix: 3
Refusing to tag v0.113.25: feat/fix commits landed after the last version bump
```

With this bump the same check passes:

```
$ bash scripts/release-status.sh
  root version:  0.113.26
  CHANGELOG has [0.113.26]: true
  uncovered feat/fix: 0
exit 0
```

So merging should auto-create `v0.113.26`. Publishing stays manual afterwards.

## Verification

- `pnpm test`: 1300 passed, 9 skipped
- `bash scripts/pre-push-validate.sh`: exit 0, no warnings (everything covered)
- `pnpm build`, `pnpm gen:reference` clean; all 7 `package.json` files at `0.113.26`

https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp