### PR TITLE
fix: zero-key first-run frictions found in E2E measurement

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1484,7 +1484,7 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `root` _(string)_ — Root composition file relative to --project
+- `root` _(string)_ — Project directory, or root composition file relative to --project
 - `project` _(string)_ _(default: `"."`)_ — Project directory
 - `fix` _(boolean)_ — Apply mechanical auto-fixes (currently: missing class="clip")
 

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -3856,7 +3856,7 @@ exports[`CLI --describe schemas (drift detection) > vibe scene lint --describe 1
         "type": "string",
       },
       "root": {
-        "description": "Root composition file relative to --project",
+        "description": "Project directory, or root composition file relative to --project",
         "type": "string",
       },
     },

--- a/packages/cli/src/commands/_shared/build-plan.test.ts
+++ b/packages/cli/src/commands/_shared/build-plan.test.ts
@@ -5,7 +5,7 @@ import { dirname, join, resolve } from "node:path";
 
 import { estimateSeedanceVideoCostUsd } from "@vibeframe/ai-providers";
 
-import { createBuildPlan } from "./build-plan.js";
+import { createBuildPlan, narrationCostUsd } from "./build-plan.js";
 import { augmentBackdropPrompt } from "./build-backdrop-prompt.js";
 import { backdropCacheDescriptor, narrationCacheDescriptor } from "./build-cache.js";
 import { writeAssetMetadata } from "./build-asset-metadata.js";
@@ -502,5 +502,23 @@ Body.
       `vibe storyboard revise ${dir} --from "<request>" --dry-run --json`,
     ]);
     expect(plan.nextCommands).toEqual(plan.retryWith);
+  });
+});
+
+describe("narrationCostUsd", () => {
+  it("charges $0 for local kokoro narration", () => {
+    // Regression: a flat per-narration charge made zero-key kokoro builds
+    // report phantom spend ($0.05/beat) in build-report costUsd.
+    expect(narrationCostUsd("kokoro")).toBe(0);
+  });
+
+  it("charges $0 for local/referenced and unknown providers", () => {
+    expect(narrationCostUsd("local")).toBe(0);
+    expect(narrationCostUsd(undefined)).toBe(0);
+  });
+
+  it("charges paid providers their per-beat rate", () => {
+    expect(narrationCostUsd("elevenlabs")).toBe(0.05);
+    expect(narrationCostUsd("openai")).toBe(0.01);
   });
 });

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -184,6 +184,18 @@ const MUSIC_COST_USD = 0.5;
 const ELEVENLABS_NARRATION_COST_USD = 0.05;
 /** gpt-4o-mini-tts is ~$0.015/min of audio; a beat is ~10–20s. Includes retry headroom. */
 const OPENAI_NARRATION_COST_USD = 0.01;
+
+/**
+ * Per-beat narration cost by resolved TTS provider. Kokoro runs locally and
+ * costs $0 — a flat per-narration charge here is what made zero-key builds
+ * report phantom spend. Shared by the dry-run estimate and the post-build
+ * actuals so the two can never disagree.
+ */
+export function narrationCostUsd(provider: string | undefined): number {
+  if (provider === "elevenlabs") return ELEVENLABS_NARRATION_COST_USD;
+  if (provider === "openai") return OPENAI_NARRATION_COST_USD;
+  return 0;
+}
 /** Whisper word-level transcription is ~$0.006/min; a beat is ~10–20s. */
 const TRANSCRIPT_COST_USD = 0.002;
 const COMPOSE_COST_USD = 0.06;
@@ -315,12 +327,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
     // `video:` cue (the keyframe prompt then supplies the motion prompt too).
     const videoCue = videoPrompt ?? videoReference?.raw ?? keyframePrompt;
     const musicCue = musicPrompt ?? musicReference?.raw;
-    const narrationCost =
-      resolved.narration.resolved === "elevenlabs"
-        ? ELEVENLABS_NARRATION_COST_USD
-        : resolved.narration.resolved === "openai"
-          ? OPENAI_NARRATION_COST_USD
-          : 0;
+    const narrationCost = narrationCostUsd(resolved.narration.resolved);
     const narrationCache =
       narrationText && !narrationReference
         ? narrationCacheDescriptor({

--- a/packages/cli/src/commands/_shared/compose-prompts.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.ts
@@ -25,7 +25,8 @@
  * Pairs with H1 (`vibe scene install-skill`) — the host agent reads
  * `SKILL.md` for framework rules, `DESIGN.md` for visual identity, then
  * writes each `compositions/scene-<id>.html`. After authoring, runs
- * `vibe scene lint --fix` to verify and `vibe render` to produce MP4.
+ * `vibe build <project> --stage sync` to assemble the root composition,
+ * `vibe scene lint <project> --fix` to verify, and `vibe render` for MP4.
  *
  * The internal-LLM path (`vibe scene build`, PR #176) still works — it's
  * the batch / non-agent fallback. H3 will add mode dispatch so a single
@@ -277,12 +278,13 @@ function buildInstructions(args: {
   lines.push(`3c. Never give inner \`.clip\` elements a non-zero \`data-start\` — the renderer does not toggle internal clip visibility inside sub-compositions, so phased clips render all phases at once (overlapping text). Use full-window clips and GSAP autoAlpha phase transitions instead. Also keep beats 6-15s; split anything longer in the storyboard first.`);
   lines.push(`3d. If your environment cannot write files (e.g. Claude Desktop / MCP-only hosts), author each beat's HTML and submit it with the \`scene_submit\` tool (beat id + html). It validates with the same Hyperframes lint and writes the file for you; on lint errors it returns the findings without writing — fix and resubmit.`);
   if (args.beatCount > 1) {
-    lines.push(`4. After authoring all ${args.beatCount} beat(s), run \`vibe scene lint --fix\` to validate. Fix any remaining errors by editing the HTML directly.`);
+    lines.push(`4. After authoring all ${args.beatCount} beat(s), run \`vibe build <project> --stage sync --json\` to assemble the root composition (index.html) from the fragments. Lint needs that root, so sync comes first.`);
   } else if (args.filtered) {
-    lines.push(`4. After authoring this beat, run \`vibe scene lint --fix\` to validate. Author the remaining beats with the same flow (re-call this command without \`--beat\`).`);
+    lines.push(`4. After authoring this beat, author the remaining beats with the same flow (re-call this command without \`--beat\`), then run \`vibe build <project> --stage sync --json\` to assemble the root composition.`);
   } else {
-    lines.push(`4. After authoring, run \`vibe scene lint --fix\` to validate.`);
+    lines.push(`4. After authoring, run \`vibe build <project> --stage sync --json\` to assemble the root composition (index.html). Lint needs that root, so sync comes first.`);
   }
-  lines.push(`5. Run \`vibe render\` to produce the final MP4.`);
+  lines.push(`5. Run \`vibe scene lint <project> --fix\` to validate. Fix any remaining errors by editing the HTML directly.`);
+  lines.push(`6. Run \`vibe render <project>\` to produce the final MP4.`);
   return lines;
 }

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -65,6 +65,7 @@ import { scaffoldSceneProject } from "./scene-project.js";
 import {
   backdropCostUsd,
   createBuildPlan,
+  narrationCostUsd,
   type BuildPlanResult,
   type BuildStage,
 } from "./build-plan.js";
@@ -2682,7 +2683,7 @@ function estimateActualAssetCost(
 ): number {
   let cost = 0;
   for (const outcome of outcomes) {
-    if (outcome.narrationStatus === "generated") cost += 0.05;
+    if (outcome.narrationStatus === "generated") cost += narrationCostUsd(outcome.narrationProvider);
     if (outcome.backdropStatus === "generated") cost += backdropCostUsd(imageQuality);
     if (outcome.keyframeStatus === "generated") cost += backdropCostUsd(imageQuality);
     if (outcome.videoStatus === "generated" || outcome.videoStatus === "pending") {

--- a/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
+++ b/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
@@ -405,7 +405,7 @@ const META: Record<WalkthroughTopic, Pick<WalkthroughResult, "title" | "summary"
       "Edit `STORYBOARD.md` with per-beat YAML cues (narration / backdrop / duration).",
       "Read `SKILL.md` for the framework rules and `DESIGN.md` for the visual-identity hard-gate.",
       "Run `vibe build <dir>`. With an agent host detected, the CLI emits a `needs-author` plan; the host agent authors each `compositions/scene-<id>.html` and re-invokes to render.",
-      "Run `vibe scene lint --fix` to validate, then `vibe render <dir>` to produce the MP4.",
+      "Run `vibe build <dir> --stage sync` to assemble index.html, `vibe scene lint <dir> --fix` to validate, then `vibe render <dir>` to produce the MP4.",
     ],
     relatedCommands: [
       "vibe init",

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -1208,17 +1208,25 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
 sceneCommand
   .command("lint")
   .description("Validate scene HTML against composition rules (in-process, no Chrome required)")
-  .argument("[root]", "Root composition file relative to --project", "index.html")
+  .argument(
+    "[root]",
+    "Project directory, or root composition file relative to --project",
+    "index.html"
+  )
   .option("--project <dir>", "Project directory", ".")
   .option("--fix", 'Apply mechanical auto-fixes (currently: missing class="clip")')
   .action(async (root: string, options) => {
     const startedAt = Date.now();
-    const projectDir = resolve(options.project as string);
-    if (!(await rootExists(projectDir, root))) {
+    // Same DWIM as `scene repair`: every other project command takes the
+    // project directory as its positional argument, so `vibe scene lint demo`
+    // must work too — not fail with "Root composition not found: .../demo".
+    const target = await resolveSceneRepairTarget(root, options.project as string);
+    const projectDir = target.projectDir;
+    if (!(await rootExists(projectDir, target.rootRel))) {
       exitWithError(
         generalError(
-          `Root composition not found: ${resolve(projectDir, root)}`,
-          "Run `vibe scene init` first, or pass --project <dir>."
+          `Root composition not found: ${resolve(projectDir, target.rootRel)}`,
+          "Run `vibe build <project> --stage sync` to assemble index.html first, pass a project directory, or pass --project <dir> with a root HTML path."
         )
       );
     }
@@ -1226,7 +1234,7 @@ sceneCommand
     const spinner = isJsonMode() ? null : ora("Linting scenes...").start();
     let result: ProjectLintResult;
     try {
-      result = await runProjectLint({ projectDir, rootRel: root, fix: !!options.fix });
+      result = await runProjectLint({ projectDir, rootRel: target.rootRel, fix: !!options.fix });
     } catch (error) {
       spinner?.fail("Lint failed");
       const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Context

Measured the zero-key first run end-to-end against the published 0.113.26 package in a key-less isolated environment (companion to #271/#272). Two defects surfaced; both are fixed and re-verified against the same measurement project.

## 1. Phantom narration cost

`estimateActualAssetCost` charged a flat $0.05 per generated narration regardless of provider, so a zero-key kokoro build reported `costUsd: 0.15`. The dry-run estimate already priced per provider - the actuals were a divergent copy of the same logic. Both now share `narrationCostUsd()` (kokoro/local $0, openai $0.01, elevenlabs $0.05) with regression tests.

**Verified:** forced kokoro rebuild now reports `costUsd: 0` (was 0.15).

## 2. `scene lint` dead end

Every project command takes the project directory as its positional argument except `scene lint`, which read it as a root HTML path: `vibe scene lint demo` failed with "Root composition not found: .../demo" and suggested the wrong fix (`vibe scene init`). Worse, the `scene compose-prompts` instructions told agents to run lint at a point where index.html cannot exist yet (before the sync stage).

- `scene lint` now reuses `resolveSceneRepairTarget` (same DWIM as `scene repair`).
- The not-found suggestion points at `vibe build <project> --stage sync`.
- compose-prompts instructions and the scene walkthrough insert the missing sync step before lint.

**Verified:** `vibe scene lint <dir>` lints 4 files clean on the measurement project.

## Verification

- `pnpm -F @vibeframe/cli test`: 1302 passed (snapshot updated for the lint arg description).
- `pnpm lint`, `pnpm typecheck`, `pnpm gen:reference` regenerated.
- Full pre-push gate green.

https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp