### PR TITLE
fix: keep render engine chatter off stdout so --json parses

### DIFF
--- a/packages/cli/src/commands/_shared/scene-render.ts
+++ b/packages/cli/src/commands/_shared/scene-render.ts
@@ -24,6 +24,7 @@ import {
   type RenderConfigInput,
 } from "@hyperframes/producer";
 import { preflightChrome } from "../../pipeline/renderers/chrome.js";
+import { withStdoutOnStderr } from "../../utils/stdout-guard.js";
 import { ffmpegToolsAvailable } from "./ffmpeg-gate.js";
 import { createProjectRootSyncPlan, loadProjectRootSyncBeats } from "./root-sync.js";
 import { createSubCompDurationSyncPlans } from "./sub-comp-duration-sync.js";
@@ -339,16 +340,18 @@ export async function executeSceneRender(opts: SceneRenderOptions = {}): Promise
   const start = Date.now();
 
   try {
-    await executeRenderJob(
-      job,
-      projectDir,
-      outputPath,
-      // Producer reports progress on a 0-100 scale while this callback's
-      // contract (and the audio-mux phase below) is 0..1 — normalise here so
-      // every consumer (CLI spinner, MCP progress, job records) sees 0..1.
-      (j, msg) =>
-        opts.onProgress?.(j.progress > 1 ? j.progress / 100 : j.progress, j.currentStage ?? msg),
-      opts.signal,
+    await withStdoutOnStderr(() =>
+      executeRenderJob(
+        job,
+        projectDir,
+        outputPath,
+        // Producer reports progress on a 0-100 scale while this callback's
+        // contract (and the audio-mux phase below) is 0..1 — normalise here so
+        // every consumer (CLI spinner, MCP progress, job records) sees 0..1.
+        (j, msg) =>
+          opts.onProgress?.(j.progress > 1 ? j.progress / 100 : j.progress, j.currentStage ?? msg),
+        opts.signal,
+      )
     );
   } catch (err) {
     return {

--- a/packages/cli/src/pipeline/renderers/hyperframes.ts
+++ b/packages/cli/src/pipeline/renderers/hyperframes.ts
@@ -1,6 +1,7 @@
 import type { RenderConfigInput } from "@hyperframes/producer";
 import type { RenderBackend, RenderOptions, RenderResult } from "./types.js";
 import { preflightChrome } from "./chrome.js";
+import { withStdoutOnStderr } from "../../utils/stdout-guard.js";
 
 export function createHyperframesBackend(): RenderBackend {
   return {
@@ -40,12 +41,14 @@ export function createHyperframesBackend(): RenderBackend {
       const job = createRenderJob(config);
 
       try {
-        await executeRenderJob(
-          job,
-          project.dir,
-          options.outputPath,
-          (j, msg) => { options.onProgress?.(j.progress, j.currentStage ?? msg); },
-          options.signal
+        await withStdoutOnStderr(() =>
+          executeRenderJob(
+            job,
+            project.dir,
+            options.outputPath,
+            (j, msg) => { options.onProgress?.(j.progress, j.currentStage ?? msg); },
+            options.signal
+          )
         );
         await project.cleanup();
         return {

--- a/packages/cli/src/utils/stdout-guard.test.ts
+++ b/packages/cli/src/utils/stdout-guard.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { withStdoutOnStderr } from "./stdout-guard.js";
+
+/** Capture what each stream received while `fn` runs. */
+async function capture(fn: () => Promise<void>): Promise<{ out: string; err: string }> {
+  const realOut = process.stdout.write.bind(process.stdout);
+  const realErr = process.stderr.write.bind(process.stderr);
+  let out = "";
+  let err = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    out += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    err += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = realOut;
+    process.stderr.write = realErr;
+  }
+  return { out, err };
+}
+
+describe("withStdoutOnStderr", () => {
+  it("routes library chatter to stderr so stdout stays parseable", async () => {
+    const { out, err } = await capture(async () => {
+      await withStdoutOnStderr(async () => {
+        // Stands in for the render engine's `[BrowserManager] ...` lines.
+        // Written straight to the stream because vitest intercepts `console`
+        // before it ever reaches `process.stdout.write`, which is the layer
+        // this guard swaps out.
+        process.stdout.write("[BrowserManager] Browser launched\n");
+      });
+      process.stdout.write(JSON.stringify({ ok: true }));
+    });
+
+    expect(() => JSON.parse(out)).not.toThrow();
+    expect(out).not.toContain("BrowserManager");
+    expect(err).toContain("BrowserManager");
+  });
+
+  it("restores the original writer after the callback throws", async () => {
+    const { out, err } = await capture(async () => {
+      await expect(
+        withStdoutOnStderr(async () => {
+          process.stdout.write("during\n");
+          throw new Error("render failed");
+        })
+      ).rejects.toThrow("render failed");
+      process.stdout.write("after\n");
+    });
+
+    expect(err).toContain("during");
+    expect(out).toContain("after");
+  });
+
+  it("returns the callback's value", async () => {
+    await expect(withStdoutOnStderr(async () => 42)).resolves.toBe(42);
+  });
+});

--- a/packages/cli/src/utils/stdout-guard.ts
+++ b/packages/cli/src/utils/stdout-guard.ts
@@ -1,0 +1,39 @@
+/**
+ * @module utils/stdout-guard
+ *
+ * Keep third-party chatter off stdout while a library call runs.
+ *
+ * `@hyperframes/producer` already routes its own logger to stderr for this
+ * exact reason - its docs say "producer runs inside CLI commands whose stdout
+ * is a machine-readable contract". The render engine underneath it does not
+ * honour that: `[BrowserManager]`, `[initSession:screenshot]`, and
+ * `[HyperFrames]` lines land on stdout mid-render, which makes
+ * `vibe render --json` and `vibe build --json` emit output that
+ * `JSON.parse` rejects.
+ *
+ * Redirecting rather than silencing keeps the diagnostics: on a terminal
+ * stderr is still displayed, so a human sees exactly what they saw before,
+ * while an agent reading stdout gets only the JSON envelope.
+ */
+
+/**
+ * Run `fn` with every stdout write rerouted to stderr, restoring the original
+ * writer afterwards even if `fn` throws.
+ */
+export async function withStdoutOnStderr<T>(fn: () => Promise<T>): Promise<T> {
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encoding?: BufferEncoding | ((err?: Error | null) => void),
+    callback?: (err?: Error | null) => void
+  ): boolean =>
+    typeof encoding === "function"
+      ? process.stderr.write(chunk, encoding)
+      : process.stderr.write(chunk, encoding, callback)) as typeof process.stdout.write;
+
+  try {
+    return await fn();
+  } finally {
+    process.stdout.write = original;
+  }
+}


### PR DESCRIPTION
Found while verifying #276. **`vibe render --json` and `vibe build --json` emit output that `JSON.parse` rejects.**

```
$ vibe render demo --json 2>/dev/null | head -1
[BrowserManager] Browser launched (HeadlessChrome/152.0.7928.2, screenshot, ...)
```

The render engine writes `[BrowserManager]`, `[initSession:screenshot]`, and `[HyperFrames]` lines straight to **stdout** mid-render, so the JSON envelope arrives interleaved with log text. Stdout is exactly what an agent reads, which makes this a broken contract on the primary agent-facing command.

## Why the fix lives here

`@hyperframes/producer` already holds this line for its own logger, and states the reasoning in `logger.d.ts`:

> All levels write to stderr (console.error/console.warn), never stdout — producer runs inside CLI commands whose stdout is a machine-readable contract (e.g. `validate --json`, `check --json`); an info/debug line on stdout would corrupt that output.

The engine underneath the producer does not honour that. Rather than wait on upstream, VibeFrame enforces the same rule at the two call sites it owns: both `executeRenderJob` invocations (`scene-render.ts` and the pipeline renderer) now run inside `withStdoutOnStderr`, which swaps `process.stdout.write` for the duration and restores it in a `finally` so a thrown render cannot leak the patch.

**Redirect, not silence.** On a terminal stderr still displays, so a human sees exactly what they saw before; only the machine-readable stream changes.

## Verification

| command | before | after |
|---|---|---|
| `render --json` | INVALID | **VALID** — `success: true`, 301 frames |
| `build --stage render --json` | INVALID | **VALID** |

`[BrowserManager]` lines confirmed still present on stderr after the fix.

Unit tests cover the redirect, restoration after a throw, and the return value. They write to `process.stdout` directly rather than via `console.log`, because vitest intercepts `console` before it reaches the stream layer this guard swaps — the console path is covered by the end-to-end check above.

`pnpm build`, `pnpm lint`, full `pnpm test`, and the pre-push gate pass.