### PR TITLE
fix: report where the Hyperframes rules actually live

### DIFF
--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -250,14 +250,14 @@ agreement.
 Where the skill comes from depends on your setup:
 
 - If the \`hyperframes\` skill is installed globally (e.g. Claude Code), your
-  agent already has it — \`vibe init\` does **not** copy it into the project.
-- Otherwise \`vibe init\` writes a local copy: universal \`SKILL.md\` (with
-  \`references/*.md\`) at the project root, plus host layouts
-  (\`.claude/skills/hyperframes/\`, \`.cursor/rules/hyperframes.mdc\`).
+  agent already has it and nothing else is needed.
+- Otherwise install it into this project with \`vibe scene install-skill\`,
+  which runs upstream's own installer and writes
+  \`.agents/skills/hyperframes/\`.
 
-To get editable per-project copies on demand, run
-\`vibe scene install-skill [--host all]\` (these copies are gitignored by
-default — see \`.gitignore\`).
+\`vibe init\` never copies the rules in. They come from upstream so they stay
+current, and fetching them is a network call the scaffold does not make on
+your behalf. \`vibe doctor\` reports whether your agent can read them.
 
 For render-stable text, do not apply continuous \`scale\`, \`x\`, \`y\`,
 \`filter\`, or other transform tweens to \`.scene-content\` or any ancestor
@@ -424,8 +424,10 @@ renders/
 *.vibe.json
 .vibeframe/
 
-# Vendored Hyperframes skill copies — regenerable via 'vibe scene install-skill'.
-# Delete these lines if you eject and want to commit per-project customizations.
+# Hyperframes skill copies left by older VibeFrame versions, which vendored a
+# snapshot of upstream's rules. Nothing writes these now - upstream's installer
+# owns the rules and puts them under .agents/skills/hyperframes/, which is
+# yours to commit or ignore. These lines only keep pre-existing copies quiet.
 /SKILL.md
 /references/
 /.claude/skills/hyperframes/

--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -569,7 +569,26 @@ describe("scaffoldSceneProject", () => {
     expect(await pathExists(resolve(dir, "index.html"))).toBe(false);
     expect(await pathExists(resolve(dir, "hyperframes.json"))).toBe(false);
     expect(result.groups.agent.map((p) => p.split("/").pop())).toContain("AGENTS.md");
-    expect(result.groups.agent.map((p) => p.split("/").pop())).toContain("SKILL.md");
     expect(result.groups.render).toEqual([]);
+  });
+
+  // The scaffold once advertised a vendored `SKILL.md` + `references/` that it
+  // had stopped writing, and the old assertions did not catch it because they
+  // only inspected the reported list. Check the list against the disk instead,
+  // so any future group entry has to be a file the scaffold really creates.
+  it("only reports files it actually wrote", async () => {
+    for (const profile of ["minimal", "agent", "full"] as const) {
+      const dir = await makeTmp();
+      const result = await scaffoldSceneProject({ dir, name: "fixture", profile });
+      const reported = [
+        ...result.groups.authoring,
+        ...result.groups.render,
+        ...result.groups.agent,
+      ];
+
+      for (const path of reported) {
+        expect(await pathExists(path), `${profile}: reported but missing - ${path}`).toBe(true);
+      }
+    }
   });
 });

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -622,8 +622,8 @@ no unresolved unacknowledged host-agent issues.
 **Load the \`hyperframes\` skill before authoring scenes** — it encodes the
 composition rules, motion principles, type system, and visual-identity gate.
 If your agent has it installed globally it is already available; otherwise run
-\`vibe scene install-skill\` to eject a local, editable copy (\`SKILL.md\` +
-\`references/\`, gitignored by default) and read \`SKILL.md\`.
+\`vibe scene install-skill\`, which runs upstream's installer and writes
+\`.agents/skills/hyperframes/SKILL.md\`. Read that file before authoring.
 
 **Always invoke the relevant skill before authoring scenes.** Skills encode
 framework-specific patterns (GSAP timeline registration, data-attribute
@@ -653,7 +653,7 @@ the framework-level minimum, not the cinematic craft layer.
 - \`index.html\` — root composition (timeline)
 - \`compositions/scene-*.html\` — per-scene HTML authored by you or the agent
 - \`assets/\` — generated/canonical build media (narration audio, images, video)
-- \`references/\` — composition rule docs, only when ejected via \`vibe scene install-skill\` (not user media)
+- \`.agents/skills/hyperframes/\` — upstream composition rules, when installed here rather than globally
 - \`transcript.json\` — Whisper word-level transcript (if narration exists)
 - \`hyperframes.json\` — HF registry config (speak to both toolchains)
 - \`vibe.config.json\` — canonical VibeFrame config (providers, budget)
@@ -721,8 +721,9 @@ export function buildSceneGitignore(): string {
 renders/*.mp4
 tmp/
 
-# Vendored Hyperframes skill copies — regenerable via 'vibe scene install-skill'.
-# Delete these lines if you eject and want to commit per-project customizations.
+# Hyperframes skill copies left by older VibeFrame versions. Nothing writes
+# these now - upstream's installer owns the rules and puts them under
+# .agents/skills/hyperframes/, which is yours to commit or ignore.
 /SKILL.md
 /references/
 /.claude/skills/hyperframes/
@@ -809,13 +810,12 @@ export function describeSceneScaffold(opts: {
     ];
   }
 
+  // Only files the scaffold actually writes. The Hyperframes composition rules
+  // used to be vendored here as `SKILL.md` + `references/`; upstream's own
+  // installer owns that now and puts them under `.agents/skills/hyperframes/`,
+  // so listing them as scaffold output would report files that never appear.
   if (profile === "agent" || profile === "full") {
-    groups.agent = [
-      resolve(dir, "AGENTS.md"),
-      resolve(dir, "SKILL.md"),
-      resolve(dir, "references"),
-      resolve(dir, "CLAUDE.md"),
-    ];
+    groups.agent = [resolve(dir, "AGENTS.md"), resolve(dir, "CLAUDE.md")];
   }
 
   return groups;

--- a/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
+++ b/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
@@ -63,11 +63,11 @@ narration / backdrop intent.
 1. \`vibe init my-promo --visual-style "Swiss Pulse"\` — seeds
    \`DESIGN.md\` (palette, typography, motion, transitions) plus the
    \`vibe.config.json\` / \`hyperframes.json\` / \`index.html\` scaffold.
-   In Plan H this **also installs local composition rules** at the
-   right place for your host (\`.claude/skills/hyperframes/\` for Claude
-   Code, \`.cursor/rules/hyperframes.mdc\` for Cursor, universal
-   \`SKILL.md\` for everyone else).
-2. Read \`SKILL.md\` (or the host-specific copy) — Hyperframes
+   It does **not** install the composition rules; if your agent does not
+   already have the \`hyperframes\` skill, run
+   \`vibe scene install-skill\` to fetch them from upstream into
+   \`.agents/skills/hyperframes/\`.
+2. Read \`.agents/skills/hyperframes/SKILL.md\` (or your global copy) —
    framework rules, motion principles, type system, transition recipes.
 3. Read \`DESIGN.md\` — project-specific palette / typography / motion
    signature (visual identity hard-gate).
@@ -401,9 +401,10 @@ const META: Record<WalkthroughTopic, Pick<WalkthroughResult, "title" | "summary"
     title: "Scene authoring with vibe",
     summary: "Author per-scene HTML compositions and render to MP4 (BUILD flow)",
     steps: [
-      'Run `vibe init <dir> --visual-style "<style name>"` to scaffold the project + install local composition rules.',
+      'Run `vibe init <dir> --visual-style "<style name>"` to scaffold the project.',
+      "Run `vibe scene install-skill` unless your agent already has the `hyperframes` skill; `vibe doctor` tells you which.",
       "Edit `STORYBOARD.md` with per-beat YAML cues (narration / backdrop / duration).",
-      "Read `SKILL.md` for the framework rules and `DESIGN.md` for the visual-identity hard-gate.",
+      "Read `.agents/skills/hyperframes/SKILL.md` for the framework rules and `DESIGN.md` for the visual-identity hard-gate.",
       "Run `vibe build <dir>`. With an agent host detected, the CLI emits a `needs-author` plan; the host agent authors each `compositions/scene-<id>.html` and re-invokes to render.",
       "Run `vibe build <dir> --stage sync` to assemble index.html, `vibe scene lint <dir> --fix` to validate, then `vibe render <dir>` to produce the MP4.",
     ],

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -29,6 +29,11 @@ import {
   type ComposerProvider,
 } from "./_shared/composer-resolve.js";
 import { getCostTier, TIER_COLOR, type CostTier } from "./_shared/cost-tier.js";
+import {
+  HYPERFRAMES_SKILL_INSTALL_COMMAND,
+  hyperframesSkillAvailable,
+  resolveSkillReference,
+} from "./_shared/install-skill.js";
 import { outputSuccess } from "./output.js";
 
 /**
@@ -214,7 +219,10 @@ interface DiagnosticResults {
       composer: ComposerProvider | null;
       composerEnvVar: string | null;
       sceneProjectInCwd: boolean;
+      /** Rules readable from anywhere the host agent looks: project or global. */
       skillInstalled: boolean;
+      /** Project-relative path when installed here; null for a global-only install. */
+      skillPath: string | null;
     };
     configError?: { path: string; message: string };
   };
@@ -371,7 +379,13 @@ async function runDiagnostics(): Promise<DiagnosticResults> {
     // No composer key — composerResolved stays null. Reported in render.
   }
   const sceneProjectInCwd = existsSync(resolve(cwd, "STORYBOARD.md"));
-  const skillInstalled = existsSync(resolve(cwd, "SKILL.md"));
+  // Upstream's installer owns these rules now, so "installed" means any place
+  // the host agent can actually read them: this project or the user's global
+  // skills dir. Checking only a project-root `SKILL.md` reported MISSING for a
+  // correct install and sent the user back to an installer that had nothing
+  // left to do.
+  const skillInstalled = hyperframesSkillAvailable(cwd);
+  const skillPath = resolveSkillReference(cwd);
 
   return {
     system: {
@@ -410,6 +424,7 @@ async function runDiagnostics(): Promise<DiagnosticResults> {
         composerEnvVar: composerEnv,
         sceneProjectInCwd,
         skillInstalled,
+        skillPath,
       },
       ...(configError ? { configError } : {}),
     },
@@ -568,17 +583,16 @@ function printReport(
     }
     if (sc.sceneProjectInCwd) {
       if (sc.skillInstalled) {
-        console.log(
-          `    SKILL.md     ${chalk.green("OK")}     ${chalk.dim("installed in this scene project")}`
-        );
+        const where = sc.skillPath ?? "installed globally for your agent";
+        console.log(`    HF rules     ${chalk.green("OK")}     ${chalk.dim(where)}`);
       } else {
         console.log(
-          `    SKILL.md     ${chalk.yellow("MISSING")} ${chalk.dim("Run: vibe scene install-skill")}`
+          `    HF rules     ${chalk.yellow("MISSING")} ${chalk.dim(`Run: vibe scene install-skill`)}`
         );
       }
     } else {
       console.log(
-        `    SKILL.md     ${chalk.dim("(no STORYBOARD.md in cwd — skill is per-scene-project)")}`
+        `    HF rules     ${chalk.dim("(no STORYBOARD.md in cwd — rules are per-scene-project)")}`
       );
     }
   }
@@ -796,11 +810,11 @@ function pickNextStep(results: DiagnosticResults, hasMissingProviders: boolean):
   if (!results.scope.project.initialized) {
     return "Next: run 'vibe init' in your project directory to scaffold AGENTS.md / CLAUDE.md / .env.example.";
   }
-  // Plan H — nudge a scene project that's missing the skill files.
-  // Without SKILL.md the agentic compose path can't run.
+  // Nudge a scene project whose host agent has no Hyperframes rules to read.
+  // Without them the agent authors scene HTML blind.
   const sc = results.scope.sceneComposer;
   if (sc.sceneProjectInCwd && !sc.skillInstalled) {
-    return "Next: run 'vibe scene install-skill' so your host agent can read the Hyperframes rules from this project.";
+    return `Next: run 'vibe scene install-skill' (or '${HYPERFRAMES_SKILL_INSTALL_COMMAND}') so your host agent can read the Hyperframes composition rules.`;
   }
   if (hasMissingProviders) {
     return "Run 'vibe setup' to add more provider keys.";

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -867,7 +867,7 @@ export const sceneComposePromptsTool = defineTool({
   title: "Get Scene Authoring Prompts",
   annotations: { readOnly: true, openWorld: false },
   description:
-    "Emit the per-beat compose plan for the host agent to author scene HTML itself. Reads STORYBOARD.md + DESIGN.md and returns each beat's outputPath + userPrompt + cues + body, plus references to the project's SKILL.md (Hyperframes rules) and DESIGN.md (visual identity). The host agent writes each compositions/scene-<id>.html file directly — VibeFrame makes NO LLM call here. Hosts that cannot write files (e.g. Claude Desktop) submit each authored beat with scene_submit instead. Pairs with scene_install_skill (Phase H1). Phase H2 of the agentic-native composer plan; the internal-LLM batch path (build) remains as a fallback for non-agent contexts.",
+    "Emit the per-beat compose plan for the host agent to author scene HTML itself. Reads STORYBOARD.md + DESIGN.md and returns each beat's outputPath + userPrompt + cues + body, plus the path to the Hyperframes rules (skillReference) and DESIGN.md (visual identity). The host agent writes each compositions/scene-<id>.html file directly — VibeFrame makes NO LLM call here, and there is no internal-LLM fallback: authoring is always the host agent's job. Hosts that cannot write files (e.g. Claude Desktop) submit each authored beat with scene_submit instead. Pairs with scene_install_skill, which fetches the rules from upstream when the agent does not already have them.",
   schema: sceneComposePromptsSchema,
   async execute(args, ctx) {
     const projectDir = resolve(ctx.workingDirectory, args.projectDir);


### PR DESCRIPTION
Three surfaces still described the vendored skill copy that #278 removed.

`vibe init --json` listed `SKILL.md` and `references/` as scaffold output
even though nothing writes them any more, so agents were told about files
that never appeared. `vibe doctor` looked for the rules only at a project
root `SKILL.md`, which meant a correct install under
`.agents/skills/hyperframes/` reported MISSING and sent the user to an
installer that had nothing left to do. The guidance `vibe init` writes into
user projects still explained the old eject-a-local-copy flow, and the
scene_compose_prompts tool still referred to an internal-LLM fallback that
#276 deleted.

doctor now resolves the rules the same way the compose path does, through
`hyperframesSkillAvailable`, and reports `skillPath` so an agent can see
whether they are in the project or global.

The scaffold test that should have caught the phantom files only inspected
the reported list, so it passed while the files were missing. It now checks
every reported path against the disk across all three profiles.

Claude-Session: https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp
