### PR TITLE
docs: lead with the generation layer instead of the zero-key path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,75 @@
 # VibeFrame
 
-Turn a written brief into a rendered MP4 using a coding agent.
+Let your coding agent generate real video, on your own provider keys, under a spend ceiling it cannot cross.
 
-VibeFrame is a CLI tool and MCP server for agentic video workflows. It takes a
-brief, scaffolds a structured storyboard project, routes generation calls to AI
-providers, and produces a reviewed MP4. The CLI is the stable runtime — JSON
-output, dry runs, cost gates, and machine-readable reports that Codex, Claude
-Code, Cursor, and other host agents can act on.
+VibeFrame is a CLI and MCP server that gives Claude Code, Codex, Cursor, or any bash-capable agent the commands to plan a video, generate the assets from frontier models - Seedance, Runway, Veo, Kling - and render a finished MP4.
+Every paid step sits behind a dry run and a hard `--max-cost` ceiling, and every failure comes back as machine-readable recovery actions instead of a stack trace.
 
-Your existing coding agent is the outer loop. VibeFrame provides the
-video-specific commands and reports. `vibe agent` exists as a fallback when you
-do not have another agent available.
+Scene composition is [Hyperframes](https://github.com/heygen-com/hyperframes)' job, not ours.
+VibeFrame installs its skill and builds the generation, cost, and review layer around it.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/vericontext/vibeframe/actions/workflows/ci.yml/badge.svg)](https://github.com/vericontext/vibeframe/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/vericontext/vibeframe)](https://github.com/vericontext/vibeframe/stargazers)
 
-## Start with zero API keys
+## Know the price before anything is spent
 
-The first render costs $0 and needs no provider accounts.
-Narration runs on local Kokoro TTS, scenes are HTML/CSS composed by your coding agent, and the render is headless Chrome plus FFmpeg.
+`--dry-run` prices the whole build without calling a provider or needing a single key.
+Pair it with `--max-cost` and the build refuses to start when the estimate is over your ceiling:
+
+```bash
+vibe build film --dry-run --max-cost 3 --json
+```
+
+```json
+{
+  "error": {
+    "code": "COST_CAP_EXCEEDED",
+    "message": "Estimated cost $10.93 exceeds --max-cost $3.00.",
+    "suggestion": "Raise --max-cost or reduce the stage/provider scope.",
+    "retryWith": [
+      "vibe build . --stage all --skip-backdrop --json",
+      "vibe build . --stage all --max-cost 10.93 --json"
+    ],
+    "recoverable": true
+  }
+}
+```
+
+It exits non-zero, so an agent loop stops instead of guessing.
+`retryWith` gives it the two cheaper ways forward it can take without asking you.
+The same dry run also names the keys each stage would need, so you find out what a video costs before you own an account:
+
+```text
+Keyframe generation will need openai (OPENAI_API_KEY), but no key/config is available.
+Video generation will need seedance (FAL_API_KEY), but no key/config is available.
+```
+
+This is the part of VibeFrame that has no equivalent in a credit-based tool.
+Your keys, your bill, your ceiling.
+
+## Try it with no keys at all
+
+Before wiring up any provider, the whole pipeline runs locally for $0: local Kokoro TTS narration, HTML/CSS scenes composed by your coding agent, and a headless Chrome plus FFmpeg render.
 
 ```bash
 npm install -g @vibeframe/cli
 vibe init demo --from "30-second video introducing my project"
 ```
 
-Then ask your coding agent (Claude Code, Codex, Cursor, ...) to finish it:
+Then ask your coding agent to finish it:
 
 > Build demo/ into a rendered MP4 with zero API keys.
 > Use `vibe build demo --tts kokoro --skip-backdrop --json`, author the scene
 > HTML from `vibe scene compose-prompts demo --json`, then run
 > `vibe build demo --stage sync --json` and `vibe render demo --json`.
 
-The agent authors each scene against the project's design contract, and every other step is a deterministic CLI command.
-Measured cold-start on this exact sequence: about 4 to 5 minutes from `npm install` to a reviewed 1080p MP4, including a one-time ~530 MB local voice model download.
+Measured cold start on that exact sequence: about 4 to 5 minutes from `npm install` to a reviewed 1080p MP4, including a one-time ~530 MB voice model download.
 Repeat runs skip the downloads.
-
 No coding agent available? The same commands work by hand - `vibe scene compose-prompts` prints the full per-scene authoring brief for you.
 
-API keys only enter the picture when you want provider-generated images, video, or premium voices - and each key unlocks exactly the commands listed by `vibe doctor`.
+It is a real render, and it is the cheapest way to see whether the workflow fits you.
+It is not the point of the tool: the paid generation path above is.
 
 ## Requirements
 
@@ -47,8 +77,9 @@ API keys only enter the picture when you want provider-generated images, video, 
 - FFmpeg
 - Chrome or Chromium (for HTML scene rendering)
 
-That is the whole zero-key stack: FFmpeg edits, Kokoro TTS narration, HTML scene composition, detection, timeline work, and rendering all run locally.
-AI image and video generation is BYO-key: add provider keys such as `OPENAI_API_KEY`, `FAL_API_KEY`, or `GOOGLE_API_KEY` only for the providers you actually use (full list in [MODELS.md](MODELS.md)).
+Everything local runs on those three: FFmpeg edits, Kokoro narration, HTML scene composition, detection, timeline work, and rendering.
+Generation is BYO-key - add `OPENAI_API_KEY`, `FAL_API_KEY`, `GOOGLE_API_KEY`, `RUNWAY_API_SECRET`, or `KLING_API_KEY` only for the providers you actually use (full list in [MODELS.md](MODELS.md)).
+`vibe doctor` lists exactly which commands each key unlocks.
 
 ## Install
 
@@ -240,10 +271,11 @@ vibe build my-film --beat wonder --stage assets --force --skip-video  # regenera
 vibe build my-film --max-cost 6        # animate the approved keyframes
 ```
 
-## Directed AI video — one character, many scenes
+## What the spend buys: one character, many scenes
 
-This is the paid, provider-backed end of the same pipeline.
-One brief in, a directed short film out: VibeFrame reuses a single character sheet across every scene, generates a cheap image storyboard you review first, then animates only the stills you approve with image-to-video and composes the final render - all driven by `vibe build`.
+Generating four shots that look like the same film is the hard part, and it is what the paid path is for.
+VibeFrame reuses a single character sheet across every scene, generates a cheap image storyboard you review first, then animates only the stills you approve with image-to-video and composes the final render - all driven by `vibe build`.
+Reviewing stills before animating is also the cheapest way to keep a run under its ceiling, since the stills cost a fraction of the video.
 
 ```bash
 # frontmatter declares the character once, reused everywhere:
@@ -525,10 +557,8 @@ VibeFrame wraps lower-level composition engines rather than replacing them:
 | [Hyperframes](https://github.com/heygen-com/hyperframes) | HTML/CSS/JS scene composition and deterministic browser capture.                 |
 | VibeFrame                                                | Storyboard/design files, provider routing, build reports, render inspection, edit/remix commands, and host-agent guidance. |
 
-Use Hyperframes directly when the job is only HTML scene authoring and
-rendering. Use VibeFrame when the job includes storyboard planning,
-image/video/audio generation, narration, build reports, or editing steps around
-the composition layer.
+If the job is only HTML scene authoring and rendering, use Hyperframes directly - it is the better tool for that and VibeFrame installs its skill for you either way.
+Reach for VibeFrame when the job involves paid generation: frontier image and video models, character continuity across scenes, narration, cost ceilings, build reports, or editing steps around the composition layer.
 
 VibeFrame is not affiliated with HeyGen. See [CREDITS.md](CREDITS.md) for
 dependency and provenance notes.

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -12,15 +12,16 @@ const inter = Inter({ subsets: ["latin"] });
 // source. Falls back to conservative static numbers if env var lookup fails.
 const AI_PROVIDERS = process.env.NEXT_PUBLIC_AI_PROVIDERS ?? "15";
 const MCP_TOOLS = process.env.NEXT_PUBLIC_MCP_TOOLS ?? "85";
-const SHARE_DESCRIPTION = `Turn STORYBOARD.md and DESIGN.md into generated assets, review reports, and rendered video from the terminal with ${AI_PROVIDERS} AI providers and ${MCP_TOOLS} MCP tools.`;
+const SHARE_TITLE = "VibeFrame - frontier video generation for coding agents";
+const SHARE_DESCRIPTION = `Let your coding agent generate video on Seedance, Runway, Veo, or Kling with your own keys, behind a dry run and a hard --max-cost ceiling. ${AI_PROVIDERS} AI providers, ${MCP_TOOLS} MCP tools, MIT.`;
 
 export const metadata: Metadata = {
-  title: "VibeFrame — Storyboard-first video CLI for AI agents",
+  title: SHARE_TITLE,
   description: SHARE_DESCRIPTION,
-  keywords: ["video CLI", "storyboard to video", "STORYBOARD.md", "DESIGN.md", "AI agent", "agentic CLI", "build-report.json", "review-report.json", "MCP", "YAML pipelines", "Claude Code", "OpenAI Codex", "Cursor", "Aider", "Gemini CLI", "OpenCode", "agents.md", "open source"],
+  keywords: ["AI video generation", "Seedance", "Runway", "Veo", "Kling", "BYO key", "cost cap", "video CLI", "storyboard to video", "STORYBOARD.md", "DESIGN.md", "AI agent", "agentic CLI", "build-report.json", "review-report.json", "MCP", "YAML pipelines", "Claude Code", "OpenAI Codex", "Cursor", "Aider", "Gemini CLI", "OpenCode", "agents.md", "open source"],
   metadataBase: new URL("https://vibeframe.ai"),
   openGraph: {
-    title: "VibeFrame — Storyboard-first video CLI for AI agents",
+    title: SHARE_TITLE,
     description: SHARE_DESCRIPTION,
     type: "website",
     url: "https://vibeframe.ai",
@@ -28,7 +29,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "VibeFrame — Storyboard-first video CLI for AI agents",
+    title: SHARE_TITLE,
     description: SHARE_DESCRIPTION,
   },
 };

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 
 export const runtime = "edge";
-export const alt = "VibeFrame — Storyboard-first video CLI for coding agents";
+export const alt = "VibeFrame - frontier video generation for coding agents";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -117,7 +117,7 @@ export default async function Image() {
             textAlign: "center",
           }}
         >
-          Video workflows from terminal, YAML, and MCP.
+          Your keys. Your bill. Your ceiling.
         </div>
 
         {/* Terminal preview */}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -62,34 +62,33 @@ export default function LandingPage() {
         <div className="mx-auto max-w-5xl text-center">
           <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/5 px-4 py-1.5 text-sm text-primary mb-8 animate-fade-in">
             <Terminal className="w-4 h-4" />
-            <span>Brief-to-MP4 workflow for coding agents</span>
+            <span>Frontier video generation for coding agents</span>
             <span className="px-2 py-0.5 rounded-full bg-primary/20 text-xs font-medium">
               v{process.env.NEXT_PUBLIC_VERSION}
             </span>
           </div>
 
           <h1 className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tight mb-6 animate-fade-in-up">
-            Brief to MP4
+            Let your agent generate video
             <br />
-            <span className="text-primary">with your coding agent.</span>
+            <span className="text-primary">under a ceiling it cannot cross.</span>
           </h1>
 
           <p className="text-2xl sm:text-3xl font-semibold text-foreground/90 mb-6 animate-fade-in-up delay-75">
-            The CLI is the agent workflow layer.
+            Your keys. Your bill. Your limit.
           </p>
 
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto mb-10 animate-fade-in-up delay-100">
-            VibeFrame turns a written brief into{" "}
+            VibeFrame gives Claude Code, Codex, or Cursor the commands to plan a video, generate the
+            assets from{" "}
+            <span className="text-foreground font-medium">Seedance, Runway, Veo, and Kling</span> on
+            your own provider keys, and render a finished MP4. Every paid step sits behind a dry run
+            and a hard{" "}
             <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-sm">
-              STORYBOARD.md
+              --max-cost
             </code>{" "}
-            and{" "}
-            <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-sm">
-              DESIGN.md
-            </code>{" "}
-            and then routes asset generation, scene composition, build reports, render inspection,
-            and the final rendered MP4 through commands any bash-capable coding agent can run. Your
-            coding agent&apos;s own loop stays the outer loop; VibeFrame supplies the video runtime.
+            ceiling, and every failure comes back as machine-readable recovery actions instead of a
+            stack trace.
           </p>
 
           <div className="grid lg:grid-cols-[1.35fr_0.65fr] gap-4 max-w-5xl mx-auto mb-10 text-left animate-fade-in-up delay-150">
@@ -98,34 +97,34 @@ export default function LandingPage() {
                 <div className="w-3 h-3 rounded-full bg-red-500/80" />
                 <div className="w-3 h-3 rounded-full bg-yellow-500/80" />
                 <div className="w-3 h-3 rounded-full bg-green-500/80" />
-                <span className="ml-2 text-xs text-muted-foreground font-mono">agent loop</span>
+                <span className="ml-2 text-xs text-muted-foreground font-mono">
+                  the spend gate
+                </span>
               </div>
               <pre className="p-4 sm:p-5 text-xs sm:text-sm overflow-x-auto">
                 <code className="text-muted-foreground">
-                  # Brief → local narration → agent-authored scenes → MP4{"\n"}
+                  # price the whole build first - no provider call, no key needed{"\n"}
+                </code>
+                <code className="text-foreground">
+                  vibe build film --dry-run --max-cost 3 --json{"\n"}
+                </code>
+                <code className="text-muted-foreground">{'{ "error": {\n'}</code>
+                <code className="text-red-400">{'    "code": "COST_CAP_EXCEEDED",\n'}</code>
+                <code className="text-red-400">
+                  {'    "message": "Estimated cost $10.93 exceeds --max-cost $3.00.",\n'}
+                </code>
+                <code className="text-muted-foreground">{'    "retryWith": [\n'}</code>
+                <code className="text-muted-foreground">
+                  {'      "vibe build . --stage all --skip-backdrop --json",\n'}
                 </code>
                 <code className="text-muted-foreground">
-                  # $0 · zero API keys · local Kokoro TTS + Chrome/FFmpeg render{"\n"}
+                  {'      "vibe build . --stage all --max-cost 10.93 --json"\n'}
                 </code>
-                <code className="text-foreground">
-                  vibe init demo --from brief.md --json{"\n"}
-                </code>
-                <code className="text-foreground">
-                  vibe build demo --tts kokoro --skip-backdrop --json{"\n"}
-                </code>
-                <code className="text-muted-foreground">
-                  # your coding agent authors each scene from the compose plan{"\n"}
-                </code>
-                <code className="text-foreground">
-                  vibe scene compose-prompts demo --json{"\n"}
-                </code>
-                <code className="text-foreground">vibe build demo --stage sync --json{"\n"}</code>
-                <code className="text-foreground">vibe render demo --json{"\n"}</code>
-                <code className="text-foreground">
-                  vibe inspect render demo --cheap --json{"\n"}
-                </code>
+                <code className="text-muted-foreground">{"    ],\n"}</code>
+                <code className="text-muted-foreground">{'    "recoverable": true\n'}</code>
+                <code className="text-muted-foreground">{"} }\n"}</code>
                 <code className="text-green-400">
-                  {"✓ renders/demo.mp4 — reviewed 1080p render, $0 spent"}
+                  {"# exit 1 - the agent stops instead of guessing"}
                 </code>
               </pre>
             </div>
@@ -160,8 +159,8 @@ export default function LandingPage() {
             </div>
           </div>
           <p className="text-sm text-muted-foreground -mt-4 mb-8 animate-fade-in-up delay-200">
-            The first render costs $0 and needs no API keys — local TTS, HTML scenes, Chrome +
-            FFmpeg.
+            Want to look before you spend? The whole pipeline also runs locally for $0 with no keys
+            at all - local TTS, HTML scenes, Chrome + FFmpeg.
           </p>
 
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4 animate-fade-in-up delay-300">
@@ -282,36 +281,45 @@ export default function LandingPage() {
               </p>
             </div>
             <div className="bg-secondary/50 border border-border/50 rounded-xl p-5">
-              <div className="text-xs text-muted-foreground mb-2">3. Build · free assets</div>
+              <div className="text-xs text-muted-foreground mb-2">3. Price · before any spend</div>
               <code className="font-mono text-xs text-foreground block break-all">
-                vibe build launch --tts kokoro --skip-backdrop --json
+                vibe build launch --dry-run --max-cost 12 --json
               </code>
               <p className="text-xs text-muted-foreground mt-3">
-                Local Kokoro narration, $0. Your agent then authors scene HTML from the compose
-                plan.
+                Costs nothing and needs no key. Prints the estimate and names the keys each stage
+                would need.
               </p>
             </div>
             <div className="bg-secondary/50 border border-border/50 rounded-xl p-5">
-              <div className="text-xs text-muted-foreground mb-2">4. Render · review</div>
+              <div className="text-xs text-muted-foreground mb-2">4. Generate · under the cap</div>
+              <code className="font-mono text-xs text-foreground block break-all">
+                vibe setup --scope project && vibe build launch --max-cost 12 --json
+              </code>
+              <p className="text-xs text-muted-foreground mt-3">
+                BYO-key generation on Seedance, Runway, Veo, or Kling. Over the ceiling it refuses
+                and hands back recovery actions.
+              </p>
+            </div>
+            <div className="bg-secondary/50 border border-border/50 rounded-xl p-5">
+              <div className="text-xs text-muted-foreground mb-2">5. Render · review</div>
               <code className="font-mono text-xs text-foreground block break-all">
                 vibe render launch --json && vibe inspect render launch --cheap --json
               </code>
               <p className="text-xs text-muted-foreground mt-3">
-                Chrome + FFmpeg render, still $0. Writes reports agents can inspect, repair, and
+                Chrome + FFmpeg render, free. Writes reports agents can inspect, repair, and
                 re-render.
               </p>
             </div>
-            <div className="bg-secondary/50 border border-border/50 rounded-xl p-5">
-              <div className="text-xs text-muted-foreground mb-2">5. Add keys · only if needed</div>
-              <code className="font-mono text-xs text-foreground block break-all">
-                vibe setup --scope project && vibe build launch --dry-run --max-cost 5 --json
-              </code>
-              <p className="text-xs text-muted-foreground mt-3">
-                BYO-key unlocks provider image/video generation — always behind dry runs and cost
-                gates.
-              </p>
-            </div>
           </div>
+
+          <p className="text-center text-sm text-muted-foreground mt-8">
+            Evaluating first?{" "}
+            <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
+              vibe build launch --tts kokoro --skip-backdrop --json
+            </code>{" "}
+            runs steps 3 and 4 entirely locally for $0 - local Kokoro narration and agent-authored
+            HTML scenes, no provider account needed.
+          </p>
 
           <p className="text-center text-sm text-muted-foreground mt-8">
             Primary path: <span className="text-foreground font-medium">BUILD</span> from storyboard

--- a/apps/web/app/twitter-image.tsx
+++ b/apps/web/app/twitter-image.tsx
@@ -1,6 +1,6 @@
 export { default } from "./opengraph-image";
 
 export const runtime = "edge";
-export const alt = "VibeFrame — Storyboard-first video CLI for coding agents";
+export const alt = "VibeFrame - frontier video generation for coding agents";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";


### PR DESCRIPTION
The README and vibeframe.ai both led with "brief to MP4" and "your first
render costs $0, no API keys". Both claims are true and neither is ours.
Hyperframes ships a no-key CLI with local Kokoro TTS to a far larger
audience, so leading with that story positions VibeFrame as a derivative
of the tool it depends on. "Brief to MP4" is what every peer in this space
says, which makes it worth nothing as a first line.

What is actually distinct after the subtraction series is the paid layer:
BYO-key generation across Seedance, Runway, Veo, and Kling, priced by a
dry run before anything is spent, capped by a --max-cost ceiling that
refuses rather than truncates, and recoverable through machine-readable
nextActions. A credit-based tool has no reason to build a feature whose
job is to make you generate less.

So both surfaces now lead with that and demote the zero-key path to what
it really is: the cheapest way to evaluate the workflow before paying for
anything. It is still documented, still measured, just no longer the
identity. The Hyperframes relationship moves into the opening paragraph -
composition is theirs, we install their skill, and the generation layer
around it is ours.

The hero output is copied from a real run, not composed for the page:
a four-beat film priced at $10.93 refusing a $3.00 ceiling, with the two
retryWith commands the CLI actually emits.

Claude-Session: https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp
