### PR TITLE
fix: make runtime strings and generated templates match the shipped product

### DIFF
--- a/.agents/skills/vibe-scene/SKILL.md
+++ b/.agents/skills/vibe-scene/SKILL.md
@@ -31,8 +31,8 @@ The `vibe scene ...` namespace is the lower-level authoring surface:
 
 | Path                       | Use when                                                                                | Commands                                                     |
 | -------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Self-contained batch build | A human is running the demo or CI should produce scene HTML without a host coding agent | `vibe build --mode batch --composer openai`                  |
-| Host-agent authoring       | Claude Code/Codex/Cursor should write the scene HTML from a plan                        | `vibe build --mode agent`, then `vibe scene compose-prompts` |
+| Host-agent authoring       | Claude Code/Codex/Cursor writes the scene HTML from a plan (default)                    | `vibe build`, then `vibe scene compose-prompts`              |
+| Deterministic template     | CI or a human demo should produce scene HTML without a coding agent (no LLM call)       | `vibe build --composer template`                             |
 | Single-scene draft         | You need a quick template scene or fallback HTML                                        | `vibe scene add`                                             |
 
 Default recommendation for public demos and reproducible dogfood runs:
@@ -41,11 +41,10 @@ Default recommendation for public demos and reproducible dogfood runs:
 vibe init my-video --profile agent --ratio 16:9
 # edit DESIGN.md and STORYBOARD.md
 vibe build my-video \
-  --mode batch \
-  --composer openai \
   --tts kokoro \
   --skip-backdrop \
   --skip-render
+# (the host agent authors compositions/scene-*.html, then re-run vibe build)
 vibe scene lint index.html --project my-video --fix
 vibe render my-video -o renders/final.mp4 --quality standard
 ```
@@ -61,7 +60,6 @@ authors `compositions/scene-*.html`.
 
 ```bash
 vibe build my-video \
-  --mode agent \
   --tts kokoro \
   --skip-backdrop \
   --skip-render
@@ -69,7 +67,7 @@ vibe build my-video \
 vibe scene compose-prompts my-video --json
 ```
 
-If `vibe build --mode agent` returns a `needs-author` plan:
+If `vibe build` returns a `needs-author` plan:
 
 1. Read the compose plan.
 2. Author each missing `compositions/scene-<id>.html`.
@@ -173,8 +171,8 @@ correct and deterministic.
 
 - `Root composition not found`: run `vibe build` once so the render scaffold is
   created, or use `vibe init --profile full`.
-- `needs-author`: expected in `--mode agent`; author the listed scene files and
-  rerun build.
+- `needs-author`: expected when the host agent authors scenes (the default);
+  author the listed scene files and rerun build.
 - `OPENAI_API_KEY not set`: use `--skip-backdrop` for a local composition test,
   or configure the key before generating backdrops.
 - Render hangs at 0%: run `vibe doctor`; install Chrome or set `CHROME_PATH`.

--- a/.claude/skills/vibe-scene/SKILL.md
+++ b/.claude/skills/vibe-scene/SKILL.md
@@ -33,8 +33,8 @@ The `vibe scene ...` namespace is the lower-level authoring surface:
 
 | Path                       | Use when                                                                                | Commands                                                     |
 | -------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Self-contained batch build | A human is running the demo or CI should produce scene HTML without a host coding agent | `vibe build --mode batch --composer openai`                  |
-| Host-agent authoring       | Claude Code/Codex/Cursor should write the scene HTML from a plan                        | `vibe build --mode agent`, then `vibe scene compose-prompts` |
+| Host-agent authoring       | Claude Code/Codex/Cursor writes the scene HTML from a plan (default)                    | `vibe build`, then `vibe scene compose-prompts`              |
+| Deterministic template     | CI or a human demo should produce scene HTML without a coding agent (no LLM call)       | `vibe build --composer template`                             |
 | Single-scene draft         | You need a quick template scene or fallback HTML                                        | `vibe scene add`                                             |
 
 Default recommendation for public demos and reproducible dogfood runs:
@@ -43,11 +43,10 @@ Default recommendation for public demos and reproducible dogfood runs:
 vibe init my-video --profile agent --ratio 16:9
 # edit DESIGN.md and STORYBOARD.md
 vibe build my-video \
-  --mode batch \
-  --composer openai \
   --tts kokoro \
   --skip-backdrop \
   --skip-render
+# (the host agent authors compositions/scene-*.html, then re-run vibe build)
 vibe scene lint index.html --project my-video --fix
 vibe render my-video -o renders/final.mp4 --quality standard
 ```
@@ -63,7 +62,6 @@ authors `compositions/scene-*.html`.
 
 ```bash
 vibe build my-video \
-  --mode agent \
   --tts kokoro \
   --skip-backdrop \
   --skip-render
@@ -71,7 +69,7 @@ vibe build my-video \
 vibe scene compose-prompts my-video --json
 ```
 
-If `vibe build --mode agent` returns a `needs-author` plan:
+If `vibe build` returns a `needs-author` plan:
 
 1. Read the compose plan.
 2. Author each missing `compositions/scene-<id>.html`.
@@ -175,8 +173,8 @@ correct and deterministic.
 
 - `Root composition not found`: run `vibe build` once so the render scaffold is
   created, or use `vibe init --profile full`.
-- `needs-author`: expected in `--mode agent`; author the listed scene files and
-  rerun build.
+- `needs-author`: expected when the host agent authors scenes (the default);
+  author the listed scene files and rerun build.
 - `OPENAI_API_KEY not set`: use `--skip-backdrop` for a local composition test,
   or configure the key before generating backdrops.
 - Render hangs at 0%: run `vibe doctor`; install Chrome or set `CHROME_PATH`.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ vibe inspect render my-video --beat hook --cheap --json
 Each storyboard beat carries YAML cues:
 
 ````markdown
-## Beat hook — Open
+## Beat hook - Open
 
 ```yaml
 narration: "Start with a storyboard. VibeFrame turns each beat into a render plan."
@@ -253,7 +253,7 @@ characters:
   rival: { image: "media/rival-ref.png" }
 ---
 
-## Beat hook — Hook
+## Beat hook - Hook
 
 ```yaml
 duration: 5

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -480,7 +480,7 @@ Cost tier: _not tagged_
 
 #### `vibe setup`
 
-Configure VibeFrame (LLM provider, API keys)
+Configure VibeFrame (video/image provider keys, LLM provider)
 
 Product surface: `public`
 Note: Initial configuration helper.

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -144,7 +144,7 @@ characters:
   rival: { image: "media/rival-ref.png" }
 ---
 
-## Beat hook — Hook
+## Beat hook - Hook
 
 ```yaml
 duration: 5

--- a/packages/cli/CONTEXT.md
+++ b/packages/cli/CONTEXT.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-VibeFrame CLI (`vibe`) is a CLI-first video toolkit. Every operation is
+VibeFrame CLI (`vibe`) generates AI video on the user's own provider keys
+(Seedance, Runway, Veo, Kling), behind dry runs and a hard `--max-cost`
+ceiling, and edits the results. Every operation is
 a shell command. The same surface is exposed as MCP tools through
 [`@vibeframe/mcp-server`](https://www.npmjs.com/package/@vibeframe/mcp-server).
 For long-running video work, your host's agent loop (Claude Code, Codex,
@@ -12,7 +14,7 @@ VibeFrame owns the video-specific command surface, JSON reports, cost gates,
 deterministic repair, render inspection, and `retryWith` recovery hints.
 
 For the full reference (every flag, default, enum), read
-[`docs/cli-reference.md`](../../docs/cli-reference.md) — auto-generated
+[`docs/cli-reference.md`](../../docs/cli-reference.md) - auto-generated
 from `vibe schema --list`. This file is the _agent quickstart_: rules,
 conventions, and discovery hooks.
 
@@ -27,7 +29,7 @@ host agent loop -> vibe context/schema -> plan dry-run -> build with budget
 -> repair/edit using nextActions/fixOwner -> repeat until stop rules pass
 ```
 
-Copy-paste agent prompt (Codex) — a plain prompt, not a built-in command:
+Copy-paste agent prompt (Codex) - a plain prompt, not a built-in command:
 
 ```text
 Build my-video/ into a reviewed VibeFrame MP4. Use --json for every vibe
@@ -44,7 +46,7 @@ AI review score is >= 90 when AI review is requested, and unresolved host-agent 
 accepted with a written reason, or reported as blocked.
 ```
 
-Copy-paste agent prompt (Claude Code) — a plain prompt, not a built-in command:
+Copy-paste agent prompt (Claude Code) - a plain prompt, not a built-in command:
 
 ```text
 Finish the VibeFrame render for my-video/ using your host's agent loop as
@@ -71,15 +73,15 @@ vibe guide <topic> --json              # Step-by-step guides (motion | scene | p
 
 ## Global rules
 
-1. **`--json` everywhere** — auto-enabled on non-TTY stdout but pass
+1. **`--json` everywhere** - auto-enabled on non-TTY stdout but pass
    explicitly for clarity. Output goes to **stdout**.
-2. **`--dry-run` before any paid call** — returns a `costUsd` estimate
+2. **`--dry-run` before any paid call** - returns a `costUsd` estimate
    in the JSON envelope without spending. Validates inputs.
-3. **`--stdin` for complex options** — `echo '{"key":"value"}' | vibe
+3. **`--stdin` for complex options** - `echo '{"key":"value"}' | vibe
 <cmd> --stdin --json`. CLI flags still win on conflict.
-4. **`--fields <list>`** — limit JSON output fields on read-heavy
+4. **`--fields <list>`** - limit JSON output fields on read-heavy
    commands (e.g. `--fields "path,duration"`).
-5. **`--describe`** — print a command's JSON Schema and exit (no
+5. **`--describe`** - print a command's JSON Schema and exit (no
    execution). Useful for prompt-time discovery.
 
 ## Cost tiers

--- a/packages/cli/src/agent/prompts/system.ts
+++ b/packages/cli/src/agent/prompts/system.ts
@@ -9,7 +9,7 @@ export function getSystemPrompt(context: AgentContext): string {
     ? `Current project: ${context.projectPath}`
     : "No timeline loaded. Use timeline_create or project_create to start.";
 
-  return `You are VibeFrame, an AI video editing assistant. You help users edit videos through natural language commands.
+  return `You are VibeFrame, an AI video generation and editing assistant. You help users generate video from frontier models on their own provider keys - behind dry runs and cost caps - and edit the results, through natural language commands.
 
 ## Current Context
 - Working directory: ${context.workingDirectory}
@@ -17,10 +17,10 @@ export function getSystemPrompt(context: AgentContext): string {
 
 ## Your Capabilities
 You have access to tools for:
-1. **Timeline Management**: Create, open, save, and modify low-level timeline JSON state
-2. **Timeline Editing**: Add sources, create clips, add tracks, apply effects, trim, split, move, and delete clips
-3. **Media Analysis**: Detect scenes, silence, and beats in media files
-4. **AI Generation**: Generate images, videos, TTS, sound effects, music, and more
+1. **AI Generation**: Generate images, videos, TTS, sound effects, music, and more on the user's provider keys
+2. **Media Analysis**: Detect scenes, silence, and beats in media files
+3. **Timeline Management**: Create, open, save, and modify low-level timeline JSON state
+4. **Timeline Editing**: Add sources, create clips, add tracks, apply effects, trim, split, move, and delete clips
 5. **Export**: Export projects to video files
 
 ## Guidelines

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -3940,7 +3940,7 @@ exports[`CLI --describe schemas (drift detection) > vibe scene submit --describe
 
 exports[`CLI --describe schemas (drift detection) > vibe setup --describe 1`] = `
 {
-  "description": "Configure VibeFrame (LLM provider, API keys)",
+  "description": "Configure VibeFrame (video/image provider keys, LLM provider)",
   "name": "setup",
   "note": "Initial configuration helper.",
   "parameters": {

--- a/packages/cli/src/commands/_shared/init-templates.ts
+++ b/packages/cli/src/commands/_shared/init-templates.ts
@@ -16,31 +16,32 @@
  * OpenAI Codex, Cursor, Aider, Sourcegraph Cody, OpenCode, and (via
  * the @AGENTS.md import) Claude Code. Gemini CLI users may want to
  * also keep a sibling \`GEMINI.md\` since that's its primary context
- * file. Keep this as the canonical source of truth for agent guidance —
+ * file. Keep this as the canonical source of truth for agent guidance -
  * \`CLAUDE.md\` and \`GEMINI.md\` just import it.
  */
 export const AGENTS_MD = `# AGENTS.md
 
-This project uses [VibeFrame](https://github.com/vericontext/vibeframe) —
-a CLI for AI-powered video editing. The \`vibe\` command provides 80+
-subcommands for video generation, editing, analysis, and pipeline
-orchestration. Cost tiers below — **always confirm with the user before
-running High / Very High tier commands**.
+This project uses [VibeFrame](https://github.com/vericontext/vibeframe) -
+a CLI for AI video generation on the user's own provider keys (Seedance,
+Runway, Veo, Kling), behind dry runs and a hard \`--max-cost\` ceiling.
+The \`vibe\` command provides 80+ subcommands for video generation,
+editing, and analysis. Cost tiers below - **always confirm with the user
+before running High / Very High tier commands**.
 
 ## Agent host coverage
 
 VibeFrame's CLI works with any bash-capable AI coding agent. Six host
 families have first-class auto-detection and scaffolds today:
 
-- **Claude Code** — \`CLAUDE.md\` (this file's import wrapper) +
+- **Claude Code** - \`CLAUDE.md\` (this file's import wrapper) +
   \`AGENTS.md\` + \`/vibe-*\` slash commands.
-- **OpenAI Codex** — reads \`AGENTS.md\` natively (agents.md spec).
-- **Cursor** — reads \`AGENTS.md\` plus \`.cursor/rules/\` for project
+- **OpenAI Codex** - reads \`AGENTS.md\` natively (agents.md spec).
+- **Cursor** - reads \`AGENTS.md\` plus \`.cursor/rules/\` for project
   rules; supports MCP via \`.cursor/mcp.json\`.
-- **Aider** — reads \`AGENTS.md\` (binary-only detection by VibeFrame).
-- **Gemini CLI** — primary context file is \`GEMINI.md\`; also reads
+- **Aider** - reads \`AGENTS.md\` (binary-only detection by VibeFrame).
+- **Gemini CLI** - primary context file is \`GEMINI.md\`; also reads
   \`AGENTS.md\` if present.
-- **OpenCode** — reads \`AGENTS.md\` (officially supported per
+- **OpenCode** - reads \`AGENTS.md\` (officially supported per
   \`opencode.ai/docs/rules\`); supports MCP via \`.opencode/mcp.json\`.
 
 Run \`vibe doctor\` to see which host(s) the CLI detects in your
@@ -50,7 +51,7 @@ fallback.
 
 ## Self-discovery
 
-Don't memorise the command surface — read it from the CLI:
+Don't memorise the command surface - read it from the CLI:
 
 \`\`\`bash
 vibe --help                    # command groups overview
@@ -70,10 +71,10 @@ vibe guide pipeline            # step-by-step authoring guide (pipeline)
 Routing the user's request correctly is the most important judgement call
 you'll make. Do not force everything into a scene project.
 
-**ASSET — default for any single-asset request OR ambiguous prompt.**
+**ASSET - default for any single-asset request OR ambiguous prompt.**
 If the user asks for a single image, single video clip, sound effect, music
-bed, or narration file — **OR pastes a visual/audio brief without explicit
-storyboard / scene / multi-scene language** — treat it as ASSET. Use
+bed, or narration file - **OR pastes a visual/audio brief without explicit
+storyboard / scene / multi-scene language** - treat it as ASSET. Use
 \`vibe generate ...\` directly. Do **not** edit \`DESIGN.md\`,
 \`STORYBOARD.md\`, run \`vibe scene ...\`, or auto-load the hyperframes
 skill until BUILD intent is explicit. The visual-identity hard-gate
@@ -90,13 +91,13 @@ If genuinely uncertain, ask one short question: *"single asset or
 multi-scene project?"* before authoring DESIGN.md or loading the
 hyperframes skill.
 
-**BUILD — create new video from text intent.**
+**BUILD - create new video from text intent.**
 Use \`vibe build\` with a STORYBOARD.md + DESIGN.md. The
 skills-driven pipeline (v0.60+) dispatches narration TTS + backdrop
 image-gen per beat, composes scene HTML via the bundled composition rules
 bundle, then renders to MP4. Idempotent re-runs reuse cached assets.
 
-**REMIX — transform existing video / audio.**
+**REMIX - transform existing video / audio.**
 Use \`vibe remix\`, \`vibe edit\`, or \`vibe audio\`. One-shot,
 batch-oriented operations on a file the user already has on disk.
 \`vibe edit text-overlay\` is the free deterministic path for simple static
@@ -156,7 +157,7 @@ starting from a media file and wants it transformed, it's REMIX.
 When you run vibe commands programmatically:
 
 1. **Always \`--json\`** for structured output you can parse without regex
-2. **Always \`--dry-run\` first** for any High/Very-High tier command — it returns
+2. **Always \`--dry-run\` first** for any High/Very-High tier command - it returns
    the cost estimate without spending API budget
 3. **Use \`vibe schema <command>\`** to discover parameters; do not guess flags
 4. **Pass complex options via \`--stdin\`**:
@@ -198,7 +199,7 @@ vibe host doctor all --json # verify readiness
 
 Default setup is snippet-only; use \`--write\` when you want VibeFrame to merge
 the generated config. Keep provider keys in \`.vibeframe/config.yaml\`, user
-config, or env files — not in app host config.
+config, or env files - not in app host config.
 
 ## Host agent loop
 
@@ -209,7 +210,7 @@ budget caps, \`build-report.json\`, \`review-report.json\`, \`nextActions\`,
 \`safeToAutoRun\`, \`requiresConfirmation\`, \`fixOwner\`, deterministic repair,
 and render inspection for the host agent to decide what to do next.
 
-Copy-paste agent prompt (Codex) — a plain prompt, not a built-in command:
+Copy-paste agent prompt (Codex) - a plain prompt, not a built-in command:
 
 \`\`\`text
 Build this VibeFrame project into renders/final.mp4. Use --json for every
@@ -226,7 +227,7 @@ remaining host-agent issue is fixed, accepted with rationale, or reported as
 blocked.
 \`\`\`
 
-Copy-paste agent prompt (Claude Code) — a plain prompt, not a built-in command:
+Copy-paste agent prompt (Claude Code) - a plain prompt, not a built-in command:
 
 \`\`\`text
 Finish this VibeFrame render using your host's agent loop as the outer
@@ -241,7 +242,7 @@ no unresolved unacknowledged host-agent issues.
 
 ### Composition rules (scene HTML)
 
-Composition rules live in the **Hyperframes skill** — framework rules, motion
+Composition rules live in the **Hyperframes skill** - framework rules, motion
 principles, type system, and visual-identity hard-gate. **Load that skill
 before authoring any scene composition HTML under \`compositions/\`.** The same
 rules govern \`vibe scene lint\`, so your authored HTML and the linter stay in
@@ -265,22 +266,12 @@ containing live text/cards. Put ambient zoom/parallax on background or media
 layers only; text should enter briefly and then hold still at its final CSS
 position.
 
-### Scene composer (batch / non-agent fallback)
+### Scene composer (non-agent fallback)
 
-When you don't want to author HTML yourself, \`vibe build --mode batch\` runs an
-LLM internally with the same skill bundle. It auto-picks a provider based
-on available keys (\`claude > gemini > openai\`) — pass \`--composer <name>\`
-to force one:
-
-| Provider | Env var | Spike notes (v0.70) |
-|---|---|---|
-| Claude (default) | \`ANTHROPIC_API_KEY\` | ~9 s/beat. Fastest, validated baseline. |
-| Gemini | \`GOOGLE_API_KEY\` | ~20 s/beat. ~2.6× cheaper than Claude. |
-| OpenAI | \`OPENAI_API_KEY\` | ~70 s/beat. gpt-5 reasoning latency — opt-in only. |
-
-All three pass first-shot lint at every effort tier on the \`vibeframe-promo\`
-fixture. Quality on more complex storyboards may differ — fall back to
-\`--composer claude\` if a non-default provider repeatedly fails lint.
+Scene HTML is authored by you, the host agent - the CLI makes no LLM call
+during \`vibe build\`. When no agent is available to author scenes, pass
+\`--composer template\` for the deterministic no-model composer
+(concat background + lower-thirds).
 
 ## Project conventions
 
@@ -300,7 +291,7 @@ export const CLAUDE_MD = `@AGENTS.md
 
 # Claude Code overrides
 
-This file imports \`AGENTS.md\` (above) — that's the canonical source.
+This file imports \`AGENTS.md\` (above) - that's the canonical source.
 Add anything Claude-Code-specific *below*; everything generic should
 stay in AGENTS.md so other agent hosts (Codex, Cursor, Aider, Gemini CLI, OpenCode) see it
 too.
@@ -308,11 +299,11 @@ too.
 ## Skills
 
 If you ran \`vibe init\` with Claude Code detected, the VibeFrame skill
-pack is available as slash commands (consolidated to 2 in v0.62 — the
+pack is available as slash commands (consolidated to 2 in v0.62 - the
 overview content moved into AGENTS.md above):
 
-- \`/vibe-pipeline\` — YAML pipeline authoring helper (Video as Code)
-- \`/vibe-scene\` — per-scene HTML authoring + \`vibe build\`
+- \`/vibe-pipeline\` - YAML pipeline authoring helper (Video as Code)
+- \`/vibe-scene\` - per-scene HTML authoring + \`vibe build\`
 
 Claude-specific routing note: follow the ASSET / BUILD / REMIX decision
 rules in \`AGENTS.md\`. In particular, a request for one generated image or
@@ -350,7 +341,7 @@ export const GEMINI_MD = `@AGENTS.md
 
 # Gemini CLI overrides
 
-This project's canonical agent guidance lives in \`AGENTS.md\` — read
+This project's canonical agent guidance lives in \`AGENTS.md\` - read
 it first. The \`@AGENTS.md\` line above is the import marker; if
 Gemini CLI doesn't inline imported files in your version, open
 \`AGENTS.md\` directly. Both files are kept in sync by \`vibe init\`.
@@ -382,11 +373,11 @@ export function renderEnvExample(opts: EnvExampleOptions = {}): string {
 # Run \`vibe doctor\` to see what's currently detected.
 
 `;
-  return `# VibeFrame API keys — copy this file to \`.env\` and fill in what you need.
+  return `# VibeFrame API keys - copy this file to \`.env\` and fill in what you need.
 # Free local fallbacks work without any keys. See README for the full list.
 
 ${fallback}# ── LLM provider / optional \`vibe agent\` fallback (pick one) ───────────
-ANTHROPIC_API_KEY=                    # Claude — recommended default
+ANTHROPIC_API_KEY=                    # Claude - recommended default
 OPENAI_API_KEY=                       # GPT-5-mini · Whisper · gpt-image-2
 GOOGLE_API_KEY=                       # Gemini · Veo
 XAI_API_KEY=                          # Grok image+video
@@ -395,7 +386,7 @@ OPENROUTER_API_KEY=                   # multiplexes any provider above
 
 # ── Media providers ─────────────────────────────────────────────────────
 ELEVENLABS_API_KEY=                   # paid TTS / SFX / music (Kokoro is the free fallback)
-FAL_API_KEY=                              # Seedance 2.0 — default video provider since v0.57
+FAL_API_KEY=                              # Seedance 2.0 - default video provider since v0.57
 IMGBB_API_KEY=                        # image hosting for Seedance/Kling image-to-video
 RUNWAY_API_SECRET=                    # Runway Gen-4.5 video
 KLING_API_KEY=                        # Kling video
@@ -436,7 +427,7 @@ renders/
 
 /**
  * vibe.project.yaml minimal scaffold. Only written when no project
- * config exists — `vibe init` never overwrites an existing file unless
+ * config exists - `vibe init` never overwrites an existing file unless
  * --force.
  */
 export function renderProjectYaml(opts: { name: string }): string {
@@ -447,13 +438,13 @@ aspect: "16:9"
 defaults:
   exportQuality: standard
 
-# Optional — uncomment to set per-primitive provider preferences.
+# Optional - uncomment to set per-primitive provider preferences.
 # providers:
 #   tts: elevenlabs       # auto | elevenlabs | kokoro
 #   image: openai         # openai | gemini | grok
 #   music: elevenlabs
 
-# Optional — cap total spend per pipeline run.
+# Optional - cap total spend per pipeline run.
 # budget:
 #   maxUsd: 5.00
 `;

--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -63,14 +63,14 @@ describe("SceneKind", () => {
   });
 
   it("buildScriptMd is always emittable and names the project", () => {
-    expect(buildScriptMd("my-film", "cinema")).toContain("# my-film — Script");
+    expect(buildScriptMd("my-film", "cinema")).toContain("# my-film - Script");
     expect(buildScriptMd("promo", "product")).toContain("Product walkthrough");
     expect(buildScriptMd("loop", "motion")).toContain("Motion piece");
   });
 
   it("buildCharactersMd seeds a cast block with a reference sheet", () => {
     const md = buildCharactersMd("my-film");
-    expect(md).toContain("# my-film — Characters");
+    expect(md).toContain("# my-film - Characters");
     expect(md).toContain("assets/characters/hero.png");
   });
 
@@ -304,7 +304,7 @@ describe("buildStoryboardMd", () => {
 describe("buildDesignMd", () => {
   it("emits placeholder sections when no style is provided", () => {
     const md = buildDesignMd({ name: "my-promo" });
-    expect(md).toContain("# my-promo — Design");
+    expect(md).toContain("# my-promo - Design");
     expect(md).toContain("Hard-gate (BUILD flow only).");
     // Section headings are stable.
     expect(md).toContain("## Style");
@@ -417,7 +417,7 @@ describe("scaffoldSceneProject", () => {
     const dir = await makeTmp();
     await scaffoldSceneProject({ dir, name: "fixture" });
     const design = await readFile(resolve(dir, "DESIGN.md"), "utf-8");
-    expect(design).toContain("# fixture — Design");
+    expect(design).toContain("# fixture - Design");
     expect(design).toContain("--visual-style");
     // Should NOT pre-fill from any specific style:
     expect(design).not.toContain("Swiss Pulse");

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -1,7 +1,7 @@
 /**
  * @module _shared/scene-project
  *
- * Helpers for scaffolding a "scene project" — a directory that works as both
+ * Helpers for scaffolding a "scene project" - a directory that works as both
  * a VibeFrame project (via `vibe.config.json`) AND a HeyGen Hyperframes
  * project (via `hyperframes.json` + `meta.json` + `index.html`). Either
  * toolchain can be run inside the directory.
@@ -22,13 +22,13 @@ export type SceneAspect = "16:9" | "9:16" | "1:1" | "4:5";
 export type SceneScaffoldProfile = "minimal" | "agent" | "full";
 
 /**
- * Project KIND — orthogonal to {@link SceneScaffoldProfile} (which decides which
+ * Project KIND - orthogonal to {@link SceneScaffoldProfile} (which decides which
  * files exist). Kind decides which pipeline STAGES run and which composer is the
  * default:
- * - `cinema` / `story` — directed, character-driven; keyframe→i2v, LLM composer.
- * - `aivideo` — character + i2v, the deterministic `template` composer.
- * - `product` — backdrop/asset-centric (no i2v keyframes).
- * - `motion` — pure HTML/CSS/GSAP graphics (no AI image/video assets).
+ * - `cinema` / `story` - directed, character-driven; keyframe→i2v, LLM composer.
+ * - `aivideo` - character + i2v, the deterministic `template` composer.
+ * - `product` - backdrop/asset-centric (no i2v keyframes).
+ * - `motion` - pure HTML/CSS/GSAP graphics (no AI image/video assets).
  */
 export type SceneKind = "cinema" | "product" | "aivideo" | "story" | "motion";
 
@@ -181,7 +181,7 @@ export function mergeHyperframesConfig(
 }
 
 /**
- * Minimal valid Hyperframes root composition — empty (no sub-compositions
+ * Minimal valid Hyperframes root composition - empty (no sub-compositions
  * yet). A later `vibe scene add` inserts `<div class="clip" ...>` children.
  */
 export function buildEmptyRootHtml(opts: { aspect: SceneAspect; duration: number }): string {
@@ -228,7 +228,7 @@ export function buildEmptyRootHtml(opts: { aspect: SceneAspect; duration: number
 }
 
 /**
- * Project-local `DESIGN.md` template — the visual-identity hard-gate.
+ * Project-local `DESIGN.md` template - the visual-identity hard-gate.
  *
  * Hyperframes' `hyperframes` skill teaches: "no scene HTML before DESIGN.md is
  * authored." This template seeds that contract so the project never opens
@@ -236,7 +236,7 @@ export function buildEmptyRootHtml(opts: { aspect: SceneAspect; duration: number
  * from the vendored named-style data (`visual-styles.ts`); otherwise the
  * user (or agent) fills the placeholders.
  *
- * The agent-driven craft path expects this file as input — see
+ * The agent-driven craft path expects this file as input - see
  * `.claude/skills/vibe-scene/SKILL.md`.
  */
 /**
@@ -275,16 +275,16 @@ colors:
 `;
 
   const intro = style
-    ? `Visual identity for **${name}**, scaffolded from the **${style.name}** style (after ${style.designer}). Customise freely — this file is the single source of truth for every scene's palette, typography, and motion.`
+    ? `Visual identity for **${name}**, scaffolded from the **${style.name}** style (after ${style.designer}). Customise freely - this file is the single source of truth for every scene's palette, typography, and motion.`
     : `Visual identity for **${name}**. Fill the sections below before authoring any scene HTML or generating any backdrop. Pick a named style with \`vibe scene list-styles\` if you want a credible starting point.`;
 
   const moodLine = style
     ? `**Mood:** ${style.mood} · **Best for:** ${style.bestFor}`
-    : `**Mood:** _(one line — what should the viewer FEEL?)_`;
+    : `**Mood:** _(one line - what should the viewer FEEL?)_`;
 
   const palette = style
     ? `${style.palette.map((c) => `- \`${c}\``).join("\n")}\n\n${style.paletteNotes}`
-    : `- _hex_ — primary\n- _hex_ — accent\n\n_2–3 colours max. Declare explicit hex values; never name colours abstractly._`;
+    : `- _hex_ - primary\n- _hex_ - accent\n\n_2–3 colours max. Declare explicit hex values; never name colours abstractly._`;
 
   const typography = style
     ? style.typography
@@ -306,7 +306,7 @@ colors:
     ? style.avoid.map((a) => `- ${a}`).join("\n")
     : `- _anti-pattern 1_\n- _anti-pattern 2_\n- _anti-pattern 3_`;
 
-  return `${frontmatter}# ${name} — Design
+  return `${frontmatter}# ${name} - Design
 
 > **Hard-gate (BUILD flow only).** This file is the visual contract for
 > the scene-project flow (\`vibe build\`, \`vibe scene ...\`, composition
@@ -355,20 +355,20 @@ ${style ? `_This file was seeded by \`vibe scene init --visual-style "${style.na
 }
 
 /**
- * Always-on `SCRIPT.md` — the narrative spine authored before the beat-level
+ * Always-on `SCRIPT.md` - the narrative spine authored before the beat-level
  * STORYBOARD.md. Kind tailors the guidance (a `motion`/`product` script is a
  * shot/asset list; a `story`/`cinema` script is a scene-by-scene narrative).
  */
 export function buildScriptMd(name: string, kind: SceneKind = DEFAULT_SCENE_KIND): string {
   const intent =
     kind === "product"
-      ? "Product walkthrough — what each section demonstrates, in order."
+      ? "Product walkthrough - what each section demonstrates, in order."
       : kind === "motion"
-        ? "Motion piece — the message and the beats of on-screen text/graphics."
+        ? "Motion piece - the message and the beats of on-screen text/graphics."
         : kind === "aivideo"
-          ? "AI-video script — the spoken/voiced narrative the generated shots illustrate."
-          : "Narrative script — scene-by-scene story, dialogue, and voiceover.";
-  return `# ${name} — Script
+          ? "AI-video script - the spoken/voiced narrative the generated shots illustrate."
+          : "Narrative script - scene-by-scene story, dialogue, and voiceover.";
+  return `# ${name} - Script
 
 > **Authoring order:** SCRIPT.md (this file) → STORYBOARD.md (beats + cues)${
     kindHasCast(kind) ? " → CHARACTERS.md (cast bible)" : ""
@@ -399,12 +399,12 @@ Voiceover / on-screen: …
 }
 
 /**
- * Kind-gated `CHARACTERS.md` — the cast bible. Promotes today's STORYBOARD
+ * Kind-gated `CHARACTERS.md` - the cast bible. Promotes today's STORYBOARD
  * \`characters:\` frontmatter into first-class identity blocks (reference sheet
  * path + an identity-lock description used to keep keyframes/i2v on-model).
  */
 export function buildCharactersMd(name: string): string {
-  return `# ${name} — Characters
+  return `# ${name} - Characters
 
 > Each character is referenced from STORYBOARD beats via the \`characters:\` cue.
 > The reference sheet + identity block keep keyframes and image-to-video on-model
@@ -413,8 +413,8 @@ export function buildCharactersMd(name: string): string {
 ## hero
 
 - **Reference sheet:** \`assets/characters/hero.png\` (a clean, front-lit full-body
-  or portrait sheet — the identity anchor for keyframe edits).
-- **Identity:** one paragraph of fixed, on-model traits — age, build, hair,
+  or portrait sheet - the identity anchor for keyframe edits).
+- **Identity:** one paragraph of fixed, on-model traits - age, build, hair,
   wardrobe, palette. Keep this stable across every beat.
 - **Range:** expressions / poses this character should hit.
 
@@ -434,14 +434,14 @@ tts: auto
 imageProvider: openai
 ---
 
-# ${name} — Storyboard
+# ${name} - Storyboard
 
 Edit these beats before running \`vibe build\`. Each beat starts with
 YAML cues that drive narration, backdrop generation, and timing.
 Pacing: keep beats 6-15 seconds (split longer ones); a 90s video should
 have 6-8 beats, not 3 long ones.
 
-## Beat hook — Hook
+## Beat hook - Hook
 
 \`\`\`yaml
 narration: "Introduce the promise in one crisp sentence."
@@ -452,7 +452,7 @@ duration: 4
 Show the core visual identity immediately. Keep copy short enough for one
 screen and one spoken breath.
 
-## Beat proof — Proof
+## Beat proof - Proof
 
 \`\`\`yaml
 narration: "Show the mechanism or proof point that makes the promise believable."
@@ -463,7 +463,7 @@ duration: 4
 Use this beat for the concrete differentiator: command, workflow, metric, or
 before/after.
 
-## Beat close — Close
+## Beat close - Close
 
 \`\`\`yaml
 narration: "Close with the action the viewer should remember."
@@ -478,7 +478,7 @@ final beat.
 
 /** Project-local AGENTS.md that orients every agent host to both toolchains. */
 export function buildProjectAgentsMd(name: string): string {
-  return `# ${name} — Scene Authoring Project
+  return `# ${name} - Scene Authoring Project
 
 This is the canonical cross-agent guidance file for this scene project.
 Claude Code imports it through \`CLAUDE.md\`; Codex, Cursor, Aider,
@@ -517,7 +517,7 @@ contradict DESIGN.md are rejected by the Hyperframes \`hyperframes\`
 skill.
 
 Single-asset requests (\`vibe generate image|video|speech|...\`) do NOT
-consult this file — run the generate command directly.
+consult this file - run the generate command directly.
 
 Browse named styles: \`vibe scene list-styles\`. Re-seed from one with
 \`vibe scene init . --visual-style "Swiss Pulse"\` (idempotent).
@@ -532,8 +532,9 @@ after init, those two files are the working source of truth.
 Use \`media/\` for user-provided source files: product photos, screenshots,
 logos, B-roll, recorded narration, or reference clips. Keep those inputs
 inside this project so build references stay project-relative. Do not put user
-media in \`references/\`; that directory is reserved for local composition
-rules installed by VibeFrame.
+media in \`references/\`; older VibeFrame versions vendored composition rules
+there, and current installs keep the rules under \`.agents/skills/hyperframes/\`
+via \`vibe scene install-skill\`.
 
 When a beat should reuse a local file, reference it from \`STORYBOARD.md\`
 with a project-relative path:
@@ -589,7 +590,7 @@ project-level agent loop; it provides \`--json\` commands, dry runs, cost caps,
 \`requiresConfirmation\`, \`fixOwner\`, deterministic repair, and render
 inspection for the host agent to reason over.
 
-Copy-paste agent prompts — plain prompts, not a built-in command:
+Copy-paste agent prompts - plain prompts, not a built-in command:
 
 \`\`\`text
 Build this VibeFrame project into renders/final.mp4. Use --json for every
@@ -617,9 +618,9 @@ target duration/aspect ratio, clean render inspection, any AI review score >= 90
 no unresolved unacknowledged host-agent issues.
 \`\`\`
 
-## Skills — USE THESE FIRST
+## Skills - USE THESE FIRST
 
-**Load the \`hyperframes\` skill before authoring scenes** — it encodes the
+**Load the \`hyperframes\` skill before authoring scenes** - it encodes the
 composition rules, motion principles, type system, and visual-identity gate.
 If your agent has it installed globally it is already available; otherwise run
 \`vibe scene install-skill\`, which runs upstream's installer and writes
@@ -631,7 +632,7 @@ semantics, VibeFrame pipeline conventions) that are NOT in generic web docs.
 
 | Skill             | Command          | When to use                                                                           |
 | ----------------- | ---------------- | ------------------------------------------------------------------------------------- |
-| **hyperframes**   | \`/hyperframes\`   | Cinematic-quality composition — DESIGN.md hard-gate, named styles, motion principles  |
+| **hyperframes**   | \`/hyperframes\`   | Cinematic-quality composition - DESIGN.md hard-gate, named styles, motion principles  |
 | **vibe-scene**    | \`/vibe-scene\`    | VibeFrame's authoring loop, AI assets, lint feedback, pipeline integration            |
 | **gsap**          | \`/gsap\`          | GSAP tweens, timelines, easing                                                        |
 
@@ -642,22 +643,22 @@ npx skills add heygen-com/hyperframes
 \`\`\`
 
 Restart your agent session (or reload the skill list) after installing.
-If skills aren't available, follow the **Key Rules** below — they cover
+If skills aren't available, follow the **Key Rules** below - they cover
 the framework-level minimum, not the cinematic craft layer.
 
 ## Project structure
 
-- \`DESIGN.md\` — visual identity contract (palette, type, motion, transitions)
-- \`STORYBOARD.md\` — per-beat narration/backdrop/duration cues for \`vibe build\`
-- \`media/\` — user-provided source files (photos, logos, clips, voice recordings)
-- \`index.html\` — root composition (timeline)
-- \`compositions/scene-*.html\` — per-scene HTML authored by you or the agent
-- \`assets/\` — generated/canonical build media (narration audio, images, video)
-- \`.agents/skills/hyperframes/\` — upstream composition rules, when installed here rather than globally
-- \`transcript.json\` — Whisper word-level transcript (if narration exists)
-- \`hyperframes.json\` — HF registry config (speak to both toolchains)
-- \`vibe.config.json\` — canonical VibeFrame config (providers, budget)
-- \`renders/\` — output MP4s
+- \`DESIGN.md\` - visual identity contract (palette, type, motion, transitions)
+- \`STORYBOARD.md\` - per-beat narration/backdrop/duration cues for \`vibe build\`
+- \`media/\` - user-provided source files (photos, logos, clips, voice recordings)
+- \`index.html\` - root composition (timeline)
+- \`compositions/scene-*.html\` - per-scene HTML authored by you or the agent
+- \`assets/\` - generated/canonical build media (narration audio, images, video)
+- \`.agents/skills/hyperframes/\` - upstream composition rules, when installed here rather than globally
+- \`transcript.json\` - Whisper word-level transcript (if narration exists)
+- \`hyperframes.json\` - HF registry config (speak to both toolchains)
+- \`vibe.config.json\` - canonical VibeFrame config (providers, budget)
+- \`renders/\` - output MP4s
 
 ## Commands
 
@@ -667,7 +668,7 @@ vibe build                                                 # STORYBOARD.md → n
 vibe scene lint                                             # Validate scenes (in-process HF linter)
 vibe render                                                 # Render to MP4
 
-# Hyperframes CLI (if installed — works in this project too)
+# Hyperframes CLI (if installed - works in this project too)
 npx hyperframes preview
 npx hyperframes render
 \`\`\`
@@ -675,7 +676,7 @@ npx hyperframes render
 ## Key Rules (for hand-authored scene HTML)
 
 1. Every timed element needs \`data-start\`, \`data-duration\`, and \`data-track-index\`.
-2. Elements with timing **MUST** have \`class="clip"\` — the framework uses this for visibility control.
+2. Elements with timing **MUST** have \`class="clip"\` - the framework uses this for visibility control.
 3. Timelines must be paused and registered on \`window.__timelines\`:
    \`\`\`js
    window.__timelines = window.__timelines || {};
@@ -687,12 +688,12 @@ npx hyperframes render
    \`filter\` tweens to \`.scene-content\` or any ancestor containing live text.
    Animate background/media layers instead; text/cards should enter briefly and
    then hold still at their final CSS positions.
-7. Only deterministic logic — no \`Date.now()\`, \`Math.random()\`, or network fetches.
+7. Only deterministic logic - no \`Date.now()\`, \`Math.random()\`, or network fetches.
 
-## Linting — run after changes
+## Linting - run after changes
 
 \`\`\`bash
-vibe scene lint           # preferred — in-process, no network
+vibe scene lint           # preferred - in-process, no network
 vibe scene lint --fix     # auto-fix mechanical issues
 vibe scene lint --json    # structured output for agent loops
 \`\`\`
@@ -703,7 +704,7 @@ vibe scene lint --json    # structured output for agent loops
 export function buildProjectClaudeMd(name: string): string {
   return `@AGENTS.md
 
-# ${name} — Claude Code Overrides
+# ${name} - Claude Code Overrides
 
 This file imports \`AGENTS.md\`; keep cross-agent VibeFrame and
 Hyperframes instructions there so Codex, Cursor, Aider, Gemini CLI, and
@@ -714,7 +715,7 @@ only when this project needs them.
 
 /** Minimal .gitignore for a scene project. */
 export function buildSceneGitignore(): string {
-  return `# VibeFrame — caches, checkpoints, and project-scope config.yaml (may contain API keys)
+  return `# VibeFrame - caches, checkpoints, and project-scope config.yaml (may contain API keys)
 .vibeframe/
 
 # Render outputs
@@ -753,7 +754,7 @@ export interface ScaffoldOptions {
   visualStyle?: VisualStyle;
   /** Scaffold shape. Defaults to "full" for backward-compatible programmatic use. */
   profile?: SceneScaffoldProfile;
-  /** Project kind — drives which pipeline stages run + the default composer. */
+  /** Project kind - drives which pipeline stages run + the default composer. */
   kind?: SceneKind;
 }
 
@@ -856,7 +857,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
   const merged: string[] = [];
 
   if (profile === "full") {
-    // hyperframes.json — merge if exists, else create.
+    // hyperframes.json - merge if exists, else create.
     const hfPath = resolve(dir, "hyperframes.json");
     const hfDefaults = buildHyperframesConfig();
     if (await pathExists(hfPath)) {
@@ -870,7 +871,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
       created.push(hfPath);
     }
 
-    // meta.json — preserve existing (id shouldn't change).
+    // meta.json - preserve existing (id shouldn't change).
     const metaPath = resolve(dir, "meta.json");
     if (await pathExists(metaPath)) {
       skipped.push(metaPath);
@@ -883,7 +884,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
       created.push(metaPath);
     }
 
-    // index.html — preserve existing (user may have edited root).
+    // index.html - preserve existing (user may have edited root).
     const rootPath = resolve(dir, "index.html");
     if (await pathExists(rootPath)) {
       skipped.push(rootPath);
@@ -893,7 +894,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
     }
   }
 
-  // vibe.project.yaml — preserve existing; this is VibeFrame's own config.
+  // vibe.project.yaml - preserve existing; this is VibeFrame's own config.
   const vibeConfigJsonPath = resolve(dir, VIBE_CONFIG_FILENAME);
   if (await pathExists(vibeConfigJsonPath)) {
     skipped.push(vibeConfigJsonPath);
@@ -903,7 +904,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
   }
 
   if (profile === "agent" || profile === "full") {
-    // AGENTS.md — canonical cross-tool guidance; preserve existing.
+    // AGENTS.md - canonical cross-tool guidance; preserve existing.
     const agentsPath = resolve(dir, "AGENTS.md");
     if (await pathExists(agentsPath)) {
       skipped.push(agentsPath);
@@ -912,7 +913,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
       created.push(agentsPath);
     }
 
-    // CLAUDE.md — preserve existing content, but ensure it imports AGENTS.md.
+    // CLAUDE.md - preserve existing content, but ensure it imports AGENTS.md.
     const claudePath = resolve(dir, "CLAUDE.md");
     if (await pathExists(claudePath)) {
       const existing = await readFile(claudePath, "utf-8");
@@ -928,7 +929,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
     }
   }
 
-  // DESIGN.md — visual-identity hard-gate (Hyperframes skill convention).
+  // DESIGN.md - visual-identity hard-gate (Hyperframes skill convention).
   // Preserve existing so users can hand-edit between init runs.
   const designPath = resolve(dir, "DESIGN.md");
   if (await pathExists(designPath)) {
@@ -938,7 +939,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
     created.push(designPath);
   }
 
-  // STORYBOARD.md — starter cues for the one-shot build flow.
+  // STORYBOARD.md - starter cues for the one-shot build flow.
   // Preserve existing so users can hand-edit between init runs.
   const storyboardPath = resolve(dir, "STORYBOARD.md");
   if (await pathExists(storyboardPath)) {
@@ -948,7 +949,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
     created.push(storyboardPath);
   }
 
-  // SCRIPT.md — always-on narrative spine (authored before STORYBOARD beats).
+  // SCRIPT.md - always-on narrative spine (authored before STORYBOARD beats).
   const scriptPath = resolve(dir, "SCRIPT.md");
   if (await pathExists(scriptPath)) {
     skipped.push(scriptPath);
@@ -957,7 +958,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
     created.push(scriptPath);
   }
 
-  // CHARACTERS.md — only for kinds with a recurring cast (cinema/story/aivideo).
+  // CHARACTERS.md - only for kinds with a recurring cast (cinema/story/aivideo).
   if (kindHasCast(kind)) {
     const charactersPath = resolve(dir, "CHARACTERS.md");
     if (await pathExists(charactersPath)) {
@@ -968,7 +969,7 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
     }
   }
 
-  // .gitignore — preserve existing.
+  // .gitignore - preserve existing.
   const gitignorePath = resolve(dir, ".gitignore");
   if (await pathExists(gitignorePath)) {
     skipped.push(gitignorePath);

--- a/packages/cli/src/commands/_shared/storyboard-draft.ts
+++ b/packages/cli/src/commands/_shared/storyboard-draft.ts
@@ -39,7 +39,7 @@ providers:
 # ${product} - Storyboard
 
 Pacing: keep beats 6-15 seconds. Longer beats render as static, overstuffed
-scenes — split them instead.
+scenes - split them instead.
 
 Brief: ${brief}
 

--- a/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.test.ts
+++ b/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.test.ts
@@ -65,9 +65,12 @@ describe("walkthroughs", () => {
       expect(r.content).toContain("--asset");
     });
 
-    it("scene walkthrough mentions Plan H mode dispatch (--mode agent)", () => {
+    it("scene walkthrough describes agent authoring and the template fallback", () => {
       const r = loadWalkthrough("scene");
-      expect(r.content).toMatch(/--mode agent/);
+      // The internal LLM composer is gone (#276): the guide must not point
+      // agents at removed --mode batch, and must name the surviving fallback.
+      expect(r.content).not.toMatch(/--mode batch/);
+      expect(r.content).toContain("--composer template");
       expect(r.content).toContain("compose-prompts");
     });
 

--- a/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
+++ b/packages/cli/src/commands/_shared/walkthroughs/walkthroughs.ts
@@ -5,7 +5,7 @@
  * `/vibe-pipeline` slash commands. After Plan H, host agents
  * (Claude Code, Codex, Cursor, Aider, Gemini CLI, OpenCode) all read
  * SKILL.md from the user's project and can drive `vibe build`
- * directly — but discoverability of the *workflow* itself was still
+ * directly - but discoverability of the *workflow* itself was still
  * Claude-Code-only via the slash menu.
  *
  * `vibe guide <topic>` closes that gap: any host (or a human at
@@ -32,20 +32,22 @@ export interface WalkthroughResult {
   steps: string[];
   /** Related vibe CLI commands referenced by the walkthrough. */
   relatedCommands: string[];
-  /** Full markdown body — same content the Claude Code slash command loads. */
+  /** Full markdown body - same content the Claude Code slash command loads. */
   content: string;
 }
 
 const SCENE_WALKTHROUGH = `# Scene authoring with vibe
 
 A scene project is a directory that is **bilingual**: it works with both
-\`vibe\` and \`npx hyperframes\`. Each scene is one HTML file with scoped CSS
-and a paused GSAP timeline. Cheap to edit, cheap to lint, expensive only
+\`vibe\` and \`npx hyperframes\`. Scene composition is Hyperframes' job:
+each scene is one HTML file with scoped CSS and a paused GSAP timeline,
+authored to upstream's composition rules (install them with
+\`vibe scene install-skill\`). Cheap to edit, cheap to lint, expensive only
 at render.
 
-\`vibe build\` (v0.60+) is the supported one-shot driver from a
-written storyboard to an MP4. Plan H (v0.70) added \`--mode agent\` so the
-host agent itself authors the per-beat HTML — no internal LLM call.
+\`vibe build\` is the supported one-shot driver from a written storyboard
+to an MP4. The host agent authors the per-beat HTML - the CLI makes no
+internal LLM call.
 
 ## Three authoring paths
 
@@ -60,20 +62,20 @@ narration / backdrop intent.
 
 ## High-craft path
 
-1. \`vibe init my-promo --visual-style "Swiss Pulse"\` — seeds
+1. \`vibe init my-promo --visual-style "Swiss Pulse"\` - seeds
    \`DESIGN.md\` (palette, typography, motion, transitions) plus the
    \`vibe.config.json\` / \`hyperframes.json\` / \`index.html\` scaffold.
    It does **not** install the composition rules; if your agent does not
    already have the \`hyperframes\` skill, run
    \`vibe scene install-skill\` to fetch them from upstream into
    \`.agents/skills/hyperframes/\`.
-2. Read \`.agents/skills/hyperframes/SKILL.md\` (or your global copy) —
+2. Read \`.agents/skills/hyperframes/SKILL.md\` (or your global copy) -
    framework rules, motion principles, type system, transition recipes.
-3. Read \`DESIGN.md\` — project-specific palette / typography / motion
+3. Read \`DESIGN.md\` - project-specific palette / typography / motion
    signature (visual identity hard-gate).
 4. Author each scene HTML directly under \`compositions/scene-<id>.html\`
    using the rules from steps 2 and 3. The skill enforces the visual
-   identity contract — scenes that contradict DESIGN.md fail lint.
+   identity contract - scenes that contradict DESIGN.md fail lint.
 5. \`vibe scene lint --fix\` for mechanical issues, \`vibe render my-promo\`
    to MP4.
 
@@ -87,16 +89,16 @@ vibe scene lint
 vibe render my-promo
 \`\`\`
 
-\`vibe init\` is **idempotent** — running it on an existing Hyperframes
+\`vibe init\` is **idempotent** - running it on an existing Hyperframes
 directory merges \`hyperframes.json\` instead of clobbering it. Safe to
 invoke on user-provided projects.
 
 ## Subcommands
 
 \`\`\`bash
-# Project flow (top-level — preferred entry points)
+# Project flow (top-level - preferred entry points)
 vibe init <dir> [-r 16:9|9:16|1:1|4:5] [-d <sec>] [--visual-style "<name>"]
-vibe build [<dir>] [--mode agent|batch|auto]         # H3 dispatch
+vibe build [<dir>] [--composer template]          # agent authors scenes by default
 vibe render [<dir>] [--fps 30] [--quality standard] [--format mp4]
 
 # Lower-level scene authoring
@@ -109,11 +111,11 @@ vibe scene lint [<root>] [--json] [--fix]
 
 ## Style presets (for \`vibe scene add --style\`)
 
-- **simple** — backdrop + bottom caption (default)
-- **announcement** — single huge headline, gradient text
-- **explainer** — kicker + title + subtitle stack
-- **kinetic-type** — words animate in word-by-word
-- **product-shot** — corner label + bottom headline + slow zoom
+- **simple** - backdrop + bottom caption (default)
+- **announcement** - single huge headline, gradient text
+- **explainer** - kicker + title + subtitle stack
+- **kinetic-type** - words animate in word-by-word
+- **product-shot** - corner label + bottom headline + slow zoom
 
 All presets accept \`--narration <text|file>\`, \`--visuals <prompt>\`,
 \`--headline\`, \`--kicker\`. With \`--narration\`, scene duration auto-derives
@@ -123,21 +125,19 @@ from the generated TTS audio.
 
 \`\`\`bash
 vibe init my-promo --visual-style "Swiss Pulse" -d 12
-# (edit STORYBOARD.md with per-beat YAML cues — narration, backdrop, duration)
+# (edit STORYBOARD.md with per-beat YAML cues - narration, backdrop, duration)
 vibe build my-promo
 \`\`\`
 
 \`vibe build\` reads the STORYBOARD frontmatter + per-beat cues,
 dispatches TTS + image-gen per beat, then either:
 
-- **\`--mode agent\`** (default when an agent host is detected) — emits a
-  \`needs-author\` plan via \`vibe scene compose-prompts\`. The host agent
-  authors each \`compositions/scene-<id>.html\` itself, then re-invoking
-  \`vibe build\` proceeds to lint + render.
-- **\`--mode batch\`** — VibeFrame runs an internal LLM (Claude / OpenAI /
-  Gemini) to compose the HTML, then renders.
-
-\`VIBE_BUILD_MODE\` env var overrides the auto-resolve.
+- **Agent authoring** (default) - emits a \`needs-author\` plan via
+  \`vibe scene compose-prompts\`. The host agent authors each
+  \`compositions/scene-<id>.html\` itself, then re-invoking \`vibe build\`
+  proceeds to lint + render. The CLI makes no internal LLM call.
+- **\`--composer template\`** - the deterministic no-model composer
+  (concat background + lower-thirds), for when no agent is available.
 
 ## Lint feedback loop
 
@@ -147,7 +147,7 @@ vibe scene lint --json --fix
 
 Returns structured findings. The recommended loop: 1) run lint with
 \`--fix\` (mechanical fixes applied), 2) if \`errorCount > 0\`, edit the
-scene HTML, 3) re-lint. Cap retries at 3 — if errors persist, fall back
+scene HTML, 3) re-lint. Cap retries at 3 - if errors persist, fall back
 to a template preset (\`vibe scene add <id> --style simple --force\`)
 and surface the error to the user.
 
@@ -224,9 +224,9 @@ The full set lives in \`packages/cli/src/pipeline/executor.ts\`.
 
 ## Variable references
 
-- \`$<step-id>.output\` — previous step's output path
-- \`$<step-id>.result.<field>\` — structured field from JSON result
-- \`\${ENV_VAR}\` — environment variable
+- \`$<step-id>.output\` - previous step's output path
+- \`$<step-id>.result.<field>\` - structured field from JSON result
+- \`\${ENV_VAR}\` - environment variable
 - Values can be templated: \`"\${SCRIPT_TITLE} - Episode \${EPISODE}"\`
 
 ## Running
@@ -243,12 +243,12 @@ Checkpoints land next to the YAML: \`pipeline.yaml.checkpoint.json\`.
 
 ## Authoring tips
 
-1. **Start from a tiny YAML** — keep it in your project directory and run
+1. **Start from a tiny YAML** - keep it in your project directory and run
    \`vibe run pipeline.yaml --dry-run\` before spending provider budget.
-2. **Dry-run first** — you see estimated cost and resolved variable
+2. **Dry-run first** - you see estimated cost and resolved variable
    graph before spending API credits.
 3. **Keep step ids short and descriptive** (\`intro\`, \`scene1\`, \`voice\`,
-   \`bgm\`) — they appear in logs and variable refs.
+   \`bgm\`) - they appear in logs and variable refs.
 4. **Name outputs** with extensions matching the action (\`.mp4\`, \`.mp3\`,
    \`.png\`, \`.json\`).
 5. **Declare \`budget:\`** on expensive pipelines:
@@ -272,10 +272,10 @@ When the user has a working shell sequence, extract steps:
 - Wrap the entire chain in a \`name:\` + \`steps:\` skeleton
 
 The \`compose\` action is the catch-all assembly step (audio mux, video
-overlay, etc.) — useful at the tail of a pipeline.
+overlay, etc.) - useful at the tail of a pipeline.
 `;
 
-const ARCHITECTURE_WALKTHROUGH = `# vibe agent / build / run — when to pick which
+const ARCHITECTURE_WALKTHROUGH = `# vibe agent / build / run - when to pick which
 
 The CLI has three orchestrating commands that coordinate other primitives:
 \`vibe agent\`, \`vibe build\`, \`vibe run\`. New users routinely ask which one
@@ -304,14 +304,14 @@ built-in fallback when you do not already have an agent host.
 - "I have a finished script + visual identity" → \`vibe build\`
 - "I want this to run again next month" → \`vibe run\`
 
-If two seem to fit, pick the rightmost one — more reproducible, less surprise.
+If two seem to fit, pick the rightmost one - more reproducible, less surprise.
 
 ## Cost-tier awareness (v0.83+)
 
 Every primitive subcommand carries a cost tier (\`free\` / \`low\` / \`high\` /
 \`very-high\`). \`vibe schema --list\` exposes the tier as JSON, and each
 \`vibe <group> <sub> --help\` page shows it as a colored footer. Use
-\`vibe doctor --test-keys\` before kicking off any high-cost orchestrator —
+\`vibe doctor --test-keys\` before kicking off any high-cost orchestrator -
 a single bad key wastes time and money.
 
 ## Cross-command primitives
@@ -423,7 +423,7 @@ const META: Record<WalkthroughTopic, Pick<WalkthroughResult, "title" | "summary"
     title: "YAML pipelines (Video as Code)",
     summary: "Author and run reproducible multi-step video workflows",
     steps: [
-      "Sketch the workflow as YAML — `name`, `description`, then `steps:` with `id` + `action` + inputs/outputs.",
+      "Sketch the workflow as YAML - `name`, `description`, then `steps:` with `id` + `action` + inputs/outputs.",
       "Reference previous step outputs via `$<step-id>.output` (or `$<step-id>.result.<field>` for structured returns).",
       "Run `vibe run pipeline.yaml --dry-run` to see the resolved graph + cost estimate before spending API budget.",
       "Add a `budget:` block (tokens / cost_usd / max_tool_errors) to cap expensive runs.",
@@ -466,7 +466,7 @@ const CONTENT: Record<WalkthroughTopic, string> = {
 /** All walkthrough topics this CLI knows. */
 export const WALKTHROUGH_TOPICS: readonly WalkthroughTopic[] = ["motion", "scene", "pipeline", "architecture"] as const;
 
-/** Pure data accessor — no I/O. Throws on unknown topic. */
+/** Pure data accessor - no I/O. Throws on unknown topic. */
 export function loadWalkthrough(topic: WalkthroughTopic): WalkthroughResult {
   const meta = META[topic];
   const content = CONTENT[topic];

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -552,7 +552,7 @@ function printNeedsAuthor(result: SceneBuildResult): void {
   console.log("  Then run: vibe build");
   console.log(
     chalk.dim(
-      "  Use `vibe build --mode batch` when you want the CLI to call an LLM composer instead."
+      "  Use `vibe build --composer template` for the deterministic no-model composer instead."
     )
   );
 }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -38,7 +38,7 @@ import { outputSuccess } from "./output.js";
 
 /**
  * Mapping of env vars to the commands they unlock. Derived from the
- * provider registry — each provider's `commandsUnlocked` aggregates by
+ * provider registry - each provider's `commandsUnlocked` aggregates by
  * apiKey. Pre-v0.68 this was hand-maintained alongside the provider
  * arrays; v0.68 collapsed both into the registry.
  */
@@ -75,7 +75,7 @@ export const doctorCommand = new Command("doctor")
     `
 Examples:
   $ vibe doctor              Compact health summary (issues + Ready %)
-  $ vibe doctor --verbose    Full report — all providers, composer, free commands
+  $ vibe doctor --verbose    Full report - all providers, composer, free commands
   $ vibe doctor --test-keys  Validate each configured key against its provider
   $ vibe doctor --json       Machine-readable output
 `
@@ -110,7 +110,7 @@ Examples:
  * The Homebrew core `ffmpeg` formula on macOS ships **without** several
  * libs we need (`libfreetype` → drawtext, `libass` → subtitles). The
  * `homebrew-ffmpeg/ffmpeg` tap rebuilds with the kitchen sink. Apple's
- * suggestions used to read "brew reinstall ffmpeg" — that does nothing
+ * suggestions used to read "brew reinstall ffmpeg" - that does nothing
  * because the formula itself omits the libs. Fixed in v0.79.1. */
 const REQUIRED_FFMPEG_FILTERS: Record<string, { commands: string[]; fix: Record<string, string> }> =
   {
@@ -195,11 +195,11 @@ interface DiagnosticResults {
       cwd: string;
       /** True when ANY of (AGENTS.md / CLAUDE.md / vibe.project.yaml) exists. */
       initialized: boolean;
-      /** Per-file existence — each entry is informational for the report. */
+      /** Per-file existence - each entry is informational for the report. */
       files: { path: string; exists: boolean }[];
       /** `<cwd>/.vibeframe/config.yaml` path (whether or not it exists). */
       configPath: string;
-      /** `<cwd>/.vibeframe/config.yaml` exists — `vibe setup --scope project` has run here. */
+      /** `<cwd>/.vibeframe/config.yaml` exists - `vibe setup --scope project` has run here. */
       configFileExists: boolean;
     };
     agentHosts: {
@@ -376,7 +376,7 @@ async function runDiagnostics(): Promise<DiagnosticResults> {
     composerEnv = composerEnvVar(r.provider);
   } catch (err) {
     if (!(err instanceof ComposerResolveError)) throw err;
-    // No composer key — composerResolved stays null. Reported in render.
+    // No composer key - composerResolved stays null. Reported in render.
   }
   const sceneProjectInCwd = existsSync(resolve(cwd, "STORYBOARD.md"));
   // Upstream's installer owns these rules now, so "installed" means any place
@@ -510,7 +510,7 @@ function printReport(
   console.log();
   console.log(chalk.bold("  Scope"));
 
-  // Config scope — which config.yaml is being read
+  // Config scope - which config.yaml is being read
   const userActive = results.scope.activeScope === "user" && results.scope.user.configured;
   const projectActive = results.scope.activeScope === "project";
   const activeMark = chalk.cyan(" ← active");
@@ -551,7 +551,7 @@ function printReport(
     console.log(`    Cfg error  ${chalk.red(results.scope.configError.message)}`);
   }
 
-  // Project init — vibe init scaffolding (AGENTS.md / CLAUDE.md / vibe.project.yaml)
+  // Project init - vibe init scaffolding (AGENTS.md / CLAUDE.md / vibe.project.yaml)
   if (results.scope.project.initialized) {
     const present = results.scope.project.files.filter((f) => f.exists).map((f) => f.path);
     console.log(`    Init       ${chalk.green("OK")}       ${chalk.dim(present.join(", "))}`);
@@ -561,10 +561,10 @@ function printReport(
     );
   }
 
-  // Agent hosts — informational
+  // Agent hosts - informational
   console.log(`    Agents     ${chalk.dim(results.scope.agentHosts.summary)}`);
 
-  // Plan H — scene composer (verbose only — most users don't tune this).
+  // Scene composer (verbose only - most users don't tune this).
   if (verbose) {
     console.log();
     console.log(chalk.bold("  Scene composer (vibe build)"));
@@ -574,11 +574,11 @@ function printReport(
     );
     if (sc.composer) {
       console.log(
-        `    Revise LLM   ${chalk.green("OK")}     ${chalk.dim(`${composerLabel(sc.composer)} (${sc.composerEnvVar}) — powers 'vibe storyboard revise'`)}`
+        `    Revise LLM   ${chalk.green("OK")}     ${chalk.dim(`${composerLabel(sc.composer)} (${sc.composerEnvVar}) - powers 'vibe storyboard revise'`)}`
       );
     } else {
       console.log(
-        `    Revise LLM   ${chalk.yellow("--")}     ${chalk.dim("no ANTHROPIC_API_KEY / GOOGLE_API_KEY / OPENAI_API_KEY — 'vibe storyboard revise' unavailable")}`
+        `    Revise LLM   ${chalk.yellow("--")}     ${chalk.dim("no ANTHROPIC_API_KEY / GOOGLE_API_KEY / OPENAI_API_KEY - 'vibe storyboard revise' unavailable")}`
       );
     }
     if (sc.sceneProjectInCwd) {
@@ -592,7 +592,7 @@ function printReport(
       }
     } else {
       console.log(
-        `    HF rules     ${chalk.dim("(no STORYBOARD.md in cwd — rules are per-scene-project)")}`
+        `    HF rules     ${chalk.dim("(no STORYBOARD.md in cwd - rules are per-scene-project)")}`
       );
     }
   }
@@ -604,7 +604,7 @@ function printReport(
   const missing: string[] = [];
 
   // Friendly label disambiguates gateways (Seedance 2.0 via fal.ai) from
-  // direct providers — derived from the `displayName`+`gateway` pair when
+  // direct providers - derived from the `displayName`+`gateway` pair when
   // present, else the apiKey's own label.
   const labelFor = (configKey: string, fallbackEnv: string): string => {
     const label = getDisplayLabelForApiKey(configKey);
@@ -633,7 +633,7 @@ function printReport(
         );
       }
     } else {
-      // Compact: one summary line — keeps the "what's missing" signal but
+      // Compact: one summary line - keeps the "what's missing" signal but
       // doesn't blast 11 rows when the user has only configured 2.
       console.log(
         chalk.dim(
@@ -643,7 +643,7 @@ function printReport(
     }
   }
 
-  // Free commands (verbose only — they're always available, no signal in
+  // Free commands (verbose only - they're always available, no signal in
   // the default view).
   if (verbose) {
     console.log();
@@ -651,7 +651,7 @@ function printReport(
     console.log(`    ${chalk.dim(FREE_COMMANDS.join(", "))}`);
   }
 
-  // Summary — three counts, each describing a different slice. Three
+  // Summary - three counts, each describing a different slice. Three
   // numbers used to drift unlabeled (catalog total, runnable count,
   // cost-tagged count) so they're now grouped together with explicit
   // labels and `vibe schema --list` is the canonical "show me
@@ -690,7 +690,7 @@ function printReport(
   }
 
   // ── v0.61: scope-aware "what to do next" hint ────────────────────────
-  // Prioritise scope problems over provider gaps — a user without setup
+  // Prioritise scope problems over provider gaps - a user without setup
   // configured can't run 'vibe setup' to add providers either.
   const nextStep = pickNextStep(results, missing.length > 0);
   if (nextStep) {
@@ -747,7 +747,7 @@ function countCostTiers(program: Command): Record<CostTier, number> {
 }
 
 /**
- * `--test-keys` driver. Runs sequentially — most providers rate-limit
+ * `--test-keys` driver. Runs sequentially - most providers rate-limit
  * authenticated requests and parallelism would also clutter the
  * progressive output.
  */
@@ -760,7 +760,7 @@ async function runLiveKeyTests(results: DiagnosticResults): Promise<void> {
 
   const configured = Object.entries(results.providers).filter(([, info]) => info.configured);
   if (configured.length === 0) {
-    console.log(chalk.dim("    No keys configured — nothing to test."));
+    console.log(chalk.dim("    No keys configured - nothing to test."));
     return;
   }
 
@@ -778,7 +778,7 @@ async function runLiveKeyTests(results: DiagnosticResults): Promise<void> {
       process.env[info.envVar] ||
       PROVIDER_ENV_ALIASES[info.envVar]?.map((alias) => process.env[alias]).find(Boolean) ||
       activeConfig?.providers[name as keyof typeof activeConfig.providers];
-    if (!value) continue; // shouldn't happen — info.configured already checked
+    if (!value) continue; // shouldn't happen - info.configured already checked
     process.stdout.write(`    ${name.padEnd(12)} `);
     const result = await testKey(name, value);
     if (result.skipped) {
@@ -801,7 +801,7 @@ async function runLiveKeyTests(results: DiagnosticResults): Promise<void> {
  *  4. everything ok → no hint
  */
 function pickNextStep(results: DiagnosticResults, hasMissingProviders: boolean): string | null {
-  // Either scope satisfies "configured" — project-only users shouldn't be
+  // Either scope satisfies "configured" - project-only users shouldn't be
   // nagged to run user-scope setup.
   const anyConfigured = results.scope.user.configured || results.scope.project.configFileExists;
   if (!anyConfigured) {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -71,7 +71,7 @@ function parseScope(raw: unknown): Scope {
 }
 
 export const setupCommand = new Command("setup")
-  .description("Configure VibeFrame (LLM provider, API keys)")
+  .description("Configure VibeFrame (video/image provider keys, LLM provider)")
   .option("--reset", "Reset configuration to defaults")
   .option("--full", "Run full setup with all optional providers")
   .option("--show", "Show current configuration (for debugging)")
@@ -102,8 +102,8 @@ Non-interactive examples (no TTY required):
   vibe setup --scope project --yes --import-env           Project-only setup (./.vibeframe/config.yaml)
 
 Scopes:
-  user    (default) ~/.vibeframe/config.yaml — shared across every project
-  project ./.vibeframe/config.yaml — gitignored, isolates keys/defaults to this directory
+  user    (default) ~/.vibeframe/config.yaml - shared across every project
+  project ./.vibeframe/config.yaml - gitignored, isolates keys/defaults to this directory
           When a project config exists at the cwd, it is used and the user file is ignored.
 
 Exit codes (non-interactive):
@@ -357,7 +357,7 @@ const AI_FEATURES: AIFeature[] = [
     label: "Audio",
     desc: "TTS, SFX, music, voice clone",
     defaultProvider:
-      "ElevenLabs (paid, premium quality) — falls back to local Kokoro when no key (free, since v0.54)",
+      "ElevenLabs (paid, premium quality) - falls back to local Kokoro when no key (free, since v0.54)",
     alsoAvailable: "Replicate MusicGen (music only)",
     keyHint: "0-1 key",
     keys: [
@@ -605,7 +605,7 @@ function mergeSelectedFeatures(current: AIFeature[], next: AIFeature[]): AIFeatu
 /**
  * Non-interactive setup for CI / devcontainer / scripted bootstrap.
  *
- * Exits 0 even when no fields are touched — running `vibe setup --yes` with no
+ * Exits 0 even when no fields are touched - running `vibe setup --yes` with no
  * other flags is a valid "ensure config file exists" idempotency op, similar
  * to `git init`. Prints a one-line summary so callers can grep for it.
  */
@@ -744,7 +744,7 @@ async function runSetupWizard(fullSetup = false, scope: Scope = "user"): Promise
     scope === "project"
       ? "applies to this project only · user config is ignored while this file exists · add .vibeframe/ to .gitignore"
       : "applies to every project for this user";
-  console.log(chalk.bold.magenta("VibeFrame Setup") + chalk.bold(` — ${scope} scope`));
+  console.log(chalk.bold.magenta("VibeFrame Setup") + chalk.bold(` - ${scope} scope`));
   console.log(chalk.dim(`${cfgPath} · ${scopeNote}`));
   if (userStatus?.source === "legacy") {
     console.log(
@@ -762,7 +762,7 @@ async function runSetupWizard(fullSetup = false, scope: Scope = "user"): Promise
   console.log();
 
   // Show detected agent hosts up-front so the user knows VibeFrame can
-  // tell what they have. Informational only — never blocks setup.
+  // tell what they have. Informational only - never blocks setup.
   const hosts = detectedAgentHosts();
   console.log(chalk.dim(`Agent hosts: ${summariseAgentHosts(hosts)}`));
   console.log();
@@ -785,17 +785,17 @@ async function runSetupWizard(fullSetup = false, scope: Scope = "user"): Promise
   console.log();
 
   const topLabels = [
+    `Generate AI video ${chalk.dim("(build from a storyboard, remix highlights, auto-shorts)")}`,
+    `AI features ${chalk.dim("(pick what you need - images, videos, audio, editing)")}`,
     `Edit videos offline ${chalk.dim("(silence-cut, fade, noise-reduce, detect)")} ${chalk.green("no API keys")}`,
-    `AI features ${chalk.dim("(pick what you need — images, videos, audio, editing)")}`,
-    `Full AI pipeline ${chalk.dim("(build, remix highlights, auto-shorts)")}`,
-    `Full provider list ${chalk.dim("(every supported provider, one by one — same as --full)")}`,
+    `Full provider list ${chalk.dim("(every supported provider, one by one - same as --full)")}`,
   ];
 
   const topIndex = await promptSelect(chalk.cyan("  Select [1-4]: "), topLabels, 0);
   console.log();
 
   // ── Edit videos (FREE) ─────────────────────────────────────────────
-  if (topIndex === 0) {
+  if (topIndex === 2) {
     await saveConfig(config, { scope });
     await completeOrContinue(config, "vibe edit silence-cut video.mp4 -o clean.mp4", [], scope);
     return;
@@ -809,8 +809,8 @@ async function runSetupWizard(fullSetup = false, scope: Scope = "user"): Promise
     return;
   }
 
-  // ── Full AI pipeline ───────────────────────────────────────────────
-  if (topIndex === 2) {
+  // ── Generate AI video (full pipeline) ──────────────────────────────
+  if (topIndex === 0) {
     config.llm.provider = "claude";
     const pipelineKeys: AIFeatureKey[] = [
       {
@@ -818,7 +818,7 @@ async function runSetupWizard(fullSetup = false, scope: Scope = "user"): Promise
         envVar: "ANTHROPIC_API_KEY",
         name: "Anthropic",
         url: "https://console.anthropic.com/settings/keys",
-        what: "Claude — storyboard generation + reasoning",
+        what: "Claude - storyboard generation + reasoning",
       },
       {
         configKey: "openai",
@@ -832,7 +832,7 @@ async function runSetupWizard(fullSetup = false, scope: Scope = "user"): Promise
         envVar: "FAL_API_KEY",
         name: "fal.ai",
         url: "https://fal.ai/dashboard/keys",
-        what: "Seedance 2.0 — video generation, default since v0.57",
+        what: "Seedance 2.0 - video generation, default since v0.57",
       },
       {
         configKey: "elevenlabs",
@@ -1196,7 +1196,7 @@ async function collectKeys(
 }
 
 /**
- * Custom setup — provider-by-provider (old --full flow)
+ * Custom setup - provider-by-provider (old --full flow)
  */
 async function runCustomSetup(
   config: Awaited<ReturnType<typeof loadConfig>> & object,
@@ -1222,7 +1222,7 @@ async function runCustomSetup(
     xai: "Grok 4.1 Fast, 2M context, great for tool calling",
     openrouter: "300+ models via one API key (Claude, GPT, Gemini, Llama, etc.)",
     evolink: "GPT-5, Claude, Gemini, DeepSeek & more via one key",
-    ollama: "Free, local, no API key — offline capable (default: llama3.2)",
+    ollama: "Free, local, no API key - offline capable (default: llama3.2)",
   };
   const providerLabels = providers.map((p) => {
     const rec = p === "claude" ? chalk.dim(" (recommended)") : "";
@@ -1243,7 +1243,7 @@ async function runCustomSetup(
   console.log(chalk.dim("   Press Enter to skip any provider you don't need."));
   console.log();
 
-  // Derived from the provider registry — adding/editing a row means
+  // Derived from the provider registry - adding/editing a row means
   // editing `defineApiKey({...setupDescription})` in
   // `packages/ai-providers/src/api-keys.ts`. The order follows declaration
   // order in api-keys.ts.
@@ -1321,7 +1321,7 @@ async function showComplete(
 
   // The first try-this command is what most users will run next; copy it
   // to the clipboard so they can paste straight into the next prompt.
-  // Best-effort — failures are silent (missing pbcopy/xclip, headless CI).
+  // Best-effort - failures are silent (missing pbcopy/xclip, headless CI).
   const primaryTry = features.length > 1 ? features[0].tryCommand : defaultTryCommand;
   if (features.length > 1) {
     console.log(chalk.bold("  Try these:"));
@@ -1345,7 +1345,7 @@ async function showComplete(
     )
   );
 
-  // Surface every registered guide — the topic table is the single
+  // Surface every registered guide - the topic table is the single
   // source of truth (`walkthroughs.ts`), so adding a topic there shows up
   // here automatically. When an agent host is detected, the `scene` flow
   // is the canonical entry point so we tag it (recommended).
@@ -1363,7 +1363,7 @@ async function showComplete(
   console.log(chalk.dim("    vibe schema --list        Discover every command"));
   console.log(chalk.dim("    vibe setup                Re-run user-scope setup anytime"));
 
-  // Tab-completion install hint — pick the user's likely shell from
+  // Tab-completion install hint - pick the user's likely shell from
   // $SHELL, fall back to a generic line. Runs once at setup time so
   // returning users see it.
   const shellHint = pickCompletionHint(process.env.SHELL);
@@ -1373,30 +1373,30 @@ async function showComplete(
     console.log(chalk.dim(`    ${shellHint}`));
   }
 
-  // Tailored hint when an agent host is detected — points at the file
-  // `vibe init` will scaffold for that host, and surfaces the Plan H
-  // agentic compose path so they know `vibe build` will dispatch to
-  // their host agent automatically.
+  // Tailored hint when an agent host is detected - points at the file
+  // `vibe init` will scaffold for that host. Scene HTML is authored by the
+  // host agent; there is no internal LLM composer (removed in v0.113).
   const hosts = detectedAgentHosts();
   const primary = hosts[0];
   if (primary) {
     console.log();
     console.log(
       chalk.dim(
-        `  Detected ${primary.label} — \`vibe init\` will scaffold ${primary.projectFiles.join(" + ")} in your project.`
+        `  Detected ${primary.label} - \`vibe init\` will scaffold ${primary.projectFiles.join(" + ")} in your project.`
       )
     );
     console.log(
       chalk.dim(
-        `  Scene composer will auto-dispatch to ${primary.label} (${chalk.bold("--mode agent")}). ` +
-          `Run \`vibe init my-promo\` to scaffold a video project + install local composition rules.`
+        `  ${primary.label} authors each scene during \`vibe build\`. ` +
+          `Run \`vibe init my-promo\` to scaffold a video project.`
       )
     );
   } else {
     console.log();
     console.log(
       chalk.dim(
-        `  No agent host detected — \`vibe build\` will use the internal LLM composer (${chalk.bold("--mode batch")}).`
+        `  No agent host detected - scenes are authored by a coding agent during \`vibe build\`; ` +
+          `pass ${chalk.bold("--composer template")} for the deterministic no-model fallback.`
       )
     );
   }
@@ -1411,7 +1411,7 @@ async function setupClaudeCode(): Promise<void> {
   console.log(chalk.bold.cyan("Claude Code Integration"));
   console.log(chalk.dim("─".repeat(40)));
   console.log();
-  console.log("  VibeFrame CLI is self-discoverable — no extra setup needed.");
+  console.log("  VibeFrame CLI is self-discoverable - no extra setup needed.");
   console.log("  Claude Code can use these commands to understand the CLI:");
   console.log();
   console.log(`  ${chalk.green("vibe --help")}                  All command groups`);
@@ -1436,7 +1436,7 @@ function maskApiKey(key: string): string {
  *
  * Default mode lists only set keys + the LLM provider + config path.
  * `--verbose` re-adds unset rows, the Defaults block, and the
- * Resolution order — useful when troubleshooting why a key isn't being
+ * Resolution order - useful when troubleshooting why a key isn't being
  * picked up. The default keeps a returning user's status check to
  * roughly the screen height.
  */
@@ -1558,13 +1558,13 @@ async function showConfig(opts: { verbose: boolean } = { verbose: false }): Prom
   if (!verbose && unsetCount > 0) {
     console.log(
       chalk.dim(
-        `  (${unsetCount} provider${unsetCount === 1 ? "" : "s"} unset — run with --verbose to list)`
+        `  (${unsetCount} provider${unsetCount === 1 ? "" : "s"} unset - run with --verbose to list)`
       )
     );
   }
   console.log();
 
-  // Defaults + resolution order are debugging aids — only useful when
+  // Defaults + resolution order are debugging aids - only useful when
   // something's actually wrong. Hide behind --verbose by default.
   if (verbose) {
     if (config) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -119,7 +119,7 @@ const program = new Command();
 program
   .name("vibe")
   .showSuggestionAfterError(true)
-  .description("VibeFrame CLI - video projects, AI media generation, and workflow automation")
+  .description("VibeFrame CLI - AI video generation on your own provider keys, behind dry runs and a hard cost cap")
   .version(pkg.version)
   .option("--json", "Output in JSON format")
   .option("-q, --quiet", "Output only the primary result value (path, URL, or ID)")

--- a/packages/cli/src/utils/first-run.ts
+++ b/packages/cli/src/utils/first-run.ts
@@ -59,19 +59,23 @@ export async function markBannerShown(): Promise<void> {
 export function showFirstRunBanner(): void {
   console.log();
   console.log(chalk.cyan.bold("  Welcome to VibeFrame!"));
-  console.log(chalk.dim("  AI-native video editing from your terminal."));
+  console.log(chalk.dim("  Frontier video generation for your coding agent. Your keys, your ceiling."));
   console.log();
   console.log(
-    `  ${chalk.white("1.")} ${chalk.green("vibe setup")}         Configure API keys ${chalk.dim("(1 min)")}`
+    `  ${chalk.white("1.")} ${chalk.green("vibe init demo --from \"30s video\"")}  Scaffold a project ${chalk.dim("(no key needed)")}`
   );
-  console.log(`  ${chalk.white("2.")} ${chalk.green("vibe doctor")}        Check system health`);
-  console.log(`  ${chalk.white("3.")} ${chalk.green("vibe --help")}        See all commands`);
+  console.log(
+    `  ${chalk.white("2.")} ${chalk.green("vibe build demo --dry-run")}          Price it before any spend`
+  );
+  console.log(
+    `  ${chalk.white("3.")} ${chalk.green("vibe setup")}                         Add provider keys when a step generates`
+  );
   console.log();
   console.log(chalk.dim("  Try without keys:"));
   console.log(
-    `    ${chalk.green("vibe demo")}                          Run sample edits on a test video`
+    `    ${chalk.green("vibe build demo --dry-run --max-cost 5")}  See the cost gate refuse an over-budget build`
   );
+  console.log(chalk.dim("    vibe demo                        Run sample edits on a test video"));
   console.log(chalk.dim("    vibe edit silence-cut video.mp4 -o clean.mp4"));
-  console.log(chalk.dim("    vibe detect scenes video.mp4"));
   console.log();
 }

--- a/packages/mcp-server/build-mcpb.js
+++ b/packages/mcp-server/build-mcpb.js
@@ -167,8 +167,9 @@ const manifest = {
   version: pkg.version,
   description: pkg.description,
   long_description:
-    "AI-native video editing for Claude Desktop. Draft a storyboard, generate narration and backdrops, " +
-    "author HTML/GSAP scenes (scene_submit lets Claude write them in-chat), and render the result to MP4 — " +
+    "AI video generation for Claude Desktop, on your own provider keys and behind dry runs and cost caps. " +
+    "Draft a storyboard, generate narration, backdrops, and video clips, author HTML/GSAP scenes " +
+    "(scene_submit lets Claude write them in-chat), and render the result to MP4 - " +
     "all inside the workspace folder you pick below. Free local narration (Kokoro) is bundled and needs no " +
     "install; rendering requires Google Chrome and ffmpeg on this machine.",
   author: {

--- a/packages/mcp-server/src/cli-flags.ts
+++ b/packages/mcp-server/src/cli-flags.ts
@@ -13,9 +13,10 @@ function usage(version: string): string {
   return [
     `VibeFrame MCP Server v${version}`,
     "",
-    "AI-native video editing exposed over the Model Context Protocol (stdio).",
+    "AI video generation and editing exposed over the Model Context Protocol",
+    "(stdio), on your own provider keys and behind dry runs and cost caps.",
     "It is launched by an MCP client (Claude Desktop, Cursor, Claude Code), not",
-    "run directly — there is normally nothing to interact with on the terminal.",
+    "run directly - there is normally nothing to interact with on the terminal.",
     "",
     "Add it to your client config:",
     "",


### PR DESCRIPTION
Follow-up to #283 (metadata/docs). This PR aligns what the **running CLI actually prints and writes** with the product that ships today.

## Stale behavior claims (worst first)

- **`vibe init` wrote stale claims into every user project.** The generated project `AGENTS.md` claimed "AI-powered video editing", documented the internal LLM composer removed in #276 (provider auto-selection `claude > gemini > openai` + a per-provider latency table), and said VibeFrame installs composition rules into `references/` (removed in #278). These files are read by the *user's* agents on every session, so the errors propagated into their work.
- **Three surfaces pointed at the removed `--mode batch` composer**: setup's no-agent hint, build's `needs-author` next-step hint, and `vibe guide scene`. All now point at `--composer template`, the fallback that exists.
- **`.agents/skills/vibe-scene/SKILL.md` recommended `vibe build --mode batch --composer openai` as the default demo path** - a command that no longer does what it says. Replaced with the host-agent path; `.claude/` mirror regenerated via `pnpm agent-sync`.

## Identity strings

- First-run banner: "AI-native video editing" + "step 1: configure API keys" → leads with `init` + `--dry-run` pricing (no key needed); keys move to the point where a step generates.
- `vibe --help` top-level description, `vibe setup` description, agent-mode system prompt, `CONTEXT.md` (ships in the npm tarball), mcp-server `--help`, and the `.mcpb` store copy all carry the generation-on-your-keys / hard-cost-cap identity now.
- `vibe setup` goal menu leads with the generation lane instead of offline editing.

## Consistency

- The scene scaffold emitted em-dash beat headings (`## Beat hook — Hook`) while the brief drafter emitted hyphens; the parser accepts `—`/`:`/`-` interchangeably. Both generators now emit hyphens, and the README / docs examples follow.
- Em dashes swept from every touched runtime/template string.

## Tests

- Walkthrough test now asserts `--mode batch` is NOT mentioned and `--composer template` is (the old test asserted the stale content).
- `vibe setup --describe` drift snapshot updated; scene-project expectations follow the hyphen headings.
- E2E: ran `vibe init` (both scene and `--type agent` paths) in a clean directory and grepped the generated files - no stale claims, no em dashes.
- `pnpm -F @vibeframe/cli test` 1230 passed, mcp-server 73 passed, lint clean, `gen:reference:check` green.

https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp