### PR TITLE
docs: carry the generation positioning through the site body and installer

### DIFF
--- a/apps/web/app/demo/page.tsx
+++ b/apps/web/app/demo/page.tsx
@@ -51,7 +51,7 @@ export default function DemoPage() {
           <div className="text-center mb-8">
             <div className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/5 px-4 py-1.5 text-sm text-blue-400 mb-6 animate-fade-in">
               <Video className="w-4 h-4" />
-              <span>Agentic storyboard demo</span>
+              <span>Agent demo · brief to MP4</span>
             </div>
             <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight mb-6 animate-fade-in-up">
               From setup
@@ -61,13 +61,17 @@ export default function DemoPage() {
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto mb-8 animate-fade-in-up delay-100">
               The demo starts with{" "}
               <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-sm">
-                vibe setup --scope project
-              </code>
-              , runs{" "}
-              <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-sm">
                 vibe init launch
-              </code>
-              , then a host agent researches a topic and edits{" "}
+              </code>{" "}
+              and a free{" "}
+              <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-sm">
+                --dry-run
+              </code>{" "}
+              price check (keys come in at{" "}
+              <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-sm">
+                vibe setup --scope project
+              </code>{" "}
+              once a step generates), then a host agent researches a topic and edits{" "}
               <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-sm">
                 STORYBOARD.md
               </code>{" "}
@@ -126,7 +130,7 @@ export default function DemoPage() {
               Build, generate, edit, and remix are separate lanes.
             </h2>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto mb-8">
-              Use the storyboard project loop for full videos. Use primitives for one asset. Use
+              Use the project loop for full videos. Use primitives for one asset. Use
               edit/remix/audio when the input is already a media file.
             </p>
           </div>
@@ -150,7 +154,7 @@ export default function DemoPage() {
         </div>
       </section>
 
-      {/* Reproducible surfaces — copy-paste command sequences for each entry point. */}
+      {/* Reproducible surfaces - copy-paste command sequences for each entry point. */}
       <section className="py-20 px-4 border-t border-border/50">
         <div className="mx-auto max-w-5xl">
           <div className="text-center mb-12">
@@ -164,7 +168,7 @@ export default function DemoPage() {
               <span className="text-primary">from your terminal.</span>
             </h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto mb-12 animate-fade-in-up delay-100">
-              Plain CLI, optional built-in agent, or a host agent — same project files and command
+              Plain CLI, optional built-in agent, or a host agent - same project files and command
               contracts. Each surface below is the exact command sequence you run.
             </p>
           </div>
@@ -177,9 +181,9 @@ export default function DemoPage() {
               command="vibe generate image '...' -o frame.png && vibe generate video '...' -i frame.png -o clip.mp4 && vibe inspect media clip.mp4"
             />
             <TapeCard
-              badge="2 · Storyboard dogfood"
-              title="Storyboard build"
-              note="Host agent runs the fuller storyboard build, report, render, and YAML workflow"
+              badge="2 · Project dogfood"
+              title="Priced project build"
+              note="Host agent runs the full build under a cost cap, reports, render, and YAML workflow"
               command="vibe init launch --from brief.md && vibe build launch --max-cost 5 && vibe render launch && vibe run workflow.yaml"
             />
           </div>

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -188,7 +188,7 @@ export default async function Image() {
             color: "#71717a",
           }}
         >
-          <span>Open source video CLI</span>
+          <span>Frontier video generation for coding agents</span>
           <span>•</span>
           <span>MIT</span>
           <span>•</span>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -189,7 +189,7 @@ export default function LandingPage() {
             </Link>
           </div>
           <p className="mt-4 text-xs text-muted-foreground animate-fade-in-up delay-300">
-            Desktop extension: open the downloaded .mcpb, pick a workspace folder, done — no
+            Desktop extension: open the downloaded .mcpb, pick a workspace folder, done - no
             terminal needed.
           </p>
         </div>
@@ -220,8 +220,8 @@ export default function LandingPage() {
             <div className="rounded-lg border border-border/50 bg-secondary/30 p-4">
               <div className="font-mono font-semibold text-foreground">BUILD</div>
               <p className="mt-2 text-muted-foreground">
-                Primary path: rough brief, optional media, setup, init, storyboard/design, generated
-                assets, composition, render.
+                Primary path: rough brief, optional media, dry-run price, generated assets on your
+                keys, Hyperframes composition, render.
               </p>
             </div>
             <div className="rounded-lg border border-border/50 bg-secondary/30 p-4">
@@ -322,7 +322,7 @@ export default function LandingPage() {
           </p>
 
           <p className="text-center text-sm text-muted-foreground mt-8">
-            Primary path: <span className="text-foreground font-medium">BUILD</span> from storyboard
+            Primary path: <span className="text-foreground font-medium">price, then generate</span>{" "}
             via{" "}
             <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
               vibe build
@@ -404,7 +404,7 @@ export default function LandingPage() {
             {[
               ["Storyboard", "list, get, set, move, validate, revise"],
               ["Plan", "costs, missing cues, provider needs"],
-              ["Build", "assets, scene composition, timing sync"],
+              ["Build", "generated assets under --max-cost, composition, timing sync"],
               ["Review", "inspect project, inspect render, reports"],
               ["Repair", "deterministic scene fixes after review"],
               ["Primitives", "generate, edit, remix, audio, YAML"],
@@ -421,7 +421,7 @@ export default function LandingPage() {
         </div>
       </section>
 
-      {/* ② Use with your AI agent — host-agnostic showcase + Tier 2 callout */}
+      {/* ② Use with your AI agent - host-agnostic showcase + Tier 2 callout */}
       <section className="py-20 px-4 border-t border-border/50 relative">
         <div className="mx-auto max-w-5xl">
           <div className="text-center mb-12">
@@ -457,7 +457,7 @@ export default function LandingPage() {
             />
           </div>
 
-          {/* Six-host grid — equal cards, same example, different scaffold target */}
+          {/* Six-host grid - equal cards, same example, different scaffold target */}
           <div className="text-center mb-6">
             <p className="text-sm text-muted-foreground">
               <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
@@ -516,7 +516,7 @@ export default function LandingPage() {
         </div>
       </section>
 
-      {/* ②.5 — Step-by-step workflow guides */}
+      {/* ②.5 - Step-by-step workflow guides */}
       <section className="py-20 px-4 border-t border-border/50 relative">
         <div className="mx-auto max-w-5xl">
           <div className="text-center mb-10">
@@ -546,7 +546,14 @@ export default function LandingPage() {
                 vibe guide scene
               </div>
               <p className="text-sm text-muted-foreground">
-                Scene authoring — STORYBOARD.md → composed video via{" "}
+                Scene authoring - STORYBOARD.md → video composed on{" "}
+                <a
+                  href="https://github.com/heygen-com/hyperframes"
+                  className="text-primary hover:underline"
+                >
+                  Hyperframes
+                </a>{" "}
+                rules via{" "}
                 <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
                   vibe build
                 </code>{" "}
@@ -612,7 +619,7 @@ export default function LandingPage() {
               <div className="bg-background/50 backdrop-blur-sm rounded-xl p-4 mb-6 border border-border/50">
                 <p className="text-sm text-muted-foreground mb-2">In Claude Desktop:</p>
                 <p className="text-foreground italic">
-                  "Load the scene guide, build the storyboard project in demo-video, then render the
+                  "Dry-run the build in demo-video, then generate under a $10 cap and render the
                   final MP4"
                 </p>
               </div>
@@ -681,13 +688,13 @@ export default function LandingPage() {
               <FeatureItem
                 icon={<Wand2 className="w-5 h-5" />}
                 title="Natural Language"
-                description="'Build this storyboard into a launch video' — when no host agent is available"
+                description="'Build this storyboard into a launch video' - when no host agent is available"
                 gradient="from-blue-500 to-cyan-500"
               />
               <FeatureItem
                 icon={<Zap className="w-5 h-5" />}
                 title={`${process.env.NEXT_PUBLIC_LLM_PROVIDERS} LLM Providers`}
-                description="OpenAI, Claude, Gemini, xAI Grok, OpenRouter, Ollama, Evolink — swap with -p flag"
+                description="OpenAI, Claude, Gemini, xAI Grok, OpenRouter, Ollama, Evolink - swap with -p flag"
                 gradient="from-yellow-500 to-orange-500"
               />
               <FeatureItem
@@ -719,7 +726,7 @@ export default function LandingPage() {
               Declarative YAML pipelines when you need them
             </h2>
             <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-              The storyboard project loop is the default. Use YAML when you need a reproducible
+              The project loop is the default. Use YAML when you need a reproducible
               multi-step workflow with budget guards, checkpoints, and step references.
             </p>
           </div>
@@ -753,7 +760,7 @@ export default function LandingPage() {
               <code className="text-purple-400">{"    action: "}</code>
               <code className="text-blue-400">{"generate-tts\n"}</code>
               <code className="text-purple-400">{"    text: "}</code>
-              <code className="text-green-400">{'"Start with a storyboard."\n'}</code>
+              <code className="text-green-400">{'"Generated on your own keys."\n'}</code>
               <code className="text-purple-400">{"    output: "}</code>
               <code className="text-yellow-400">{"assets/narration.mp3"}</code>
             </pre>
@@ -776,18 +783,26 @@ export default function LandingPage() {
           <div className="text-center mb-16">
             <h2 className="text-3xl sm:text-4xl font-bold mb-4">Primary path and escape hatches</h2>
             <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-              Start with the storyboard build. Drop into primitives only when an agent needs one
-              asset, one edit, or one reproducible pipeline.
+              Start with the priced build: dry-run first, generate under the cap. Drop into
+              primitives only when an agent needs one asset, one edit, or one reproducible
+              pipeline.
             </p>
           </div>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
             <PipelineCard
               icon={<Film className="w-6 h-6" />}
-              title="Storyboard Build"
-              command="vibe build my-video --json"
-              description="STORYBOARD.md + DESIGN.md to assets, scenes, reports"
+              title="Build Under a Cap"
+              command="vibe build my-video --max-cost 12 --json"
+              description="STORYBOARD.md + DESIGN.md to generated assets, scenes, reports - refuses over the ceiling"
               gradient="from-blue-500 to-purple-500"
+            />
+            <PipelineCard
+              icon={<Sparkles className="w-6 h-6" />}
+              title="Frontier Generation"
+              command="vibe generate video"
+              description="One clip on Seedance, Runway, Veo, or Kling - your keys, dry-run priced"
+              gradient="from-purple-500 to-pink-500"
             />
             <PipelineCard
               icon={<Layers className="w-6 h-6" />}
@@ -797,11 +812,11 @@ export default function LandingPage() {
               gradient="from-green-500 to-teal-500"
             />
             <PipelineCard
-              icon={<Sparkles className="w-6 h-6" />}
-              title="Auto Highlights"
+              icon={<Zap className="w-6 h-6" />}
+              title="Auto Highlights + Shorts"
               command="vibe remix highlights"
-              description="Long video → AI analysis → best moments"
-              gradient="from-purple-500 to-pink-500"
+              description="Long video → best moments, or vertical shorts with captions"
+              gradient="from-orange-500 to-yellow-500"
             />
             <PipelineCard
               icon={<MessageSquare className="w-6 h-6" />}
@@ -809,13 +824,6 @@ export default function LandingPage() {
               command="vibe remix animated-caption"
               description="Word-by-word TikTok/Reels-style captions"
               gradient="from-pink-500 to-red-500"
-            />
-            <PipelineCard
-              icon={<Zap className="w-6 h-6" />}
-              title="Auto Shorts"
-              command="vibe remix auto-shorts"
-              description="Long video → vertical shorts with captions"
-              gradient="from-orange-500 to-yellow-500"
             />
             <PipelineCard
               icon={<Wand2 className="w-6 h-6" />}
@@ -832,11 +840,11 @@ export default function LandingPage() {
       <section className="py-20 px-4">
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="text-3xl sm:text-4xl font-bold mb-4">
-            Open source storyboard workflows for agents.
+            Open source frontier video generation for coding agents.
           </h2>
           <p className="text-muted-foreground text-lg mb-8">
-            MIT licensed · v{process.env.NEXT_PUBLIC_VERSION} · project files, JSON reports,
-            terminal commands, YAML, and MCP workflows.
+            MIT licensed · v{process.env.NEXT_PUBLIC_VERSION} · your keys, your bill, your ceiling
+            - CLI, MCP tools, JSON reports, and recovery contracts.
           </p>
 
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/apps/web/components/demo-showcase.tsx
+++ b/apps/web/components/demo-showcase.tsx
@@ -18,14 +18,14 @@ export function DemoShowcase() {
         <DemoVideoCard
           eyebrow="Process highlight"
           title="Agent loop in under a minute"
-          description="From rough brief and optional media inputs through setup, research, storyboard/design updates, image cues, build, render, and review."
+          description="From rough brief and optional media inputs through dry-run pricing, research, storyboard/design updates, capped generation, render, and review."
           src={PROCESS_HIGHLIGHT_VIDEO}
           icon={<Terminal className="w-4 h-4" />}
         />
         <DemoVideoCard
           eyebrow="Final result"
           title="The rendered MP4"
-          description="The shareable MP4 from the storyboard-driven build path, without exposing the whole process."
+          description="The shareable MP4 from the generation build path, without exposing the whole process."
           src={RESULT_VIDEO}
           icon={<Film className="w-4 h-4" />}
         />
@@ -55,13 +55,13 @@ function FlagshipCard() {
       <div className="p-5">
         <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
           <PlayCircle className="w-4 h-4" />
-          Flagship render — one character, many scenes
+          Flagship render - one character, many scenes
         </div>
         <h3 className="text-xl font-semibold text-foreground">
-          Chasing Light — one photographer across a single arctic night
+          Chasing Light - one photographer across a single arctic night
         </h3>
         <p className="mt-2 text-sm leading-6 text-muted-foreground">
-          Trek, first aurora, the whole sky, dawn — the same character throughout. Character sheet →
+          Trek, first aurora, the whole sky, dawn - the same character throughout. Character sheet →
           image storyboard → image-to-video → composed render, generated end-to-end by{" "}
           <code>vibe build</code>.
         </p>

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -5,7 +5,7 @@
 # Default (CLI-only, fastest):
 #   curl -fsSL https://vibeframe.ai/install.sh | bash
 #
-# Full installation (includes web UI):
+# Full installation (builds every workspace package, including the website):
 #   curl -fsSL https://vibeframe.ai/install.sh | bash -s -- --full
 #
 
@@ -68,9 +68,9 @@ banner() {
   echo -e "${MAGENTA} ╚████╔╝ ██║██████╔╝███████╗${NC}  ${MAGENTA}██║     ██║  ██║██║  ██║██║ ╚═╝ ██║███████╗${NC}"
   echo -e "${MAGENTA}  ╚═══╝  ╚═╝╚═════╝ ╚══════╝${NC}  ${MAGENTA}╚═╝     ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝${NC}"
   echo ""
-  echo -e "${DIM}AI-First Video Editor${NC}"
+  echo -e "${DIM}Frontier video generation for your coding agent. Your keys, your ceiling.${NC}"
   if [ "$FULL_INSTALL" = true ]; then
-    echo -e "${DIM}Full installation (CLI + Web UI)${NC}"
+    echo -e "${DIM}Full installation (all workspace packages)${NC}"
   else
     echo -e "${DIM}CLI installation${NC}"
   fi
@@ -292,24 +292,13 @@ echo ""
 echo -e "${DIM}─────────────────────────────────────────${NC}"
 echo ""
 
-if [ "$FULL_INSTALL" = true ]; then
-  echo "Quick start:"
-  echo ""
-  echo -e "  ${CYAN}vibe setup${NC}                # Configure API keys"
-  echo -e "  ${CYAN}vibe doctor${NC}               # Check what's ready"
-  echo -e "  ${CYAN}vibe guide${NC}                # Choose the right workflow"
-  echo -e "  ${CYAN}vibe --help${NC}               # Show all commands"
-  echo -e "  ${CYAN}pnpm dev${NC}                  # Start web UI (http://localhost:3000)"
-else
-  echo "Quick start:"
-  echo ""
-  echo -e "  ${CYAN}vibe setup${NC}                # Configure API keys"
-  echo -e "  ${CYAN}vibe doctor${NC}               # Check what's ready"
-  echo -e "  ${CYAN}vibe guide${NC}                # Choose the right workflow"
-  echo -e "  ${CYAN}vibe --help${NC}               # Show all commands"
-  echo ""
-  echo -e "${DIM}Want web UI? Reinstall with: curl ... | bash -s -- --full${NC}"
-fi
+echo "Quick start:"
+echo ""
+echo -e "  ${CYAN}vibe init demo --from \"30s video\"${NC}   # Scaffold a project (no key needed)"
+echo -e "  ${CYAN}vibe build demo --dry-run${NC}           # Price it before any spend"
+echo -e "  ${CYAN}vibe setup${NC}                          # Add provider keys when a step generates"
+echo -e "  ${CYAN}vibe doctor${NC}                         # Check what's ready"
+echo -e "  ${CYAN}vibe --help${NC}                         # Show all commands"
 echo ""
 
 # Ask to run setup (unless skipped)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@
 # Default (CLI-only, fastest):
 #   curl -fsSL https://vibeframe.ai/install.sh | bash
 #
-# Full installation (includes web UI):
+# Full installation (builds every workspace package, including the website):
 #   curl -fsSL https://vibeframe.ai/install.sh | bash -s -- --full
 #
 
@@ -68,9 +68,9 @@ banner() {
   echo -e "${MAGENTA} ╚████╔╝ ██║██████╔╝███████╗${NC}  ${MAGENTA}██║     ██║  ██║██║  ██║██║ ╚═╝ ██║███████╗${NC}"
   echo -e "${MAGENTA}  ╚═══╝  ╚═╝╚═════╝ ╚══════╝${NC}  ${MAGENTA}╚═╝     ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝${NC}"
   echo ""
-  echo -e "${DIM}AI-First Video Editor${NC}"
+  echo -e "${DIM}Frontier video generation for your coding agent. Your keys, your ceiling.${NC}"
   if [ "$FULL_INSTALL" = true ]; then
-    echo -e "${DIM}Full installation (CLI + Web UI)${NC}"
+    echo -e "${DIM}Full installation (all workspace packages)${NC}"
   else
     echo -e "${DIM}CLI installation${NC}"
   fi
@@ -292,24 +292,13 @@ echo ""
 echo -e "${DIM}─────────────────────────────────────────${NC}"
 echo ""
 
-if [ "$FULL_INSTALL" = true ]; then
-  echo "Quick start:"
-  echo ""
-  echo -e "  ${CYAN}vibe setup${NC}                # Configure API keys"
-  echo -e "  ${CYAN}vibe doctor${NC}               # Check what's ready"
-  echo -e "  ${CYAN}vibe guide${NC}                # Choose the right workflow"
-  echo -e "  ${CYAN}vibe --help${NC}               # Show all commands"
-  echo -e "  ${CYAN}pnpm dev${NC}                  # Start web UI (http://localhost:3000)"
-else
-  echo "Quick start:"
-  echo ""
-  echo -e "  ${CYAN}vibe setup${NC}                # Configure API keys"
-  echo -e "  ${CYAN}vibe doctor${NC}               # Check what's ready"
-  echo -e "  ${CYAN}vibe guide${NC}                # Choose the right workflow"
-  echo -e "  ${CYAN}vibe --help${NC}               # Show all commands"
-  echo ""
-  echo -e "${DIM}Want web UI? Reinstall with: curl ... | bash -s -- --full${NC}"
-fi
+echo "Quick start:"
+echo ""
+echo -e "  ${CYAN}vibe init demo --from \"30s video\"${NC}   # Scaffold a project (no key needed)"
+echo -e "  ${CYAN}vibe build demo --dry-run${NC}           # Price it before any spend"
+echo -e "  ${CYAN}vibe setup${NC}                          # Add provider keys when a step generates"
+echo -e "  ${CYAN}vibe doctor${NC}                         # Check what's ready"
+echo -e "  ${CYAN}vibe --help${NC}                         # Show all commands"
 echo ""
 
 # Ask to run setup (unless skipped)


### PR DESCRIPTION
Follow-up to #281 (hero) and #283 (metadata/docs). The vibeframe.ai hero was repositioned, but everything below it still argued the retired storyboard-workflow identity - and the curl installer opened with the oldest identity of all.

## What changed

- **`scripts/install.sh`** printed **"AI-First Video Editor"** (the first string most users ever see, via `curl https://vibeframe.ai/install.sh | bash`), advertised a "Web UI" that is not a product surface, and listed `vibe setup` (API keys) as the first post-install command. It now carries the generation identity and a quick start that prices before it spends. `apps/web/public/install.sh` is the prebuild-generated copy.
- **Final CTA**: "Open source storyboard workflows for agents" → "Open source frontier video generation for coding agents", with the keys/bill/ceiling line.
- **"Primary path and escape hatches"** led with the storyboard build over a 6-card grid where 4 cards were edit/remix. The grid now leads with **Build Under a Cap** and **Frontier Generation** (Seedance, Runway, Veo, Kling); remix cards compressed.
- **Hyperframes was never named anywhere on the site**, even though the positioning delegates scene composition to it. The BUILD lane card and the `vibe guide scene` card now name and link it.
- **Demo page** framed `vibe setup` (keys) as step 1; now leads with init + free dry-run, keys at the point of generation.
- Storyboard-first phrasing softened across the YAML section, MCP example prompt, demo lanes, and showcase captions - storyboard stays as the mechanism, not the headline.
- OG image tagline "Open source video CLI" → "Frontier video generation for coding agents".
- Em dashes removed from all rendered copy in touched files.

## Verification

- `pnpm -F @vibeframe/web build` green (public/install.sh regenerated by prebuild)
- `pnpm -F @vibeframe/web lint` clean, `bash -n scripts/install.sh` OK
- Full-page local render checked visually via Playwright

https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp