### PR TITLE
fix: make the --max-cost refusal use the structured error envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,25 @@ vibe build film --dry-run --max-cost 3 --json
 
 ```json
 {
-  "error": {
-    "code": "COST_CAP_EXCEEDED",
-    "message": "Estimated cost $10.93 exceeds --max-cost $3.00.",
-    "suggestion": "Raise --max-cost or reduce the stage/provider scope.",
-    "retryWith": [
-      "vibe build . --stage all --skip-backdrop --json",
-      "vibe build . --stage all --max-cost 10.93 --json"
-    ],
-    "recoverable": true
-  }
+  "success": false,
+  "error": "Estimated cost $10.93 exceeds --max-cost $3.00.",
+  "code": "COST_CAP_EXCEEDED",
+  "exitCode": 1,
+  "suggestion": "Raise --max-cost or reduce the stage/provider scope.",
+  "retryWith": [
+    "vibe build . --stage all --skip-backdrop --json",
+    "vibe build . --stage all --max-cost 10.93 --json"
+  ],
+  "recoverable": true,
+  "retryable": false,
+  "data": { "plan": { "estimatedCostUsd": 10.93, "...": "the full priced plan" } }
 }
 ```
 
-It exits non-zero, so an agent loop stops instead of guessing.
-`retryWith` gives it the two cheaper ways forward it can take without asking you.
+The envelope goes to stderr and the command exits 1, so an agent loop stops
+instead of guessing. `retryWith` gives it the two cheaper ways forward it can
+take without asking you, and `data.plan` carries the priced plan the refusal
+was based on, so it never has to re-run just to learn the estimate.
 The same dry run also names the keys each stage would need, so you find out what a video costs before you own an account:
 
 ```text

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -108,23 +108,28 @@ export default function LandingPage() {
                 <code className="text-foreground">
                   vibe build film --dry-run --max-cost 3 --json{"\n"}
                 </code>
-                <code className="text-muted-foreground">{'{ "error": {\n'}</code>
-                <code className="text-red-400">{'    "code": "COST_CAP_EXCEEDED",\n'}</code>
+                <code className="text-muted-foreground">{"{\n"}</code>
+                <code className="text-muted-foreground">{'  "success": false,\n'}</code>
                 <code className="text-red-400">
-                  {'    "message": "Estimated cost $10.93 exceeds --max-cost $3.00.",\n'}
+                  {'  "error": "Estimated cost $10.93 exceeds --max-cost $3.00.",\n'}
                 </code>
-                <code className="text-muted-foreground">{'    "retryWith": [\n'}</code>
+                <code className="text-red-400">{'  "code": "COST_CAP_EXCEEDED",\n'}</code>
+                <code className="text-muted-foreground">{'  "exitCode": 1,\n'}</code>
+                <code className="text-muted-foreground">{'  "retryWith": [\n'}</code>
                 <code className="text-muted-foreground">
-                  {'      "vibe build . --stage all --skip-backdrop --json",\n'}
+                  {'    "vibe build . --stage all --skip-backdrop --json",\n'}
                 </code>
                 <code className="text-muted-foreground">
-                  {'      "vibe build . --stage all --max-cost 10.93 --json"\n'}
+                  {'    "vibe build . --stage all --max-cost 10.93 --json"\n'}
                 </code>
-                <code className="text-muted-foreground">{"    ],\n"}</code>
-                <code className="text-muted-foreground">{'    "recoverable": true\n'}</code>
-                <code className="text-muted-foreground">{"} }\n"}</code>
+                <code className="text-muted-foreground">{"  ],\n"}</code>
+                <code className="text-muted-foreground">{'  "recoverable": true,\n'}</code>
+                <code className="text-muted-foreground">
+                  {'  "data": { "plan": { "estimatedCostUsd": 10.93 } }\n'}
+                </code>
+                <code className="text-muted-foreground">{"}\n"}</code>
                 <code className="text-green-400">
-                  {"# exit 1 - the agent stops instead of guessing"}
+                  {"# stderr, exit 1 - the agent stops instead of guessing"}
                 </code>
               </pre>
             </div>

--- a/packages/cli/CONTEXT.md
+++ b/packages/cli/CONTEXT.md
@@ -125,13 +125,17 @@ vibe guide <topic> --json              # Step-by-step guides (motion | scene | p
 }
 ```
 
-| Code            | Exit | Meaning             | Recovery                   |
-| --------------- | ---- | ------------------- | -------------------------- |
-| `USAGE_ERROR`   | 2    | bad arg             | check `vibe schema <cmd>`  |
-| `NOT_FOUND`     | 3    | file missing        | verify path                |
-| `AUTH_ERROR`    | 4    | key missing/invalid | `vibe doctor`              |
-| `API_ERROR`     | 5    | provider failed     | retry if `retryable: true` |
-| `NETWORK_ERROR` | 6    | connection          | retry with backoff         |
+| Code                 | Exit | Meaning                     | Recovery                          |
+| -------------------- | ---- | --------------------------- | --------------------------------- |
+| `COST_CAP_EXCEEDED`  | 1    | estimate over `--max-cost`  | follow `retryWith`; do not re-run as-is |
+| `USAGE_ERROR`        | 2    | bad arg                     | check `vibe schema <cmd>`         |
+| `NOT_FOUND`          | 3    | file missing                | verify path                       |
+| `AUTH_ERROR`         | 4    | key missing/invalid         | `vibe doctor`                     |
+| `API_ERROR`          | 5    | provider failed             | retry if `retryable: true`        |
+| `NETWORK_ERROR`      | 6    | connection                  | retry with backoff                |
+
+`COST_CAP_EXCEEDED` also carries `data.plan` - the priced plan the refusal was
+based on - so a refused call still tells you what the build would have cost.
 
 ## Authentication
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -20,6 +20,7 @@ import {
 } from "./_shared/build-plan.js";
 import { parseStoryboard } from "./_shared/storyboard-parse.js";
 import {
+  costCapError,
   exitWithError,
   generalError,
   isJsonMode,
@@ -186,38 +187,22 @@ Advanced equivalent: \`vibe scene build\`.`
         return;
       }
       if (maxCostUsd !== undefined && plan.estimatedCostUsd > maxCostUsd) {
-        const warning = `Estimated cost $${plan.estimatedCostUsd.toFixed(2)} exceeds --max-cost $${maxCostUsd.toFixed(2)}.`;
-        const retryWith = unique([
-          ...plan.retryWith,
-          `vibe build ${projectDirArg} --stage ${stage} --skip-backdrop --json`,
-          `vibe build ${projectDirArg} --stage ${stage} --max-cost ${plan.estimatedCostUsd} --json`,
-        ]);
-        if (isJsonMode() || isQuietMode()) {
-          outputSuccess({
-            command: "build",
-            startedAt,
-            dryRun: true,
-            warnings: [warning],
-            data: {
-              params,
-              plan,
-              costCapUsd: maxCostUsd,
-              code: "COST_CAP_EXCEEDED",
-              message: warning,
-              suggestion: "Raise --max-cost or reduce the stage/provider scope.",
-              retryWith,
-              recoverable: true,
-            },
-          });
-          process.exitCode = 1;
-          return;
-        }
-        console.log(chalk.red(warning));
-        if (retryWith.length > 0) {
-          console.log(chalk.dim(`Retry: ${retryWith[0]}`));
-        }
-        process.exitCode = 1;
-        return;
+        // A refused build is a failure, not a success carrying a warning, so
+        // it takes the same structured-error path as every other refusal:
+        // `success:false` on stderr, exit 1. The priced plan rides along in
+        // `data` so the caller still gets the estimate it was refused on.
+        exitWithError(
+          costCapError({
+            estimatedCostUsd: plan.estimatedCostUsd,
+            maxCostUsd,
+            retryWith: unique([
+              ...plan.retryWith,
+              `vibe build ${projectDirArg} --stage ${stage} --skip-backdrop --json`,
+              `vibe build ${projectDirArg} --stage ${stage} --max-cost ${plan.estimatedCostUsd} --json`,
+            ]),
+            data: { params, plan, costCapUsd: maxCostUsd },
+          })
+        );
       }
       if (!isJsonMode() && !isQuietMode()) {
         printBuildDryRun(projectDirArg, params, plan);

--- a/packages/cli/src/commands/error-envelopes.test.ts
+++ b/packages/cli/src/commands/error-envelopes.test.ts
@@ -24,8 +24,9 @@
  *   vitest run -u` and review the diff.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync } from "child_process";
+import { rmSync } from "node:fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -137,6 +138,81 @@ describe("structured error envelope (exitWithError → stderr)", () => {
       expect(env).toMatchSnapshot();
     });
   }
+});
+
+describe("--max-cost refusal (COST_CAP_EXCEEDED)", () => {
+  // This contract had no test, which is why it drifted: the gate used to emit
+  // a *success* envelope carrying a warning (exit 1, fields buried under
+  // `data`), while README and vibeframe.ai documented an error envelope. On
+  // top of that, `plan` reported COST_CAP_EXCEEDED/exit 1 under --json but
+  // USAGE_ERROR/exit 2 without it - two contracts for one condition,
+  // switched by a formatting flag.
+  //
+  // Build a throwaway project so the estimate is non-zero, then cap below it.
+  const projectDir = "/tmp/vibeframe-costcap-fixture";
+
+  function run(cmd: string): CliErrorResult {
+    return runCliExpectError(cmd);
+  }
+
+  beforeAll(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+    execSync(`${CLI} init ${projectDir} --from "a 30 second test video" --json`, {
+      encoding: "utf-8",
+      stdio: "ignore",
+      env: HERMETIC_ENV,
+      cwd: HERMETIC_CWD,
+    });
+  });
+
+  afterAll(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  for (const cmd of [
+    `build ${projectDir} --dry-run --max-cost 0.01 --json`,
+    `plan ${projectDir} --max-cost 0.01 --json`,
+  ]) {
+    it(`${cmd.split(" ")[0]} refuses on stderr with the standard error envelope`, () => {
+      const res = run(cmd);
+
+      // Refusal is a failure: exit 1, nothing on stdout, envelope on stderr.
+      expect(res.status).toBe(1);
+      expect(res.stdout.trim()).toBe("");
+
+      const env = JSON.parse(res.stderr) as Record<string, unknown>;
+      expect(env.success).toBe(false);
+      expect(env.code).toBe("COST_CAP_EXCEEDED");
+      expect(env.exitCode).toBe(1);
+      expect(env.recoverable).toBe(true);
+      expect(typeof env.error).toBe("string");
+      expect(env.suggestion).toBe("Raise --max-cost or reduce the stage/provider scope.");
+
+      // retryWith must offer a real way forward, including raising the cap to
+      // the actual estimate.
+      const retryWith = env.retryWith as string[];
+      expect(Array.isArray(retryWith)).toBe(true);
+      expect(retryWith.some((r) => r.includes("--max-cost"))).toBe(true);
+
+      // The priced plan rides along, so a refused caller does not have to make
+      // a second call to learn what it would have cost.
+      const data = env.data as Record<string, unknown>;
+      expect(data).toBeDefined();
+      expect(typeof data.costCapUsd).toBe("number");
+
+      // The old shape must not come back.
+      expect(env).not.toHaveProperty("warnings");
+    });
+  }
+
+  it("plan reports the same code and exit status with and without --json", () => {
+    const json = run(`plan ${projectDir} --max-cost 0.01 --json`);
+    const plain = run(`plan ${projectDir} --max-cost 0.01`);
+    expect(plain.status).toBe(json.status);
+    // Non-TTY stdout auto-enables JSON, so both emit the envelope; the point
+    // is that neither downgrades to USAGE_ERROR/exit 2.
+    expect(JSON.parse(plain.stderr).code).toBe("COST_CAP_EXCEEDED");
+  });
 });
 
 describe("structured error envelope — catch-all code", () => {

--- a/packages/cli/src/commands/output.ts
+++ b/packages/cli/src/commands/output.ts
@@ -30,6 +30,12 @@ export interface StructuredError {
   retryWith?: string[];
   recoverable?: boolean;
   retryable: boolean;
+  /**
+   * Structured context carried alongside the failure, so a refusal can hand
+   * back the evidence it refused on instead of forcing a second call. Used by
+   * the `--max-cost` gate to return the priced build plan with the refusal.
+   */
+  data?: Record<string, unknown>;
 }
 
 export function usageError(msg: string, suggestion?: string): StructuredError {
@@ -103,6 +109,34 @@ export function generalError(msg: string, suggestion?: string): StructuredError 
   return { success: false, error: msg, code: "ERROR", exitCode: ExitCode.GENERAL, suggestion, retryable: false };
 }
 
+/**
+ * The `--max-cost` refusal. A command that declines to spend is a failure, so
+ * it takes the structured error path like every other refusal: `success:false`
+ * on stderr, exit 1. `data` carries the priced plan the refusal was based on,
+ * so an agent gets the estimate and the reason from one call.
+ *
+ * `recoverable: true` because the caller has two real ways forward (raise the
+ * ceiling, or narrow the scope), both spelled out in `retryWith`.
+ */
+export function costCapError(opts: {
+  estimatedCostUsd: number;
+  maxCostUsd: number;
+  retryWith: string[];
+  data?: Record<string, unknown>;
+}): StructuredError {
+  return {
+    success: false,
+    error: `Estimated cost $${opts.estimatedCostUsd.toFixed(2)} exceeds --max-cost $${opts.maxCostUsd.toFixed(2)}.`,
+    code: "COST_CAP_EXCEEDED",
+    exitCode: ExitCode.GENERAL,
+    suggestion: "Raise --max-cost or reduce the stage/provider scope.",
+    retryWith: opts.retryWith,
+    recoverable: true,
+    retryable: false,
+    data: opts.data,
+  };
+}
+
 /** Output structured error then exit */
 export function exitWithError(err: StructuredError): never {
   if (isJsonMode()) {
@@ -116,6 +150,11 @@ export function exitWithError(err: StructuredError): never {
     console.error(chalk.red(`\n  ${err.error}`));
     if (err.suggestion) {
       console.error(chalk.dim(`  ${err.suggestion}`));
+    }
+    // Show one concrete way forward. The JSON branch already carries the full
+    // list; a terminal user only needs the first one to keep moving.
+    if (err.retryWith && err.retryWith.length > 0) {
+      console.error(chalk.dim(`  Retry: ${err.retryWith[0]}`));
     }
     console.error();
   }

--- a/packages/cli/src/commands/plan.ts
+++ b/packages/cli/src/commands/plan.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { resolve } from "node:path";
 
 import { createBuildPlan, type BuildPlanResult, type BuildStage } from "./_shared/build-plan.js";
-import { exitWithError, isJsonMode, outputSuccess, usageError } from "./output.js";
+import { costCapError, exitWithError, isJsonMode, outputSuccess, usageError } from "./output.js";
 
 const VALID_STAGES: BuildStage[] = ["assets", "transcript", "compose", "sync", "render", "all"];
 const VALID_MODES = ["agent", "batch", "auto"] as const;
@@ -114,35 +114,21 @@ export const planCommand = new Command("plan")
     }
 
     if (maxCost !== undefined && plan.estimatedCostUsd > maxCost) {
-      const warning = `Estimated cost $${plan.estimatedCostUsd.toFixed(2)} exceeds --max-cost $${maxCost.toFixed(2)}.`;
-      const data = {
-        ...plan,
-        costCapUsd: maxCost,
-        code: "COST_CAP_EXCEEDED",
-        message: warning,
-        suggestion: "Raise --max-cost or reduce the stage/provider scope.",
-        recoverable: true,
-        retryWith: [
-          ...plan.retryWith,
-          `vibe plan ${projectDirArg} --stage ${stage} --skip-backdrop --json`,
-          `vibe build ${projectDirArg} --stage ${stage} --max-cost ${plan.estimatedCostUsd} --json`,
-        ].filter((value, index, all) => value.length > 0 && all.indexOf(value) === index),
-      };
-      if (isJsonMode()) {
-        outputSuccess({
-          command: "plan",
-          startedAt,
-          data,
-          warnings: [warning],
-        });
-        process.exitCode = 1;
-        return;
-      }
+      // One refusal contract regardless of output mode. This used to emit a
+      // success envelope with exit 1 under --json but a USAGE_ERROR with exit
+      // 2 without it, so the same condition reported two different codes and
+      // two different exit codes depending on a formatting flag.
       exitWithError(
-        usageError(
-          `Estimated cost $${plan.estimatedCostUsd.toFixed(2)} exceeds --max-cost $${maxCost.toFixed(2)}.`,
-          `Raise --max-cost or reduce the stage/provider scope.`
-        )
+        costCapError({
+          estimatedCostUsd: plan.estimatedCostUsd,
+          maxCostUsd: maxCost,
+          retryWith: [
+            ...plan.retryWith,
+            `vibe plan ${projectDirArg} --stage ${stage} --skip-backdrop --json`,
+            `vibe build ${projectDirArg} --stage ${stage} --max-cost ${plan.estimatedCostUsd} --json`,
+          ].filter((value, index, all) => value.length > 0 && all.indexOf(value) === index),
+          data: { ...plan, costCapUsd: maxCost },
+        })
       );
     }
 


### PR DESCRIPTION
Found while re-verifying the README and landing page: **the spend gate does not return what both surfaces say it returns.**

## The bug

README's first section and the vibeframe.ai hero terminal both show the gate returning an error envelope. The CLI emitted a **success** envelope on stdout carrying a warning, with `code`/`message`/`suggestion`/`retryWith`/`recoverable` buried under `data` and no top-level `error` at all.

Captured from a real refusal before the change:

```
top-level keys: command, costUsd, data, dryRun, elapsedMs, warnings
.error present? NO
```

Exit 1 was correct - that part of the docs was true. The payload was not. An agent taught by either surface to branch on the error envelope had nothing to branch on.

**`vibe plan` was worse.** Under `--json` it reported `COST_CAP_EXCEEDED` / exit 1; without `--json` it fell through to `usageError`, reporting `USAGE_ERROR` / **exit 2**. One condition, two codes and two exit codes, selected by a formatting flag - and `build` and `plan` disagreed with each other too.

## The fix

`AGENTS.md` already requires `exitWithError()` for structured errors, and a refusal to spend is a failure. Both commands, both output modes, now take that path: `success:false` on stderr, `COST_CAP_EXCEEDED`, exit 1.

The one thing the old shape did well was return the priced plan *with* the refusal, so a refused caller didn't need a second call to learn the estimate. Kept, via a new optional `data` field on `StructuredError`. Additive; every other error is unchanged.

`exitWithError`'s human branch now also prints the first `retryWith` entry - `build.ts` printed that hint before and would have lost it in the move.

## Contract change (deliberate)

Exit code unchanged (1). Field names unchanged - they move from `data.*` to top level, and the envelope moves from stdout to stderr. Nothing in the repo parsed the old shape; the only consumers were the docs.

## Docs

The old examples were wrong in a **second** way: they nested fields under an `"error": { ... }` object, a shape that exists nowhere in the codebase. The real envelope is flat with `error` as a string, exactly as `CONTEXT.md` documents. Corrected in the README example, the hero terminal, and the `CONTEXT.md` error table (which gains the `COST_CAP_EXCEEDED` row plus a note about `data.plan`).

## Test

The gate had **no test** - that is why it drifted. `error-envelopes.test.ts` now covers `build` and `plan`: stderr envelope, exit 1, empty stdout, `data.costCapUsd` present, `retryWith` offering a raised cap, and no `warnings` key so the old shape can't come back. Plus a case asserting `plan` reports the same code and status with and without `--json`.

Full suite: **1233 passed** (3 new). Build, lint, `gen:reference:check` green; hero verified visually.

https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp