### PR TITLE
fix: point scene authors at the contract that is actually present

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,25 @@ Before wiring up any provider, the whole pipeline runs locally for $0: local Kok
 ```bash
 npm install -g @vibeframe/cli
 vibe init demo --from "30-second video introducing my project"
+vibe scene install-skill demo    # Hyperframes' own installer; the rules your agent authors against
 ```
 
 Then ask your coding agent to finish it:
 
 > Build demo/ into a rendered MP4 with zero API keys.
-> Use `vibe build demo --tts kokoro --skip-backdrop --json`, author the scene
-> HTML from `vibe scene compose-prompts demo --json`, then run
-> `vibe build demo --stage sync --json` and `vibe render demo --json`.
+> Read `demo/AGENTS.md` ("Key Rules for hand-authored scene HTML") first, then
+> run `vibe build demo --tts kokoro --skip-backdrop --json` and author the
+> scene HTML from `vibe scene compose-prompts demo --json`.
+> Run `vibe build demo --stage sync --json` and fix every lint error it
+> reports before rendering - it exits non-zero while any remain.
+> Then `vibe render demo --json`.
 
-Measured cold start on that exact sequence: about 4 to 5 minutes from `npm install` to a reviewed 1080p MP4, including a one-time ~88 MB voice model download.
+Measured cold start (v0.113.29, isolated environment, no keys): install 63s, `vibe init` 1s, `vibe build --tts kokoro --skip-backdrop` 66s including the one-time ~88 MB voice model download, and `vibe render` 64s.
+That is about 3 minutes of machine time; the scene-authoring pass in the middle is your agent's, so the wall clock depends on it and on how many lint rounds it needs.
 Repeat runs skip the download.
-No coding agent available? The same commands work by hand - `vibe scene compose-prompts` prints the full per-scene authoring brief for you.
+
+Treat `vibe build --stage sync` as the gate: it lints the composed scenes and exits non-zero on real errors - an unregistered GSAP timeline, a composition div missing `data-width`/`data-height`. Rendering past a failed sync produces a black MP4, so fix the scenes first.
+No coding agent available? `vibe scene add <id> --style announcement --headline "..." --no-audio --no-image` writes a lint-clean template scene with no model call, and doubles as a reference for the file shape.
 
 It is a real render, and it is the cheapest way to see whether the workflow fits you.
 It is not the point of the tool: the paid generation path above is.

--- a/packages/cli/src/commands/_shared/compose-prompts.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.ts
@@ -159,10 +159,10 @@ export async function getComposePrompts(opts: ComposePromptsOptions): Promise<Co
   });
 
   if (!existsSync(designPath)) {
-    return baseError(`DESIGN.md not found at ${designPath}. Run \`vibe scene init <dir>\` first.`);
+    return baseError(`DESIGN.md not found at ${designPath}. Run \`vibe init <dir>\` first.`);
   }
   if (!existsSync(storyboardPath)) {
-    return baseError(`STORYBOARD.md not found at ${storyboardPath}. Run \`vibe scene init <dir>\` to create a starter, or add STORYBOARD.md with per-beat cues.`);
+    return baseError(`STORYBOARD.md not found at ${storyboardPath}. Run \`vibe init <dir>\` to create a starter, or add STORYBOARD.md with per-beat cues.`);
   }
 
   if (!hyperframesSkillAvailable(projectDir)) {
@@ -265,7 +265,16 @@ function buildInstructions(args: {
   if (args.skillRef) {
     lines.push(`1. Read \`${args.skillRef}\` for the Hyperframes framework rules + house style. This is the visual-identity hard-gate.`);
   } else {
-    lines.push(`1. Run \`vibe scene install-skill\` to install the Hyperframes composition rules, then read them.`);
+    // Point at the project's own AGENTS.md first: `vibe init` writes the
+    // "Key Rules (for hand-authored scene HTML)" section, and unlike the
+    // installed skill it is present and complete offline. Upstream's
+    // installer writes a ROUTER whose actual contract sits behind
+    // `/hyperframes-core`, which only resolves in a host that has upstream's
+    // domain skills - so an agent that follows install-skill alone can end up
+    // authoring blind.
+    lines.push(
+      `1. Read this project's \`AGENTS.md\` section "Key Rules (for hand-authored scene HTML)" - written by \`vibe init\`, and the authoritative local contract. \`vibe scene install-skill\` adds Hyperframes' house style on top, but note it installs a ROUTER whose full contract sits behind \`/hyperframes-core\`, which resolves only in a host that has upstream's Hyperframes skills.`
+    );
   }
   lines.push(`2. Read \`DESIGN.md\` for project-specific palette, typography, motion signature.`);
   if (args.compositionRef) {
@@ -275,6 +284,7 @@ function buildInstructions(args: {
   lines.push(`3b. Use each beat's \`finalDurationSec\` (narration-synced) for \`data-duration\` and timeline anchors when present — NOT the storyboard \`duration\`, which is only the minimum. Scenes composed at the storyboard duration end early and render black tails.`);
   lines.push(`3c. Never give inner \`.clip\` elements a non-zero \`data-start\` — the renderer does not toggle internal clip visibility inside sub-compositions, so phased clips render all phases at once (overlapping text). Use full-window clips and GSAP autoAlpha phase transitions instead. Also keep beats 6-15s; split anything longer in the storyboard first.`);
   lines.push(`3d. If your environment cannot write files (e.g. Claude Desktop / MCP-only hosts), author each beat's HTML and submit it with the \`scene_submit\` tool (beat id + html). It validates with the same Hyperframes lint and writes the file for you; on lint errors it returns the findings without writing — fix and resubmit.`);
+  lines.push(`3e. Hard requirements the linter fails on, so satisfy them even without the full contract. A scene file is a \`<template id="scene-<id>-template">\` wrapping ONE \`<div data-composition-id="scene-<id>" data-start="0" data-duration="<sec>" data-width="1920" data-height="1080">\` — not a standalone \`<!doctype html>\` document. Register the paused GSAP timeline on the registry OBJECT keyed by composition id: \`window.__timelines = window.__timelines || {}; window.__timelines["scene-<id>"] = tl;\` — it is not an array, and \`.push()\` leaves the timeline undiscovered, which renders a black frame because \`gsap.from\` holds elements at their start state. Also put \`class="clip"\` on every timed element and give timeline-visible elements a stable \`id\`. Generate a reference scene with \`vibe scene add <id> --style <preset> --no-audio --no-image\` and match its shape.`);
   if (args.beatCount > 1) {
     lines.push(`4. After authoring all ${args.beatCount} beat(s), run \`vibe build <project> --stage sync --json\` to assemble the root composition (index.html) from the fragments. Lint needs that root, so sync comes first.`);
   } else if (args.filtered) {

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -529,7 +529,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
       phase: "failed",
       mode,
       selectedStage,
-      error: `STORYBOARD.md not found at ${storyboardPath}. Run \`vibe scene init <dir>\` to create a starter, or add STORYBOARD.md with per-beat cues.`,
+      error: `STORYBOARD.md not found at ${storyboardPath}. Run \`vibe init <dir>\` to create a starter, or add STORYBOARD.md with per-beat cues.`,
       beats: [],
       stageReports,
       warnings,

--- a/packages/cli/src/commands/_shared/scene-html-emit.ts
+++ b/packages/cli/src/commands/_shared/scene-html-emit.ts
@@ -818,7 +818,7 @@ export function insertClipIntoRoot(rootHtml: string, clip: ClipReferenceInput): 
   const closeMatch = rootHtml.match(/\n(\s*)<\/div>(\s*\n\s*<script>)/);
   if (!closeMatch) {
     throw new Error(
-      "Could not find root composition closing </div>. Ensure index.html follows the layout from `vibe scene init`."
+      "Could not find root composition closing </div>. Ensure index.html follows the layout from `vibe init`."
     );
   }
   const closeIdx = closeMatch.index!;

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -164,7 +164,7 @@ export function buildHyperframesMeta(name: string, now: Date = new Date()): Hype
 
 /**
  * Merge an existing Hyperframes config with our defaults, preserving any
- * user-authored keys and nested values. `vibe scene init` is idempotent:
+ * user-authored keys and nested values. `vibe init` is idempotent:
  * running it on a directory that already has `hyperframes.json` must never
  * lose user config.
  */
@@ -350,7 +350,7 @@ ${avoid}
 ---
 
 _Browse other named styles: \`vibe scene list-styles\`_
-${style ? `_This file was seeded by \`vibe scene init --visual-style "${style.name}"\`._` : `_Seed this file from a named style: \`vibe scene init <dir> --visual-style "<name>"\`._`}
+${style ? `_This file was seeded by \`vibe init --visual-style "${style.name}"\`._` : `_Seed this file from a named style: \`vibe init <dir> --visual-style "<name>"\`._`}
 `;
 }
 
@@ -520,7 +520,7 @@ Single-asset requests (\`vibe generate image|video|speech|...\`) do NOT
 consult this file - run the generate command directly.
 
 Browse named styles: \`vibe scene list-styles\`. Re-seed from one with
-\`vibe scene init . --visual-style "Swiss Pulse"\` (idempotent).
+\`vibe init . --visual-style "Swiss Pulse"\` (idempotent).
 
 ## Brief and local media
 
@@ -675,9 +675,21 @@ npx hyperframes render
 
 ## Key Rules (for hand-authored scene HTML)
 
+0. A scene file is a \`<template id="scene-<id>-template">\` wrapping ONE
+   composition div - not a standalone \`<!doctype html>\` document:
+   \`\`\`html
+   <template id="scene-hook-template">
+     <div data-composition-id="scene-hook" data-start="0" data-duration="3.3"
+          data-width="1920" data-height="1080">…</div>
+   </template>
+   \`\`\`
+   The composition div **MUST** carry \`data-width\` and \`data-height\`.
 1. Every timed element needs \`data-start\`, \`data-duration\`, and \`data-track-index\`.
 2. Elements with timing **MUST** have \`class="clip"\` - the framework uses this for visibility control.
-3. Timelines must be paused and registered on \`window.__timelines\`:
+3. Timelines must be paused and registered on \`window.__timelines\`, which is an
+   OBJECT keyed by composition id - not an array, and \`.push()\` leaves the
+   timeline undiscovered, which renders a black frame because \`gsap.from\` holds
+   elements at their start state:
    \`\`\`js
    window.__timelines = window.__timelines || {};
    window.__timelines["composition-id"] = gsap.timeline({ paused: true });

--- a/packages/cli/src/commands/_shared/scene-render.ts
+++ b/packages/cli/src/commands/_shared/scene-render.ts
@@ -307,7 +307,7 @@ export async function executeSceneRender(opts: SceneRenderOptions = {}): Promise
       kind: "render",
       beat: opts.beatId ?? null,
       root,
-      error: `Root composition not found: ${resolve(projectDir, root)}. Run \`vibe scene init\` first.`,
+      error: `Root composition not found: ${resolve(projectDir, root)}. Run \`vibe build ${projectDir}\` once to create the render scaffold, or scaffold it up front with \`vibe init <dir> --profile full\`.`,
     };
   }
   const chrome = await preflightChrome();

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -398,7 +398,7 @@ sceneCommand
       console.log(chalk.dim("Show details: "), chalk.cyan('vibe scene list-styles "<name>"'));
       console.log(
         chalk.dim("Seed DESIGN.md:"),
-        chalk.cyan('vibe scene init <dir> --visual-style "<name>"')
+        chalk.cyan('vibe init <dir> --visual-style "<name>"')
       );
       return;
     }
@@ -436,7 +436,7 @@ sceneCommand
     console.log();
     console.log(
       chalk.dim("Seed DESIGN.md:"),
-      chalk.cyan(`vibe scene init <dir> --visual-style "${style.name}"`)
+      chalk.cyan(`vibe init <dir> --visual-style "${style.name}"`)
     );
   });
 
@@ -839,7 +839,9 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
   });
 
   if (!(await pathExists(rootPath))) {
-    return errResult(`Root composition not found: ${rootPath}. Run \`vibe scene init\` first.`);
+    return errResult(
+      `Root composition not found: ${rootPath}. Run \`vibe build\` once to create the render scaffold, or scaffold it up front with \`vibe init <dir> --profile full\`.`
+    );
   }
   if (!opts.force && (await pathExists(scenePath))) {
     return errResult(`Scene already exists: ${sceneRel}. Re-run with --force to overwrite.`);


### PR DESCRIPTION
Found by re-running the README's zero-key path end to end on a clean install (v0.113.29, isolated HOME, no keys). **It reached a rendered MP4 in 4m17s - and the MP4 was black.**

## What actually happened

The scene HTML was authored in the wrong shape. A scene file is a `<template>` wrapping one composition div carrying `data-width`/`data-height`, and `window.__timelines` is an **object keyed by composition id**, not an array. Registering with `.push()` leaves the timeline undiscovered, and since `gsap.from` holds elements at their start state, an undiscovered timeline renders black.

**The CLI behaved correctly throughout.** `vibe build --stage sync` linted the scenes, reported 9 error-severity findings (`missing_timeline_registry`, `gsap_timeline_not_registered`, `root_missing_dimensions`) and exited 1. The render only proceeded because that gate was ignored.

*(I initially reported this as "sync fails on warnings-only" - that was wrong. I had truncated the output and seen only the first two warnings. The severity histogram is 9 error / 3 warning / 3 info.)*

## The real gap: where the instructions point

The correct contract **already ships in every project** - `vibe init` writes "Key Rules (for hand-authored scene HTML)" into `AGENTS.md`, with the right registry pattern.

But `vibe scene compose-prompts` never mentioned it. Step 1 said to run `vibe scene install-skill` and "read the rules" - and what that installs is upstream's **router** skill, whose actual contract sits behind `/hyperframes-core`, a reference that resolves only in a host that has upstream's domain skills. An agent following step 1 alone authors blind.

- Step 1 now points at the project's own `AGENTS.md` first, and states plainly what `install-skill` does and does not deliver.
- New **step 3e** inlines the requirements the linter fails on: the `<template>` wrapper, `data-width`/`data-height`, the object registry (with the black-frame consequence spelled out), `class="clip"`, stable ids, and `vibe scene add ... --no-audio --no-image` as a known-good reference.
- The generated `AGENTS.md` Key Rules gain the two rules they were missing (the `<template>` shape and `data-width`/`data-height`), and rule 3 now says the registry is an object, not an array.

**Verified empirically:** re-authoring one scene against the new 3e drops it from 3 lint errors to **0**, while the two untouched scenes stay at 3 each.

## Also: a command that does not exist

`vibe scene init` was removed, but **11 references across 7 files** still told users to run it - including the error `vibe scene add` prints when there is no root composition. Replaced with `vibe init`.

For the two "Root composition not found" messages that still is not enough, because the default `agent` profile does not write `index.html` (confirmed: `vibe init x` then `scene add` fails; `vibe init x --profile full` works). Those now name the commands that actually help: `vibe build` once, or `vibe init <dir> --profile full`.

## README

Zero-key section updated to the measured run: the agent reads `AGENTS.md`, `--stage sync` is called out as a gate that must pass before rendering, and the timing is restated as measured machine time (install 63s, init 1s, build 66s incl. the one-time ~88 MB voice model, render 64s) with the authoring pass called out as agent-dependent - rather than folded into one "4 to 5 minutes to a reviewed MP4".

Full suite: 1230 passed. Build, lint, `gen:reference:check` green.

https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp