### PR TITLE
chore: remove em dashes from the CLI reference by fixing its sources

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -7,7 +7,7 @@ tags: [cli, reference, generated]
 
 # VibeFrame CLI Reference
 
-> **Auto-generated** from `vibe schema --list`. Do not edit by hand —
+> **Auto-generated** from `vibe schema --list`. Do not edit by hand -
 > run `pnpm gen:reference` after any flag/command change.
 
 VibeFrame is CLI-first: every operation is a shell command. This file
@@ -139,7 +139,7 @@ listed in their command sections for compatibility.
 | **Very High**  |     4 | `generate.video` · `edit.fill-gaps` · `generate.video-extend` · `remix.regenerate-scene`                                                                                    | $5–$50+ per call                                                                                  |
 | **Not tagged** |    15 | `build` · `doctor` · `guide` · `init` · `plan` · `preview` · `render` · `setup` · +7 more                                                                                   | Utility/orchestration/reference commands; inspect command behavior before assuming provider spend |
 
-> **Tip:** Run `<paid command> --dry-run --json` first — the response
+> **Tip:** Run `<paid command> --dry-run --json` first - the response
 > includes a `costUsd` estimate when the command supports dry-run.
 
 ## JSON envelope
@@ -217,15 +217,15 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `provider` _(string)_ _(openai \| claude \| gemini \| ollama \| xai \| openrouter \| evolink)_ _(default: `"openai"`)_ — LLM provider (openai, claude, gemini, ollama, xai, openrouter, evolink)
-- `model` _(string)_ — Model to use (provider-specific)
-- `project` _(string)_ — Timeline file or directory to load
-- `verbose` _(boolean)_ — Show verbose output including tool calls
-- `maxTurns` _(number)_ _(default: `10`)_ — Maximum turns per request
-- `input` _(string)_ — Run a single query and exit (non-interactive)
-- `confirm` _(boolean)_ — Confirm before every tool — broadens the default cost gate (paid only) to all calls
-- `noConfirm` _(boolean)_ — Disable all confirm prompts including the high/very-high cost gate (CI / automation)
-- `budgetUsd` _(number)_ — Reject tool calls past this cumulative USD ceiling using conservative tier estimates
+- `provider` _(string)_ _(openai \| claude \| gemini \| ollama \| xai \| openrouter \| evolink)_ _(default: `"openai"`)_ - LLM provider (openai, claude, gemini, ollama, xai, openrouter, evolink)
+- `model` _(string)_ - Model to use (provider-specific)
+- `project` _(string)_ - Timeline file or directory to load
+- `verbose` _(boolean)_ - Show verbose output including tool calls
+- `maxTurns` _(number)_ _(default: `10`)_ - Maximum turns per request
+- `input` _(string)_ - Run a single query and exit (non-interactive)
+- `confirm` _(boolean)_ - Confirm before every tool - broadens the default cost gate (paid only) to all calls
+- `noConfirm` _(boolean)_ - Disable all confirm prompts including the high/very-high cost gate (CI / automation)
+- `budgetUsd` _(number)_ - Reject tool calls past this cumulative USD ceiling using conservative tier estimates
 
 #### `vibe assemble`
 
@@ -238,11 +238,11 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Video project directory
-- `video` _(string)_ _(default: `"preview.mp4"`)_ — Rendered video to add audio to (default: preview.mp4)
-- `root` _(string)_ _(default: `"index.html"`)_ — Root composition file
-- `format` _(string)_ _(default: `"mp4"`)_ — Output container: mp4|webm|mov
-- `dryRun` _(boolean)_ — Preview parameters without muxing
+- `project-dir` _(string)_ - Video project directory
+- `video` _(string)_ _(default: `"preview.mp4"`)_ - Rendered video to add audio to (default: preview.mp4)
+- `root` _(string)_ _(default: `"index.html"`)_ - Root composition file
+- `format` _(string)_ _(default: `"mp4"`)_ - Output container: mp4|webm|mov
+- `dryRun` _(boolean)_ - Preview parameters without muxing
 
 #### `vibe build`
 
@@ -255,28 +255,28 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Video project directory
-- `stage` _(string)_ _(default: `"all"`)_ — Build stage: assets|transcript|compose|sync|render|all
-- `beat` _(string)_ — Restrict asset/compose work to one beat id
-- `mode` _(string)_ _(default: `"auto"`)_ — Retained for compatibility; scene HTML is always authored by your host agent unless --composer template is set
-- `composer` _(string)_ — Set to `template` for the deterministic AI-video composer (concat bg + lower-thirds, no model). Omit to let the host agent author each scene.
-- `maxCost` _(number)_ — Fail before provider spend when estimated cost exceeds this USD cap
-- `skipNarration` _(boolean)_ — Don't dispatch TTS even when beats declare narration cues
-- `skipBackdrop` _(boolean)_ — Don't dispatch image-gen even when beats declare backdrop cues
-- `skipVideo` _(boolean)_ — Don't dispatch video generation even when beats declare video cues
-- `skipKeyframe` _(boolean)_ — Don't generate keyframe stills (review keyframes first with --skip-video, then build)
-- `skipMusic` _(boolean)_ — Don't dispatch music generation even when beats declare music cues
-- `skipTranscript` _(boolean)_ — Don't transcribe narration for word-sync (default: transcribe when narration + OpenAI key exist)
-- `skipRender` _(boolean)_ — Compose only — don't render to MP4
-- `tts` _(string)_ — TTS provider: auto|elevenlabs|openai|kokoro
-- `voice` _(string)_ — Voice id
-- `imageProvider` _(string)_ — Image provider: openai|gemini|grok
-- `videoProvider` _(string)_ — Video provider: seedance|grok|kling|runway|veo
-- `musicProvider` _(string)_ — Music provider: elevenlabs|replicate
-- `quality` _(string)_ _(default: `"hd"`)_ — Image quality: standard|hd
-- `imageSize` _(string)_ _(default: `"1536x1024"`)_ — Image size: 1024x1024|1536x1024|1024x1536
-- `force` _(boolean)_ — Re-dispatch primitives even when assets already exist
-- `dryRun` _(boolean)_ — Preview parameters without dispatching
+- `project-dir` _(string)_ - Video project directory
+- `stage` _(string)_ _(default: `"all"`)_ - Build stage: assets|transcript|compose|sync|render|all
+- `beat` _(string)_ - Restrict asset/compose work to one beat id
+- `mode` _(string)_ _(default: `"auto"`)_ - Retained for compatibility; scene HTML is always authored by your host agent unless --composer template is set
+- `composer` _(string)_ - Set to `template` for the deterministic AI-video composer (concat bg + lower-thirds, no model). Omit to let the host agent author each scene.
+- `maxCost` _(number)_ - Fail before provider spend when estimated cost exceeds this USD cap
+- `skipNarration` _(boolean)_ - Don't dispatch TTS even when beats declare narration cues
+- `skipBackdrop` _(boolean)_ - Don't dispatch image-gen even when beats declare backdrop cues
+- `skipVideo` _(boolean)_ - Don't dispatch video generation even when beats declare video cues
+- `skipKeyframe` _(boolean)_ - Don't generate keyframe stills (review keyframes first with --skip-video, then build)
+- `skipMusic` _(boolean)_ - Don't dispatch music generation even when beats declare music cues
+- `skipTranscript` _(boolean)_ - Don't transcribe narration for word-sync (default: transcribe when narration + OpenAI key exist)
+- `skipRender` _(boolean)_ - Compose only - don't render to MP4
+- `tts` _(string)_ - TTS provider: auto|elevenlabs|openai|kokoro
+- `voice` _(string)_ - Voice id
+- `imageProvider` _(string)_ - Image provider: openai|gemini|grok
+- `videoProvider` _(string)_ - Video provider: seedance|grok|kling|runway|veo
+- `musicProvider` _(string)_ - Music provider: elevenlabs|replicate
+- `quality` _(string)_ _(default: `"hd"`)_ - Image quality: standard|hd
+- `imageSize` _(string)_ _(default: `"1536x1024"`)_ - Image size: 1024x1024|1536x1024|1024x1536
+- `force` _(boolean)_ - Re-dispatch primitives even when assets already exist
+- `dryRun` _(boolean)_ - Preview parameters without dispatching
 
 `--dry-run --json` returns `data.plan.kind:"build-plan"`. `build --dry-run` and real `build` validate `STORYBOARD.md` before cost caps or provider dispatch, and invalid storyboards fail with `code:"STORYBOARD_VALIDATION_FAILED"` plus validate/revise `retryWith` commands.
 Real `build` runs deterministic scene repair after compose and sync before render. JSON/build-report payloads include `providerResolution`, nested asset `sourcePath`, nested `composition` status/cache metadata, and `sceneRepair`; repair failures use `code:"SCENE_REPAIR_FAILED"` and `sceneRepair.retryWith`. `scene repair` also fixes root clip refs, root duration, and root narration audio wiring.
@@ -294,7 +294,7 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `shell` _(string)_ **required** — Target shell: zsh | bash | fish
+- `shell` _(string)_ **required** - Target shell: zsh | bash | fish
 
 #### `vibe context`
 
@@ -307,7 +307,7 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `format` _(string)_ _(default: `"markdown"`)_ — Output format: markdown | json
+- `format` _(string)_ _(default: `"markdown"`)_ - Output format: markdown | json
 
 #### `vibe demo`
 
@@ -320,8 +320,8 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `keep` _(boolean)_ — Keep demo output files after completion
-- `json` _(boolean)_ — Output results as JSON
+- `keep` _(boolean)_ - Keep demo output files after completion
+- `json` _(boolean)_ - Output results as JSON
 
 #### `vibe doctor`
 
@@ -334,9 +334,9 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `json` _(boolean)_ — Output in JSON format
-- `verbose` _(boolean)_ — Show full report (every provider row, scene composer block, free-command list)
-- `testKeys` _(boolean)_ — Make a lightweight authenticated request to each provider (validates configured keys; skips providers without a cheap test endpoint)
+- `json` _(boolean)_ - Output in JSON format
+- `verbose` _(boolean)_ - Show full report (every provider row, scene composer block, free-command list)
+- `testKeys` _(boolean)_ - Make a lightweight authenticated request to each provider (validates configured keys; skips providers without a cheap test endpoint)
 
 #### `vibe guide`
 
@@ -349,8 +349,8 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `topic` _(string)_ — Guide topic: motion | scene | pipeline | architecture. Omit to list all.
-- `list` _(boolean)_ — List available guides and exit
+- `topic` _(string)_ - Guide topic: motion | scene | pipeline | architecture. Omit to list all.
+- `list` _(boolean)_ - List available guides and exit
 
 #### `vibe init`
 
@@ -363,18 +363,18 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Project directory (defaults to cwd)
-- `type` _(string)_ _(default: `"scene"`)_ — Project type: scene (video project) | agent (agent files only)
-- `profile` _(string)_ _(minimal \| agent \| full)_ _(default: `"agent"`)_ — Scene profile: minimal (storyboard/design only), agent (recommended), full (render scaffold upfront)
-- `from` _(string)_ — Draft STORYBOARD.md and DESIGN.md from a brief string or text/markdown file
-- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1 \| 4:5)_ _(default: `"16:9"`)_ — Scene aspect ratio: 16:9, 9:16, 1:1, 4:5
-- `duration` _(number)_ _(default: `10`)_ — Default scene/root duration in seconds
-- `visualStyle` _(string)_ — Seed scene DESIGN.md from a named style
-- `kind` _(string)_ _(default: `"cinema"`)_ — Project kind: cinema | story | aivideo | product | motion (drives pipeline stages + default composer)
-- `agent` _(string)_ _(default: `"auto"`)_ — Agent target: claude-code | codex | cursor | aider | gemini-cli | opencode | all | auto
-- `mcp` _(boolean)_ — Also write project-scoped MCP config for Codex/Claude Code/Cursor
-- `force` _(boolean)_ — Overwrite existing files instead of skipping
-- `dryRun` _(boolean)_ — Print the file list without writing anything
+- `project-dir` _(string)_ - Project directory (defaults to cwd)
+- `type` _(string)_ _(default: `"scene"`)_ - Project type: scene (video project) | agent (agent files only)
+- `profile` _(string)_ _(minimal \| agent \| full)_ _(default: `"agent"`)_ - Scene profile: minimal (storyboard/design only), agent (recommended), full (render scaffold upfront)
+- `from` _(string)_ - Draft STORYBOARD.md and DESIGN.md from a brief string or text/markdown file
+- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1 \| 4:5)_ _(default: `"16:9"`)_ - Scene aspect ratio: 16:9, 9:16, 1:1, 4:5
+- `duration` _(number)_ _(default: `10`)_ - Default scene/root duration in seconds
+- `visualStyle` _(string)_ - Seed scene DESIGN.md from a named style
+- `kind` _(string)_ _(default: `"cinema"`)_ - Project kind: cinema | story | aivideo | product | motion (drives pipeline stages + default composer)
+- `agent` _(string)_ _(default: `"auto"`)_ - Agent target: claude-code | codex | cursor | aider | gemini-cli | opencode | all | auto
+- `mcp` _(boolean)_ - Also write project-scoped MCP config for Codex/Claude Code/Cursor
+- `force` _(boolean)_ - Overwrite existing files instead of skipping
+- `dryRun` _(boolean)_ - Print the file list without writing anything
 
 #### `vibe plan`
 
@@ -387,24 +387,24 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Video project directory
-- `stage` _(string)_ _(default: `"all"`)_ — Stage to plan: assets|transcript|compose|sync|render|all
-- `beat` _(string)_ — Restrict the plan to one beat
-- `mode` _(string)_ _(default: `"auto"`)_ — Build mode: agent|batch|auto
-- `skipNarration` _(boolean)_ — Don't include narration generation in the plan
-- `skipBackdrop` _(boolean)_ — Don't include backdrop image generation in the plan
-- `skipVideo` _(boolean)_ — Don't include video generation in the plan
-- `skipMusic` _(boolean)_ — Don't include music generation in the plan
-- `tts` _(string)_ — TTS provider: auto|elevenlabs|openai|kokoro
-- `voice` _(string)_ — Voice id
-- `imageProvider` _(string)_ — Image provider: openai|gemini|grok
-- `videoProvider` _(string)_ — Video provider: seedance|grok|kling|runway|veo
-- `musicProvider` _(string)_ — Music provider: elevenlabs|replicate
-- `quality` _(string)_ — Image quality: standard|hd
-- `imageSize` _(string)_ — Image size: 1024x1024|1536x1024|1024x1536
-- `composer` _(string)_ — Batch composer: claude|openai|gemini
-- `force` _(boolean)_ — Plan regeneration even when outputs already exist
-- `maxCost` _(number)_ — Fail if estimated cost exceeds this USD cap
+- `project-dir` _(string)_ - Video project directory
+- `stage` _(string)_ _(default: `"all"`)_ - Stage to plan: assets|transcript|compose|sync|render|all
+- `beat` _(string)_ - Restrict the plan to one beat
+- `mode` _(string)_ _(default: `"auto"`)_ - Build mode: agent|batch|auto
+- `skipNarration` _(boolean)_ - Don't include narration generation in the plan
+- `skipBackdrop` _(boolean)_ - Don't include backdrop image generation in the plan
+- `skipVideo` _(boolean)_ - Don't include video generation in the plan
+- `skipMusic` _(boolean)_ - Don't include music generation in the plan
+- `tts` _(string)_ - TTS provider: auto|elevenlabs|openai|kokoro
+- `voice` _(string)_ - Voice id
+- `imageProvider` _(string)_ - Image provider: openai|gemini|grok
+- `videoProvider` _(string)_ - Video provider: seedance|grok|kling|runway|veo
+- `musicProvider` _(string)_ - Music provider: elevenlabs|replicate
+- `quality` _(string)_ - Image quality: standard|hd
+- `imageSize` _(string)_ - Image size: 1024x1024|1536x1024|1024x1536
+- `composer` _(string)_ - Batch composer: claude|openai|gemini
+- `force` _(boolean)_ - Plan regeneration even when outputs already exist
+- `maxCost` _(number)_ - Fail if estimated cost exceeds this USD cap
 
 JSON payload: `data.kind` is `"build-plan"` and includes `schemaVersion:"1"`, `status:"ready"|"invalid"`, `summary`, `providerResolution`, cache-aware asset plans, asset reference metadata, `validation`, `retryWith`, and `nextCommands`. Invalid storyboards exit non-zero with `code:"STORYBOARD_VALIDATION_FAILED"`.
 
@@ -419,17 +419,17 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Video project directory
-- `output` _(string)_ — Output file (default: preview.mp4 in the project dir)
-- `root` _(string)_ _(default: `"index.html"`)_ — Root composition file
-- `beat` _(string)_ — Preview only one storyboard beat using a temporary root
-- `fps` _(number)_ _(default: `24`)_ — Frames per second: 24|30|60
-- `quality` _(string)_ _(default: `"draft"`)_ — Quality preset: draft|standard|high
-- `format` _(string)_ _(default: `"mp4"`)_ — Output container: mp4|webm|mov
-- `workers` _(number)_ _(default: `1`)_ — Capture workers (1-16, default 1)
-- `open` _(boolean)_ — Open the preview in the OS default app after render
-- `reveal` _(boolean)_ — Reveal the preview in Finder/file manager after render
-- `dryRun` _(boolean)_ — Preview parameters without rendering
+- `project-dir` _(string)_ - Video project directory
+- `output` _(string)_ - Output file (default: preview.mp4 in the project dir)
+- `root` _(string)_ _(default: `"index.html"`)_ - Root composition file
+- `beat` _(string)_ - Preview only one storyboard beat using a temporary root
+- `fps` _(number)_ _(default: `24`)_ - Frames per second: 24|30|60
+- `quality` _(string)_ _(default: `"draft"`)_ - Quality preset: draft|standard|high
+- `format` _(string)_ _(default: `"mp4"`)_ - Output container: mp4|webm|mov
+- `workers` _(number)_ _(default: `1`)_ - Capture workers (1-16, default 1)
+- `open` _(boolean)_ - Open the preview in the OS default app after render
+- `reveal` _(boolean)_ - Reveal the preview in Finder/file manager after render
+- `dryRun` _(boolean)_ - Preview parameters without rendering
 
 #### `vibe render`
 
@@ -442,19 +442,19 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Video project directory
-- `output` _(string)_ — Output file (default: renders/<name>-<timestamp>.<format>)
-- `out` _(string)_ — (deprecated) alias for --output
-- `root` _(string)_ _(default: `"index.html"`)_ — Root composition file
-- `beat` _(string)_ — Render only one storyboard beat using a temporary root
-- `fps` _(number)_ _(default: `30`)_ — Frames per second: 24|30|60
-- `quality` _(string)_ _(default: `"standard"`)_ — Quality preset: draft|standard|high
-- `format` _(string)_ _(default: `"mp4"`)_ — Output container: mp4|webm|mov
-- `workers` _(number)_ _(default: `1`)_ — Capture workers (1-16, default 1)
-- `open` _(boolean)_ — Open the rendered video in the OS default app after render
-- `reveal` _(boolean)_ — Reveal the rendered video in Finder/file manager after render
-- `silent` _(boolean)_ — Emit silent video (skip audio mux); add audio later with `vibe assemble`
-- `dryRun` _(boolean)_ — Preview parameters without rendering
+- `project-dir` _(string)_ - Video project directory
+- `output` _(string)_ - Output file (default: renders/<name>-<timestamp>.<format>)
+- `out` _(string)_ - (deprecated) alias for --output
+- `root` _(string)_ _(default: `"index.html"`)_ - Root composition file
+- `beat` _(string)_ - Render only one storyboard beat using a temporary root
+- `fps` _(number)_ _(default: `30`)_ - Frames per second: 24|30|60
+- `quality` _(string)_ _(default: `"standard"`)_ - Quality preset: draft|standard|high
+- `format` _(string)_ _(default: `"mp4"`)_ - Output container: mp4|webm|mov
+- `workers` _(number)_ _(default: `1`)_ - Capture workers (1-16, default 1)
+- `open` _(boolean)_ - Open the rendered video in the OS default app after render
+- `reveal` _(boolean)_ - Reveal the rendered video in Finder/file manager after render
+- `silent` _(boolean)_ - Emit silent video (skip audio mux); add audio later with `vibe assemble`
+- `dryRun` _(boolean)_ - Preview parameters without rendering
 
 #### `vibe run`
 
@@ -467,16 +467,16 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `pipeline` _(string)_ **required** — Path to pipeline YAML file
-- `output` _(string)_ — Output directory for step results
-- `dryRun` _(boolean)_ — Validate and show execution plan without running
-- `resume` _(boolean)_ — Resume from last checkpoint (skip completed steps)
-- `failFast` _(boolean)_ — Stop on first failed step (default: continue)
-- `budgetUsd` _(number)_ — Abort if upper-bound cost estimate exceeds this USD amount
-- `budgetTokens` _(number)_ — Abort if provider token usage exceeds this count
-- `maxErrors` _(number)_ — Abort if failed step count exceeds this
-- `effort` _(string)_ — LLM effort level: low|medium|high|xhigh (Opus 4.7)
-- `json` _(boolean)_ — Output results as JSON
+- `pipeline` _(string)_ **required** - Path to pipeline YAML file
+- `output` _(string)_ - Output directory for step results
+- `dryRun` _(boolean)_ - Validate and show execution plan without running
+- `resume` _(boolean)_ - Resume from last checkpoint (skip completed steps)
+- `failFast` _(boolean)_ - Stop on first failed step (default: continue)
+- `budgetUsd` _(number)_ - Abort if upper-bound cost estimate exceeds this USD amount
+- `budgetTokens` _(number)_ - Abort if provider token usage exceeds this count
+- `maxErrors` _(number)_ - Abort if failed step count exceeds this
+- `effort` _(string)_ - LLM effort level: low|medium|high|xhigh (Opus 4.7)
+- `json` _(boolean)_ - Output results as JSON
 
 #### `vibe setup`
 
@@ -489,16 +489,16 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `reset` _(boolean)_ — Reset configuration to defaults
-- `full` _(boolean)_ — Run full setup with all optional providers
-- `show` _(boolean)_ — Show current configuration (for debugging)
-- `verbose` _(boolean)_ — With --show: include unset providers + Resolution order + Defaults block
-- `claudeCode` _(boolean)_ — Show Claude Code integration guide
-- `yes` _(boolean)_ — Non-interactive: write config without prompting (CI / devcontainer)
-- `provider` _(string)_ — Set the Agent LLM provider (claude | openai | gemini | xai | openrouter | evolink | ollama)
-- `importEnv` _(boolean)_ — Promote API keys from .env / shell env into config.yaml
-- `test` _(boolean)_ — After save, live-test each configured key (exits 7 if any FAIL)
-- `scope` _(string)_ _(default: `"user"`)_ — Where to save: 'user' (~/.vibeframe/config.yaml, shared) or 'project' (./.vibeframe/config.yaml, gitignored, this project only)
+- `reset` _(boolean)_ - Reset configuration to defaults
+- `full` _(boolean)_ - Run full setup with all optional providers
+- `show` _(boolean)_ - Show current configuration (for debugging)
+- `verbose` _(boolean)_ - With --show: include unset providers + Resolution order + Defaults block
+- `claudeCode` _(boolean)_ - Show Claude Code integration guide
+- `yes` _(boolean)_ - Non-interactive: write config without prompting (CI / devcontainer)
+- `provider` _(string)_ - Set the Agent LLM provider (claude | openai | gemini | xai | openrouter | evolink | ollama)
+- `importEnv` _(boolean)_ - Promote API keys from .env / shell env into config.yaml
+- `test` _(boolean)_ - After save, live-test each configured key (exits 7 if any FAIL)
+- `scope` _(string)_ _(default: `"user"`)_ - Where to save: 'user' (~/.vibeframe/config.yaml, shared) or 'project' (./.vibeframe/config.yaml, gitignored, this project only)
 
 ### `generate`
 
@@ -514,11 +514,11 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `description` _(string)_ **required** — Background description
-- `apiKey` _(string)_ — OpenAI API key (or set OPENAI_API_KEY env)
-- `output` _(string)_ — Output file path (downloads image)
-- `aspect` _(string)_ _(16:9 \| 9:16 \| 1:1)_ _(default: `"16:9"`)_ — Aspect ratio: 16:9, 9:16, 1:1
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `description` _(string)_ **required** - Background description
+- `apiKey` _(string)_ - OpenAI API key (or set OPENAI_API_KEY env)
+- `output` _(string)_ - Output file path (downloads image)
+- `aspect` _(string)_ _(16:9 \| 9:16 \| 1:1)_ _(default: `"16:9"`)_ - Aspect ratio: 16:9, 9:16, 1:1
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate image`
 
@@ -530,17 +530,17 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `prompt` _(string)_ — Image description prompt (interactive if omitted)
-- `provider` _(string)_ _(openai \| gemini \| grok \| runway)_ — Provider: openai (default when OPENAI_API_KEY set), gemini, grok, runway
-- `apiKey` _(string)_ — API key (or set env: OPENAI_API_KEY, GOOGLE_API_KEY)
-- `output` _(string)_ — Output file path (downloads image)
-- `size` _(string)_ _(default: `"1024x1024"`)_ — Image size (openai: 1024x1024, 1536x1024, 1024x1536)
-- `ratio` _(string)_ _(default: `"1:1"`)_ — Aspect ratio (gemini: 1:1, 1:4, 1:8, 4:1, 8:1, 16:9, 9:16, 3:4, 4:3, etc.)
-- `quality` _(string)_ _(standard \| hd)_ _(default: `"standard"`)_ — Quality: standard, hd (openai only)
-- `style` _(string)_ _(vivid \| natural)_ _(default: `"vivid"`)_ — Style: vivid, natural (openai only)
-- `count` _(number)_ _(default: `1`)_ — Number of images to generate
-- `model` _(string)_ — Model. Gemini: flash, 3.1-flash, latest, pro. OpenAI: 2 (default), 1.5
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `prompt` _(string)_ - Image description prompt (interactive if omitted)
+- `provider` _(string)_ _(openai \| gemini \| grok \| runway)_ - Provider: openai (default when OPENAI_API_KEY set), gemini, grok, runway
+- `apiKey` _(string)_ - API key (or set env: OPENAI_API_KEY, GOOGLE_API_KEY)
+- `output` _(string)_ - Output file path (downloads image)
+- `size` _(string)_ _(default: `"1024x1024"`)_ - Image size (openai: 1024x1024, 1536x1024, 1024x1536)
+- `ratio` _(string)_ _(default: `"1:1"`)_ - Aspect ratio (gemini: 1:1, 1:4, 1:8, 4:1, 8:1, 16:9, 9:16, 3:4, 4:3, etc.)
+- `quality` _(string)_ _(standard \| hd)_ _(default: `"standard"`)_ - Quality: standard, hd (openai only)
+- `style` _(string)_ _(vivid \| natural)_ _(default: `"vivid"`)_ - Style: vivid, natural (openai only)
+- `count` _(number)_ _(default: `1`)_ - Number of images to generate
+- `model` _(string)_ - Model. Gemini: flash, 3.1-flash, latest, pro. OpenAI: 2 (default), 1.5
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate motion`
 
@@ -554,22 +554,22 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `description` _(string)_ **required** — Natural language description of the motion graphic
-- `apiKey` _(string)_ — Anthropic API key (or set ANTHROPIC_API_KEY env)
-- `output` _(string)_ _(default: `"motion.tsx"`)_ — Output file path
-- `duration` _(number)_ _(default: `5`)_ — Duration in seconds
-- `width` _(number)_ _(default: `1920`)_ — Width in pixels
-- `height` _(number)_ _(default: `1080`)_ — Height in pixels
-- `fps` _(number)_ _(default: `30`)_ — Frame rate
-- `style` _(string)_ _(minimal \| corporate \| playful \| cinematic)_ — Style preset: minimal, corporate, playful, cinematic
-- `render` _(boolean)_ — Render the generated code with Remotion (output .webm)
-- `video` _(string)_ — Base video to composite the motion graphic onto
-- `image` _(string)_ — Image to analyze with Gemini — color/mood fed into Claude prompt
-- `understand` _(string)_ _(default: `"auto"`)_ — Analyze --video with Gemini before generating motion: auto, off, required
-- `understandingPrompt` _(string)_ — Custom prompt for --video understanding
-- `fromTsx` _(string)_ — Refine an existing TSX file instead of generating from scratch
-- `model` _(string)_ _(default: `"sonnet"`)_ — LLM model: sonnet (default), opus, gemini, gemini-2.5-pro, gemini-3.1-pro
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `description` _(string)_ **required** - Natural language description of the motion graphic
+- `apiKey` _(string)_ - Anthropic API key (or set ANTHROPIC_API_KEY env)
+- `output` _(string)_ _(default: `"motion.tsx"`)_ - Output file path
+- `duration` _(number)_ _(default: `5`)_ - Duration in seconds
+- `width` _(number)_ _(default: `1920`)_ - Width in pixels
+- `height` _(number)_ _(default: `1080`)_ - Height in pixels
+- `fps` _(number)_ _(default: `30`)_ - Frame rate
+- `style` _(string)_ _(minimal \| corporate \| playful \| cinematic)_ - Style preset: minimal, corporate, playful, cinematic
+- `render` _(boolean)_ - Render the generated code with Remotion (output .webm)
+- `video` _(string)_ - Base video to composite the motion graphic onto
+- `image` _(string)_ - Image to analyze with Gemini - color/mood fed into Claude prompt
+- `understand` _(string)_ _(default: `"auto"`)_ - Analyze --video with Gemini before generating motion: auto, off, required
+- `understandingPrompt` _(string)_ - Custom prompt for --video understanding
+- `fromTsx` _(string)_ - Refine an existing TSX file instead of generating from scratch
+- `model` _(string)_ _(default: `"sonnet"`)_ - LLM model: sonnet (default), opus, gemini, gemini-2.5-pro, gemini-3.1-pro
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate music`
 
@@ -581,16 +581,16 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `prompt` _(string)_ **required** — Description of the music to generate
-- `provider` _(string)_ _(elevenlabs \| replicate)_ _(default: `"elevenlabs"`)_ — Provider: elevenlabs (default, up to 10min), replicate (MusicGen, max 30s)
-- `apiKey` _(string)_ — API key (or set ELEVENLABS_API_KEY / REPLICATE_API_TOKEN env)
-- `duration` _(number)_ _(default: `8`)_ — Duration in seconds (elevenlabs: 3-600, replicate: 1-30)
-- `instrumental` _(boolean)_ — Force instrumental music, no vocals (ElevenLabs only)
-- `melody` _(string)_ — Reference melody audio file for conditioning (Replicate only)
-- `model` _(string)_ _(large \| stereo-large \| melody-large \| stereo-melody-large)_ _(default: `"stereo-large"`)_ — Model variant (Replicate only): large, stereo-large, melody-large, stereo-melody-large
-- `output` _(string)_ _(default: `"music.mp3"`)_ — Output audio file path
-- `noWait` _(boolean)_ — Don't wait for generation to complete (Replicate async mode)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `prompt` _(string)_ **required** - Description of the music to generate
+- `provider` _(string)_ _(elevenlabs \| replicate)_ _(default: `"elevenlabs"`)_ - Provider: elevenlabs (default, up to 10min), replicate (MusicGen, max 30s)
+- `apiKey` _(string)_ - API key (or set ELEVENLABS_API_KEY / REPLICATE_API_TOKEN env)
+- `duration` _(number)_ _(default: `8`)_ - Duration in seconds (elevenlabs: 3-600, replicate: 1-30)
+- `instrumental` _(boolean)_ - Force instrumental music, no vocals (ElevenLabs only)
+- `melody` _(string)_ - Reference melody audio file for conditioning (Replicate only)
+- `model` _(string)_ _(large \| stereo-large \| melody-large \| stereo-melody-large)_ _(default: `"stereo-large"`)_ - Model variant (Replicate only): large, stereo-large, melody-large, stereo-melody-large
+- `output` _(string)_ _(default: `"music.mp3"`)_ - Output audio file path
+- `noWait` _(boolean)_ - Don't wait for generation to complete (Replicate async mode)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate music-status`
 
@@ -604,8 +604,8 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `task-id` _(string)_ **required** — Task ID from music generation
-- `apiKey` _(string)_ — Replicate API token (or set REPLICATE_API_TOKEN env)
+- `task-id` _(string)_ **required** - Task ID from music generation
+- `apiKey` _(string)_ - Replicate API token (or set REPLICATE_API_TOKEN env)
 
 #### `vibe generate narration`
 
@@ -618,11 +618,11 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `text` _(string)_ — Narration text (interactive if omitted)
-- `apiKey` _(string)_ — ElevenLabs API key (or set ELEVENLABS_API_KEY env)
-- `output` _(string)_ _(default: `"narration.mp3"`)_ — Output audio file path
-- `voice` _(string)_ _(default: `"21m00Tcm4TlvDq8ikWAM"`)_ — Voice ID (default: Rachel)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `text` _(string)_ - Narration text (interactive if omitted)
+- `apiKey` _(string)_ - ElevenLabs API key (or set ELEVENLABS_API_KEY env)
+- `output` _(string)_ _(default: `"narration.mp3"`)_ - Output audio file path
+- `voice` _(string)_ _(default: `"21m00Tcm4TlvDq8ikWAM"`)_ - Voice ID (default: Rachel)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate sound-effect`
 
@@ -634,12 +634,12 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `prompt` _(string)_ **required** — Description of the sound effect
-- `apiKey` _(string)_ — ElevenLabs API key (or set ELEVENLABS_API_KEY env)
-- `output` _(string)_ _(default: `"sound-effect.mp3"`)_ — Output audio file path
-- `duration` _(number)_ — Duration in seconds (0.5-22, default: auto)
-- `promptInfluence` _(string)_ — Prompt influence (0-1, default: 0.3)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `prompt` _(string)_ **required** - Description of the sound effect
+- `apiKey` _(string)_ - ElevenLabs API key (or set ELEVENLABS_API_KEY env)
+- `output` _(string)_ _(default: `"sound-effect.mp3"`)_ - Output audio file path
+- `duration` _(number)_ - Duration in seconds (0.5-22, default: auto)
+- `promptInfluence` _(string)_ - Prompt influence (0-1, default: 0.3)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate speech`
 
@@ -653,13 +653,13 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `text` _(string)_ — Text to convert to speech (interactive if omitted)
-- `apiKey` _(string)_ — ElevenLabs API key (or set ELEVENLABS_API_KEY env)
-- `output` _(string)_ _(default: `"output.mp3"`)_ — Output audio file path
-- `voice` _(string)_ _(default: `"21m00Tcm4TlvDq8ikWAM"`)_ — Voice ID (default: Rachel)
-- `listVoices` _(boolean)_ — List available voices
-- `fitDuration` _(number)_ — Speed up audio to fit target duration (via FFmpeg atempo)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `text` _(string)_ - Text to convert to speech (interactive if omitted)
+- `apiKey` _(string)_ - ElevenLabs API key (or set ELEVENLABS_API_KEY env)
+- `output` _(string)_ _(default: `"output.mp3"`)_ - Output audio file path
+- `voice` _(string)_ _(default: `"21m00Tcm4TlvDq8ikWAM"`)_ - Voice ID (default: Rachel)
+- `listVoices` _(boolean)_ - List available voices
+- `fitDuration` _(number)_ - Speed up audio to fit target duration (via FFmpeg atempo)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate storyboard`
 
@@ -673,13 +673,13 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `content` _(string)_ **required** — Content to analyze (text or file path)
-- `apiKey` _(string)_ — Anthropic API key (or set ANTHROPIC_API_KEY env)
-- `output` _(string)_ — Output JSON file path
-- `duration` _(number)_ — Target total duration in seconds
-- `file` _(boolean)_ — Treat content argument as file path
-- `creativity` _(string)_ _(default: `"low"`)_ — Creativity level: low (default, consistent) or high (varied, unexpected)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `content` _(string)_ **required** - Content to analyze (text or file path)
+- `apiKey` _(string)_ - Anthropic API key (or set ANTHROPIC_API_KEY env)
+- `output` _(string)_ - Output JSON file path
+- `duration` _(number)_ - Target total duration in seconds
+- `file` _(boolean)_ - Treat content argument as file path
+- `creativity` _(string)_ _(default: `"low"`)_ - Creativity level: low (default, consistent) or high (varied, unexpected)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate thumbnail`
 
@@ -691,13 +691,13 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `description` _(string)_ — Thumbnail description (for DALL-E generation)
-- `apiKey` _(string)_ — API key (OpenAI for generation, Google for best-frame)
-- `output` _(string)_ — Output file path
-- `style` _(string)_ _(youtube \| instagram \| tiktok \| twitter)_ — Platform style: youtube, instagram, tiktok, twitter
-- `bestFrame` _(string)_ — Extract best thumbnail frame from video using Gemini AI
-- `prompt` _(string)_ — Custom prompt for best-frame analysis
-- `model` _(string)_ _(default: `"flash"`)_ — Gemini model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
+- `description` _(string)_ - Thumbnail description (for DALL-E generation)
+- `apiKey` _(string)_ - API key (OpenAI for generation, Google for best-frame)
+- `output` _(string)_ - Output file path
+- `style` _(string)_ _(youtube \| instagram \| tiktok \| twitter)_ - Platform style: youtube, instagram, tiktok, twitter
+- `bestFrame` _(string)_ - Extract best thumbnail frame from video using Gemini AI
+- `prompt` _(string)_ - Custom prompt for best-frame analysis
+- `model` _(string)_ _(default: `"flash"`)_ - Gemini model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
 
 #### `vibe generate video`
 
@@ -709,29 +709,29 @@ Cost tier: `very-high`
 
 **Parameters:**
 
-- `prompt` _(string)_ — Text prompt describing the video (interactive if omitted)
-- `provider` _(string)_ — Provider: seedance (ByteDance Seedance 2.0 via fal.ai), grok, kling, runway, veo, omni (Gemini Omni, experimental). `fal` is a deprecated v0.x alias for seedance and will be removed in 1.0.
-- `apiKey` _(string)_ — API key (or set FAL_API_KEY / XAI_API_KEY / RUNWAY_API_SECRET / KLING_API_KEY / GOOGLE_API_KEY env)
-- `output` _(string)_ — Output file path (downloads video)
-- `image` _(string)_ — Reference image for image-to-video
-- `duration` _(number)_ _(default: `5`)_ — Duration in seconds. Seedance accepts 4-15; Kling accepts 5 or 10; Veo maps to 6 or 8.
-- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1)_ — Aspect ratio: 16:9, 9:16, or 1:1 (auto-detected from image if omitted)
-- `seed` _(number)_ — Random seed for reproducibility (Runway only)
-- `mode` _(string)_ _(default: `"std"`)_ — Generation mode: std or pro (Kling only)
-- `seedanceModel` _(string)_ _(default: `"quality"`)_ — Seedance variant: quality or fast (fal.ai only)
-- `negative` _(string)_ — Negative prompt - what to avoid (Kling/Veo)
-- `resolution` _(string)_ — Video resolution: 480p, 720p, 1080p, or 4k depending on provider
-- `lastFrame` _(string)_ — Last frame image for frame interpolation (Veo) or Seedance end frame
-- `endImage` _(string)_ — Ending frame image for Seedance image-to-video
-- `refImages` _(string)_ — Reference images for Seedance reference-to-video or Veo character consistency
-- `refVideos` _(string)_ — Reference videos for Seedance reference-to-video
-- `refAudio` _(string)_ — Reference audio for Seedance reference-to-video
-- `noGenerateAudio` _(boolean)_ — Disable native audio when the provider supports it
-- `person` _(string)_ — Person generation: allow_all, allow_adult (Veo only)
-- `veoModel` _(string)_ _(default: `"3.1-fast"`)_ — Veo model: 3.0, 3.1, 3.1-fast (default: 3.1-fast)
-- `runwayModel` _(string)_ _(default: `"gen4.5"`)_ — Runway model: gen4.5 (default, text+image-to-video), gen4_turbo (image-to-video only)
-- `noWait` _(boolean)_ — Start generation and return task ID without waiting
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `prompt` _(string)_ - Text prompt describing the video (interactive if omitted)
+- `provider` _(string)_ - Provider: seedance (ByteDance Seedance 2.0 via fal.ai), grok, kling, runway, veo, omni (Gemini Omni, experimental). `fal` is a deprecated v0.x alias for seedance and will be removed in 1.0.
+- `apiKey` _(string)_ - API key (or set FAL_API_KEY / XAI_API_KEY / RUNWAY_API_SECRET / KLING_API_KEY / GOOGLE_API_KEY env)
+- `output` _(string)_ - Output file path (downloads video)
+- `image` _(string)_ - Reference image for image-to-video
+- `duration` _(number)_ _(default: `5`)_ - Duration in seconds. Seedance accepts 4-15; Kling accepts 5 or 10; Veo maps to 6 or 8.
+- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1)_ - Aspect ratio: 16:9, 9:16, or 1:1 (auto-detected from image if omitted)
+- `seed` _(number)_ - Random seed for reproducibility (Runway only)
+- `mode` _(string)_ _(default: `"std"`)_ - Generation mode: std or pro (Kling only)
+- `seedanceModel` _(string)_ _(default: `"quality"`)_ - Seedance variant: quality or fast (fal.ai only)
+- `negative` _(string)_ - Negative prompt - what to avoid (Kling/Veo)
+- `resolution` _(string)_ - Video resolution: 480p, 720p, 1080p, or 4k depending on provider
+- `lastFrame` _(string)_ - Last frame image for frame interpolation (Veo) or Seedance end frame
+- `endImage` _(string)_ - Ending frame image for Seedance image-to-video
+- `refImages` _(string)_ - Reference images for Seedance reference-to-video or Veo character consistency
+- `refVideos` _(string)_ - Reference videos for Seedance reference-to-video
+- `refAudio` _(string)_ - Reference audio for Seedance reference-to-video
+- `noGenerateAudio` _(boolean)_ - Disable native audio when the provider supports it
+- `person` _(string)_ - Person generation: allow_all, allow_adult (Veo only)
+- `veoModel` _(string)_ _(default: `"3.1-fast"`)_ - Veo model: 3.0, 3.1, 3.1-fast (default: 3.1-fast)
+- `runwayModel` _(string)_ _(default: `"gen4.5"`)_ - Runway model: gen4.5 (default, text+image-to-video), gen4_turbo (image-to-video only)
+- `noWait` _(boolean)_ - Start generation and return task ID without waiting
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate video-cancel`
 
@@ -744,9 +744,9 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `task-id` _(string)_ **required** — Task ID to cancel
-- `provider` _(string)_ _(grok \| runway)_ _(default: `"grok"`)_ — Provider: grok, runway
-- `apiKey` _(string)_ — API key (or set XAI_API_KEY / RUNWAY_API_SECRET env)
+- `task-id` _(string)_ **required** - Task ID to cancel
+- `provider` _(string)_ _(grok \| runway)_ _(default: `"grok"`)_ - Provider: grok, runway
+- `apiKey` _(string)_ - API key (or set XAI_API_KEY / RUNWAY_API_SECRET env)
 
 #### `vibe generate video-extend`
 
@@ -759,16 +759,16 @@ Cost tier: `very-high`
 
 **Parameters:**
 
-- `id` _(string)_ **required** — Kling video ID or Veo operation name
-- `provider` _(string)_ _(kling \| veo)_ _(default: `"kling"`)_ — Provider: kling, veo
-- `apiKey` _(string)_ — API key (KLING_API_KEY or GOOGLE_API_KEY)
-- `output` _(string)_ — Output file path
-- `prompt` _(string)_ — Continuation prompt
-- `duration` _(number)_ _(default: `5`)_ — Duration: 5 or 10 (Kling), 4/6/8 (Veo)
-- `negative` _(string)_ — Negative prompt (what to avoid, Kling only)
-- `veoModel` _(string)_ _(default: `"3.1"`)_ — Veo model: 3.0, 3.1, 3.1-fast
-- `noWait` _(boolean)_ — Start extension and return task ID without waiting
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `id` _(string)_ **required** - Kling video ID or Veo operation name
+- `provider` _(string)_ _(kling \| veo)_ _(default: `"kling"`)_ - Provider: kling, veo
+- `apiKey` _(string)_ - API key (KLING_API_KEY or GOOGLE_API_KEY)
+- `output` _(string)_ - Output file path
+- `prompt` _(string)_ - Continuation prompt
+- `duration` _(number)_ _(default: `5`)_ - Duration: 5 or 10 (Kling), 4/6/8 (Veo)
+- `negative` _(string)_ - Negative prompt (what to avoid, Kling only)
+- `veoModel` _(string)_ _(default: `"3.1"`)_ - Veo model: 3.0, 3.1, 3.1-fast
+- `noWait` _(boolean)_ - Start extension and return task ID without waiting
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe generate video-status`
 
@@ -782,12 +782,12 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `task-id` _(string)_ **required** — Task ID from video generation
-- `provider` _(string)_ _(grok \| runway \| kling \| veo)_ _(default: `"grok"`)_ — Provider: grok, runway, kling, veo
-- `apiKey` _(string)_ — API key (or set XAI_API_KEY / RUNWAY_API_SECRET / KLING_API_KEY / GOOGLE_API_KEY env)
-- `type` _(string)_ _(default: `"text2video"`)_ — Task type: text2video or image2video (Kling only)
-- `wait` _(boolean)_ — Wait for completion
-- `output` _(string)_ — Download video when complete
+- `task-id` _(string)_ **required** - Task ID from video generation
+- `provider` _(string)_ _(grok \| runway \| kling \| veo)_ _(default: `"grok"`)_ - Provider: grok, runway, kling, veo
+- `apiKey` _(string)_ - API key (or set XAI_API_KEY / RUNWAY_API_SECRET / KLING_API_KEY / GOOGLE_API_KEY env)
+- `type` _(string)_ _(default: `"text2video"`)_ - Task type: text2video or image2video (Kling only)
+- `wait` _(boolean)_ - Wait for completion
+- `output` _(string)_ - Download video when complete
 
 ### `edit`
 
@@ -801,15 +801,15 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `output` _(string)_ — Output file path (default: <name>-captioned.<ext>)
-- `style` _(string)_ _(minimal \| bold \| outline \| karaoke)_ _(default: `"bold"`)_ — Caption style: minimal, bold, outline, karaoke (default: bold)
-- `fontSize` _(number)_ — Override auto-calculated font size
-- `color` _(string)_ _(default: `"white"`)_ — Font color (default: white)
-- `language` _(string)_ — Language code for transcription (e.g., en, ko)
-- `position` _(string)_ _(top \| center \| bottom)_ _(default: `"bottom"`)_ — Caption position: top, center, bottom (default: bottom)
-- `apiKey` _(string)_ — OpenAI API key (or set OPENAI_API_KEY env)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `output` _(string)_ - Output file path (default: <name>-captioned.<ext>)
+- `style` _(string)_ _(minimal \| bold \| outline \| karaoke)_ _(default: `"bold"`)_ - Caption style: minimal, bold, outline, karaoke (default: bold)
+- `fontSize` _(number)_ - Override auto-calculated font size
+- `color` _(string)_ _(default: `"white"`)_ - Font color (default: white)
+- `language` _(string)_ - Language code for transcription (e.g., en, ko)
+- `position` _(string)_ _(top \| center \| bottom)_ _(default: `"bottom"`)_ - Caption position: top, center, bottom (default: bottom)
+- `apiKey` _(string)_ - OpenAI API key (or set OPENAI_API_KEY env)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit fade`
 
@@ -821,13 +821,13 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `output` _(string)_ — Output file path (default: <name>-faded.<ext>)
-- `fadeIn` _(number)_ _(default: `1`)_ — Fade-in duration in seconds (default: 1)
-- `fadeOut` _(number)_ _(default: `1`)_ — Fade-out duration in seconds (default: 1)
-- `audioOnly` _(boolean)_ — Apply fade to audio only (video stream copied)
-- `videoOnly` _(boolean)_ — Apply fade to video only (audio stream copied)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `output` _(string)_ - Output file path (default: <name>-faded.<ext>)
+- `fadeIn` _(number)_ _(default: `1`)_ - Fade-in duration in seconds (default: 1)
+- `fadeOut` _(number)_ _(default: `1`)_ - Fade-out duration in seconds (default: 1)
+- `audioOnly` _(boolean)_ - Apply fade to audio only (video stream copied)
+- `videoOnly` _(boolean)_ - Apply fade to video only (audio stream copied)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit fill-gaps`
 
@@ -839,14 +839,14 @@ Cost tier: `very-high`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `provider` _(string)_ _(default: `"kling"`)_ — AI provider (kling)
-- `output` _(string)_ — Output project path (default: overwrite)
-- `dir` _(string)_ — Directory to save generated videos
-- `prompt` _(string)_ — Custom prompt for video generation
-- `dryRun` _(boolean)_ — Show gaps without generating
-- `mode` _(string)_ _(default: `"std"`)_ — Generation mode: std or pro (Kling)
-- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1)_ _(default: `"16:9"`)_ — Aspect ratio: 16:9, 9:16, or 1:1
+- `project` _(string)_ **required** - Timeline file or directory
+- `provider` _(string)_ _(default: `"kling"`)_ - AI provider (kling)
+- `output` _(string)_ - Output project path (default: overwrite)
+- `dir` _(string)_ - Directory to save generated videos
+- `prompt` _(string)_ - Custom prompt for video generation
+- `dryRun` _(boolean)_ - Show gaps without generating
+- `mode` _(string)_ _(default: `"std"`)_ - Generation mode: std or pro (Kling)
+- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1)_ _(default: `"16:9"`)_ - Aspect ratio: 16:9, 9:16, or 1:1
 
 #### `vibe edit grade`
 
@@ -858,13 +858,13 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `style` _(string)_ — Style description (e.g., 'cinematic warm')
-- `preset` _(string)_ — Built-in preset: film-noir, vintage, cinematic-warm, cool-tones, high-contrast, pastel, cyberpunk, horror
-- `output` _(string)_ — Output video file path
-- `analyzeOnly` _(boolean)_ — Show filter without applying
-- `apiKey` _(string)_ — Anthropic API key (or set ANTHROPIC_API_KEY env)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `style` _(string)_ - Style description (e.g., 'cinematic warm')
+- `preset` _(string)_ - Built-in preset: film-noir, vintage, cinematic-warm, cool-tones, high-contrast, pastel, cyberpunk, horror
+- `output` _(string)_ - Output video file path
+- `analyzeOnly` _(boolean)_ - Show filter without applying
+- `apiKey` _(string)_ - Anthropic API key (or set ANTHROPIC_API_KEY env)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit image`
 
@@ -876,14 +876,14 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `images` _(array)_ **required** — Input image file(s) followed by edit prompt
-- `provider` _(string)_ _(gemini \| openai \| grok)_ _(default: `"gemini"`)_ — Provider: gemini (default), openai, grok
-- `apiKey` _(string)_ — API key (or set env variable)
-- `output` _(string)_ _(default: `"edited.png"`)_ — Output file path
-- `model` _(string)_ _(default: `"flash"`)_ — Model: flash/3.1-flash/latest/pro (Gemini only)
-- `ratio` _(string)_ — Output aspect ratio
-- `size` _(string)_ — Resolution: 1K, 2K, 4K (Gemini Pro only)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `images` _(array)_ **required** - Input image file(s) followed by edit prompt
+- `provider` _(string)_ _(gemini \| openai \| grok)_ _(default: `"gemini"`)_ - Provider: gemini (default), openai, grok
+- `apiKey` _(string)_ - API key (or set env variable)
+- `output` _(string)_ _(default: `"edited.png"`)_ - Output file path
+- `model` _(string)_ _(default: `"flash"`)_ - Model: flash/3.1-flash/latest/pro (Gemini only)
+- `ratio` _(string)_ - Output aspect ratio
+- `size` _(string)_ - Resolution: 1K, 2K, 4K (Gemini Pro only)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit interpolate`
 
@@ -895,12 +895,12 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `output` _(string)_ — Output file path
-- `factor` _(number)_ _(2 \| 4 \| 8)_ _(default: `2`)_ — Slow motion factor: 2, 4, or 8
-- `fps` _(number)_ — Target output FPS
-- `mode` _(string)_ _(default: `"quality"`)_ — Speed/quality tradeoff: fast or quality
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `output` _(string)_ - Output file path
+- `factor` _(number)_ _(2 \| 4 \| 8)_ _(default: `2`)_ - Slow motion factor: 2, 4, or 8
+- `fps` _(number)_ - Target output FPS
+- `mode` _(string)_ _(default: `"quality"`)_ - Speed/quality tradeoff: fast or quality
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit jump-cut`
 
@@ -912,14 +912,14 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `output` _(string)_ — Output file path (default: <name>-jumpcut.<ext>)
-- `fillers` _(string)_ — Comma-separated filler words to detect
-- `padding` _(number)_ _(default: `0.05`)_ — Padding around cuts in seconds (default: 0.05)
-- `language` _(string)_ — Language code for transcription (e.g., en, ko)
-- `analyzeOnly` _(boolean)_ — Only detect fillers, don't cut
-- `apiKey` _(string)_ — OpenAI API key (or set OPENAI_API_KEY env)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `output` _(string)_ - Output file path (default: <name>-jumpcut.<ext>)
+- `fillers` _(string)_ - Comma-separated filler words to detect
+- `padding` _(number)_ _(default: `0.05`)_ - Padding around cuts in seconds (default: 0.05)
+- `language` _(string)_ - Language code for transcription (e.g., en, ko)
+- `analyzeOnly` _(boolean)_ - Only detect fillers, don't cut
+- `apiKey` _(string)_ - OpenAI API key (or set OPENAI_API_KEY env)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit motion-overlay`
 
@@ -931,22 +931,22 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `description` _(string)_ — Motion overlay description (omit when using --asset)
-- `asset` _(string)_ — User-provided .json/.lottie animation to overlay
-- `output` _(string)_ — Output video file path
-- `duration` _(number)_ — Overlay/render duration in seconds
-- `start` _(number)_ _(default: `0`)_ — Overlay start time in seconds
-- `style` _(string)_ — Style preset for generated overlays: minimal, corporate, playful, cinematic
-- `model` _(string)_ _(default: `"sonnet"`)_ — LLM model for generated overlays: sonnet, opus, gemini, gemini-2.5-pro, gemini-3.1-pro
-- `understand` _(string)_ _(default: `"auto"`)_ — Analyze video before generated overlay: auto, off, required
-- `understandingPrompt` _(string)_ — Custom prompt for video understanding
-- `position` _(string)_ _(full \| center \| top-left \| top-right \| bottom-left \| bottom-right)_ _(default: `"full"`)_ — Lottie position: full, center, top-left, top-right, bottom-left, bottom-right
-- `scale` _(number)_ — Lottie overlay scale (0.01-2)
-- `opacity` _(number)_ _(default: `1`)_ — Lottie overlay opacity (0-1)
-- `loop` _(boolean)_ _(default: `true`)_ — Loop Lottie overlay
-- `noLoop` _(boolean)_ — Do not loop Lottie overlay
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `description` _(string)_ - Motion overlay description (omit when using --asset)
+- `asset` _(string)_ - User-provided .json/.lottie animation to overlay
+- `output` _(string)_ - Output video file path
+- `duration` _(number)_ - Overlay/render duration in seconds
+- `start` _(number)_ _(default: `0`)_ - Overlay start time in seconds
+- `style` _(string)_ - Style preset for generated overlays: minimal, corporate, playful, cinematic
+- `model` _(string)_ _(default: `"sonnet"`)_ - LLM model for generated overlays: sonnet, opus, gemini, gemini-2.5-pro, gemini-3.1-pro
+- `understand` _(string)_ _(default: `"auto"`)_ - Analyze video before generated overlay: auto, off, required
+- `understandingPrompt` _(string)_ - Custom prompt for video understanding
+- `position` _(string)_ _(full \| center \| top-left \| top-right \| bottom-left \| bottom-right)_ _(default: `"full"`)_ - Lottie position: full, center, top-left, top-right, bottom-left, bottom-right
+- `scale` _(number)_ - Lottie overlay scale (0.01-2)
+- `opacity` _(number)_ _(default: `1`)_ - Lottie overlay opacity (0-1)
+- `loop` _(boolean)_ _(default: `true`)_ - Loop Lottie overlay
+- `noLoop` _(boolean)_ - Do not loop Lottie overlay
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit noise-reduce`
 
@@ -958,11 +958,11 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `input` _(string)_ **required** — Audio or video file path
-- `output` _(string)_ — Output file path (default: <name>-denoised.<ext>)
-- `strength` _(string)_ _(low \| medium \| high)_ _(default: `"medium"`)_ — Noise reduction strength: low, medium, high (default: medium)
-- `noiseFloor` _(number)_ — Custom noise floor in dB (overrides strength preset)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `input` _(string)_ **required** - Audio or video file path
+- `output` _(string)_ - Output file path (default: <name>-denoised.<ext>)
+- `strength` _(string)_ _(low \| medium \| high)_ _(default: `"medium"`)_ - Noise reduction strength: low, medium, high (default: medium)
+- `noiseFloor` _(number)_ - Custom noise floor in dB (overrides strength preset)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit reframe`
 
@@ -974,14 +974,14 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `aspect` _(string)_ _(9:16 \| 1:1 \| 4:5)_ _(default: `"9:16"`)_ — Target aspect ratio: 9:16, 1:1, 4:5
-- `focus` _(string)_ _(auto \| face \| center \| action)_ _(default: `"auto"`)_ — Focus mode: auto, face, center, action
-- `output` _(string)_ — Output video file path
-- `analyzeOnly` _(boolean)_ — Show crop regions without applying
-- `keyframes` _(string)_ — Export keyframes to JSON file
-- `apiKey` _(string)_ — Anthropic API key (or set ANTHROPIC_API_KEY env)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `aspect` _(string)_ _(9:16 \| 1:1 \| 4:5)_ _(default: `"9:16"`)_ - Target aspect ratio: 9:16, 1:1, 4:5
+- `focus` _(string)_ _(auto \| face \| center \| action)_ _(default: `"auto"`)_ - Focus mode: auto, face, center, action
+- `output` _(string)_ - Output video file path
+- `analyzeOnly` _(boolean)_ - Show crop regions without applying
+- `keyframes` _(string)_ - Export keyframes to JSON file
+- `apiKey` _(string)_ - Anthropic API key (or set ANTHROPIC_API_KEY env)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit silence-cut`
 
@@ -993,17 +993,17 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `output` _(string)_ — Output file path (default: <name>-cut.<ext>)
-- `noise` _(number)_ _(default: `-30`)_ — Silence threshold in dB (default: -30)
-- `minDuration` _(number)_ _(default: `0.5`)_ — Minimum silence duration to cut (default: 0.5)
-- `padding` _(number)_ _(default: `0.1`)_ — Padding around non-silent segments (default: 0.1)
-- `analyzeOnly` _(boolean)_ — (deprecated — use `vibe detect silence`) Only detect silence, don't cut
-- `useGemini` _(boolean)_ — Use Gemini Video Understanding for context-aware silence detection
-- `model` _(string)_ — Gemini model (default: flash)
-- `lowRes` _(boolean)_ — Low resolution mode for longer videos (Gemini only)
-- `apiKey` _(string)_ — Google API key override (or set GOOGLE_API_KEY env)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `output` _(string)_ - Output file path (default: <name>-cut.<ext>)
+- `noise` _(number)_ _(default: `-30`)_ - Silence threshold in dB (default: -30)
+- `minDuration` _(number)_ _(default: `0.5`)_ - Minimum silence duration to cut (default: 0.5)
+- `padding` _(number)_ _(default: `0.1`)_ - Padding around non-silent segments (default: 0.1)
+- `analyzeOnly` _(boolean)_ - (deprecated - use `vibe detect silence`) Only detect silence, don't cut
+- `useGemini` _(boolean)_ - Use Gemini Video Understanding for context-aware silence detection
+- `model` _(string)_ - Gemini model (default: flash)
+- `lowRes` _(boolean)_ - Low resolution mode for longer videos (Gemini only)
+- `apiKey` _(string)_ - Google API key override (or set GOOGLE_API_KEY env)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit speed-ramp`
 
@@ -1015,15 +1015,15 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `output` _(string)_ — Output video file path
-- `style` _(string)_ _(dramatic \| smooth \| action)_ _(default: `"dramatic"`)_ — Style: dramatic, smooth, action
-- `minSpeed` _(string)_ _(default: `"0.25"`)_ — Minimum speed factor
-- `maxSpeed` _(string)_ _(default: `"4.0"`)_ — Maximum speed factor
-- `analyzeOnly` _(boolean)_ — Show keyframes without applying
-- `language` _(string)_ — Language code for transcription
-- `apiKey` _(string)_ — Anthropic API key (or set ANTHROPIC_API_KEY env)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `output` _(string)_ - Output video file path
+- `style` _(string)_ _(dramatic \| smooth \| action)_ _(default: `"dramatic"`)_ - Style: dramatic, smooth, action
+- `minSpeed` _(string)_ _(default: `"0.25"`)_ - Minimum speed factor
+- `maxSpeed` _(string)_ _(default: `"4.0"`)_ - Maximum speed factor
+- `analyzeOnly` _(boolean)_ - Show keyframes without applying
+- `language` _(string)_ - Language code for transcription
+- `apiKey` _(string)_ - Anthropic API key (or set ANTHROPIC_API_KEY env)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit text-overlay`
 
@@ -1035,16 +1035,16 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `text` _(string)_ — Text lines to overlay (repeat for multiple)
-- `style` _(string)_ _(lower-third \| center-bold \| subtitle \| minimal)_ _(default: `"lower-third"`)_ — Overlay style: lower-third, center-bold, subtitle, minimal
-- `fontSize` _(string)_ — Font size in pixels (auto-calculated if omitted)
-- `fontColor` _(string)_ _(default: `"white"`)_ — Font color (default: white)
-- `fade` _(number)_ _(default: `0.3`)_ — Fade in/out duration in seconds
-- `start` _(number)_ _(default: `0`)_ — Start time in seconds
-- `end` _(number)_ — End time in seconds (default: video duration)
-- `output` _(string)_ — Output video file path
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `text` _(string)_ - Text lines to overlay (repeat for multiple)
+- `style` _(string)_ _(lower-third \| center-bold \| subtitle \| minimal)_ _(default: `"lower-third"`)_ - Overlay style: lower-third, center-bold, subtitle, minimal
+- `fontSize` _(string)_ - Font size in pixels (auto-calculated if omitted)
+- `fontColor` _(string)_ _(default: `"white"`)_ - Font color (default: white)
+- `fade` _(number)_ _(default: `0.3`)_ - Fade in/out duration in seconds
+- `start` _(number)_ _(default: `0`)_ - Start time in seconds
+- `end` _(number)_ - End time in seconds (default: video duration)
+- `output` _(string)_ - Output video file path
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit translate-srt`
 
@@ -1056,13 +1056,13 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `srt` _(string)_ **required** — SRT file path
-- `target` _(string)_ — Target language (e.g., ko, es, fr, ja, zh)
-- `output` _(string)_ — Output file path (default: <name>-<target>.srt)
-- `provider` _(string)_ _(claude \| openai)_ _(default: `"claude"`)_ — Translation provider: claude, openai (default: claude)
-- `source` _(string)_ — Source language (auto-detected if omitted)
-- `apiKey` _(string)_ — API key (or set ANTHROPIC_API_KEY / OPENAI_API_KEY env)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `srt` _(string)_ **required** - SRT file path
+- `target` _(string)_ - Target language (e.g., ko, es, fr, ja, zh)
+- `output` _(string)_ - Output file path (default: <name>-<target>.srt)
+- `provider` _(string)_ _(claude \| openai)_ _(default: `"claude"`)_ - Translation provider: claude, openai (default: claude)
+- `source` _(string)_ - Source language (auto-detected if omitted)
+- `apiKey` _(string)_ - API key (or set ANTHROPIC_API_KEY / OPENAI_API_KEY env)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe edit upscale`
 
@@ -1074,14 +1074,14 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `output` _(string)_ — Output file path
-- `scale` _(string)_ _(default: `"2"`)_ — Scale factor: 2 or 4
-- `model` _(string)_ _(real-esrgan \| topaz)_ _(default: `"real-esrgan"`)_ — Model: real-esrgan, topaz
-- `ffmpeg` _(boolean)_ — Use FFmpeg lanczos (free, no API)
-- `apiKey` _(string)_ — Replicate API token (or set REPLICATE_API_TOKEN env)
-- `noWait` _(boolean)_ — Start processing and return task ID without waiting
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `output` _(string)_ - Output file path
+- `scale` _(string)_ _(default: `"2"`)_ - Scale factor: 2 or 4
+- `model` _(string)_ _(real-esrgan \| topaz)_ _(default: `"real-esrgan"`)_ - Model: real-esrgan, topaz
+- `ffmpeg` _(boolean)_ - Use FFmpeg lanczos (free, no API)
+- `apiKey` _(string)_ - Replicate API token (or set REPLICATE_API_TOKEN env)
+- `noWait` _(boolean)_ - Start processing and return task ID without waiting
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 ### `inspect`
 
@@ -1095,17 +1095,17 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `source` _(string)_ **required** — Image/video file path, image URL, or YouTube URL
-- `prompt` _(string)_ **required** — Analysis prompt (e.g., 'Describe this image', 'Summarize this video')
-- `apiKey` _(string)_ — Google API key (or set GOOGLE_API_KEY env)
-- `model` _(string)_ _(default: `"flash"`)_ — Model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
-- `fps` _(number)_ — Frames per second for video (default: 1)
-- `start` _(number)_ — Start offset in seconds (video only)
-- `end` _(number)_ — End offset in seconds (video only)
-- `lowRes` _(boolean)_ — Use low resolution mode (fewer tokens)
-- `verbose` _(boolean)_ — Show token usage
-- `fields` _(string)_ — Comma-separated fields to include in output (e.g., response,model)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `source` _(string)_ **required** - Image/video file path, image URL, or YouTube URL
+- `prompt` _(string)_ **required** - Analysis prompt (e.g., 'Describe this image', 'Summarize this video')
+- `apiKey` _(string)_ - Google API key (or set GOOGLE_API_KEY env)
+- `model` _(string)_ _(default: `"flash"`)_ - Model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
+- `fps` _(number)_ - Frames per second for video (default: 1)
+- `start` _(number)_ - Start offset in seconds (video only)
+- `end` _(number)_ - End offset in seconds (video only)
+- `lowRes` _(boolean)_ - Use low resolution mode (fewer tokens)
+- `verbose` _(boolean)_ - Show token usage
+- `fields` _(string)_ - Comma-separated fields to include in output (e.g., response,model)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe inspect project`
 
@@ -1117,10 +1117,10 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ — VibeFrame project directory
-- `beat` _(string)_ — Inspect only one storyboard beat where beat-scoped checks apply
-- `output` _(string)_ — Write review report to this path (default: <project>/review-report.json)
-- `noReport` _(boolean)_ — Do not write review-report.json
+- `project-dir` _(string)_ - VibeFrame project directory
+- `beat` _(string)_ - Inspect only one storyboard beat where beat-scoped checks apply
+- `output` _(string)_ - Write review report to this path (default: <project>/review-report.json)
+- `noReport` _(boolean)_ - Do not write review-report.json
 
 `review-report.json` payload uses `kind:"review"`, `mode:"project"`, `summary`, `sourceReports`, `nextActions`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. Command output keeps `data.kind:"project"`.
 
@@ -1134,15 +1134,15 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `project-dir` _(string)_ — VibeFrame project directory
-- `cheap` _(boolean)_ — Run local checks only (default; no AI/API calls)
-- `ai` _(boolean)_ — Also run Gemini video review and merge findings into review-report.json
-- `model` _(string)_ _(default: `"flash"`)_ — Gemini model for --ai: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
-- `beat` _(string)_ — Inspect a render for one storyboard beat
-- `video` _(string)_ — Rendered video path. Defaults to build-report outputPath or latest renders/\* video.
-- `output` _(string)_ — Write review report to this path (default: <project>/review-report.json)
-- `noReport` _(boolean)_ — Do not write review-report.json
-- `dryRun` _(boolean)_ — Preview parameters without probing video or calling Gemini
+- `project-dir` _(string)_ - VibeFrame project directory
+- `cheap` _(boolean)_ - Run local checks only (default; no AI/API calls)
+- `ai` _(boolean)_ - Also run Gemini video review and merge findings into review-report.json
+- `model` _(string)_ _(default: `"flash"`)_ - Gemini model for --ai: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
+- `beat` _(string)_ - Inspect a render for one storyboard beat
+- `video` _(string)_ - Rendered video path. Defaults to build-report outputPath or latest renders/\* video.
+- `output` _(string)_ - Write review report to this path (default: <project>/review-report.json)
+- `noReport` _(boolean)_ - Do not write review-report.json
+- `dryRun` _(boolean)_ - Preview parameters without probing video or calling Gemini
 
 `review-report.json` payload uses `kind:"review"`, `mode:"render"`, `summary`, `sourceReports`, `nextActions`, `retryWith`, and issue-level `fixOwner:"vibe"|"host-agent"`. `--ai` maps Gemini findings to host-agent-owned issues.
 
@@ -1158,13 +1158,13 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `source` _(string)_ **required** — Video file path
-- `storyboard` _(string)_ — Storyboard JSON file for context
-- `autoApply` _(boolean)_ — Automatically apply fixable corrections
-- `verify` _(boolean)_ — Run verification pass after applying fixes
-- `model` _(string)_ _(default: `"flash"`)_ — Gemini model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
-- `output` _(string)_ — Output video file path (for auto-apply)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `source` _(string)_ **required** - Video file path
+- `storyboard` _(string)_ - Storyboard JSON file for context
+- `autoApply` _(boolean)_ - Automatically apply fixable corrections
+- `verify` _(boolean)_ - Run verification pass after applying fixes
+- `model` _(string)_ _(default: `"flash"`)_ - Gemini model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
+- `output` _(string)_ - Output video file path (for auto-apply)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe inspect suggest`
 
@@ -1177,11 +1177,11 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `instruction` _(string)_ **required** — Natural language instruction
-- `apiKey` _(string)_ — Google API key (or set GOOGLE_API_KEY env)
-- `apply` _(boolean)_ — Apply the first suggestion automatically
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `instruction` _(string)_ **required** - Natural language instruction
+- `apiKey` _(string)_ - Google API key (or set GOOGLE_API_KEY env)
+- `apply` _(boolean)_ - Apply the first suggestion automatically
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe inspect video`
 
@@ -1195,17 +1195,17 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `source` _(string)_ **required** — Video file path or YouTube URL
-- `prompt` _(string)_ **required** — Analysis prompt (e.g., 'Summarize this video')
-- `apiKey` _(string)_ — Google API key (or set GOOGLE_API_KEY env)
-- `model` _(string)_ _(default: `"flash"`)_ — Model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
-- `fps` _(number)_ — Frames per second (default: 1, higher for action)
-- `start` _(number)_ — Start offset in seconds (for clipping)
-- `end` _(number)_ — End offset in seconds (for clipping)
-- `lowRes` _(boolean)_ — Use low resolution mode (fewer tokens, longer videos)
-- `verbose` _(boolean)_ — Show token usage
-- `fields` _(string)_ — Comma-separated fields to include in output (e.g., response,model)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `source` _(string)_ **required** - Video file path or YouTube URL
+- `prompt` _(string)_ **required** - Analysis prompt (e.g., 'Summarize this video')
+- `apiKey` _(string)_ - Google API key (or set GOOGLE_API_KEY env)
+- `model` _(string)_ _(default: `"flash"`)_ - Model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-\* model ID
+- `fps` _(number)_ - Frames per second (default: 1, higher for action)
+- `start` _(number)_ - Start offset in seconds (for clipping)
+- `end` _(number)_ - End offset in seconds (for clipping)
+- `lowRes` _(boolean)_ - Use low resolution mode (fewer tokens, longer videos)
+- `verbose` _(boolean)_ - Show token usage
+- `fields` _(string)_ - Comma-separated fields to include in output (e.g., response,model)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 ### `audio`
 
@@ -1220,14 +1220,14 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `samples` _(array)_ — Audio sample files (1-25 files)
-- `apiKey` _(string)_ — ElevenLabs API key (or set ELEVENLABS_API_KEY env)
-- `name` _(string)_ — Voice name (required)
-- `description` _(string)_ — Voice description
-- `labels` _(string)_ — Labels as JSON (e.g., '{"accent": "american"}')
-- `removeNoise` _(boolean)_ — Remove background noise from samples
-- `list` _(boolean)_ — List all available voices
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `samples` _(array)_ - Audio sample files (1-25 files)
+- `apiKey` _(string)_ - ElevenLabs API key (or set ELEVENLABS_API_KEY env)
+- `name` _(string)_ - Voice name (required)
+- `description` _(string)_ - Voice description
+- `labels` _(string)_ - Labels as JSON (e.g., '{"accent": "american"}')
+- `removeNoise` _(boolean)_ - Remove background noise from samples
+- `list` _(boolean)_ - List all available voices
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe audio dub`
 
@@ -1239,13 +1239,13 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `media` _(string)_ **required** — Input media file (video or audio)
-- `language` _(string)_ — Target language code (e.g., es, ko, ja) (required)
-- `source` _(string)_ — Source language code (default: auto-detect)
-- `voice` _(string)_ — ElevenLabs voice ID for output
-- `analyzeOnly` _(boolean)_ — Only analyze and show timing, don't generate audio
-- `output` _(string)_ — Output file path
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `media` _(string)_ **required** - Input media file (video or audio)
+- `language` _(string)_ - Target language code (e.g., es, ko, ja) (required)
+- `source` _(string)_ - Source language code (default: auto-detect)
+- `voice` _(string)_ - ElevenLabs voice ID for output
+- `analyzeOnly` _(boolean)_ - Only analyze and show timing, don't generate audio
+- `output` _(string)_ - Output file path
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe audio duck`
 
@@ -1257,14 +1257,14 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `music` _(string)_ **required** — Background music file path
-- `voice` _(string)_ — Voice/narration track (required)
-- `output` _(string)_ — Output audio file path
-- `threshold` _(number)_ _(default: `-30`)_ — Sidechain threshold in dB
-- `ratio` _(string)_ _(default: `"3"`)_ — Compression ratio
-- `attack` _(number)_ _(default: `20`)_ — Attack time in ms
-- `release` _(number)_ _(default: `200`)_ — Release time in ms
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `music` _(string)_ **required** - Background music file path
+- `voice` _(string)_ - Voice/narration track (required)
+- `output` _(string)_ - Output audio file path
+- `threshold` _(number)_ _(default: `-30`)_ - Sidechain threshold in dB
+- `ratio` _(string)_ _(default: `"3"`)_ - Compression ratio
+- `attack` _(number)_ _(default: `20`)_ - Attack time in ms
+- `release` _(number)_ _(default: `200`)_ - Release time in ms
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe audio isolate`
 
@@ -1276,10 +1276,10 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `audio` _(string)_ **required** — Input audio file path
-- `apiKey` _(string)_ — ElevenLabs API key (or set ELEVENLABS_API_KEY env)
-- `output` _(string)_ _(default: `"vocals.mp3"`)_ — Output audio file path
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `audio` _(string)_ **required** - Input audio file path
+- `apiKey` _(string)_ - ElevenLabs API key (or set ELEVENLABS_API_KEY env)
+- `output` _(string)_ _(default: `"vocals.mp3"`)_ - Output audio file path
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe audio list-voices`
 
@@ -1292,7 +1292,7 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `apiKey` _(string)_ — ElevenLabs API key (or set ELEVENLABS_API_KEY env)
+- `apiKey` _(string)_ - ElevenLabs API key (or set ELEVENLABS_API_KEY env)
 
 #### `vibe audio transcribe`
 
@@ -1304,11 +1304,11 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `audio` _(string)_ **required** — Audio file path
-- `apiKey` _(string)_ — OpenAI API key (or set OPENAI_API_KEY env)
-- `language` _(string)_ — Language code (e.g., en, ko)
-- `output` _(string)_ — Output file path
-- `format` _(string)_ _(json \| srt \| vtt)_ — Output format: json, srt, vtt (auto-detected from extension)
+- `audio` _(string)_ **required** - Audio file path
+- `apiKey` _(string)_ - OpenAI API key (or set OPENAI_API_KEY env)
+- `language` _(string)_ - Language code (e.g., en, ko)
+- `output` _(string)_ - Output file path
+- `format` _(string)_ _(json \| srt \| vtt)_ - Output format: json, srt, vtt (auto-detected from extension)
 
 ### `remix`
 
@@ -1322,17 +1322,17 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `style` _(string)_ _(default: `"highlight"`)_ — Style preset (default: highlight)
-- `highlightColor` _(string)_ _(default: `"#FFFF00"`)_ — Active word highlight color
-- `fontSize` _(string)_ — Font size (default: auto based on resolution)
-- `position` _(string)_ _(top \| center \| bottom)_ _(default: `"bottom"`)_ — Caption position: top, center, bottom
-- `wordsPerGroup` _(number)_ — Words shown at once (default: auto 3-5)
-- `maxChars` _(number)_ — Max characters per group
-- `language` _(string)_ — Whisper language hint
-- `fast` _(boolean)_ — Use ASS/FFmpeg only (no Remotion, forces ASS tier styles)
-- `output` _(string)_ — Output file path
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `style` _(string)_ _(default: `"highlight"`)_ - Style preset (default: highlight)
+- `highlightColor` _(string)_ _(default: `"#FFFF00"`)_ - Active word highlight color
+- `fontSize` _(string)_ - Font size (default: auto based on resolution)
+- `position` _(string)_ _(top \| center \| bottom)_ _(default: `"bottom"`)_ - Caption position: top, center, bottom
+- `wordsPerGroup` _(number)_ - Words shown at once (default: auto 3-5)
+- `maxChars` _(number)_ - Max characters per group
+- `language` _(string)_ - Whisper language hint
+- `fast` _(boolean)_ - Use ASS/FFmpeg only (no Remotion, forces ASS tier styles)
+- `output` _(string)_ - Output file path
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe remix auto-shorts`
 
@@ -1344,19 +1344,19 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `output` _(string)_ — Output file (single) or directory (multiple)
-- `duration` _(number)_ _(default: `60`)_ — Target duration in seconds (15-60)
-- `count` _(number)_ _(default: `1`)_ — Number of shorts to generate
-- `aspect` _(string)_ _(9:16 \| 1:1)_ _(default: `"9:16"`)_ — Aspect ratio: 9:16, 1:1
-- `outputDir` _(string)_ — Output directory for multiple shorts
-- `addCaptions` _(boolean)_ — Add auto-generated captions
-- `captionStyle` _(string)_ _(minimal \| bold \| animated)_ _(default: `"bold"`)_ — Caption style: minimal, bold, animated
-- `analyzeOnly` _(boolean)_ — Show segments without generating
-- `language` _(string)_ — Language code for transcription
-- `useGemini` _(boolean)_ — Use Gemini Video Understanding for enhanced visual+audio analysis
-- `lowRes` _(boolean)_ — Use low resolution mode for longer videos (Gemini only)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `output` _(string)_ - Output file (single) or directory (multiple)
+- `duration` _(number)_ _(default: `60`)_ - Target duration in seconds (15-60)
+- `count` _(number)_ _(default: `1`)_ - Number of shorts to generate
+- `aspect` _(string)_ _(9:16 \| 1:1)_ _(default: `"9:16"`)_ - Aspect ratio: 9:16, 1:1
+- `outputDir` _(string)_ - Output directory for multiple shorts
+- `addCaptions` _(boolean)_ - Add auto-generated captions
+- `captionStyle` _(string)_ _(minimal \| bold \| animated)_ _(default: `"bold"`)_ - Caption style: minimal, bold, animated
+- `analyzeOnly` _(boolean)_ - Show segments without generating
+- `language` _(string)_ - Language code for transcription
+- `useGemini` _(boolean)_ - Use Gemini Video Understanding for enhanced visual+audio analysis
+- `lowRes` _(boolean)_ - Use low resolution mode for longer videos (Gemini only)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe remix highlights`
 
@@ -1368,17 +1368,17 @@ Cost tier: `high`
 
 **Parameters:**
 
-- `media` _(string)_ **required** — Video or audio file path
-- `output` _(string)_ — Output JSON file with highlights
-- `project` _(string)_ — Create project with highlight clips
-- `duration` _(number)_ _(default: `60`)_ — Target highlight reel duration
-- `count` _(number)_ — Maximum number of highlights
-- `threshold` _(number)_ _(default: `0.7`)_ — Confidence threshold (0-1)
-- `criteria` _(string)_ _(default: `"all"`)_ — Selection criteria: emotional | informative | funny | all
-- `language` _(string)_ — Language code for transcription (e.g., en, ko)
-- `useGemini` _(boolean)_ — Use Gemini Video Understanding for enhanced visual+audio analysis
-- `lowRes` _(boolean)_ — Use low resolution mode for longer videos (Gemini only)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `media` _(string)_ **required** - Video or audio file path
+- `output` _(string)_ - Output JSON file with highlights
+- `project` _(string)_ - Create project with highlight clips
+- `duration` _(number)_ _(default: `60`)_ - Target highlight reel duration
+- `count` _(number)_ - Maximum number of highlights
+- `threshold` _(number)_ _(default: `0.7`)_ - Confidence threshold (0-1)
+- `criteria` _(string)_ _(default: `"all"`)_ - Selection criteria: emotional | informative | funny | all
+- `language` _(string)_ - Language code for transcription (e.g., en, ko)
+- `useGemini` _(boolean)_ - Use Gemini Video Understanding for enhanced visual+audio analysis
+- `lowRes` _(boolean)_ - Use low resolution mode for longer videos (Gemini only)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe remix regenerate-scene`
 
@@ -1392,18 +1392,18 @@ Cost tier: `very-high`
 
 **Parameters:**
 
-- `project-dir` _(string)_ **required** — Path to the script-to-video output directory
-- `scene` _(string)_ — Scene number(s) to regenerate (1-based), e.g., 3 or 3,4,5
-- `videoOnly` _(boolean)_ — Only regenerate video
-- `narrationOnly` _(boolean)_ — Only regenerate narration
-- `imageOnly` _(boolean)_ — Only regenerate image
-- `generator` _(string)_ _(default: `"grok"`)_ — Video generator: grok | kling | runway | veo
-- `imageProvider` _(string)_ _(default: `"gemini"`)_ — Image provider: gemini | openai | grok
-- `voice` _(string)_ — ElevenLabs voice ID for narration
-- `aspectRatio` _(string)_ _(default: `"16:9"`)_ — Aspect ratio: 16:9 | 9:16 | 1:1
-- `retries` _(number)_ _(default: `2`)_ — Number of retries for video generation failures
-- `referenceScene` _(string)_ — Use another scene's image as reference for character consistency
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project-dir` _(string)_ **required** - Path to the script-to-video output directory
+- `scene` _(string)_ - Scene number(s) to regenerate (1-based), e.g., 3 or 3,4,5
+- `videoOnly` _(boolean)_ - Only regenerate video
+- `narrationOnly` _(boolean)_ - Only regenerate narration
+- `imageOnly` _(boolean)_ - Only regenerate image
+- `generator` _(string)_ _(default: `"grok"`)_ - Video generator: grok | kling | runway | veo
+- `imageProvider` _(string)_ _(default: `"gemini"`)_ - Image provider: gemini | openai | grok
+- `voice` _(string)_ - ElevenLabs voice ID for narration
+- `aspectRatio` _(string)_ _(default: `"16:9"`)_ - Aspect ratio: 16:9 | 9:16 | 1:1
+- `retries` _(number)_ _(default: `2`)_ - Number of retries for video generation failures
+- `referenceScene` _(string)_ - Use another scene's image as reference for character consistency
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 ### `scene`
 
@@ -1417,35 +1417,35 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `name` _(string)_ **required** — Scene name (slugified into the composition id)
-- `style` _(string)_ _(simple \| announcement \| explainer \| kinetic-type \| product-shot)_ _(default: `"simple"`)_ — Style preset: simple, announcement, explainer, kinetic-type, product-shot
-- `narration` _(string)_ — Narration text (or path to a .txt file). Drives TTS + scene duration.
-- `narrationFile` _(string)_ — Existing narration audio file (.wav/.mp3). Skips TTS — useful with hyperframes tts, Mac say, or other external tools.
-- `duration` _(number)_ — Explicit scene duration in seconds (overrides narration audio)
-- `visuals` _(string)_ — Image prompt — generates assets/scene-<id>.png via the configured image provider
-- `headline` _(string)_ — Visible headline (defaults to the humanised scene name)
-- `kicker` _(string)_ — Small label above the headline (explainer / product-shot)
-- `insertInto` _(string)_ _(default: `"index.html"`)_ — Root composition file to update
-- `project` _(string)_ _(default: `"."`)_ — Project directory
-- `noStoryboard` _(boolean)_ — Do not sync STORYBOARD.md; insert this scene directly into the root composition only
-- `imageProvider` _(string)_ _(gemini \| openai)_ _(default: `"gemini"`)_ — Image provider: gemini, openai
-- `tts` _(string)_ _(auto \| elevenlabs \| openai \| kokoro)_ _(default: `"auto"`)_ — TTS provider: auto, elevenlabs, openai, kokoro (default auto — ElevenLabs key > OpenAI key > Kokoro local)
-- `voice` _(string)_ — Voice id (ElevenLabs name/id, OpenAI voice like marin, or Kokoro id like af_heart)
-- `noAudio` _(boolean)_ — Skip TTS even when --narration is provided (useful for tests/agent dry runs)
-- `noImage` _(boolean)_ — Skip image generation even when --visuals is provided
-- `noTranscribe` _(boolean)_ — Skip Whisper word-level transcribe step (no transcript-<id>.json emitted)
-- `transcribeLanguage` _(string)_ — BCP-47 language code passed to Whisper (e.g. en, ko)
-- `force` _(boolean)_ — Overwrite an existing compositions/scene-<id>.html
-- `lottie` _(string)_ — Lottie animation file (.json/.lottie) to overlay on the scene
-- `lottiePosition` _(string)_ _(full \| center \| top-left \| top-right \| bottom-left \| bottom-right)_ _(default: `"full"`)_ — Lottie position: full, center, top-left, top-right, bottom-left, bottom-right
-- `lottieScale` _(number)_ — Lottie overlay scale (0.01-2)
-- `lottieOpacity` _(number)_ _(default: `1`)_ — Lottie overlay opacity (0-1)
-- `lottieNoLoop` _(boolean)_ — Do not loop the Lottie animation
-- `dryRun` _(boolean)_ — Preview parameters without writing files or calling APIs
+- `name` _(string)_ **required** - Scene name (slugified into the composition id)
+- `style` _(string)_ _(simple \| announcement \| explainer \| kinetic-type \| product-shot)_ _(default: `"simple"`)_ - Style preset: simple, announcement, explainer, kinetic-type, product-shot
+- `narration` _(string)_ - Narration text (or path to a .txt file). Drives TTS + scene duration.
+- `narrationFile` _(string)_ - Existing narration audio file (.wav/.mp3). Skips TTS - useful with hyperframes tts, Mac say, or other external tools.
+- `duration` _(number)_ - Explicit scene duration in seconds (overrides narration audio)
+- `visuals` _(string)_ - Image prompt - generates assets/scene-<id>.png via the configured image provider
+- `headline` _(string)_ - Visible headline (defaults to the humanised scene name)
+- `kicker` _(string)_ - Small label above the headline (explainer / product-shot)
+- `insertInto` _(string)_ _(default: `"index.html"`)_ - Root composition file to update
+- `project` _(string)_ _(default: `"."`)_ - Project directory
+- `noStoryboard` _(boolean)_ - Do not sync STORYBOARD.md; insert this scene directly into the root composition only
+- `imageProvider` _(string)_ _(gemini \| openai)_ _(default: `"gemini"`)_ - Image provider: gemini, openai
+- `tts` _(string)_ _(auto \| elevenlabs \| openai \| kokoro)_ _(default: `"auto"`)_ - TTS provider: auto, elevenlabs, openai, kokoro (default auto - ElevenLabs key > OpenAI key > Kokoro local)
+- `voice` _(string)_ - Voice id (ElevenLabs name/id, OpenAI voice like marin, or Kokoro id like af_heart)
+- `noAudio` _(boolean)_ - Skip TTS even when --narration is provided (useful for tests/agent dry runs)
+- `noImage` _(boolean)_ - Skip image generation even when --visuals is provided
+- `noTranscribe` _(boolean)_ - Skip Whisper word-level transcribe step (no transcript-<id>.json emitted)
+- `transcribeLanguage` _(string)_ - BCP-47 language code passed to Whisper (e.g. en, ko)
+- `force` _(boolean)_ - Overwrite an existing compositions/scene-<id>.html
+- `lottie` _(string)_ - Lottie animation file (.json/.lottie) to overlay on the scene
+- `lottiePosition` _(string)_ _(full \| center \| top-left \| top-right \| bottom-left \| bottom-right)_ _(default: `"full"`)_ - Lottie position: full, center, top-left, top-right, bottom-left, bottom-right
+- `lottieScale` _(number)_ - Lottie overlay scale (0.01-2)
+- `lottieOpacity` _(number)_ _(default: `1`)_ - Lottie overlay opacity (0-1)
+- `lottieNoLoop` _(boolean)_ - Do not loop the Lottie animation
+- `dryRun` _(boolean)_ - Preview parameters without writing files or calling APIs
 
 #### `vibe scene compose-prompts`
 
-Emit the per-beat compose plan for the host agent to author HTML itself (Phase H2 — no LLM call)
+Emit the per-beat compose plan for the host agent to author HTML itself (no LLM call)
 
 Product surface: `internal`
 Note: Agent-mode build primitive; prefer vibe build --mode agent.
@@ -1454,8 +1454,8 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Project directory containing STORYBOARD.md / DESIGN.md
-- `beat` _(string)_ — Restrict the plan to a single beat by id (e.g. 'hook', '1')
+- `project-dir` _(string)_ - Project directory containing STORYBOARD.md / DESIGN.md
+- `beat` _(string)_ - Restrict the plan to a single beat by id (e.g. 'hook', '1')
 
 #### `vibe scene install-skill`
 
@@ -1468,10 +1468,10 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Project directory containing STORYBOARD.md / DESIGN.md
-- `global` _(boolean)_ — Install at user level (~/.claude/skills) instead of into the project
-- `force` _(boolean)_ — Reinstall even when the skill is already available
-- `dryRun` _(boolean)_ — Print the command that would run without running it
+- `project-dir` _(string)_ - Project directory containing STORYBOARD.md / DESIGN.md
+- `global` _(boolean)_ - Install at user level (~/.claude/skills) instead of into the project
+- `force` _(boolean)_ - Reinstall even when the skill is already available
+- `dryRun` _(boolean)_ - Print the command that would run without running it
 
 #### `vibe scene lint`
 
@@ -1483,9 +1483,9 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `root` _(string)_ — Project directory, or root composition file relative to --project
-- `project` _(string)_ _(default: `"."`)_ — Project directory
-- `fix` _(boolean)_ — Apply mechanical auto-fixes (currently: missing class="clip")
+- `root` _(string)_ - Project directory, or root composition file relative to --project
+- `project` _(string)_ _(default: `"."`)_ - Project directory
+- `fix` _(boolean)_ - Apply mechanical auto-fixes (currently: missing class="clip")
 
 #### `vibe scene list-styles`
 
@@ -1497,7 +1497,7 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `name` _(string)_ — Style name to inspect (omit to list all)
+- `name` _(string)_ - Style name to inspect (omit to list all)
 
 #### `vibe scene repair`
 
@@ -1509,9 +1509,9 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `root` _(string)_ — Project directory, or root composition file relative to --project
-- `project` _(string)_ _(default: `"."`)_ — Project directory
-- `dryRun` _(boolean)_ — Preview repairs without writing files
+- `root` _(string)_ - Project directory, or root composition file relative to --project
+- `project` _(string)_ _(default: `"."`)_ - Project directory
+- `dryRun` _(boolean)_ - Preview repairs without writing files
 
 #### `vibe scene submit`
 
@@ -1523,11 +1523,11 @@ Cost tier: _not tagged_
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Project directory containing STORYBOARD.md
-- `beat` _(string)_ — Beat id from STORYBOARD.md (e.g. 'hook')
-- `file` _(string)_ — Read the scene HTML from a file ('-' reads raw HTML from stdin)
-- `html` _(string)_ — Scene HTML inline (mainly for the global --stdin JSON payload: {"html": "..."})
-- `validateOnly` _(boolean)_ — Lint without writing the file
+- `project-dir` _(string)_ - Project directory containing STORYBOARD.md
+- `beat` _(string)_ - Beat id from STORYBOARD.md (e.g. 'hook')
+- `file` _(string)_ - Read the scene HTML from a file ('-' reads raw HTML from stdin)
+- `html` _(string)_ - Scene HTML inline (mainly for the global --stdin JSON payload: {"html": "..."})
+- `validateOnly` _(boolean)_ - Lint without writing the file
 
 ### `timeline`
 
@@ -1542,13 +1542,13 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `source-id` _(string)_ **required** — Source ID to use
-- `track` _(string)_ — Track ID (defaults to first matching track)
-- `start` _(number)_ _(default: `0`)_ — Start time in timeline
-- `duration` _(number)_ — Clip duration (defaults to source duration)
-- `offset` _(number)_ _(default: `0`)_ — Source start offset
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `source-id` _(string)_ **required** - Source ID to use
+- `track` _(string)_ - Track ID (defaults to first matching track)
+- `start` _(number)_ _(default: `0`)_ - Start time in timeline
+- `duration` _(number)_ - Clip duration (defaults to source duration)
+- `offset` _(number)_ _(default: `0`)_ - Source start offset
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline add-effect`
 
@@ -1561,13 +1561,13 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `clip-id` _(string)_ **required** — Clip ID
-- `effect-type` _(string)_ **required** — Effect type (fadeIn, fadeOut, blur, brightness, contrast, saturation, speed, volume)
-- `start` _(number)_ _(default: `0`)_ — Effect start time (relative to clip)
-- `duration` _(number)_ — Effect duration (defaults to clip duration)
-- `params` _(string)_ _(default: `"{}"`)_ — Effect parameters as JSON
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `clip-id` _(string)_ **required** - Clip ID
+- `effect-type` _(string)_ **required** - Effect type (fadeIn, fadeOut, blur, brightness, contrast, saturation, speed, volume)
+- `start` _(number)_ _(default: `0`)_ - Effect start time (relative to clip)
+- `duration` _(number)_ - Effect duration (defaults to clip duration)
+- `params` _(string)_ _(default: `"{}"`)_ - Effect parameters as JSON
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline add-source`
 
@@ -1580,12 +1580,12 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `media` _(string)_ **required** — Media file path
-- `name` _(string)_ — Source name (defaults to filename)
-- `type` _(string)_ _(video \| audio \| image \| lottie)_ — Media type (video, audio, image, lottie)
-- `duration` _(number)_ — Duration in seconds (required for images)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `media` _(string)_ **required** - Media file path
+- `name` _(string)_ - Source name (defaults to filename)
+- `type` _(string)_ _(video \| audio \| image \| lottie)_ - Media type (video, audio, image, lottie)
+- `duration` _(number)_ - Duration in seconds (required for images)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline add-track`
 
@@ -1598,10 +1598,10 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `type` _(string)_ **required** — Track type (video, audio)
-- `name` _(string)_ — Track name
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `type` _(string)_ **required** - Track type (video, audio)
+- `name` _(string)_ - Track name
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline create`
 
@@ -1614,11 +1614,11 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `name` _(string)_ **required** — Timeline name or path (e.g., 'my-video' or 'output/my-video')
-- `output` _(string)_ — Output file path (overrides name-based path)
-- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1 \| 4:5)_ _(default: `"16:9"`)_ — Aspect ratio (16:9, 9:16, 1:1, 4:5)
-- `fps` _(number)_ _(default: `30`)_ — Frame rate
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `name` _(string)_ **required** - Timeline name or path (e.g., 'my-video' or 'output/my-video')
+- `output` _(string)_ - Output file path (overrides name-based path)
+- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1 \| 4:5)_ _(default: `"16:9"`)_ - Aspect ratio (16:9, 9:16, 1:1, 4:5)
+- `fps` _(number)_ _(default: `30`)_ - Frame rate
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline delete-clip`
 
@@ -1631,9 +1631,9 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `clip-id` _(string)_ **required** — Clip ID to delete
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `clip-id` _(string)_ **required** - Clip ID to delete
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline duplicate-clip`
 
@@ -1646,10 +1646,10 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `clip-id` _(string)_ **required** — Clip ID to duplicate
-- `time` _(number)_ — Start time for duplicate (default: after original)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `clip-id` _(string)_ **required** - Clip ID to duplicate
+- `time` _(number)_ - Start time for duplicate (default: after original)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline info`
 
@@ -1662,7 +1662,7 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `file` _(string)_ **required** — Timeline file or directory
+- `file` _(string)_ **required** - Timeline file or directory
 
 #### `vibe timeline list`
 
@@ -1675,10 +1675,10 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `sources` _(boolean)_ — List sources only
-- `tracks` _(boolean)_ — List tracks only
-- `clips` _(boolean)_ — List clips only
+- `project` _(string)_ **required** - Timeline file or directory
+- `sources` _(boolean)_ - List sources only
+- `tracks` _(boolean)_ - List tracks only
+- `clips` _(boolean)_ - List clips only
 
 #### `vibe timeline move-clip`
 
@@ -1691,11 +1691,11 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `clip-id` _(string)_ **required** — Clip ID to move
-- `time` _(number)_ — New start time
-- `track` _(string)_ — Move to different track
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `clip-id` _(string)_ **required** - Clip ID to move
+- `time` _(number)_ - New start time
+- `track` _(string)_ - Move to different track
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline set`
 
@@ -1708,11 +1708,11 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `file` _(string)_ **required** — Timeline file or directory
-- `name` _(string)_ — Timeline name
-- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1 \| 4:5)_ — Aspect ratio (16:9, 9:16, 1:1, 4:5)
-- `fps` _(number)_ — Frame rate
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `file` _(string)_ **required** - Timeline file or directory
+- `name` _(string)_ - Timeline name
+- `ratio` _(string)_ _(16:9 \| 9:16 \| 1:1 \| 4:5)_ - Aspect ratio (16:9, 9:16, 1:1, 4:5)
+- `fps` _(number)_ - Frame rate
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline split-clip`
 
@@ -1725,10 +1725,10 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `clip-id` _(string)_ **required** — Clip ID to split
-- `time` _(number)_ _(default: `0`)_ — Split time relative to clip start
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `clip-id` _(string)_ **required** - Clip ID to split
+- `time` _(number)_ _(default: `0`)_ - Split time relative to clip start
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe timeline trim-clip`
 
@@ -1741,11 +1741,11 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `clip-id` _(string)_ **required** — Clip ID
-- `start` _(number)_ — New start time
-- `duration` _(number)_ — New duration
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `clip-id` _(string)_ **required** - Clip ID
+- `start` _(number)_ - New start time
+- `duration` _(number)_ - New duration
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 ### `detect`
 
@@ -1759,9 +1759,9 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `audio` _(string)_ **required** — Audio file path
-- `output` _(string)_ — Output JSON file with timestamps
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `audio` _(string)_ **required** - Audio file path
+- `output` _(string)_ - Output JSON file with timestamps
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe detect scenes`
 
@@ -1773,11 +1773,11 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `video` _(string)_ **required** — Video file path
-- `threshold` _(number)_ _(default: `0.3`)_ — Scene change threshold (0-1)
-- `output` _(string)_ — Output JSON file with timestamps
-- `project` _(string)_ — Add scenes as clips to project
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `video` _(string)_ **required** - Video file path
+- `threshold` _(number)_ _(default: `0.3`)_ - Scene change threshold (0-1)
+- `output` _(string)_ - Output JSON file with timestamps
+- `project` _(string)_ - Add scenes as clips to project
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe detect silence`
 
@@ -1789,11 +1789,11 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `media` _(string)_ **required** — Media file path
-- `noise` _(number)_ _(default: `-30`)_ — Noise threshold in dB
-- `duration` _(number)_ _(default: `0.5`)_ — Minimum silence duration
-- `output` _(string)_ — Output JSON file with timestamps
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `media` _(string)_ **required** - Media file path
+- `noise` _(number)_ _(default: `-30`)_ - Noise threshold in dB
+- `duration` _(number)_ _(default: `0.5`)_ - Minimum silence duration
+- `output` _(string)_ - Output JSON file with timestamps
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 ### `batch`
 
@@ -1808,14 +1808,14 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `effect-type` _(string)_ **required** — Effect type (fadeIn, fadeOut, blur, etc.)
-- `clip-ids` _(array)_ — Clip IDs to apply effect to (or --all)
-- `all` _(boolean)_ _(default: `false`)_ — Apply to all clips
-- `duration` _(number)_ _(default: `1`)_ — Effect duration
-- `start` _(number)_ _(default: `0`)_ — Effect start time (relative to clip)
-- `intensity` _(string)_ _(default: `"1"`)_ — Effect intensity (0-1)
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `effect-type` _(string)_ **required** - Effect type (fadeIn, fadeOut, blur, etc.)
+- `clip-ids` _(array)_ - Clip IDs to apply effect to (or --all)
+- `all` _(boolean)_ _(default: `false`)_ - Apply to all clips
+- `duration` _(number)_ _(default: `1`)_ - Effect duration
+- `start` _(number)_ _(default: `0`)_ - Effect start time (relative to clip)
+- `intensity` _(string)_ _(default: `"1"`)_ - Effect intensity (0-1)
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe batch concat`
 
@@ -1828,13 +1828,13 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `source-ids` _(array)_ — Source IDs to concatenate (or --all)
-- `all` _(boolean)_ _(default: `false`)_ — Concatenate all sources in order
-- `track` _(string)_ — Track to place clips on
-- `start` _(number)_ _(default: `0`)_ — Starting time
-- `gap` _(number)_ _(default: `0`)_ — Gap between clips
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `source-ids` _(array)_ - Source IDs to concatenate (or --all)
+- `all` _(boolean)_ _(default: `false`)_ - Concatenate all sources in order
+- `track` _(string)_ - Track to place clips on
+- `start` _(number)_ _(default: `0`)_ - Starting time
+- `gap` _(number)_ _(default: `0`)_ - Gap between clips
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe batch import`
 
@@ -1847,12 +1847,12 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `directory` _(string)_ **required** — Directory containing media files
-- `recursive` _(boolean)_ _(default: `false`)_ — Search subdirectories
-- `duration` _(number)_ _(default: `5`)_ — Default duration for images
-- `filter` _(string)_ — Filter files by extension (e.g., '.mp4,.mov')
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `directory` _(string)_ **required** - Directory containing media files
+- `recursive` _(boolean)_ _(default: `false`)_ - Search subdirectories
+- `duration` _(number)_ _(default: `5`)_ - Default duration for images
+- `filter` _(string)_ - Filter files by extension (e.g., '.mp4,.mov')
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 #### `vibe batch info`
 
@@ -1865,7 +1865,7 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
+- `project` _(string)_ **required** - Timeline file or directory
 
 #### `vibe batch remove-clips`
 
@@ -1878,11 +1878,11 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project` _(string)_ **required** — Timeline file or directory
-- `clip-ids` _(array)_ — Clip IDs to remove
-- `all` _(boolean)_ _(default: `false`)_ — Remove all clips
-- `track` _(string)_ — Remove clips from specific track only
-- `dryRun` _(boolean)_ — Preview parameters without executing
+- `project` _(string)_ **required** - Timeline file or directory
+- `clip-ids` _(array)_ - Clip IDs to remove
+- `all` _(boolean)_ _(default: `false`)_ - Remove all clips
+- `track` _(string)_ - Remove clips from specific track only
+- `dryRun` _(boolean)_ - Preview parameters without executing
 
 ### `media`
 
@@ -1897,7 +1897,7 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `file` _(string)_ **required** — Media file path
+- `file` _(string)_ **required** - Media file path
 
 #### `vibe media info`
 
@@ -1910,7 +1910,7 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `file` _(string)_ **required** — Media file path
+- `file` _(string)_ **required** - Media file path
 
 ### `storyboard`
 
@@ -1924,8 +1924,8 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ **required** — Project directory
-- `beat` _(string)_ **required** — Beat id
+- `project-dir` _(string)_ **required** - Project directory
+- `beat` _(string)_ **required** - Beat id
 
 #### `vibe storyboard list`
 
@@ -1937,7 +1937,7 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Project directory
+- `project-dir` _(string)_ - Project directory
 
 #### `vibe storyboard move`
 
@@ -1949,9 +1949,9 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ **required** — Project directory
-- `beat` _(string)_ **required** — Beat id to move
-- `after` _(string)_ — Place the beat after this beat id
+- `project-dir` _(string)_ **required** - Project directory
+- `beat` _(string)_ **required** - Beat id to move
+- `after` _(string)_ - Place the beat after this beat id
 
 #### `vibe storyboard revise`
 
@@ -1963,11 +1963,11 @@ Cost tier: `low`
 
 **Parameters:**
 
-- `project-dir` _(string)_ **required** — Project directory
-- `from` _(string)_ — Revision request or path to a text/markdown file
-- `duration` _(number)_ — Target total duration in seconds
-- `composer` _(string)_ — Revision LLM provider: claude|openai|gemini
-- `dryRun` _(boolean)_ — Preview the revised storyboard without writing
+- `project-dir` _(string)_ **required** - Project directory
+- `from` _(string)_ - Revision request or path to a text/markdown file
+- `duration` _(number)_ - Target total duration in seconds
+- `composer` _(string)_ - Revision LLM provider: claude|openai|gemini
+- `dryRun` _(boolean)_ - Preview the revised storyboard without writing
 
 JSON payload: `data.kind` is `"storyboard-revision"` and includes `provider`, `summary`, `changedBeats`, `validation`, `wrote`, `warnings`, and `retryWith`. Use `--dry-run` before writing.
 
@@ -1981,12 +1981,12 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ **required** — Project directory
-- `beat` _(string)_ **required** — Beat id
-- `key` _(string)_ **required** — Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters | eyebrow | title | caption | kicker | sub
-- `value` _(array)_ — Cue value. Use --json-value to pass a JSON scalar/object.
-- `jsonValue` _(boolean)_ — Parse value as JSON instead of a string
-- `unset` _(boolean)_ — Remove the cue key from the beat
+- `project-dir` _(string)_ **required** - Project directory
+- `beat` _(string)_ **required** - Beat id
+- `key` _(string)_ **required** - Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters | eyebrow | title | caption | kicker | sub
+- `value` _(array)_ - Cue value. Use --json-value to pass a JSON scalar/object.
+- `jsonValue` _(boolean)_ - Parse value as JSON instead of a string
+- `unset` _(boolean)_ - Remove the cue key from the beat
 
 #### `vibe storyboard validate`
 
@@ -1998,7 +1998,7 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Project directory
+- `project-dir` _(string)_ - Project directory
 
 ### `design`
 
@@ -2013,7 +2013,7 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ — Project directory
+- `project-dir` _(string)_ - Project directory
 
 ### `status`
 
@@ -2027,11 +2027,11 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `job-id` _(string)_ **required** — Local job id from a no-wait command
-- `project` _(string)_ — Project directory containing .vibeframe/jobs
-- `noRefresh` _(boolean)_ — Read local job record only; do not call provider APIs
-- `wait` _(boolean)_ — Wait for completion when the provider status helper supports it
-- `output` _(string)_ — Download result media when complete
+- `job-id` _(string)_ **required** - Local job id from a no-wait command
+- `project` _(string)_ - Project directory containing .vibeframe/jobs
+- `noRefresh` _(boolean)_ - Read local job record only; do not call provider APIs
+- `wait` _(boolean)_ - Wait for completion when the provider status helper supports it
+- `output` _(string)_ - Download result media when complete
 
 JSON payload: `data.kind` is `"job"` and includes flat job fields (`id`, `jobType`, `provider`, `status`, timestamps), `progress`, `result`, `retryWith`, and the raw `job` record for compatibility.
 
@@ -2045,8 +2045,8 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `project-dir` _(string)_ — VibeFrame project directory
-- `refresh` _(boolean)_ — Refresh active supported jobs before summarizing
+- `project-dir` _(string)_ - VibeFrame project directory
+- `refresh` _(boolean)_ - Refresh active supported jobs before summarizing
 
 JSON payload: `data.kind` is `"project"` and includes `status`, `currentStage`, `beats` readiness counts, `jobs.latest`, `build`, `review`, `warnings`, `nextActions`, and `retryWith`. `review` includes `mode`, issue/error/warning/info counts, `fixOwners`, `sourceReports`, `nextActions`, and `retryWith`; top-level `nextActions` is the preferred resume contract, while `retryWith` remains the compatibility fallback.
 
@@ -2062,8 +2062,8 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `host` _(string)_ — Host target: codex | claude | claude-code | claude-desktop | cursor | all
-- `project-dir` _(string)_ — Project directory to inspect
+- `host` _(string)_ - Host target: codex | claude | claude-code | claude-desktop | cursor | all
+- `project-dir` _(string)_ - Project directory to inspect
 
 #### `vibe host list`
 
@@ -2085,8 +2085,8 @@ Cost tier: `free`
 
 **Parameters:**
 
-- `host` _(string)_ — Host target: codex | claude | claude-code | claude-desktop | cursor | all
-- `project-dir` _(string)_ — Project directory for project-scoped config
-- `write` _(boolean)_ — Write config files instead of printing snippets only
-- `dryRun` _(boolean)_ — Show file actions without writing
-- `force` _(boolean)_ — Replace an existing vibeframe MCP entry
+- `host` _(string)_ - Host target: codex | claude | claude-code | claude-desktop | cursor | all
+- `project-dir` _(string)_ - Project directory for project-scoped config
+- `write` _(boolean)_ - Write config files instead of printing snippets only
+- `dryRun` _(boolean)_ - Show file actions without writing
+- `force` _(boolean)_ - Replace an existing vibeframe MCP entry

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -12,7 +12,7 @@ exports[`CLI --describe schemas (drift detection) > vibe agent --describe 1`] = 
         "type": "number",
       },
       "confirm": {
-        "description": "Confirm before every tool — broadens the default cost gate (paid only) to all calls",
+        "description": "Confirm before every tool - broadens the default cost gate (paid only) to all calls",
         "type": "boolean",
       },
       "input": {
@@ -631,7 +631,7 @@ exports[`CLI --describe schemas (drift detection) > vibe build --describe 1`] = 
         "type": "boolean",
       },
       "skipRender": {
-        "description": "Compose only — don't render to MP4",
+        "description": "Compose only - don't render to MP4",
         "type": "boolean",
       },
       "skipTranscript": {
@@ -1461,7 +1461,7 @@ exports[`CLI --describe schemas (drift detection) > vibe edit silence-cut --desc
   "parameters": {
     "properties": {
       "analyzeOnly": {
-        "description": "(deprecated — use \`vibe detect silence\`) Only detect silence, don't cut",
+        "description": "(deprecated - use \`vibe detect silence\`) Only detect silence, don't cut",
         "type": "boolean",
       },
       "apiKey": {
@@ -1912,7 +1912,7 @@ exports[`CLI --describe schemas (drift detection) > vibe generate motion --descr
         "type": "number",
       },
       "image": {
-        "description": "Image to analyze with Gemini — color/mood fed into Claude prompt",
+        "description": "Image to analyze with Gemini - color/mood fed into Claude prompt",
         "type": "string",
       },
       "model": {
@@ -3710,7 +3710,7 @@ exports[`CLI --describe schemas (drift detection) > vibe scene add --describe 1`
         "type": "string",
       },
       "narrationFile": {
-        "description": "Existing narration audio file (.wav/.mp3). Skips TTS — useful with hyperframes tts, Mac say, or other external tools.",
+        "description": "Existing narration audio file (.wav/.mp3). Skips TTS - useful with hyperframes tts, Mac say, or other external tools.",
         "type": "string",
       },
       "noAudio": {
@@ -3752,7 +3752,7 @@ exports[`CLI --describe schemas (drift detection) > vibe scene add --describe 1`
       },
       "tts": {
         "default": "auto",
-        "description": "TTS provider: auto, elevenlabs, openai, kokoro (default auto — ElevenLabs key > OpenAI key > Kokoro local)",
+        "description": "TTS provider: auto, elevenlabs, openai, kokoro (default auto - ElevenLabs key > OpenAI key > Kokoro local)",
         "enum": [
           "auto",
           "elevenlabs",
@@ -3762,7 +3762,7 @@ exports[`CLI --describe schemas (drift detection) > vibe scene add --describe 1`
         "type": "string",
       },
       "visuals": {
-        "description": "Image prompt — generates assets/scene-<id>.png via the configured image provider",
+        "description": "Image prompt - generates assets/scene-<id>.png via the configured image provider",
         "type": "string",
       },
       "voice": {
@@ -3782,7 +3782,7 @@ exports[`CLI --describe schemas (drift detection) > vibe scene add --describe 1`
 exports[`CLI --describe schemas (drift detection) > vibe scene compose-prompts --describe 1`] = `
 {
   "cost": "free",
-  "description": "Emit the per-beat compose plan for the host agent to author HTML itself (Phase H2 — no LLM call)",
+  "description": "Emit the per-beat compose plan for the host agent to author HTML itself (no LLM call)",
   "name": "scene.compose-prompts",
   "note": "Agent-mode build primitive; prefer vibe build --mode agent.",
   "parameters": {

--- a/packages/cli/src/commands/_shared/compose-prompts.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.ts
@@ -1,7 +1,7 @@
 /**
  * @module _shared/compose-prompts
  *
- * Phase H2 — agentic compose primitive. Reads `STORYBOARD.md` + `DESIGN.md`
+ * Agentic compose primitive. Reads `STORYBOARD.md` + `DESIGN.md`
  * from a scene project and emits a structured plan for the host agent
  * (Claude Code, Cursor, Codex, Aider) to author per-beat HTML files
  * itself. **No LLM call from inside the CLI** — that's the point. The

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -369,7 +369,7 @@ export const agentCommand = new Command("agent")
   .option("-v, --verbose", "Show verbose output including tool calls")
   .option("--max-turns <n>", "Maximum turns per request", "10")
   .option("-i, --input <query>", "Run a single query and exit (non-interactive)")
-  .option("-c, --confirm", "Confirm before every tool — broadens the default cost gate (paid only) to all calls")
+  .option("-c, --confirm", "Confirm before every tool - broadens the default cost gate (paid only) to all calls")
   .option("--no-confirm", "Disable all confirm prompts including the high/very-high cost gate (CI / automation)")
   .option("--budget-usd <usd>", "Reject tool calls past this cumulative USD ceiling using conservative tier estimates", parseFloat)
   .action(async (options) => {

--- a/packages/cli/src/commands/ai-edit-cli.ts
+++ b/packages/cli/src/commands/ai-edit-cli.ts
@@ -43,7 +43,7 @@ aiCommand
   .option("--noise <dB>", "Silence threshold in dB (default: -30)", "-30")
   .option("-d, --min-duration <seconds>", "Minimum silence duration to cut (default: 0.5)", "0.5")
   .option("--padding <seconds>", "Padding around non-silent segments (default: 0.1)", "0.1")
-  .option("--analyze-only", "(deprecated — use `vibe detect silence`) Only detect silence, don't cut")
+  .option("--analyze-only", "(deprecated - use `vibe detect silence`) Only detect silence, don't cut")
   .option("--use-gemini", "Use Gemini Video Understanding for context-aware silence detection")
   .option("-m, --model <model>", "Gemini model (default: flash)")
   .option("--low-res", "Low resolution mode for longer videos (Gemini only)")

--- a/packages/cli/src/commands/ai-motion.ts
+++ b/packages/cli/src/commands/ai-motion.ts
@@ -35,7 +35,7 @@ export interface MotionCommandOptions {
   render?: boolean;
   /** Base video to composite the motion graphic onto */
   video?: string;
-  /** Image to analyze with Gemini — color/mood/composition fed into Claude prompt */
+  /** Image to analyze with Gemini - color/mood/composition fed into Claude prompt */
   image?: string;
   /** Analyze base video before generating motion: auto | off | required */
   understand?: "auto" | "off" | "required";
@@ -407,7 +407,7 @@ export function registerMotionCommand(aiCommand: Command): void {
     .option("--style <style>", "Style preset: minimal, corporate, playful, cinematic")
     .option("--render", "Render the generated code with Remotion (output .webm)")
     .option("--video <path>", "Base video to composite the motion graphic onto")
-    .option("--image <path>", "Image to analyze with Gemini — color/mood fed into Claude prompt")
+    .option("--image <path>", "Image to analyze with Gemini - color/mood fed into Claude prompt")
     .option(
       "--understand <mode>",
       "Analyze --video with Gemini before generating motion: auto, off, required",

--- a/packages/cli/src/commands/assemble.ts
+++ b/packages/cli/src/commands/assemble.ts
@@ -24,7 +24,7 @@ one FFmpeg pass (-c:v copy, no re-encode). Pair it with \`vibe render --silent\`
   $ vibe render my-video --silent -o draft.mp4
   $ vibe assemble my-video --video draft.mp4
 
-Plain \`vibe render\` already renders + assembles in one shot — use this only when
+Plain \`vibe render\` already renders + assembles in one shot - use this only when
 you want the two steps separated (e.g. swap the audio bed without re-rendering).`)
   .action(async (projectDirArg: string, options) => {
     const startedAt = Date.now();

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -58,7 +58,7 @@ export const buildCommand = new Command("build")
     "--skip-transcript",
     "Don't transcribe narration for word-sync (default: transcribe when narration + OpenAI key exist)"
   )
-  .option("--skip-render", "Compose only — don't render to MP4")
+  .option("--skip-render", "Compose only - don't render to MP4")
   .option("--tts <provider>", "TTS provider: auto|elevenlabs|openai|kokoro")
   .option("--voice <id>", "Voice id")
   .option("--image-provider <name>", `Image provider: ${VALID_IMAGE_PROVIDERS.join("|")}`)

--- a/packages/cli/src/commands/remix.ts
+++ b/packages/cli/src/commands/remix.ts
@@ -41,11 +41,11 @@ export const remixCommand = new Command("remix")
   .addHelpText(
     "after",
     `
-Two flows — pick by intent:
-  BUILD     — text → MP4 (intent → AI generation → new video)
+Two flows - pick by intent:
+  BUILD     - text → MP4 (intent → AI generation → new video)
               Use \`vibe build\` with a STORYBOARD.md + DESIGN.md.
               Idempotent, agent-editable, skills-driven (v0.60+).
-  REMIX     — existing video/audio → transformed media
+  REMIX     - existing video/audio → transformed media
               Use \`vibe remix\` (this group) or \`vibe edit\` / \`vibe audio\`.
               One-shot, batch-oriented, no storyboard required.
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,5 +1,5 @@
 /**
- * `vibe run` command — Execute declarative YAML video pipelines.
+ * `vibe run` command - Execute declarative YAML video pipelines.
  *
  * Video as Code: define reproducible, shareable video workflows in YAML.
  * Each step maps to an existing CLI command's execute function.
@@ -42,10 +42,10 @@ Examples:
 
 Pipeline YAML format:
   name: my-video
-  budget:              # optional — executor aborts when exceeded
+  budget:              # optional - executor aborts when exceeded
     costUsd: 5.00
     maxToolErrors: 3
-  effort: xhigh        # optional — Opus 4.7 Task Budgets
+  effort: xhigh        # optional - Opus 4.7 Task Budgets
   steps:
     - id: image
       action: generate-image
@@ -125,7 +125,7 @@ Run 'vibe schema run' for structured parameter info.
           // Sum per-step estimates for the human-readable rollup. The
           // strings come back as `≤$X.XX` from the executor; parse the
           // numeric part to total. Steps with `UNKNOWN ACTION` or no
-          // estimate contribute 0 — the rollup undercounts when actions
+          // estimate contribute 0 - the rollup undercounts when actions
           // lack metadata, which is the safe direction.
           let totalMax = 0;
           for (let i = 0; i < result.steps.length; i++) {
@@ -145,7 +145,7 @@ Run 'vibe schema run' for structured parameter info.
           if (result.budget) {
             // Budget came from manifest or --budget-usd; show ceiling + status.
             if (result.budget.abortedBy) {
-              console.log(chalk.yellow(`  ⚠ Budget ceiling exceeded (${result.budget.abortedBy}) — execution will abort.`));
+              console.log(chalk.yellow(`  ⚠ Budget ceiling exceeded (${result.budget.abortedBy}) - execution will abort.`));
             }
           } else if (totalMax > 0) {
             console.log(chalk.dim(`  Tip: cap with --budget-usd ${Math.ceil(totalMax)} to abort if cost exceeds the estimate.`));

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -117,7 +117,7 @@ Examples:
 
 For the project flow (init / build / render), use the top-level commands.
 The \`scene init\`, \`scene build\`, and \`scene render\` legacy aliases
-are still callable but hidden from this help — they will be removed in v1.0.
+are still callable but hidden from this help - they will be removed in v1.0.
 Run 'vibe schema scene.<command>' for structured parameter info.`
   );
 
@@ -193,7 +193,7 @@ sceneCommand
   });
 
 // ---------------------------------------------------------------------------
-// `vibe scene compose-prompts` — Phase H2 agentic primitive
+// `vibe scene compose-prompts` - agentic compose primitive
 // ---------------------------------------------------------------------------
 // Emit the prompt + skill-bundle reference plan for the host agent to
 // author per-beat HTML files itself. No LLM call from the CLI. Pairs
@@ -203,7 +203,7 @@ sceneCommand
 sceneCommand
   .command("compose-prompts")
   .description(
-    "Emit the per-beat compose plan for the host agent to author HTML itself (Phase H2 — no LLM call)"
+    "Emit the per-beat compose plan for the host agent to author HTML itself (no LLM call)"
   )
   .argument("[project-dir]", "Project directory containing STORYBOARD.md / DESIGN.md", ".")
   .option("--beat <id>", "Restrict the plan to a single beat by id (e.g. 'hook', '1')")
@@ -455,12 +455,12 @@ sceneCommand
   )
   .option(
     "--narration-file <path>",
-    "Existing narration audio file (.wav/.mp3). Skips TTS — useful with hyperframes tts, Mac say, or other external tools."
+    "Existing narration audio file (.wav/.mp3). Skips TTS - useful with hyperframes tts, Mac say, or other external tools."
   )
   .option("-d, --duration <sec>", "Explicit scene duration in seconds (overrides narration audio)")
   .option(
     "--visuals <prompt>",
-    "Image prompt — generates assets/scene-<id>.png via the configured image provider"
+    "Image prompt - generates assets/scene-<id>.png via the configured image provider"
   )
   .option("--headline <text>", "Visible headline (defaults to the humanised scene name)")
   .option("--kicker <text>", "Small label above the headline (explainer / product-shot)")
@@ -473,7 +473,7 @@ sceneCommand
   .option("--image-provider <name>", "Image provider: gemini, openai", "gemini")
   .option(
     "--tts <provider>",
-    "TTS provider: auto, elevenlabs, openai, kokoro (default auto — ElevenLabs key > OpenAI key > Kokoro local)",
+    "TTS provider: auto, elevenlabs, openai, kokoro (default auto - ElevenLabs key > OpenAI key > Kokoro local)",
     "auto"
   )
   .option("--voice <id>", "Voice id (ElevenLabs name/id, OpenAI voice like marin, or Kokoro id like af_heart)")

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -186,7 +186,7 @@ const sceneAddSchema = z.object({
   visuals: z
     .string()
     .optional()
-    .describe("Image prompt — generates assets/scene-<id>.png via the configured image provider."),
+    .describe("Image prompt - generates assets/scene-<id>.png via the configured image provider."),
   headline: z
     .string()
     .optional()
@@ -843,7 +843,7 @@ export const sceneInstallSkillTool = defineTool({
 });
 
 // ---------------------------------------------------------------------------
-// scene_compose_prompts — Phase H2 agentic primitive
+// scene_compose_prompts - agentic compose primitive
 // ---------------------------------------------------------------------------
 
 const sceneComposePromptsSchema = z.object({

--- a/scripts/gen-cli-reference.mts
+++ b/scripts/gen-cli-reference.mts
@@ -94,7 +94,7 @@ tags: [cli, reference, generated]
 
 # VibeFrame CLI Reference
 
-> **Auto-generated** from \`vibe schema --list\`. Do not edit by hand —
+> **Auto-generated** from \`vibe schema --list\`. Do not edit by hand -
 > run \`pnpm gen:reference\` after any flag/command change.
 
 VibeFrame is CLI-first: every operation is a shell command. This file
@@ -265,7 +265,7 @@ function renderCostTiers(leaves: SchemaListEntry[]): string {
 
   lines.push(
     "",
-    "> **Tip:** Run `<paid command> --dry-run --json` first — the response",
+    "> **Tip:** Run `<paid command> --dry-run --json` first - the response",
     "> includes a `costUsd` estimate when the command supports dry-run.",
     ""
   );
@@ -395,7 +395,7 @@ function renderArg(name: string, schema: ParameterSchema, isRequired: boolean): 
   const def =
     schema.default !== undefined ? ` *(default: \`${JSON.stringify(schema.default)}\`)*` : "";
   const requiredMark = isRequired ? " **required**" : "";
-  return `- \`${name}\` *(${schema.type ?? "any"})*${requiredMark}${enums}${def} — ${desc}`;
+  return `- \`${name}\` *(${schema.type ?? "any"})*${requiredMark}${enums}${def} - ${desc}`;
 }
 
 function renderLeaf(leaf: RenderedLeaf): string {
@@ -512,7 +512,7 @@ function buildReference(): string {
 
   const sections: string[] = [
     HEADER,
-    // Version pins the CLI surface; no timestamp on purpose — a daily
+    // Version pins the CLI surface; no timestamp on purpose - a daily
     // regeneration would otherwise diff on `Generated: <date>` alone
     // and turn `gen:reference:check` into a false-positive.
     `> CLI version: \`${version}\``,
@@ -598,7 +598,7 @@ if (checkMode) {
       shown++;
     }
   }
-  console.error(`Sizes — committed: ${existing.length} chars, fresh: ${fresh.length} chars.`);
+  console.error(`Sizes - committed: ${existing.length} chars, fresh: ${fresh.length} chars.`);
   process.exit(1);
 }
 


### PR DESCRIPTION
`docs/cli-reference.md` is generated, so its **672** em dashes could not be swept directly - regeneration would put them straight back. They came from two places.

## 669 were one character in the generator

`scripts/gen-cli-reference.mts` renders every option row as:

```
- `flag` *(type)* — description
```

Changing that one template literal (plus the header, tip, and two log lines in the same file) removed 669.

## The other 8 were in source descriptions

Em dashes inside CLI option and command descriptions, which flow through `vibe schema` into the generated file. Fixed at the source, so they are gone from the reference **and** from `vibe --help` and the MCP tool schemas that share those strings:

| File | Option |
|---|---|
| `agent.ts` | `-c, --confirm` |
| `build.ts` | `--skip-render` |
| `ai-edit-cli.ts` | `--analyze-only` |
| `ai-motion.ts` | `--image` |
| `scene.ts` | `--narration-file`, `--visuals`, `--tts`, `compose-prompts` |
| `tools/manifest/scene.ts` | `scene_add.visuals` |

While there, dropped **"Phase H2"** from the compose-prompts description and two nearby comments - internal version archaeology in a string the user reads, and #284 removed the same phrasing elsewhere.

## Plus the help text that never reaches the reference

But does reach the terminal: `vibe scene` (hidden-subcommand note), `vibe assemble`, `vibe remix` (flow table), `vibe run` (YAML sample comments).

## Verification

- `grep -c "—" docs/cli-reference.md` = **0**
- **0** across `--help` for every top-level command plus the root
- `gen:reference:check` passes, so the file still regenerates deterministically
- Full suite 1398 passed; lint, sync-counts, agent-sync green

The `--describe` drift snapshots for the six touched commands failed, as designed - that test exists to make exactly this kind of contract edit visible in review. Updated; the diff is only the eight description strings.

https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp