### PR TITLE
fix: stop promising per-host scaffolds that vibe init never writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,8 +178,11 @@ Claude Code, and direct terminal pushes use the same version/SSOT checks.
 
 ## Agent Hosts & Sync
 
-`vibe init` writes guidance files for six hosts (Claude Code, Codex, Cursor,
-Aider, Gemini CLI, OpenCode). Separately, `pnpm agent-sync` keeps three hosts'
+`vibe init` writes one `AGENTS.md` (plus a `CLAUDE.md` that imports it) that
+serves every bash-capable host; `--mcp` adds MCP config for Claude Code,
+Codex, and Cursor. It does not emit per-host files - `projectFiles` in
+`agent-host-detect.ts` is a detection list, not a scaffold list. Separately,
+`pnpm agent-sync` keeps three hosts'
 generated config (Claude Code, Codex, Cursor) in sync from one canonical source.
 Full map + workflows: `docs/agent-hosts.md`.
 

--- a/README.md
+++ b/README.md
@@ -362,9 +362,11 @@ The `surface` field signals intent: `public` = first-run product path;
 
 ## Connect your host
 
-`vibe init` writes agent guidance for Codex, Claude Code, Cursor, Aider,
-Gemini CLI, and OpenCode, with a universal `AGENTS.md` fallback. `vibe host`
-turns that into app-ready config - it prints by default, `--write` applies:
+`vibe init` writes one `AGENTS.md` (plus a `CLAUDE.md` that imports it). That
+is the whole contract: Codex, Cursor, Aider, Gemini CLI, OpenCode, and any
+other bash-capable agent read the same file - there is no per-host scaffold.
+`vibe host` adds typed MCP config for the three hosts that support it, and
+prints by default; `--write` applies:
 
 ```bash
 vibe host setup all                              # print snippets for every host

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -367,61 +367,41 @@ export default function LandingPage() {
             </p>
           </div>
 
-          {/* Six-host grid - equal cards, same example, different scaffold target */}
-          <div className="text-center mb-6">
-            <p className="text-sm text-muted-foreground">
-              <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
-                vibe doctor
-              </code>{" "}
-              auto-detects host families and{" "}
-              <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
-                vibe host setup
-              </code>{" "}
-              prints or writes Codex, Claude, and Cursor integration config.
-            </p>
-          </div>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3 max-w-4xl mx-auto">
-            {[
-              {
-                name: "OpenAI Codex",
-                scaffold: "AGENTS.md + .codex/config.toml",
-                note: "shell + MCP",
-              },
-              {
-                name: "Claude Code",
-                scaffold: "CLAUDE.md + .mcp.json",
-                note: "shell + optional MCP",
-              },
-              {
-                name: "Cursor",
-                scaffold: ".cursor/rules + .cursor/mcp.json",
-                note: "rules + MCP",
-              },
-              { name: "Aider", scaffold: "AGENTS.md + .aider.conf.yml", note: "binary-detected" },
-              { name: "Gemini CLI", scaffold: "GEMINI.md + AGENTS.md", note: "universal fallback" },
-              { name: "OpenCode", scaffold: "AGENTS.md + .opencode/", note: "MCP-ready" },
-            ].map((host) => (
-              <div
-                key={host.name}
-                className="bg-secondary/40 border border-border/50 rounded-xl px-4 py-3"
-              >
-                <div className="font-mono text-sm font-semibold text-foreground">{host.name}</div>
-                <div className="text-xs text-muted-foreground mt-1">{host.scaffold}</div>
-                <div className="text-xs text-muted-foreground/70 mt-0.5">{host.note}</div>
+          <div className="grid md:grid-cols-2 gap-4 max-w-3xl mx-auto">
+            <div className="bg-secondary/40 border border-border/50 rounded-xl p-5">
+              <div className="font-mono text-sm font-semibold text-foreground mb-2">
+                vibe init
               </div>
-            ))}
+              <p className="text-sm text-muted-foreground">
+                Writes one <code className="text-primary">AGENTS.md</code> (plus{" "}
+                <code className="text-primary">CLAUDE.md</code>, which just imports it). That is the
+                whole contract - Codex, Cursor, Aider, Gemini CLI, OpenCode and any other
+                bash-capable agent read the same file.
+              </p>
+            </div>
+            <div className="bg-secondary/40 border border-border/50 rounded-xl p-5">
+              <div className="font-mono text-sm font-semibold text-foreground mb-2">
+                vibe host setup --write
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Adds typed MCP tools for the three hosts that support them:{" "}
+                <code className="text-primary">.mcp.json</code>,{" "}
+                <code className="text-primary">.codex/config.toml</code>,{" "}
+                <code className="text-primary">.cursor/mcp.json</code>. Optional - the CLI works
+                without it.
+              </p>
+            </div>
           </div>
 
           <p className="text-center text-muted-foreground text-sm mt-8">
-            Anyone running another bash-capable agent gets the universal
-            <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs mx-1">
-              AGENTS.md
-            </code>
-            fallback; app hosts can add typed tools with
-            <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs mx-1">
-              vibe host setup
-            </code>
-            .
+            <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
+              vibe doctor
+            </code>{" "}
+            reports which hosts it detects, and{" "}
+            <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-xs">
+              vibe host doctor all --json
+            </code>{" "}
+            verifies what landed.
           </p>
         </div>
       </section>

--- a/packages/cli/src/utils/agent-host-detect.ts
+++ b/packages/cli/src/utils/agent-host-detect.ts
@@ -35,8 +35,13 @@ export interface AgentHostInfo {
   /** Signals that fired (empty array when `detected` is false). */
   signals: AgentHostSignal[];
   /**
-   * Files this host expects in a project. Used by `vibe init` to know
-   * what to scaffold; informational here.
+   * Files that indicate this host is set up in a project - a DETECTION
+   * signal, not a scaffold list. `vibe init` does not write these: it writes
+   * one `AGENTS.md` (plus `CLAUDE.md` importing it) for every host, and
+   * `--mcp` / `vibe host setup` adds MCP config for the three hosts that
+   * support it. Reading this list as "what init creates" produced a
+   * landing-page grid that promised `GEMINI.md`, `.aider.conf.yml`,
+   * `.opencode/` and `.cursor/rules`, none of which anything writes.
    */
   projectFiles: string[];
 }


### PR DESCRIPTION
Re-audited every claim on the landing page against the CLI. Almost all of it checks out - one thing does not, and I put part of it there.

## The six-host grid was wrong for four of six rows

It gave each host its own "scaffold" column. Measured, running every value of `--agent` on 0.113.30:

```
init --agent gemini-cli  -> AGENTS.md CLAUDE.md
init --agent cursor      -> AGENTS.md CLAUDE.md
init --agent codex       -> AGENTS.md CLAUDE.md
```

**The flag does not vary the output at all.** Adding `--mcp` (or `vibe host setup all --write`) contributes `.mcp.json`, `.codex/config.toml`, `.cursor/mcp.json`. That is the complete set.

| Card | Claimed | Reality |
|---|---|---|
| OpenAI Codex | AGENTS.md + .codex/config.toml | ✅ |
| Claude Code | CLAUDE.md + .mcp.json | ✅ |
| Cursor | **.cursor/rules** + .cursor/mcp.json | never written |
| Aider | AGENTS.md + **.aider.conf.yml** | never written |
| Gemini CLI | **GEMINI.md** + AGENTS.md | never written |
| OpenCode | AGENTS.md + **.opencode/** | never written |

## My fault, and the trap

I introduced three of those four wrong rows in #285, by "correcting" the grid against `projectFiles` in `agent-host-detect.ts`. That field's doc comment read *"Used by `vibe init` to know what to scaffold"*, so I trusted it instead of running the command.

It is actually a **detection** list - files whose presence signals the host is installed. The comment now says so, states what init really writes, and notes the grid it misled, so the next reader does not repeat it.

## Chose A: describe what the tool does

Rather than add the missing files, the docs now match reality - which is the better story anyway: **one `AGENTS.md` is the whole contract**, and every bash-capable agent reads it.

- **Landing**: 6 cards → 2 (what `vibe init` writes; what `vibe host setup --write` adds), plus the doctor line. The grid implied a differentiation that does not exist.
- **README**: "writes agent guidance for Codex, Claude Code, Cursor, Aider, Gemini CLI, and OpenCode" implied per-host files; now states the single file and says explicitly there is no per-host scaffold.
- **AGENTS.md**: same correction plus the `projectFiles` pointer.

`docs/agent-hosts.md` needed no change - it documents this repo's own agent-config sync, not what init writes into a user's project.

## Everything else on the landing verified clean

Same pass, against `vibe schema --list` (101 entries):

- all 12 commands resolve (`build`, `render`, `run`, `audio.dub`, `remix.highlights`, `remix.animated-caption`, `inspect.render`, `generate.video`, `host.setup`, `doctor`, `setup`, `init`)
- all 11 flags exist in their command schemas (`--dry-run`, `--max-cost`, `--stage`, `--skip-backdrop`, `--tts`, `--from`, `--scope`, `--resume`, `--cheap`, `--write`)
- `--json` is a documented global option, which is why it is absent from per-command schemas
- all six MCP tool chips exist; "+79 more tools" arithmetic matches (85 − 6 chips)

Tests 1398 passed, lint clean, agent-sync in sync, host section screenshot-checked.

https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp