### PR TITLE
docs: restructure the README around reading order, 447 -> 306 lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # VibeFrame
 
-Let your coding agent generate real video, on your own provider keys, under a spend ceiling it cannot cross.
+**Let your coding agent generate real video, on your own provider keys, under a spend ceiling it cannot cross.**
 
-VibeFrame is a CLI and MCP server that gives Claude Code, Codex, Cursor, or any bash-capable agent the commands to plan a video, generate the assets from frontier models - Seedance, Runway, Veo, Kling - and render a finished MP4.
+VibeFrame is a CLI and MCP server for Claude Code, Codex, Cursor, or any bash-capable agent.
+It turns a written brief into a plan, generates the assets from frontier models (Seedance, Runway, Veo, Kling), and renders a finished MP4.
 Every paid step sits behind a dry run and a hard `--max-cost` ceiling, and every failure comes back as machine-readable recovery actions instead of a stack trace.
-
-Scene composition is [Hyperframes](https://github.com/heygen-com/hyperframes)' job, not ours.
-VibeFrame installs its skill and builds the generation, cost, and review layer around it.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/vericontext/vibeframe/actions/workflows/ci.yml/badge.svg)](https://github.com/vericontext/vibeframe/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/vericontext/vibeframe)](https://github.com/vericontext/vibeframe/stargazers)
+
+![One consistent character across a directed arctic night: a trek under the stars, the first aurora, the whole sky ablaze, and the walk home at dawn](docs/media/showcase-aurora.gif)
+
+One photographer across a single arctic night, 1080p, generated end to end.
+▶ **[Watch the full render](https://github.com/vericontext/vibeframe/releases/download/v0.113.11/vibeframe-showcase.mp4)**
 
 ## Know the price before anything is spent
 
@@ -26,38 +29,63 @@ vibe build film --dry-run --max-cost 3 --json
   "success": false,
   "error": "Estimated cost $10.93 exceeds --max-cost $3.00.",
   "code": "COST_CAP_EXCEEDED",
-  "exitCode": 1,
-  "suggestion": "Raise --max-cost or reduce the stage/provider scope.",
   "retryWith": [
     "vibe build . --stage all --skip-backdrop --json",
     "vibe build . --stage all --max-cost 10.93 --json"
   ],
-  "recoverable": true,
-  "retryable": false,
   "data": { "plan": { "estimatedCostUsd": 10.93, "...": "the full priced plan" } }
 }
 ```
 
-The envelope goes to stderr and the command exits 1, so an agent loop stops
-instead of guessing. `retryWith` gives it the two cheaper ways forward it can
-take without asking you, and `data.plan` carries the priced plan the refusal
-was based on, so it never has to re-run just to learn the estimate.
-The same dry run also names the keys each stage would need, so you find out what a video costs before you own an account:
+The envelope goes to stderr and the command exits 1, so an agent loop stops instead of guessing.
+`retryWith` gives it the two cheaper ways forward it can take without asking you, and `data.plan` carries the priced plan the refusal was based on, so it never has to re-run just to learn the estimate.
+
+The same dry run names the keys each stage would need, so you find out what a video costs before you own an account:
 
 ```text
 Keyframe generation will need openai (OPENAI_API_KEY), but no key/config is available.
 Video generation will need seedance (FAL_API_KEY), but no key/config is available.
 ```
 
-This is the part of VibeFrame that has no equivalent in a credit-based tool.
 Your keys, your bill, your ceiling.
 
-## Try it with no keys at all
-
-Before wiring up any provider, the whole pipeline runs locally for $0: local Kokoro TTS narration, HTML/CSS scenes composed by your coding agent, and a headless Chrome plus FFmpeg render.
+## Install
 
 ```bash
-npm install -g @vibeframe/cli
+curl -fsSL https://vibeframe.ai/install.sh | bash
+vibe doctor
+```
+
+Needs **Node.js 20+, FFmpeg, and Chrome** (or Chromium).
+`vibe doctor` verifies all three and lists which commands each provider key unlocks.
+
+Generation is the only thing that needs a key.
+FFmpeg edits, Kokoro narration, scene composition, detection, timeline work, and rendering are all local.
+Add `OPENAI_API_KEY`, `FAL_API_KEY`, `GOOGLE_API_KEY`, `RUNWAY_API_SECRET`, or `KLING_API_KEY` for the providers you actually use, via `vibe setup` or the environment.
+
+<details>
+<summary>Package names, config locations, and building from source</summary>
+
+The CLI is published as [`@vibeframe/cli`](https://www.npmjs.com/package/@vibeframe/cli) (binary `vibe`) and the MCP server as [`@vibeframe/mcp-server`](https://www.npmjs.com/package/@vibeframe/mcp-server).
+There is no bare `vibeframe` npm package from this project - that name belongs to an unrelated package, so `npx vibeframe` will not run this tool.
+
+The installer places the CLI under the XDG data directory (`~/.local/share/vibeframe` by default).
+User-scope keys live in `~/.vibeframe/config.yaml`; `vibe setup --scope project` writes `./.vibeframe/config.yaml`.
+When a project config exists at or above your current directory, VibeFrame uses it in isolation and does not merge user-scope keys.
+
+```bash
+git clone https://github.com/vericontext/vibeframe.git
+cd vibeframe && pnpm install && pnpm build
+pnpm vibe --help
+```
+
+</details>
+
+## First, a render that costs nothing
+
+Before wiring up a provider, the whole pipeline runs locally for $0: Kokoro TTS narration, HTML/CSS scenes composed by your coding agent, and a headless Chrome plus FFmpeg render.
+
+```bash
 vibe init demo --from "30-second video introducing my project"
 vibe scene install-skill demo    # Hyperframes' own installer; the rules your agent authors against
 ```
@@ -72,139 +100,42 @@ Then ask your coding agent to finish it:
 > reports before rendering - it exits non-zero while any remain.
 > Then `vibe render demo --json`.
 
-Measured cold start (v0.113.29, isolated environment, no keys): install 63s, `vibe init` 1s, `vibe build --tts kokoro --skip-backdrop` 66s including the one-time ~88 MB voice model download, and `vibe render` 64s.
-That is about 3 minutes of machine time; the scene-authoring pass in the middle is your agent's, so the wall clock depends on it and on how many lint rounds it needs.
-Repeat runs skip the download.
+Treat `--stage sync` as the gate.
+It lints the composed scenes and exits non-zero on real errors, such as an unregistered GSAP timeline or a composition div missing `data-width`/`data-height`.
+Rendering past a failed sync produces a black MP4, so fix the scenes first.
 
-Treat `vibe build --stage sync` as the gate: it lints the composed scenes and exits non-zero on real errors - an unregistered GSAP timeline, a composition div missing `data-width`/`data-height`. Rendering past a failed sync produces a black MP4, so fix the scenes first.
-No coding agent available? `vibe scene add <id> --style announcement --headline "..." --no-audio --no-image` writes a lint-clean template scene with no model call, and doubles as a reference for the file shape.
+That is about three minutes of machine time (measured on v0.113.29 in an isolated environment: 63s install, 1s init, 66s build including the one-time ~88 MB voice model download, 64s render; repeat runs skip the download).
+The scene-authoring pass in the middle is your agent's, so the wall clock depends on it and on how many lint rounds it needs.
+
+No coding agent available?
+`vibe scene add <id> --style announcement --headline "..." --no-audio --no-image` writes a lint-clean template scene with no model call, and doubles as a reference for the file shape.
 
 It is a real render, and it is the cheapest way to see whether the workflow fits you.
-It is not the point of the tool: the paid generation path above is.
+It is not the point of the tool: the paid generation path is.
 
-## Requirements
-
-- Node.js 20+
-- FFmpeg
-- Chrome or Chromium (for HTML scene rendering)
-
-Everything local runs on those three: FFmpeg edits, Kokoro narration, HTML scene composition, detection, timeline work, and rendering.
-Generation is BYO-key - add `OPENAI_API_KEY`, `FAL_API_KEY`, `GOOGLE_API_KEY`, `RUNWAY_API_SECRET`, or `KLING_API_KEY` only for the providers you actually use (full list in [MODELS.md](MODELS.md)).
-`vibe doctor` lists exactly which commands each key unlocks.
-
-## Install
+## Build a video from a brief
 
 ```bash
-curl -fsSL https://vibeframe.ai/install.sh | bash
-vibe doctor
+vibe init launch --from brief.md            # or --from "30-second launch video for VibeFrame"
+vibe build launch --dry-run --max-cost 5    # price it
+vibe build launch --max-cost 5              # generate
+vibe render launch -o renders/final.mp4     # render
+vibe inspect render launch --cheap          # check the result
 ```
 
-The installer places the CLI under the XDG data directory
-(`~/.local/share/vibeframe` by default). User-scope API keys live in
-`~/.vibeframe/config.yaml`; project-scope setup writes `./.vibeframe/config.yaml`.
-When a project config exists at or above your current directory, VibeFrame uses
-that project config in isolation and does not merge user-scope keys.
+`brief.md` can be messy notes, links, or a single line.
+What `init` produces are two files you then own:
 
-> **npm package names:** the CLI is published as
-> [`@vibeframe/cli`](https://www.npmjs.com/package/@vibeframe/cli) (binary
-> `vibe`) and the MCP server as
-> [`@vibeframe/mcp-server`](https://www.npmjs.com/package/@vibeframe/mcp-server).
-> There is no bare `vibeframe` npm package from this project - that name belongs
-> to an unrelated package, so `npx vibeframe` will not run this tool.
+| File            | What it holds                                                            |
+| --------------- | ------------------------------------------------------------------------ |
+| `STORYBOARD.md` | Beats: narration, duration, and image/video/music cues. The intent layer. |
+| `DESIGN.md`     | Palette, typography, layout, motion, transitions. The visual system.      |
 
-For local development:
+Edit them directly, or ask a coding agent to research and revise them.
+The rest is convention: `media/` for footage you supply, `assets/` for generated ones, `renders/` for output, and `vibe.config.json` for the provider, model, and quality contract.
 
-```bash
-git clone https://github.com/vericontext/vibeframe.git
-cd vibeframe
-pnpm install
-pnpm build
-pnpm vibe --help
-```
-
-## How The Pieces Fit Together
-
-Use the highest-level lane that fits the job:
-
-| Lane               | Use it when...                                        | Commands                                                             |
-| ------------------ | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| **BUILD**          | You want a complete video from a written brief        | `init`, `storyboard`, `plan`, `build`, `preview`, `render`, `inspect` |
-| **GENERATE/ASSET** | You need one standalone image, clip, voice, or music  | `generate image/video/narration/music/motion`                        |
-| **EDIT/REMIX**     | You already have media and want to change or reuse it | `edit`, `remix`, `audio`, `detect`                                   |
-
-BUILD is the primary path; the other two need no storyboard.
-
-Within a BUILD project, the files have defined roles:
-
-| Path            | Role                                                                              |
-| --------------- | --------------------------------------------------------------------------------- |
-| `brief.md`      | Optional rough input before `vibe init`; can be messy notes, links, or one line. |
-| `STORYBOARD.md` | Beats, narration, duration, and image/video/music cues. The intent layer.         |
-| `DESIGN.md`     | Palette, typography, layout, motion, and transitions. The visual system.          |
-| `media/`        | User-provided source files: photos, screenshots, logos, B-roll, voice recordings. |
-| `assets/`       | Generated or canonical build artifacts: narration, backdrops, music, video clips. |
-| `renders/`      | Final and intermediate MP4 outputs.                                               |
-
-`vibe.config.json` owns the project contract (provider, model, quality, and
-build defaults). The composition engine today is Hyperframes (HTML/CSS/JS scene
-rendering in a headless browser).
-
-## Quick Start
-
-```bash
-vibe setup    # this is where provider keys go - optional until a step generates
-vibe doctor
-vibe guide
-```
-
-Scaffold a project from a brief:
-
-```bash
-mkdir -p launch/media
-# optional: add your own photos, logos, screenshots, or B-roll
-# cp ~/Desktop/product-shot.png launch/media/
-
-cat > brief.md <<'EOF'
-Make a 30-second launch video for VibeFrame.
-
-Audience: developers using Codex, Claude Code, or Cursor.
-Message: a coding agent can turn a brief into a rendered MP4.
-Tone: technical, concise, credible.
-EOF
-
-vibe setup --scope project
-vibe init launch --from brief.md --json
-```
-
-`--from` also accepts an inline string:
-
-```bash
-vibe init launch --from "30-second launch video for VibeFrame" --json
-```
-
-After init, `STORYBOARD.md` and `DESIGN.md` are the working source of truth.
-Edit them directly or ask a coding agent to research and revise them.
-
-## Project Flow
-
-```bash
-vibe storyboard validate my-video --json
-vibe plan my-video --json
-vibe build my-video --dry-run --max-cost 5 --json
-vibe build my-video --max-cost 5 --json
-vibe status project my-video --refresh --json
-vibe inspect project my-video --json
-vibe preview my-video --json
-vibe render my-video -o renders/final.mp4 --json
-vibe inspect render my-video --cheap --json
-vibe scene repair my-video --json
-```
-
-`plan`, `build`, `preview`, `render`, and both `inspect` commands take
-`--beat <id>` to work one beat at a time instead of rebuilding everything.
-
-Each storyboard beat carries YAML cues. A cue's value is either a prompt to
-generate from, or a project-relative path to a file you already have:
+Each beat carries YAML cues.
+A cue's value is either a prompt to generate from, or a project-relative path to a file you already have:
 
 ````markdown
 ## Beat hook - Open
@@ -218,9 +149,11 @@ duration: 5
 ```
 ````
 
-`vibe init` takes a `--profile` (`minimal` | `agent` | `full`, default `agent`)
-and `--mcp` for project-scoped MCP config. Profiles, every cue key, and the
-character/keyframe workflow are in [docs/projects.md](docs/projects.md).
+Add `--json` to any command for structured output.
+`plan`, `build`, `preview`, `render`, and both `inspect` commands take `--beat <id>` to work one beat at a time instead of rebuilding everything.
+`storyboard`, `status`, and `scene repair` cover editing beats, polling async work, and deterministic fixes.
+
+Profiles (`--profile minimal | agent | full`), every cue key, and the full project flow are in [docs/projects.md](docs/projects.md).
 
 ## What the spend buys: one character, many scenes
 
@@ -246,7 +179,8 @@ video: "slow tilt up as the aurora ripples and pulses overhead"
 ````
 
 Each beat pairs a `keyframe` still with a `video` motion prompt.
-Generate the cheap image storyboard first, review it, then animate only the stills you approve - that is also the cheapest way to keep a run under its ceiling, since stills cost a fraction of the video.
+Generate the cheap image storyboard first, review it, then animate only the stills you approve.
+That is also the cheapest way to keep a run under its ceiling, since stills cost a fraction of the video.
 
 ```bash
 vibe build my-film --skip-video   # keyframe stills only (cheap) - review them first
@@ -254,76 +188,32 @@ vibe build my-film --beat wonder --stage assets --force --skip-video  # redo one
 vibe build my-film --max-cost 12  # animate the approved stills (image-to-video)
 ```
 
-▶ **[Watch the full render](https://github.com/vericontext/vibeframe/releases/download/v0.113.11/vibeframe-showcase.mp4)**:
-one photographer across a single arctic night (trek → first aurora → the
-whole sky → dawn), 1080p, generated end-to-end. Open source, MIT.
+Prompt craft for both models lives in the [AI video prompting playbook](docs/ai-video-prompting.md).
 
-![One consistent character across a directed arctic night: a trek under the stars, the first aurora, the whole sky ablaze, and the walk home at dawn](docs/media/showcase-aurora.gif)
+## One-off assets and edits
 
-Prompt craft for both models lives in the
-[AI video prompting playbook](docs/ai-video-prompting.md); the storyboard cues
-(`characters:`, `keyframe:`) are documented in [docs/projects.md](docs/projects.md).
-
-## One-Shot Media Commands
-
-Use these when the job is a single asset or media transformation, not a
-full storyboard project:
+These need no project and no storyboard:
 
 ```bash
-# Generate standalone assets
 vibe generate image "cinematic product demo frame" -p openai -o frame.png
 vibe generate video "interface animates into a polished demo" -p seedance -i frame.png -o motion.mp4
 vibe generate narration "Start with a storyboard." -o narration.mp3
-vibe generate music "minimal instrumental tech pulse" --instrumental -d 60 -o bgm.mp3
 
-# Edit existing media
 vibe edit silence-cut interview.mp4 -o clean.mp4
 vibe edit caption video.mp4 -o captioned.mp4
-vibe edit noise-reduce noisy.mp4 -o clean.mp4
 vibe detect scenes video.mp4
 
-# Remix and audio
 vibe remix highlights demo-process.mp4 -d 60 -o highlight.mp4
 vibe audio duck bgm.mp3 --voice highlight.mp4 -o bgm-ducked.mp3
 ```
 
-## YAML Pipelines
+For reproducible multi-step workflows, `vibe run pipeline.yaml` executes a budgeted YAML pipeline with `--dry-run` and `--resume`.
+Worked examples of all of the above are in [docs/recipes.md](docs/recipes.md).
 
-Use `vibe run` for reproducible multi-step workflows:
+## Drive it from an agent
 
-```yaml
-name: promo
-budget:
-  costUsd: 5
-steps:
-  - id: image
-    action: generate-image
-    prompt: "A cinematic developer-tool hero frame"
-    output: frame.png
-
-  - id: video
-    action: generate-video
-    prompt: "Slow camera push-in, subtle interface motion"
-    image: $image.output
-    provider: seedance
-    duration: 8
-    output: motion.mp4
-```
-
-```bash
-vibe run promo.yaml --dry-run
-vibe run promo.yaml
-vibe run promo.yaml --resume
-```
-
-## Agent Workflows
-
-The intended agent path: use your host's agent loop as the outer loop,
-drive VibeFrame CLI commands with `--json`, and use `build-report.json` and
-`review-report.json` as loop state.
-
-The forward pass is the Project Flow above. What makes it a loop is the
-recovery pass:
+Use your host's agent loop as the outer loop, drive the CLI with `--json`, and use `build-report.json` and `review-report.json` as loop state.
+The forward pass is the build flow above; what makes it a loop is the recovery pass:
 
 ```text
 "fix quality issues from the render review"
@@ -334,53 +224,41 @@ recovery pass:
 -> vibe inspect render launch --cheap --json
 ```
 
-`inspect` returns a `review-report.json` with pre-classified `nextActions`:
-run `safeToAutoRun:true` actions automatically, ask before
-`requiresConfirmation:true` actions, and use `retryWith` only as a fallback.
-`fixOwner:"vibe"` means the CLI can repair it deterministically;
-`fixOwner:"host-agent"` means the outer loop (or a human) must edit
-`STORYBOARD.md`, `DESIGN.md`, or compositions.
+`inspect` returns pre-classified `nextActions`: run `safeToAutoRun:true` automatically, ask before `requiresConfirmation:true`, and use `retryWith` only as a fallback.
+`fixOwner` says who acts - `"vibe"` means the CLI repairs it deterministically, `"host-agent"` means the outer loop or a human edits the source files.
 
-You do not have to write that contract into your prompt. `vibe context`
-prints it - the loop, the envelope, and the `nextActions` rules above - so
-"read `vibe context`, then build `launch/` from `brief.md` under `--max-cost 5`"
-is enough to start a host agent.
+You do not have to write any of that into your prompt.
+`vibe context` prints it, so "read `vibe context`, then build `launch/` from `brief.md` under `--max-cost 5`" is enough to start a host agent.
+The full contract with a worked report is in [docs/projects.md](docs/projects.md#host-agent-loop).
 
-### Discovering the surface
+To explore the surface:
 
 ```bash
-vibe schema --list                  # full command catalog
-vibe schema --list --surface public # first-run / product surface only
-vibe schema --list --filter free    # narrow to cost tier
-vibe context                        # agent rules, envelope, conventions
+vibe schema --list                  # full command catalog, the source of truth
+vibe schema --list --surface public # first-run product path only
+vibe schema --list --filter free    # narrow to a cost tier
 vibe guide                          # workflow guides (motion | scene | pipeline)
 ```
 
-`vibe schema` is the source of truth for command availability and parameters.
-The `surface` field signals intent: `public` = first-run product path;
-`agent` = host-agent automation; `advanced`/`legacy` = power primitives.
-
 ## Connect your host
 
-`vibe init` writes one `AGENTS.md` (plus a `CLAUDE.md` that imports it). That
-is the whole contract: Codex, Cursor, Aider, Gemini CLI, OpenCode, and any
-other bash-capable agent read the same file - there is no per-host scaffold.
-`vibe host` adds typed MCP config for the three hosts that support it, and
-prints by default; `--write` applies:
-
-```bash
-vibe host setup all                              # print snippets for every host
-vibe host setup cursor --write                   # write .cursor/mcp.json
-vibe host setup claude-desktop ~/dev/videos --write   # pass the workspace dir
-vibe host doctor all --json                      # verify what landed
-```
-
-**Claude Desktop users:** install the prebuilt extension instead of editing
-JSON - download [vibeframe.mcpb](https://github.com/vericontext/vibeframe/releases/latest/download/vibeframe.mcpb)
-and drop it into **Settings → Extensions**, then pick a workspace folder.
+`vibe init` writes one `AGENTS.md` (plus a `CLAUDE.md` that imports it).
+That is the whole contract: Codex, Cursor, Aider, Gemini CLI, OpenCode, and any other bash-capable agent read the same file, and there is no per-host scaffold.
 
 The CLI is the primary runtime; MCP is for hosts that prefer typed tool calls.
-To wire `@vibeframe/mcp-server` (binary `vibeframe-mcp`) by hand:
+`vibe host` prints config by default, and `--write` applies it:
+
+```bash
+vibe host setup all                                   # print snippets for every host
+vibe host setup cursor --write                        # write .cursor/mcp.json
+vibe host setup claude-desktop ~/dev/videos --write   # pass the workspace dir
+vibe host doctor all --json                           # verify what landed
+```
+
+**Claude Desktop users:** install the prebuilt extension instead of editing JSON.
+Download [vibeframe.mcpb](https://github.com/vericontext/vibeframe/releases/latest/download/vibeframe.mcpb), drop it into **Settings → Extensions**, then pick a workspace folder.
+
+To wire `@vibeframe/mcp-server` (binary `vibeframe-mcp`) by hand, add:
 
 ```json
 {
@@ -393,54 +271,35 @@ To wire `@vibeframe/mcp-server` (binary `vibeframe-mcp`) by hand:
 }
 ```
 
-See [packages/mcp-server/README.md](packages/mcp-server/README.md) for tool,
-resource, and prompt details.
+Tool, resource, and prompt details are in [packages/mcp-server/README.md](packages/mcp-server/README.md).
 
-## Providers
+## Where VibeFrame fits
 
-VibeFrame routes to multiple providers for LLMs, image generation, video
-generation, TTS, transcription, and analysis. Rather than duplicate the list
-here, read it from the CLI - it stays in sync with new providers automatically:
+It wraps lower-level composition engines rather than replacing them:
 
-```bash
-vibe doctor --json | jq '.data.providers'   # every provider and its env var
-vibe setup --show                           # which keys you have configured
-vibe doctor                                 # verify keys and dependencies
-```
-
-Every command carries a cost tier - `vibe schema --list --filter free|low|high|very-high`
-sorts by it before you run anything. For model and provider details, see
-[MODELS.md](MODELS.md).
-
-## Relationship To Composition Engines
-
-VibeFrame wraps lower-level composition engines rather than replacing them:
-
-| Layer                                                    | Owns                                                                            |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Remotion](https://github.com/remotion-dev/remotion)     | React-based programmatic video and component-driven motion graphics.             |
-| [Hyperframes](https://github.com/heygen-com/hyperframes) | HTML/CSS/JS scene composition and deterministic browser capture.                 |
+| Layer                                                    | Owns                                                                             |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [Remotion](https://github.com/remotion-dev/remotion)     | React-based programmatic video and component-driven motion graphics.              |
+| [Hyperframes](https://github.com/heygen-com/hyperframes) | HTML/CSS/JS scene composition and deterministic browser capture.                  |
 | VibeFrame                                                | Frontier-model generation on your own keys, dry runs and the hard `--max-cost` ceiling, storyboard/design files, build reports, render inspection, edit/remix commands, and host-agent guidance. |
 
-If the job is only HTML scene authoring and rendering, use Hyperframes directly - it is the better tool for that and VibeFrame installs its skill for you either way.
+If the job is only HTML scene authoring and rendering, use Hyperframes directly.
+It is the better tool for that, and VibeFrame installs its skill for you either way.
 Reach for VibeFrame when the job involves paid generation: frontier image and video models, character continuity across scenes, narration, cost ceilings, build reports, or editing steps around the composition layer.
 
-VibeFrame is not affiliated with HeyGen. See [CREDITS.md](CREDITS.md) for
-dependency and provenance notes.
-
-## Contributing
-
-Contributions are welcome: bug fixes, provider integrations, CLI UX
-improvements, docs, and tests. [CONTRIBUTING.md](CONTRIBUTING.md) has the
-package map, dev setup, test commands, and the `pnpm scaffold:provider` /
-`pnpm scaffold:command` generators.
+VibeFrame is not affiliated with HeyGen.
+See [CREDITS.md](CREDITS.md) for dependency and provenance notes.
 
 ## Reference
 
+- [docs/projects.md](docs/projects.md): project files, profiles, characters, keyframes, and the host agent loop.
+- [docs/recipes.md](docs/recipes.md): worked end-to-end examples.
+- [docs/ai-video-prompting.md](docs/ai-video-prompting.md): prompt craft for image and video models.
 - [MODELS.md](MODELS.md): provider and model reference.
-- [CHANGELOG.md](CHANGELOG.md): versioned release notes.
-- [ROADMAP.md](ROADMAP.md): short public roadmap.
-- [docs/projects.md](docs/projects.md): project file roles, profiles, characters, and dry runs.
+- [CONTRIBUTING.md](CONTRIBUTING.md): package map, dev setup, tests, and the `pnpm scaffold:*` generators.
+- [ROADMAP.md](ROADMAP.md) and [CHANGELOG.md](CHANGELOG.md).
+
+Contributions are welcome: bug fixes, provider integrations, CLI UX improvements, docs, and tests.
 
 ## License
 


### PR DESCRIPTION
The README had grown into reference documentation. It explained how to install three separate times, taught storyboard cue syntax twice, and put two orientation tables plus a 99-line command tour ahead of the demo. The showcase GIF, the one artifact showing what the tool actually produces, sat at line 261.

**447 -> 306 lines. Nothing is dropped.**

### What moved, and where

Two of the targets were not linked from the README at all before this.

| Left the README | Went to |
|---|---|
| 43-line "Agent Workflows" contract | `docs/projects.md#host-agent-loop` (already has it, with a fuller worked review report) |
| 28-line YAML pipeline example | `docs/recipes.md` (already has it as recipe 5, plus five more) |
| Package names, XDG paths, from-source build | a `<details>` block - relevant once, to a fraction of readers |
| BUILD / GENERATE / EDIT lane table | the section headings, which now carry that split directly |

### Reordered

Each section now answers the question the previous one raises:

`pitch -> demo GIF -> the spend gate -> install -> the $0 render -> build from a brief -> what the spend buys -> one-off commands -> agent loop -> hosts -> where it fits`

The spend gate stays ahead of the zero-key path. That ordering was deliberate and is unchanged.

### Verified against the built CLI, not by eye

- All 27 cited commands resolve in `vibe schema --list` (101 entries). `schema` is the only cited name absent, because the catalog does not list itself.
- Every cited flag appears in its own command's `--help`.
- All 11 local links resolve; the `#host-agent-loop` anchor exists.
- Both 4-backtick markdown wrappers nest their inner ```yaml fence correctly (this regressed once before, in #283).
- Zero em dashes.
- `scripts/pre-push-validate.sh` passes; only the known unreleased-commits warning.
