### PR TITLE
refactor: group `vibe --help` by use case instead of listing it twice

### DIFF
--- a/packages/cli/src/commands/_shared/help-groups.test.ts
+++ b/packages/cli/src/commands/_shared/help-groups.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { Command } from "commander";
+import {
+  COMMAND_GROUPS,
+  renderCommandGroups,
+  ungroupedCommandNames,
+  visibleTopLevelCommands,
+} from "./help-groups.js";
+
+function makeProgram(): Command {
+  const prog = new Command().name("vibe");
+  prog.addCommand(new Command("init").description("Scaffold a VibeFrame project"));
+  prog.addCommand(new Command("build").description("Build a project from STORYBOARD.md"));
+  prog
+    .addCommand(new Command("generate").alias("gen").description("Generate standalone assets"));
+  prog.addCommand(new Command("setup").description("Configure VibeFrame"));
+  prog.addCommand(new Command("timeline").description("Low-level primitive"), { hidden: true });
+  return prog;
+}
+
+describe("COMMAND_GROUPS", () => {
+  it("lists every command exactly once across all groups", () => {
+    const all = COMMAND_GROUPS.flatMap((g) => g.commands);
+    expect(all.length).toBe(new Set(all).size);
+  });
+});
+
+describe("visibleTopLevelCommands", () => {
+  it("drops hidden commands and Commander's auto help command", () => {
+    const names = visibleTopLevelCommands(makeProgram()).map((c) => c.name());
+    expect(names).toEqual(["init", "build", "generate", "setup"]);
+    expect(names).not.toContain("timeline");
+  });
+});
+
+describe("renderCommandGroups", () => {
+  it("groups commands under their use-case heading", () => {
+    const out = renderCommandGroups(makeProgram());
+    expect(out).toContain("Project video");
+    expect(out).toContain("One-off media");
+    expect(out).toContain("Agents & setup");
+    // Real description text comes from the command, not a restated copy.
+    expect(out).toContain("Scaffold a VibeFrame project");
+  });
+
+  it("renders the alias alongside the name", () => {
+    expect(renderCommandGroups(makeProgram())).toContain("generate|gen");
+  });
+
+  it("omits hidden commands", () => {
+    expect(renderCommandGroups(makeProgram())).not.toContain("Low-level primitive");
+  });
+
+  it("surfaces an ungrouped command under Other rather than dropping it", () => {
+    const prog = makeProgram();
+    prog.addCommand(new Command("brand-new").description("Not in any group yet"));
+    expect(ungroupedCommandNames(prog)).toEqual(["brand-new"]);
+    const out = renderCommandGroups(prog);
+    expect(out).toContain("Other");
+    expect(out).toContain("brand-new");
+  });
+
+  it("keeps every line within the 80-column wrap target", () => {
+    const prog = makeProgram();
+    prog.addCommand(
+      new Command("verbose").description(
+        "A deliberately long description that has to wrap across more than one line to stay readable in a narrow terminal"
+      )
+    );
+    for (const line of renderCommandGroups(prog).split("\n")) {
+      expect(line.length).toBeLessThanOrEqual(80);
+    }
+  });
+});

--- a/packages/cli/src/commands/_shared/help-groups.ts
+++ b/packages/cli/src/commands/_shared/help-groups.ts
@@ -1,0 +1,175 @@
+/**
+ * @module commands/_shared/help-groups
+ *
+ * Groups the root `vibe --help` command listing by use case instead of
+ * alphabetically.
+ *
+ * Before this, the root help printed the same commands twice: once as
+ * Commander's flat alphabetical `Commands:` block, then again under a
+ * "Common workflows" footer that re-listed most of them by use case. The
+ * footer's own preamble admitted it ("the alphabetical list above is the
+ * full command set; this section shows the typical entry points by use
+ * case"), which left the reader to map the two lists onto each other.
+ *
+ * Descriptions are read from the live command tree rather than restated
+ * here, so this file can only ever drift in *grouping*, never in wording.
+ * A command missing from {@link COMMAND_GROUPS} lands in a trailing
+ * "Other" group rather than disappearing; `help-groups.test.ts` asserts
+ * that group stays empty so adding a top-level command fails the test
+ * instead of silently degrading the help.
+ */
+
+import type { Command } from "commander";
+
+/** Terminal width the listing wraps to. */
+const WRAP_COLUMNS = 80;
+
+/** Gap between the command column and the description column. */
+const COLUMN_GAP = 2;
+
+/** Left indent for command rows. */
+const INDENT = "  ";
+
+/**
+ * Use-case groups for the root help listing, in display order.
+ *
+ * Ordered by the sequence a first-time reader needs them: build a project
+ * video, reach for a one-off asset, then wire up hosts and automation.
+ */
+export const COMMAND_GROUPS: ReadonlyArray<{
+  readonly title: string;
+  readonly commands: readonly string[];
+}> = [
+  {
+    title: "Project video",
+    commands: [
+      "init",
+      "plan",
+      "build",
+      "preview",
+      "render",
+      "assemble",
+      "storyboard",
+      "design",
+      "status",
+      "inspect",
+    ],
+  },
+  {
+    title: "One-off media",
+    commands: ["generate", "edit", "audio", "detect", "remix"],
+  },
+  {
+    title: "Agents & setup",
+    commands: [
+      "setup",
+      "doctor",
+      "host",
+      "schema",
+      "context",
+      "guide",
+      "run",
+      "agent",
+      "completion",
+    ],
+  },
+];
+
+/** Commander marks hidden subcommands with a private `_hidden` flag. */
+interface HelpHiddenCommand {
+  _hidden?: boolean;
+}
+
+/**
+ * Top-level commands that appear in help, excluding hidden ones and
+ * Commander's auto-generated `help` command.
+ */
+export function visibleTopLevelCommands(prog: Command): Command[] {
+  return prog.commands.filter(
+    (cmd) => !(cmd as unknown as HelpHiddenCommand)._hidden && cmd.name() !== "help"
+  );
+}
+
+/**
+ * Visible top-level command names that no group in {@link COMMAND_GROUPS}
+ * claims. Empty in a healthy tree; the test asserts that.
+ */
+export function ungroupedCommandNames(prog: Command): string[] {
+  const grouped = new Set(COMMAND_GROUPS.flatMap((g) => g.commands));
+  return visibleTopLevelCommands(prog)
+    .map((cmd) => cmd.name())
+    .filter((name) => !grouped.has(name));
+}
+
+/** `generate|gen` when an alias exists, otherwise just the name. */
+function displayName(cmd: Command): string {
+  const alias = cmd.aliases()[0];
+  return alias ? `${cmd.name()}|${alias}` : cmd.name();
+}
+
+/**
+ * Wrap `text` to `width`, indenting every line after the first by
+ * `hangingIndent` spaces so descriptions stay in their column.
+ */
+function wrapDescription(text: string, width: number, hangingIndent: number): string[] {
+  if (width <= 0) return [text];
+  const lines: string[] = [];
+  let current = "";
+  for (const word of text.split(/\s+/).filter(Boolean)) {
+    if (!current) {
+      current = word;
+    } else if (current.length + 1 + word.length <= width) {
+      current += ` ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+  return lines.map((line, i) => (i === 0 ? line : " ".repeat(hangingIndent) + line));
+}
+
+/**
+ * Render the grouped command listing for the root `vibe --help`.
+ *
+ * Returns the block that replaces Commander's flat `Commands:` section,
+ * already prefixed and suffixed with a blank line so it slots between the
+ * options block and the remaining help footers.
+ */
+export function renderCommandGroups(prog: Command): string {
+  const byName = new Map(visibleTopLevelCommands(prog).map((cmd) => [cmd.name(), cmd]));
+
+  const groups = COMMAND_GROUPS.map((group) => ({
+    title: group.title,
+    commands: group.commands.map((name) => byName.get(name)).filter((c): c is Command => !!c),
+  })).filter((group) => group.commands.length > 0);
+
+  // Anything a group forgot still shows up, so a new command can never
+  // vanish from help just because nobody updated COMMAND_GROUPS.
+  const leftovers = ungroupedCommandNames(prog)
+    .map((name) => byName.get(name))
+    .filter((c): c is Command => !!c);
+  if (leftovers.length > 0) {
+    groups.push({ title: "Other", commands: leftovers });
+  }
+
+  const nameWidth = Math.max(
+    ...groups.flatMap((g) => g.commands.map((c) => displayName(c).length))
+  );
+  const descColumn = INDENT.length + nameWidth + COLUMN_GAP;
+  const descWidth = WRAP_COLUMNS - descColumn;
+
+  const lines: string[] = [];
+  for (const group of groups) {
+    lines.push("", `${group.title}`);
+    for (const cmd of group.commands) {
+      const label = displayName(cmd).padEnd(nameWidth + COLUMN_GAP);
+      const desc = wrapDescription(cmd.description(), descWidth, descColumn);
+      lines.push(`${INDENT}${label}${desc[0] ?? ""}`.trimEnd());
+      for (const extra of desc.slice(1)) lines.push(extra);
+    }
+  }
+  // No trailing newline: Commander joins help sections with one, and the
+  // block that follows opens with its own blank line.
+  return lines.join("\n");
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,7 @@ if (process.env.VIBE_DEBUG === "1") {
   console.log("[CLI] Script started, loading modules...");
 }
 
-import { Command, CommanderError } from "commander";
+import { Command, CommanderError, Help } from "commander";
 import chalk from "chalk";
 // Bundled inline by esbuild — works after `tsc` (workspace dev) and after
 // `node build.js` (npm publish artifact). The previous `require("../package.json")`
@@ -52,19 +52,28 @@ import { rejectControlChars } from "./utils/input-validation.js";
 import { buildSchema } from "./commands/schema.js";
 import { getCostTier, TIER_DESCRIPTION, type CostTier } from "./commands/_shared/cost-tier.js";
 import { productSurfaceForCommandPath } from "./commands/_shared/product-surface.js";
+import { renderCommandGroups } from "./commands/_shared/help-groups.js";
 
 interface HelpHiddenCommand {
   _hidden?: boolean;
 }
 
 /**
+ * How many example commands each cost-tier row names. Two keeps every row
+ * inside 80 columns; the tier's full membership is one command away via
+ * `vibe schema --list --filter <tier>`.
+ */
+const COST_TIER_EXAMPLES = 2;
+
+/**
  * Build the "Cost tiers" footer for `vibe --help`.
  *
  * Walks the live program tree, groups subcommands by cost tier, and
- * emits one row per tier with up-to-3 example commands and the
- * canonical price-band string. Pre-fix this section was a hardcoded
- * block in `addHelpText` that drifted from the SSOT (e.g. it claimed
- * "V.High remix (...)" while `remix animated-caption` is actually low).
+ * emits one row per tier with {@link COST_TIER_EXAMPLES} example commands
+ * and the canonical price-band string. Pre-fix this section was a
+ * hardcoded block in `addHelpText` that drifted from the SSOT (e.g. it
+ * claimed "V.High remix (...)" while `remix animated-caption` is
+ * actually low).
  */
 function renderCostTierFooter(prog: Command): string {
   const buckets: Record<CostTier, string[]> = { free: [], low: [], high: [], "very-high": [] };
@@ -79,14 +88,25 @@ function renderCostTierFooter(prog: Command): string {
   for (const top of prog.commands) walk(top, "");
 
   const order: CostTier[] = ["free", "low", "high", "very-high"];
+  const rows = order
+    .map((tier) => ({
+      tier,
+      label: tier === "very-high" ? "V.High" : tier[0].toUpperCase() + tier.slice(1),
+      examples: buckets[tier].slice(0, COST_TIER_EXAMPLES).join(", "),
+    }))
+    .filter((row) => row.examples);
+
+  // Width is measured, not assumed: a fixed padEnd(50) silently overflowed
+  // once the `low` tier's three example names grew past it, pushing that
+  // row's price band out of column.
+  const exampleWidth = Math.max(...rows.map((row) => row.examples.length));
   const lines: string[] = [
     "Cost tiers (`vibe --describe <cmd>` for each tag; legacy/internal omitted here):",
   ];
-  for (const tier of order) {
-    const examples = buckets[tier].slice(0, 3).join(", ");
-    if (!examples) continue;
-    const label = tier === "very-high" ? "V.High" : tier[0].toUpperCase() + tier.slice(1);
-    lines.push(`  ${label.padEnd(7)}${examples.padEnd(50)} ${TIER_DESCRIPTION[tier]}`);
+  for (const row of rows) {
+    lines.push(
+      `  ${row.label.padEnd(7)}${row.examples.padEnd(exampleWidth)}  ${TIER_DESCRIPTION[row.tier]}`
+    );
   }
   return "\n" + lines.join("\n") + "\n";
 }
@@ -148,48 +168,33 @@ program
       }
     },
   })
+  // Root help lists commands by use case instead of alphabetically. The
+  // flat `Commands:` block is suppressed for the root only (subcommands
+  // keep Commander's default), because it used to duplicate the very
+  // listing the footer below already gave by use case.
+  .configureHelp({
+    visibleCommands(cmd) {
+      if (cmd === program) return [];
+      return Help.prototype.visibleCommands.call(this, cmd);
+    },
+  })
+  .addHelpText("after", () => renderCommandGroups(program))
   .addHelpText(
     "after",
     `
-Common workflows (the alphabetical list above is the full command set;
-this section shows the typical entry points by use case):
+Full command catalog, including the timeline, batch, and scene primitives
+this listing omits:
 
-  Get started:
-    vibe doctor                         System health + key status
-    vibe setup                          Configure API keys interactively
-    vibe init my-video                  Scaffold a video project
-    vibe storyboard validate my-video   Validate STORYBOARD.md cues
-    vibe plan my-video                  Preview build stages, cost, and missing work
-    vibe build my-video                 Build STORYBOARD.md → scene assets
-    vibe status project my-video        Check build/review/jobs status
-    vibe inspect project my-video       Inspect files, assets, and scene wiring
-    vibe render my-video                Render the project to MP4
-    vibe inspect render my-video        Inspect the final MP4
+  vibe schema --list                  Every command, with cost tier
+  vibe schema --list --surface public First-run product path only
+  vibe schema generate.video          JSON schema for one command
 
-  One-shot media:
-    vibe generate image "..."           Generate a still image
-    vibe generate video "..."           Generate a standalone AI video
-    vibe edit caption clip.mp4 -o out.mp4
-    vibe inspect media clip.mp4 "Summarize this"
-    vibe remix highlights long.mp4 -d 60
-
-  Automation & agents:
-    vibe run workflow.yaml              Video-as-YAML pipeline
-    vibe guide                          Choose the right workflow
-    vibe guide motion                   Text vs motion overlay guidance
-    vibe schema --list --surface public Compact first-run command catalog
-    vibe schema generate.video          JSON schema for any command
-    vibe context                        Agent integration quickstart
-    vibe host setup all                 Configure Codex/Claude/Cursor app integrations
-    vibe agent                          Optional built-in agent when you do not use Claude Code/Codex/etc.
-
-Common-flag note: most commands accept --dry-run to preview cost/output
-before invoking paid providers.
-`
+Most commands accept --dry-run to preview cost and output before invoking
+a paid provider.`
   )
-  // Cost tiers block — generated from the live cost-tier registry so
+  // Cost tiers block - generated from the live cost-tier registry so
   // it can't drift from `_shared/cost-tier.ts`. Picks two representative
-  // examples per tier (alphabetical first hits) instead of hand-curating.
+  // examples per tier (registry order) instead of hand-curating.
   .addHelpText("after", () => renderCostTierFooter(program));
 
 // Set JSON mode env var before subcommand parsing

--- a/scripts/dogfood-smoke.mts
+++ b/scripts/dogfood-smoke.mts
@@ -54,6 +54,19 @@ function assertRecord(value: unknown, label: string): asserts value is Record<st
 const tmp = await mkdtemp(join(tmpdir(), "vibe-dogfood-smoke-"));
 
 try {
+  // Root help groups commands by use case. `renderCommandGroups` parks any
+  // command no group claims under "Other" so it can never vanish; this
+  // asserts the real tree never needs that fallback. It also guards the
+  // Commander 12 `visibleCommands` override, which suppresses the flat
+  // alphabetical block for the root only - subcommands must keep theirs.
+  const rootHelp = runVibe(["--help"]);
+  for (const heading of ["Project video", "One-off media", "Agents & setup"]) {
+    assert.match(rootHelp, new RegExp(`^${heading}$`, "m"), `root help should group "${heading}"`);
+  }
+  assert.doesNotMatch(rootHelp, /^Other$/m, "every top-level command should belong to a group");
+  assert.doesNotMatch(rootHelp, /^Commands:$/m, "root help should not print the flat list too");
+  assert.match(runVibe(["generate", "--help"]), /^Commands:$/m, "subcommands keep their listing");
+
   const context = runJson(["context", "--json"]);
   assertRecord(context, "context");
   assert.equal(context.product, "vibeframe");


### PR DESCRIPTION
`vibe --help` printed the same commands twice: Commander's flat alphabetical `Commands:` block, then a 40-line "Common workflows" footer that re-listed most of them by use case. The footer's own preamble described the arrangement -  *"the alphabetical list above is the full command set; this section shows the typical entry points by use case"* -  which left the reader to map the two lists onto each other. Alphabetical order also interleaved three unrelated kinds of command, so `build` sat between `assemble` and `completion`.

## After

One listing, grouped by use case. **109 lines -> 68**, nothing dropped.

```
Project video
  init          Scaffold a VibeFrame project (video scene project or
                project-scope agent files)
  plan          Read STORYBOARD.md and show build plan, costs, missing cues, and
                provider needs
  build         Build a VibeFrame video project from STORYBOARD.md
  preview       Cheap draft render for a quick visual check before the full
                `vibe render`
  render        Render a VibeFrame video project to MP4/WebM/MOV
  assemble      Mux a scene project's audio onto an already-rendered (silent)
                video
  storyboard    Read, validate, and safely mutate STORYBOARD.md cue blocks
  design        Read and validate DESIGN.md (google-labs design.md format)
  status        Inspect local async jobs and project workflow status
  inspect       Inspect projects, renders, and media

One-off media
  generate|gen  Generate standalone assets (image, video, narration, music, SFX)
  edit|ed       Edit and post-process media (silence-cut, caption, grade,
                reframe, upscale...)
  audio|au      Audio operations (transcribe, dub, duck, isolate, voice clone)
  detect        Auto-detect scenes, beats, and silences in media
  remix         Repurpose existing media (highlights, auto-shorts, animated
                captions)

Agents & setup
  setup         Configure VibeFrame (video/image provider keys, LLM provider)
  doctor        Check system health and available commands
  host          Set up Codex, Claude, and Cursor app integrations
  schema        Show JSON schema for a CLI command
  context       Print CLI context/guidelines for AI agent integration
  guide         Step-by-step guide for a vibe workflow (universal /vibe-*
                slash-command equivalent)
  run           Execute a YAML video pipeline (Video as Code)
  agent         Optional built-in natural-language agent (fallback when no
                external coding agent is driving vibe)
  completion    Print a shell completion script for `vibe`

Full command catalog, including the timeline, batch, and scene primitives
this listing omits:

  vibe schema --list                  Every command, with cost tier
  vibe schema --list --surface public First-run product path only
  vibe schema generate.video          JSON schema for one command
```

Every command that was visible is still visible. The 101-command catalog gets a pointer instead of an inline dump.

## Not a new source of truth

Descriptions are read from the live command tree, so this can drift in *grouping* but never in *wording*. A command no group claims lands under a trailing `Other` heading rather than disappearing, and `dogfood-smoke.mts` asserts against the built CLI that `Other` never appears.

## Commander 12 constraint

`helpGroup()` is v13+, so the flat block is suppressed with a `visibleCommands` override. Commander copies `_helpConfiguration` into subcommands, so the override checks for the root and delegates to `Help.prototype.visibleCommands` otherwise. The smoke test pins both halves:

```ts
assert.doesNotMatch(rootHelp, /^Commands:$/m, "root help should not print the flat list too");
assert.match(runVibe(["generate", "--help"]), /^Commands:$/m, "subcommands keep their listing");
```

## Two alignment defects found while verifying

- The cost-tier footer padded examples to a fixed `padEnd(50)`, which the `low` tier had outgrown, pushing its price band out of column. Width is now measured from the rows actually rendered.
- That footer emitted 3 examples per tier while the comment beside it claimed 2. At 3 every row ran past 80 columns. 2 is now a named constant and the rows fit; `vibe schema --list --filter <tier>` still gives full membership.

```
  Free   generate.thumbnail, edit.noise-reduce      FFmpeg only, no API call
  Low    generate.narration, generate.sound-effect  $0.01-$0.10 per call
  High   generate.image, generate.motion            $1-$5 per call
  V.High generate.video, edit.fill-gaps             $5-$50+ per call
```

## Verification

- `pnpm test` - 1240 passed, 9 skipped
- `pnpm lint` - clean
- `pnpm gen:reference:check` - `docs/cli-reference.md` unchanged
- `tsx scripts/dogfood-smoke.mts` - passes against the built CLI
- `vibe --help`: 5 lines over 80 columns -> 0, no double blank lines
- 7 new unit tests in `help-groups.test.ts` covering grouping, aliases, hidden commands, the `Other` fallback, and the 80-column wrap
