### PR TITLE
docs: state the Hyperframes boundary before teaching any command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ Video generation will need seedance (FAL_API_KEY), but no key/config is availabl
 
 Your keys, your bill, your ceiling.
 
+## Where VibeFrame fits
+
+It wraps lower-level composition engines rather than replacing them:
+
+| Layer                                                    | Owns                                                                             |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [Remotion](https://github.com/remotion-dev/remotion)     | React-based programmatic video and component-driven motion graphics.              |
+| [Hyperframes](https://github.com/heygen-com/hyperframes) | HTML/CSS/JS scene composition and deterministic browser capture.                  |
+| VibeFrame                                                | Frontier-model generation on your own keys, dry runs and the hard `--max-cost` ceiling, storyboard/design files, build reports, render inspection, edit/remix commands, and host-agent guidance. |
+
+Read that table as one sentence: scene composition is delegated, generation is not.
+If the job is only HTML scene authoring and rendering, use Hyperframes directly - it is the better tool for that, and `vibe scene install-skill` installs its skill for you either way.
+Reach for VibeFrame when the job involves paid generation: frontier image and video models, character continuity across scenes, narration, cost ceilings, build reports, or editing steps around the composition layer.
+
+One consequence worth knowing before you install: the whole pipeline runs locally for $0 without a provider key, because that free half is the delegated half - Kokoro narration, agent-authored HTML/CSS scenes, headless Chrome plus FFmpeg.
+It is the cheapest way to see whether the workflow fits you, and the full walkthrough is in [docs/hyperframes.md](docs/hyperframes.md#the-zero-key-render-start-to-finish).
+It is not the point of the tool: the paid generation path below is.
+
+VibeFrame is not affiliated with HeyGen.
+See [CREDITS.md](CREDITS.md) for dependency and provenance notes.
+
 ## Install
 
 ```bash
@@ -80,38 +101,6 @@ pnpm vibe --help
 ```
 
 </details>
-
-## First, a render that costs nothing
-
-Before wiring up a provider, the whole pipeline runs locally for $0: Kokoro TTS narration, HTML/CSS scenes composed by your coding agent, and a headless Chrome plus FFmpeg render.
-
-```bash
-vibe init demo --from "30-second video introducing my project"
-vibe scene install-skill demo    # Hyperframes' own installer; the rules your agent authors against
-```
-
-Then ask your coding agent to finish it:
-
-> Build demo/ into a rendered MP4 with zero API keys.
-> Read `demo/AGENTS.md` ("Key Rules for hand-authored scene HTML") first, then
-> run `vibe build demo --tts kokoro --skip-backdrop --json` and author the
-> scene HTML from `vibe scene compose-prompts demo --json`.
-> Run `vibe build demo --stage sync --json` and fix every lint error it
-> reports before rendering - it exits non-zero while any remain.
-> Then `vibe render demo --json`.
-
-Treat `--stage sync` as the gate.
-It lints the composed scenes and exits non-zero on real errors, such as an unregistered GSAP timeline or a composition div missing `data-width`/`data-height`.
-Rendering past a failed sync produces a black MP4, so fix the scenes first.
-
-That is about three minutes of machine time (measured on v0.113.29 in an isolated environment: 63s install, 1s init, 66s build including the one-time ~88 MB voice model download, 64s render; repeat runs skip the download).
-The scene-authoring pass in the middle is your agent's, so the wall clock depends on it and on how many lint rounds it needs.
-
-No coding agent available?
-`vibe scene add <id> --style announcement --headline "..." --no-audio --no-image` writes a lint-clean template scene with no model call, and doubles as a reference for the file shape.
-
-It is a real render, and it is the cheapest way to see whether the workflow fits you.
-It is not the point of the tool: the paid generation path is.
 
 ## Build a video from a brief
 
@@ -273,27 +262,11 @@ To wire `@vibeframe/mcp-server` (binary `vibeframe-mcp`) by hand, add:
 
 Tool, resource, and prompt details are in [packages/mcp-server/README.md](packages/mcp-server/README.md).
 
-## Where VibeFrame fits
-
-It wraps lower-level composition engines rather than replacing them:
-
-| Layer                                                    | Owns                                                                             |
-| -------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| [Remotion](https://github.com/remotion-dev/remotion)     | React-based programmatic video and component-driven motion graphics.              |
-| [Hyperframes](https://github.com/heygen-com/hyperframes) | HTML/CSS/JS scene composition and deterministic browser capture.                  |
-| VibeFrame                                                | Frontier-model generation on your own keys, dry runs and the hard `--max-cost` ceiling, storyboard/design files, build reports, render inspection, edit/remix commands, and host-agent guidance. |
-
-If the job is only HTML scene authoring and rendering, use Hyperframes directly.
-It is the better tool for that, and VibeFrame installs its skill for you either way.
-Reach for VibeFrame when the job involves paid generation: frontier image and video models, character continuity across scenes, narration, cost ceilings, build reports, or editing steps around the composition layer.
-
-VibeFrame is not affiliated with HeyGen.
-See [CREDITS.md](CREDITS.md) for dependency and provenance notes.
-
 ## Reference
 
 - [docs/projects.md](docs/projects.md): project files, profiles, characters, keyframes, and the host agent loop.
 - [docs/recipes.md](docs/recipes.md): worked end-to-end examples.
+- [docs/hyperframes.md](docs/hyperframes.md): where VibeFrame ends and the composition engine begins, plus the zero-key render.
 - [docs/ai-video-prompting.md](docs/ai-video-prompting.md): prompt craft for image and video models.
 - [MODELS.md](MODELS.md): provider and model reference.
 - [CONTRIBUTING.md](CONTRIBUTING.md): package map, dev setup, tests, and the `pnpm scaffold:*` generators.

--- a/docs/hyperframes.md
+++ b/docs/hyperframes.md
@@ -48,6 +48,52 @@ Use Remotion directly when the task is a React video application or a
 component-driven motion graphics workflow and you do not need VibeFrame's
 agent/project layer.
 
+## The Zero-Key Render, Start To Finish
+
+Because the composition half is local, the whole pipeline runs for $0 before
+you own a single provider key: Kokoro TTS narration, HTML/CSS scenes composed
+by your coding agent, and a headless Chrome plus FFmpeg render.
+The scene authoring in the middle is Hyperframes' contract, not VibeFrame's -
+this is the path to use when you want to see the machinery work before paying
+for anything.
+
+```bash
+vibe init demo --from "30-second video introducing my project"
+vibe scene install-skill demo    # upstream's own installer; the rules your agent authors against
+```
+
+Then ask your coding agent to finish it:
+
+> Build demo/ into a rendered MP4 with zero API keys.
+> Read `demo/AGENTS.md` ("Key Rules for hand-authored scene HTML") first, then
+> run `vibe build demo --tts kokoro --skip-backdrop --json` and author the
+> scene HTML from `vibe scene compose-prompts demo --json`.
+> Run `vibe build demo --stage sync --json` and fix every lint error it
+> reports before rendering - it exits non-zero while any remain.
+> Then `vibe render demo --json`.
+
+Treat `--stage sync` as the gate.
+It lints the composed scenes and exits non-zero on real errors, such as an
+unregistered GSAP timeline or a composition div missing
+`data-width`/`data-height`.
+Rendering past a failed sync produces a black MP4, so fix the scenes first.
+
+That is about three minutes of machine time (measured on v0.113.29 in an
+isolated environment: 63s install, 1s init, 66s build including the one-time
+~88 MB voice model download, 64s render; repeat runs skip the download).
+The scene-authoring pass in the middle is your agent's, so the wall clock
+depends on it and on how many lint rounds it needs.
+
+No coding agent available?
+`vibe scene add <id> --style announcement --headline "..." --no-audio
+--no-image` writes a lint-clean template scene with no model call, and doubles
+as a reference for the file shape.
+
+If this is the whole job for you - HTML scene authoring and rendering, no paid
+generation - use Hyperframes directly.
+It is the better tool for that, and `vibe scene install-skill` installs its
+skill either way.
+
 ## What Each Layer Provides
 
 | Concern                         | Remotion                    | Hyperframes          | VibeFrame                                                 |


### PR DESCRIPTION
A reader asked, reasonably, why the README teaches brief-to-MP4 and character-sheet-to-MP4 when scene composition was supposed to be delegated to Hyperframes. The confusion was the README's fault, and it was structural, not a wording problem.

## What was wrong

The first hands-on thing the README asked you to do was a **31-line zero-key walkthrough that is entirely the delegated half**:

```
Kokoro TTS narration       <- upstream already ships this, no key
HTML/CSS scene authoring   <- the delegated thing
vibe scene install-skill   <- its own comment said "Hyperframes' own installer"
--stage sync lint gate, GSAP timelines, data-width/data-height
headless Chrome capture    <- the delegated thing
```

Not one frontier generation call in it.

| | Line |
|---|---|
| First appearance of the word "Hyperframes" | **90**, in a trailing comment on the second command |
| The table that explains the boundary | **276** |

A reader spent thirty lines learning work VibeFrame delegates before being told it delegates it.

Worse, two of the commands that walkthrough is built on - `scene install-skill` and `scene compose-prompts` - are classified **`internal`** by the CLI itself. The flagship walkthrough stood on a surface the CLI does not advertise.

## What changed

`## Where VibeFrame fits` moves from line 276 to **directly after the spend gate, ahead of Install and ahead of any command**. The reader learns the boundary before typing anything.

The zero-key path stays, reduced to three sentences that frame it correctly - the free half is free *because* it is the delegated half:

> One consequence worth knowing before you install: the whole pipeline runs locally for $0 without a provider key, because that free half is the delegated half - Kokoro narration, agent-authored HTML/CSS scenes, headless Chrome plus FFmpeg.
> It is the cheapest way to see whether the workflow fits you, and the full walkthrough is in docs/hyperframes.md.
> It is not the point of the tool: the paid generation path below is.

The 25 lines of walkthrough move to `docs/hyperframes.md` under a new **"The Zero-Key Render, Start To Finish"** heading. That file is the canonical boundary document and **the README did not link it at all** - the third orphaned doc this cleanup has turned up. It is now linked twice: from the boundary section and from Reference.

**306 -> 279 lines.** Nothing dropped.

## New section order

```
pitch + demo GIF
Know the price before anything is spent
Where VibeFrame fits          <- was last-but-two, now second
Install
Build a video from a brief
What the spend buys: one character, many scenes
One-off assets and edits
Drive it from an agent
Connect your host
Reference
License
```

## Verification

- Every local link and heading anchor in both files resolves (including the new `#the-zero-key-render-start-to-finish`)
- All 29 cited commands resolve against `vibe schema --list` on the post-#300 93-command catalog
- No removed command is cited
- 0 em dashes in either file
- `pnpm lint` clean, `sync-counts.sh --check` in sync
