### PR TITLE
docs: document the build and review reports, and link the hero cards to them

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -19,6 +19,13 @@ import {
 import { ThemeToggle } from "../components/theme-toggle";
 import { DemoShowcase } from "../components/demo-showcase";
 
+/**
+ * Project-files reference. The hero's four artifact cards deep-link into its
+ * headings, so an anchor change here has to be matched in docs/projects.md.
+ */
+const DOCS_PROJECTS_URL =
+  "https://github.com/vericontext/vibeframe/blob/main/docs/projects.md";
+
 export default function LandingPage() {
   return (
     <div className="min-h-screen bg-background overflow-hidden">
@@ -47,7 +54,7 @@ export default function LandingPage() {
             </Link>
             <ThemeToggle />
             <Link
-              href="https://github.com/vericontext/vibeframe#quick-start"
+              href="https://github.com/vericontext/vibeframe/blob/main/docs/README.md"
               target="_blank"
               className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors shadow-lg shadow-primary/25"
             >
@@ -135,20 +142,34 @@ export default function LandingPage() {
             </div>
             <div className="grid gap-3">
               {[
-                ["Intent", "STORYBOARD.md"],
-                ["Design", "DESIGN.md"],
-                ["Build", "build-report.json"],
-                ["Review", "review-report.json"],
-              ].map(([label, file]) => (
-                <div
+                ["Intent", "STORYBOARD.md", "Beats, narration, cues", "#project-file-roles"],
+                ["Design", "DESIGN.md", "Palette, type, motion", "#project-file-roles"],
+                [
+                  "Build",
+                  "build-report.json",
+                  "What it cost, where it stopped",
+                  "#build-and-review-reports",
+                ],
+                [
+                  "Review",
+                  "review-report.json",
+                  "What is wrong, who fixes it",
+                  "#build-and-review-reports",
+                ],
+              ].map(([label, file, blurb, anchor]) => (
+                <a
                   key={file}
-                  className="rounded-xl border border-border/60 bg-secondary/35 px-4 py-3"
+                  href={`${DOCS_PROJECTS_URL}${anchor}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="rounded-xl border border-border/60 bg-secondary/35 px-4 py-3 transition-colors hover:border-primary/60 hover:bg-secondary/60"
                 >
                   <div className="text-xs uppercase tracking-wide text-muted-foreground">
                     {label}
                   </div>
                   <div className="font-mono text-sm text-foreground mt-1">{file}</div>
-                </div>
+                  <div className="text-xs text-muted-foreground mt-1">{blurb}</div>
+                </a>
               ))}
             </div>
           </div>
@@ -539,7 +560,7 @@ export default function LandingPage() {
               <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
             </Link>
             <Link
-              href="https://github.com/vericontext/vibeframe#quick-start"
+              href="https://github.com/vericontext/vibeframe/blob/main/docs/README.md"
               target="_blank"
               className="flex items-center gap-2 rounded-lg border border-border px-6 py-3 font-medium hover:bg-secondary hover:border-primary/30 transition-all"
             >

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -103,6 +103,137 @@ vibe host setup claude-desktop ~/dev/videos --write
 
 `vibe scene ...` is the advanced namespace. It remains useful when you want to add a single HTML scene, lint scene files, install agent rules, or render a scene project with low-level options.
 
+## Build And Review Reports
+
+Two JSON files hold the state the outer loop reads between steps.
+Both are written into the project root, both are overwritten on every run, and
+both are safe to delete - the next `build` or `inspect` rewrites them.
+
+| File                 | Written by                                     | Answers                                                              |
+| -------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
+| `build-report.json`  | `vibe build`                                   | What did this build produce, what did it cost, what stage is it in?  |
+| `review-report.json` | `vibe inspect project`, `vibe inspect render`  | What is wrong, who fixes it, and what command fixes it?              |
+
+`vibe build --dry-run` does not write a report.
+It prices the build and returns the plan on stdout instead, so a dry run never
+overwrites the record of your last real build.
+`vibe render` additionally writes `render-report.json` with the latest render
+output.
+
+### build-report.json
+
+```jsonc
+{
+  "schemaVersion": "1",
+  "kind": "build",
+  "project": "/abs/path/to/my-video",
+  "phase": "needs-author",        // done | assets-only | transcript-only | pending-jobs
+                                  // | compose-only | sync-only | render-only
+                                  // | needs-author | failed
+  "status": "needs-author",       // done | running | needs-author | failed | ready
+  "currentStage": "compose",      // assets | transcript | compose | sync | render | done
+  "mode": "agent",
+  "selectedStage": "all",         // whatever --stage asked for
+  "success": true,                // the run did not error; NOT "the video is finished"
+  "estimatedCostUsd": 0,
+  "costUsd": 0,                   // what was actually spent
+  "beatSummary": { "total": 3, "assetsReady": 3, "compositionsReady": 0,
+                   "needsAuthor": ["hook", "proof", "close"] },
+  "stageReports": {               // one entry per stage, always all five
+    "assets":     { "status": "done",         "costUsd": 0, "warnings": [], "retryWith": [] },
+    "transcript": { "status": "skipped",      "costUsd": 0, "warnings": [], "retryWith": [] },
+    "compose":    { "status": "needs-author", "costUsd": 0, "warnings": [], "retryWith": [] },
+    "sync":       { "status": "skipped",      "costUsd": 0, "warnings": [], "retryWith": [] },
+    "render":     { "status": "skipped",      "costUsd": 0, "warnings": [], "retryWith": [] }
+  },
+  "beats": [ /* per-beat detail, see below */ ],
+  "jobs": [],                     // async provider tasks still in flight; poll with `vibe status job`
+  "sceneRepair": { "ran": false, "stage": null, "status": "skipped",
+                   "score": null, "fixed": [], "remainingIssues": [], "retryWith": [] },
+  "providerResolution": [],       // which provider each stage actually resolved to
+  "warnings": ["--skip-video: skipped render (no clips to capture). ..."],
+  "retryWith": ["vibe build . --stage sync --json"],
+  "totalLatencyMs": 1234
+}
+```
+
+Read `status` and `currentStage` first: together they say where the project
+stopped and what the next stage is.
+`success: true` only means the command itself did not error - a build can
+succeed and still leave `status: "needs-author"`, which is the normal state
+after the asset stage when your agent has not written the scene HTML yet.
+
+Each entry in `beats[]` carries `id`, `startSec`, `endSec`,
+`sceneDurationSec`, a nested object per asset kind (`narration`, `backdrop`,
+`video`, `music`) with `prompt`/`provider`/`path`/`status`/`sourcePath`/cache
+metadata, and a `composition` object:
+
+```jsonc
+"composition": { "path": "compositions/scene-hook.html", "exists": false, "status": "needs-author" }
+```
+
+Flat `narrationStatus`/`backdropStatus`/`videoStatus`/`musicStatus` fields are
+kept alongside the nested objects for older consumers.
+
+### review-report.json
+
+```jsonc
+{
+  "schemaVersion": "1",
+  "kind": "review",
+  "project": "/abs/path/to/my-video",
+  "mode": "project",              // project | render
+  "status": "fail",               // pass | warn | fail
+  "score": 0,
+  "summary": { "issueCount": 10, "errorCount": 4, "warningCount": 6, "infoCount": 0,
+               "fixOwners": { "vibe": 5, "hostAgent": 5 } },
+  "sourceReports": ["STORYBOARD.md", "DESIGN.md", "vibe.config.json"],
+  "issues": [ /* see below */ ],
+  "nextActions": [ /* the pre-classified fix list - prefer this */ ],
+  "retryWith": ["..."],           // compatibility fallback only
+  "reportPath": "/abs/path/to/my-video/review-report.json"
+}
+```
+
+Each issue names its own owner and carries the actions that would resolve it:
+
+```jsonc
+{
+  "severity": "warning",          // error | warning | info
+  "code": "DESIGN_PLACEHOLDER_FIELD",
+  "message": "DESIGN.md still contains placeholder palette entries.",
+  "file": "DESIGN.md",
+  "fixOwner": "host-agent",       // vibe | host-agent
+  "suggestedFix": "Fill DESIGN.md or rerun `vibe init --from ... --visual-style <name>`.",
+  "actions": [ /* same shape as nextActions entries */ ]
+}
+```
+
+`nextActions` is the list to drive from, not `issues` - it is deduplicated
+across issues and pre-classified:
+
+```jsonc
+{
+  "id": "command:vibe-build-my-video",
+  "kind": "command",              // command | agent | manual
+  "label": "Sync the project root composition",
+  "command": "vibe build my-video --stage sync --json",
+  "fixOwner": "vibe",
+  "costTier": "free",             // free | low | high | very-high | unknown
+  "safeToAutoRun": true,
+  "requiresConfirmation": false,
+  "reason": "The root composition is missing or could not be verified.",
+  "sourceIssueCodes": ["MISSING_ROOT_COMPOSITION"]
+}
+```
+
+`kind: "manual"` entries carry no `command` - they need a human or the host
+agent to edit a source file. `kind: "agent"` entries carry an `agentPrompt`
+instead.
+
+How to drive the loop from these two files is in
+[Host Agent Loop](#host-agent-loop) above.
+
 ## Project File Roles
 
 Use the folders consistently:


### PR DESCRIPTION
The landing hero shows four artifact cards. **Two of the four had no human-readable explanation anywhere.**

| Card | Explained? |
|---|---|
| Intent · `STORYBOARD.md` | Yes - `docs/projects.md` "Project File Roles", Characters, keyframe→i2v, Profiles |
| Design · `DESIGN.md` | Yes - same |
| Build · `build-report.json` | **No** |
| Review · `review-report.json` | **No** |

Everything written about the two reports, in full:

```
README.md:204                    "use them as loop state"       (one sentence)
docs/projects.md:53              "read them before deciding"    (half a sentence)
docs/hyperframes.md:106          one table cell
packages/cli/CONTEXT.md:225,297  the only actual schema
```

`CONTEXT.md` is the agent-facing file `vibe context` prints. So the only description of what is *inside* `build-report.json` was written for agents, and a human arriving from the landing page had no path to it.

## Added: `## Build And Review Reports` in docs/projects.md

Which command writes which file, that `--dry-run` deliberately writes neither (so a dry run never clobbers the record of your last real build), and an annotated example of each with the field unions spelled out.

**The field values were read off reports generated by running the CLI, not transcribed from CONTEXT.md.** A check confirms all 20 keys of a real `build-report.json` and all 12 of a real `review-report.json` appear in the new section:

```
build-report.json:  20 real keys | not mentioned in docs: none
review-report.json: 12 real keys | not mentioned in docs: none
```

The status unions (`SceneBuildPhase`, `BuildWorkflowStatus`, `BuildCurrentStage`, `ReviewStatus`, `ReviewSeverity`, `ReviewFixOwner`, `ReviewActionKind`, `ReviewActionCostTier`) come from the type declarations in `scene-build.ts` and `review-report.ts`.

It also states the thing the reports imply but never say out loud:

> `success: true` only means the command itself did not error - a build can succeed and still leave `status: "needs-author"`, which is the normal state after the asset stage when your agent has not written the scene HTML yet.

The section defers to the existing `## Host Agent Loop` for *how to drive* the loop rather than repeating it.

## Landing: the cards become entry points

Previously inert label-plus-filename tiles. Now each links into the matching heading and says what the file answers:

```
INTENT   STORYBOARD.md       Beats, narration, cues
DESIGN   DESIGN.md           Palette, type, motion
BUILD    build-report.json   What it cost, where it stopped
REVIEW   review-report.json  What is wrong, who fixes it
```

(The first draft said "You write it" for the two Markdown files. That is wrong - `vibe init` drafts them from the brief and you own them after - so all four blurbs now describe contents instead.)

## Two dead "Docs" buttons fixed

Both pointed at `github.com/vericontext/vibeframe#quick-start`. `## Quick Start` left the README in #297 - **my own restructure**. GitHub silently serves the top of the file for a missing anchor, so it never looked broken. They now point at `docs/README.md`, the docs index.

Before this PR the landing page linked to **no doc at all** - only the repo root, CHANGELOG, LICENSE, ROADMAP, npm, and hyperframes.

## Verification

- Every anchor used on the landing page resolves: two into `docs/projects.md` headings, one in-page `id`
- All 5 GitHub blob targets exist locally
- `pnpm -F @vibeframe/web lint` and `build` pass
- Hero rendered in a browser at 1440px and checked
- 0 em dashes in both touched files
- `sync-counts.sh --check` in sync
