### PR TITLE
fix: link the CLI package from the landing, and give #install-to-mp4 a referrer

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -232,7 +232,11 @@ export default function LandingPage() {
               Generated end to end by <code className="text-primary">vibe build</code>.
             </h2>
             <p className="text-muted-foreground text-lg max-w-3xl mx-auto">
-              1080p, four scenes, one consistent character. Everything below is how it was made.
+              1080p, four scenes, one consistent character.{" "}
+              <Link href="#install-to-mp4" className="text-primary hover:underline">
+                Here is how it was made
+              </Link>
+              .
             </p>
           </div>
 
@@ -555,6 +559,13 @@ export default function LandingPage() {
               className="hover:text-foreground transition-colors"
             >
               Roadmap
+            </Link>
+            <Link
+              href="https://www.npmjs.com/package/@vibeframe/cli"
+              target="_blank"
+              className="hover:text-foreground transition-colors"
+            >
+              CLI (npm)
             </Link>
             <Link
               href="https://www.npmjs.com/package/@vibeframe/mcp-server"


### PR DESCRIPTION
Two gaps found while checking the rest of the landing against the live CLI.

## First: everything else holds up

| Claim | Checked by |
|---|---|
| Hero cost-cap JSON | Generated a real rejection - `success`/`error`/`code`/`exitCode`/`retryWith`/`recoverable`/`data.plan.estimatedCostUsd` all present; stdout 0 bytes, stderr 15,385, exit 1 |
| 9 flags in the five step cards | `--from` `--dry-run` `--max-cost` `--tts` `--skip-backdrop` `--cheap` `--scope` all in `--help`; `--json` is a global root option and was confirmed working |
| "`vibe init` writes one AGENTS.md plus CLAUDE.md" | Ran it: 8-line `CLAUDE.md` whose first line is `@AGENTS.md` |
| "`vibe host setup --write` adds .mcp.json, .codex/config.toml, .cursor/mcp.json" | Ran it: all three written |
| 77 MCP tools, 6 chips, "+71 more" | Arithmetic matches `sync-counts.sh` |
| 6 pipeline card commands | All resolve in `schema --list` |
| Seedance / Runway / Veo / Kling | All four in the `generate.video` schema |
| "budget guards, checkpoints, and --resume" | `--budget-usd`, `--budget-tokens`, `--resume` all real |

No inaccuracies. These two are omissions.

## 1. The CLI package was not linked from anywhere

The footer linked `@vibeframe/mcp-server` on npm and nothing else:

```
GitHub · Changelog · Roadmap · MCP server (npm) · MIT License
```

There was **no link to `@vibeframe/cli`** on the page - the package that provides the `vibe` binary the hero tells you to install, on a page whose own MCP section says *"MCP is optional"*.

Adds `CLI (npm)` ahead of the existing MCP entry rather than replacing it:

```
GitHub · Changelog · Roadmap · CLI (npm) · MCP server (npm) · MIT License
```

Both resolve at 0.114.0.

## 2. `#install-to-mp4` lost its only referrer in #304

That PR repointed "See it in action" at the demo it had been skipping, which left the id with zero inbound links.

Rather than delete a useful deep-link target, the demo subtitle now carries it:

> 1080p, four scenes, one consistent character. [**Here is how it was made**](#install-to-mp4).

This revives the anchor and connects the finished render to the instructions for reproducing it. Verified by clicking it in a browser:

```json
{ "hash": "#install-to-mp4", "targetTopPx": 0, "headingVisible": true,
  "heading": "Five commands, start to finish." }
```

## Anchor audit

```
id #demo             linked
id #install-to-mp4   linked
```

Every id has at least one referrer, and every in-page link has a target.

## Verification

- `pnpm -F @vibeframe/web lint` and `build` pass
- Footer links enumerated from the rendered DOM, all 6 correct
- Both npm packages published at 0.114.0
- Anchor navigation exercised in a browser, not just grepped
