### PR TITLE
refactor: make the cue vocabulary one list instead of five

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Add `--json` to any command for structured output.
 `plan`, `build`, `preview`, `render`, and both `inspect` commands take `--beat <id>` to work one beat at a time instead of rebuilding everything.
 `storyboard`, `status`, and `scene repair` cover editing beats, polling async work, and deterministic fixes.
 
-Profiles (`--profile minimal | agent | full`), every cue key, and the full project flow are in [docs/projects.md](docs/projects.md).
+Those five are the common cues; there are fifteen in all, and `vibe storyboard validate` warns on anything outside them.
+Profiles (`--profile minimal | agent | full`), [the full cue vocabulary](docs/projects.md#the-cue-vocabulary), and the whole project flow are in [docs/projects.md](docs/projects.md).
 
 ## What the spend buys: one character, many scenes
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -258,6 +258,34 @@ narration: "media/voice.wav"
 asset: "media/logo.png"
 ```
 
+### The cue vocabulary
+
+Fifteen keys, and only these fifteen.
+`vibe storyboard validate` warns on anything else and `vibe storyboard set`
+refuses it, so a typo surfaces instead of being silently ignored.
+
+| Cue | Drives |
+| --- | --- |
+| `duration` | Beat length in seconds. Aim for 6-15; longer beats render static and overstuffed. |
+| `narration` | TTS text, or a path to an existing audio file. |
+| `backdrop` | Image prompt for the backdrop plate, or a path to an existing image. |
+| `video` | Motion prompt for video generation, or a path to existing footage. |
+| `keyframe` | Still prompt. Generates a keyframe, then runs image-to-video on it. |
+| `music` | Music prompt, or a path to an existing track. |
+| `asset` | A project-relative file this beat reuses instead of generating. |
+| `voice` | Voice override for this beat, above the project frontmatter default. |
+| `characters` | Names from the frontmatter `characters:` pool. One name or a list. |
+| `motion` | Animation direction for the scene-authoring agent (see below). |
+| `eyebrow` / `kicker` | Lower-third eyebrow. `eyebrow` wins when both are set. |
+| `title` | Lower-third headline. Falls back to the beat heading. |
+| `caption` / `sub` | Lower-third sub-line. `caption` wins when both are set. |
+
+`motion` is the one cue no deterministic stage reads.
+It travels to the host agent in the compose plan, where the instructions treat
+it as binding on how elements enter, hold, and leave - the same way `narration`
+is binding on the audio.
+Every other cue above feeds the build or the composer directly.
+
 ### Characters (consistent AI video)
 
 Declare a reusable character pool in the document frontmatter, then reference it

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -36,6 +36,7 @@ import {
   parseStoryboard,
   resolveCharacters,
   type ParsedStoryboard,
+  type BeatCues,
 } from "./storyboard-parse.js";
 import { readProjectConfig, type LoadedProjectConfig } from "./project-config.js";
 import { kindAssetPolicy } from "./scene-project.js";
@@ -60,7 +61,7 @@ export interface BuildPlanBeat {
   id: string;
   heading: string;
   durationSec: number | null;
-  cues: Record<string, unknown>;
+  cues: BeatCues;
   assets: {
     narration: AssetPlan | null;
     backdrop: AssetPlan | null;

--- a/packages/cli/src/commands/_shared/compose-prompts.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.ts
@@ -36,7 +36,12 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 
-import { parseStoryboard, type Beat } from "./storyboard-parse.js";
+import {
+  parseStoryboard,
+  STORYBOARD_CUE_KEYS,
+  type Beat,
+  type BeatCues,
+} from "./storyboard-parse.js";
 import { buildUserPrompt } from "./compose-beat-prompt.js";
 import { resolveProjectBeatDurations } from "./root-sync.js";
 import {
@@ -63,7 +68,7 @@ export interface ComposePromptsBeat {
    */
   finalDurationSec?: number;
   /** Per-beat YAML cues parsed from the leading code block of the body. */
-  cues?: Record<string, unknown>;
+  cues?: BeatCues;
   /** Beat body markdown (with the leading `\`\`\`yaml` cue block stripped). */
   body: string;
   /**
@@ -280,7 +285,12 @@ function buildInstructions(args: {
   if (args.compositionRef) {
     lines.push(`2b. Read \`${args.compositionRef}\` for the project STRUCTURAL contract (layout system, GSAP timeline conventions, element/track rules) — a HARD-GATE parallel to DESIGN.md; every composition must satisfy it.`);
   }
-  lines.push(`3. For each beat in the \`beats\` array below, author HTML at \`outputPath\` matching the \`userPrompt\`. The beat \`body\` carries the narrative + visual + animation intent; \`cues\` carries machine-readable per-beat overrides (narration, duration, backdrop, voice).`);
+  // The cue list is rendered from the SSOT rather than restated. The old
+  // hand-typed "(narration, duration, backdrop, voice)" named 4 of 15, so the
+  // agent was handed `motion`, `characters`, `keyframe` and the lower-third
+  // cues in the payload without ever being told they were there.
+  lines.push(`3. For each beat in the \`beats\` array below, author HTML at \`outputPath\` matching the \`userPrompt\`. The beat \`body\` carries the narrative intent; \`cues\` carries machine-readable per-beat overrides (${STORYBOARD_CUE_KEYS.join(", ")}).`);
+  lines.push(`   The \`motion\` cue, when present, is the animation direction for this beat - treat it as binding on how elements enter, hold, and leave, the same way \`narration\` is binding on the audio.`);
   lines.push(`3b. Use each beat's \`finalDurationSec\` (narration-synced) for \`data-duration\` and timeline anchors when present — NOT the storyboard \`duration\`, which is only the minimum. Scenes composed at the storyboard duration end early and render black tails.`);
   lines.push(`3c. Never give inner \`.clip\` elements a non-zero \`data-start\` — the renderer does not toggle internal clip visibility inside sub-compositions, so phased clips render all phases at once (overlapping text). Use full-window clips and GSAP autoAlpha phase transitions instead. Also keep beats 6-15s; split anything longer in the storyboard first.`);
   lines.push(`3d. If your environment cannot write files (e.g. Claude Desktop / MCP-only hosts), author each beat's HTML and submit it with the \`scene_submit\` tool (beat id + html). It validates with the same Hyperframes lint and writes the file for you; on lint errors it returns the findings without writing — fix and resubmit.`);

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -53,6 +53,7 @@ import {
   parseStoryboard,
   resolveCharacters,
   type Beat,
+  type StoryboardCueKey,
   type ResolvedCharacter,
 } from "./storyboard-parse.js";
 import { scaffoldSceneProject } from "./scene-project.js";
@@ -1251,9 +1252,16 @@ async function referencePrimitiveOutcome(
   };
 }
 
+/**
+ * `kind` is narrowed to the asset kinds that are also cue keys. The wider
+ * `BuildAssetKind` includes `"character"`, which is not a cue - the cue is
+ * `characters` (plural) - so `cue[kind]` would have been a permanent miss for
+ * that member. Nothing called it that way, but the old index signature on
+ * `BeatCues` let the mistake typecheck.
+ */
 function assetReferenceForBeat(
   projectDir: string,
-  kind: BuildAssetKind,
+  kind: Extract<BuildAssetKind, StoryboardCueKey>,
   beat: Beat
 ): AssetReferenceCandidate | null {
   const cue = beat.cues ?? {};

--- a/packages/cli/src/commands/_shared/storyboard-edit.ts
+++ b/packages/cli/src/commands/_shared/storyboard-edit.ts
@@ -4,29 +4,16 @@ import {
   beatCharacterNames,
   deriveBeatId,
   parseStoryboard,
+  STORYBOARD_CUE_KEYS,
   type Beat,
   type BeatCues,
+  type StoryboardCueKey,
 } from "./storyboard-parse.js";
 
-export const STORYBOARD_CUE_KEYS = [
-  "duration",
-  "narration",
-  "backdrop",
-  "video",
-  "keyframe",
-  "motion",
-  "voice",
-  "music",
-  "asset",
-  "characters",
-  "eyebrow",
-  "title",
-  "caption",
-  "kicker",
-  "sub",
-] as const;
-
-export type StoryboardCueKey = (typeof STORYBOARD_CUE_KEYS)[number];
+// The cue vocabulary now lives beside `BeatCues` in storyboard-parse.ts so the
+// type can be checked against it. Re-exported here because callers (and
+// `vibe storyboard set`) have always imported it from this module.
+export { STORYBOARD_CUE_KEYS, type StoryboardCueKey } from "./storyboard-parse.js";
 
 export interface StoryboardValidationIssue {
   severity: "error" | "warning";

--- a/packages/cli/src/commands/_shared/storyboard-parse.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.test.ts
@@ -8,6 +8,9 @@ import {
   parseBeatDuration,
   parseStoryboard,
   resolveCharacters,
+  STORYBOARD_CUE_KEYS,
+  type BeatCues,
+  type StoryboardCueKey,
 } from "./storyboard-parse.js";
 
 describe("parseStoryboard", () => {
@@ -426,5 +429,41 @@ describe("beatCharacterNames", () => {
     expect(beatCharacterNames({ characters: [1, "ace"] as unknown as string[] })).toEqual(["ace"]);
     expect(beatCharacterNames(undefined)).toEqual([]);
     expect(beatCharacterNames({})).toEqual([]);
+  });
+});
+
+describe("cue vocabulary is one list", () => {
+  it("declares every STORYBOARD_CUE_KEYS entry on BeatCues", () => {
+    // BeatCues has no index signature, so this object only compiles while the
+    // interface covers the whole vocabulary. Adding a key to
+    // STORYBOARD_CUE_KEYS without declaring it fails the type check here.
+    const everyCue: Required<{ [K in StoryboardCueKey]: unknown }> = {
+      duration: 5,
+      narration: "n",
+      backdrop: "b",
+      video: "v",
+      keyframe: "k",
+      motion: "m",
+      voice: "alloy",
+      music: "mu",
+      asset: "media/a.png",
+      characters: ["mira"],
+      eyebrow: "e",
+      title: "t",
+      caption: "c",
+      kicker: "ki",
+      sub: "s",
+    };
+    const cues: BeatCues = everyCue as BeatCues;
+    expect(Object.keys(cues).sort()).toEqual([...STORYBOARD_CUE_KEYS].sort());
+  });
+
+  it("round-trips every cue through the parser", () => {
+    const yaml = [...STORYBOARD_CUE_KEYS]
+      .map((k) => (k === "duration" ? "duration: 5" : `${k}: "x"`))
+      .join("\n");
+    const md = ["## Beat hook - Hook", "", "```yaml", yaml, "```", "", "Body."].join("\n");
+    const cues = parseStoryboard(md).beats[0]?.cues ?? {};
+    expect(Object.keys(cues).sort()).toEqual([...STORYBOARD_CUE_KEYS].sort());
   });
 });

--- a/packages/cli/src/commands/_shared/storyboard-parse.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.ts
@@ -124,24 +124,53 @@ export function resolveCharacters(
 }
 
 /**
+ * The complete per-beat cue vocabulary, in the order it is presented to
+ * humans and agents.
+ *
+ * This is the single source of truth. {@link BeatCues} is derived from it,
+ * `validateStoryboardMarkdown` rejects anything outside it, `vibe storyboard
+ * set` refuses unlisted keys, and the compose and revise prompts render it
+ * rather than restating it - four surfaces had drifted to four different
+ * sub-lists before this became the one list.
+ */
+export const STORYBOARD_CUE_KEYS = [
+  "duration",
+  "narration",
+  "backdrop",
+  "video",
+  "keyframe",
+  "motion",
+  "voice",
+  "music",
+  "asset",
+  "characters",
+  "eyebrow",
+  "title",
+  "caption",
+  "kicker",
+  "sub",
+] as const;
+
+export type StoryboardCueKey = (typeof STORYBOARD_CUE_KEYS)[number];
+
+/**
  * Per-beat cues extracted from the first ```yaml fenced block inside a beat
  * body. The driver passes these to TTS / image / compose calls so the
  * storyboard alone is enough source for `vibe scene build`.
+ *
+ * Every key in {@link STORYBOARD_CUE_KEYS} is declared here. There is
+ * deliberately no index signature: an unlisted key is a validation warning at
+ * runtime, so letting it typecheck only hides the drift.
  */
 export interface BeatCues {
+  /** Beat duration in seconds; overrides the `### Beat duration` subsection if both are present. */
+  duration?: number;
   /** Narration text for this beat (drives TTS + scene `<audio>` element). */
   narration?: string;
   /** Image prompt for the backdrop generation (drives T2I). */
   backdrop?: string;
-  /** Beat duration in seconds — overrides `### Beat duration` subsection if both present. */
-  duration?: number;
-  /** Voice override for this beat (overrides project frontmatter `voice`). */
-  voice?: string;
-  /**
-   * Character pool names whose reference sheets drive this beat's
-   * reference-to-video generation. A single name or a list.
-   */
-  characters?: string | string[];
+  /** Motion prompt for video generation. Pairs with `keyframe` for image-to-video. */
+  video?: string;
   /**
    * Keyframe still prompt. When set, the build generates a keyframe image for
    * this beat (using the character sheet as an edit reference when `characters`
@@ -149,13 +178,34 @@ export interface BeatCues {
    * if present, supplies the motion prompt; otherwise this text is used.
    */
   keyframe?: string;
+  /**
+   * Animation direction for the scene-authoring agent, e.g. "restrained camera
+   * push, headline settles first". Unlike the cues around it this drives no
+   * deterministic stage - it reaches the host agent through the compose plan
+   * and shapes the HTML that agent writes.
+   */
+  motion?: string;
+  /** Voice override for this beat (overrides project frontmatter `voice`). */
+  voice?: string;
+  /** Music prompt or a project-relative path to an existing track. */
+  music?: string;
+  /** Project-relative path to a file this beat should reuse instead of generating. */
+  asset?: string;
+  /**
+   * Character pool names whose reference sheets drive this beat's
+   * reference-to-video generation. A single name or a list.
+   */
+  characters?: string | string[];
   /** Lower-third overlay eyebrow/kicker (read by the deterministic composer). */
   eyebrow?: string;
   /** Lower-third headline; falls back to the beat heading when absent. */
   title?: string;
   /** Lower-third sub-line / caption. */
   caption?: string;
-  [key: string]: unknown;
+  /** Alias for `eyebrow`; `eyebrow` wins when both are present. */
+  kicker?: string;
+  /** Alias for `caption`; `caption` wins when both are present. */
+  sub?: string;
 }
 
 /** Normalize a beat's `characters` cue to a clean string[] (single or list). */

--- a/packages/cli/src/commands/_shared/storyboard-revise.ts
+++ b/packages/cli/src/commands/_shared/storyboard-revise.ts
@@ -10,7 +10,7 @@ import {
   type ComposerProvider,
 } from "./composer-resolve.js";
 import { readProjectConfig } from "./project-config.js";
-import { parseStoryboard } from "./storyboard-parse.js";
+import { parseStoryboard, STORYBOARD_CUE_KEYS } from "./storyboard-parse.js";
 import {
   validateStoryboardMarkdown,
   type StoryboardValidationIssue,
@@ -238,7 +238,10 @@ function revisionMessages(opts: {
     "Return exactly one JSON object, with no markdown fence and no prose outside JSON.",
     "The JSON object must have: storyboardMd string, summary string, changedBeats string[], warnings string[].",
     "Preserve existing frontmatter, beat ids, cue YAML keys, and useful prose unless the user asks to change structure.",
-    "Keep cue YAML valid. Allowed cue keys are duration, narration, backdrop, video, motion, voice, music, asset.",
+    // Rendered from the SSOT: this list used to be a hand-typed subset of 8,
+    // so a revise pass could silently drop `characters`, `keyframe`, and the
+    // lower-third cues it had never been told about.
+    `Keep cue YAML valid. Allowed cue keys are ${STORYBOARD_CUE_KEYS.join(", ")}.`,
     "If a target duration is supplied, every beat must have a positive duration cue and durations must sum to that target.",
   "Aim for 6-15 seconds per beat and never exceed ~15s — long beats render as static, overstuffed scenes. A 90-second video should have 6-8 beats.",
   ].join("\n");


### PR DESCRIPTION
## What I expected to find, and what was actually there

I set out to "close the cue schema". It was already closed. `STORYBOARD_CUE_KEYS` holds 15 keys, `validateStoryboardMarkdown` warns on anything outside it with per-key type checks, `characters` shape validation, and a cross-check against the frontmatter pool, and `vibe storyboard set` throws on unlisted keys. That part needed nothing.

The real defect was that **four other surfaces each restated a different subset of that list**:

| Surface | Keys | What it governs |
|---|---:|---|
| `STORYBOARD_CUE_KEYS` | **15** | the source of truth |
| `BeatCues` (TypeScript) | 9 | + `[key: string]: unknown` |
| compose prompt | 4 | what the scene-authoring agent is told exists |
| revise prompt | 8 | what the LLM is told it may keep |
| `docs/projects.md` | 9 | what a human is told exists |

## The dangerous one

`storyboard-revise.ts` told the model:

> *"Allowed cue keys are duration, narration, backdrop, video, motion, voice, music, asset."*

That omits `characters`, `keyframe`, and all five lower-third cues. **A `vibe storyboard revise` pass could drop a beat's character binding because the prompt never told it that key was allowed to stay.**

## The fix

`STORYBOARD_CUE_KEYS` moves next to `BeatCues` in `storyboard-parse.ts` - it lived in `storyboard-edit.ts`, which *imports* parse, so the type could never be checked against it - and is re-exported from its old home so no caller changes. `BeatCues` declares all 15 and drops the index signature. Both prompts interpolate the list rather than restating it.

## Removing the index signature immediately found a latent bug

```
src/commands/_shared/scene-build.ts(1260,66): error TS2551:
  Property 'character' does not exist on type 'BeatCues'. Did you mean 'characters'?
```

`assetReferenceForBeat` took a `BuildAssetKind` - whose members include `"character"` - and did `cue[kind]`. The cue is `characters`, **plural**, so that member could only ever miss. No caller passes it, but nothing would have caught it if one had. Now typed `Extract<BuildAssetKind, StoryboardCueKey>`, which documents why in the type itself.

## `motion` is real now instead of ambient

It was generated into every scaffolded storyboard, accepted by the validator, and forwarded to the scene-authoring agent inside `cues` — while the instruction beside it named only four keys, so **nothing ever told the agent it was there**. I traced every access pattern to confirm: no deterministic stage reads it.

The compose prompt now names the full vocabulary and adds:

> The `motion` cue, when present, is the animation direction for this beat - treat it as binding on how elements enter, hold, and leave, the same way `narration` is binding on the audio.

Every other cue drives a deterministic stage, and the doc comments now say which.

## Docs

`docs/projects.md` gains a cue table covering all 15, with the `eyebrow`/`kicker` and `caption`/`sub` alias pairs and their precedence spelled out. The README points at it by anchor instead of claiming "every cue key" behind a bare link.

## Verification

- 1232 CLI tests + 73 mcp-server tests pass; lint clean; `gen:reference:check` current; `sync-counts --check` in sync
- Two new tests pin the alignment: one **fails to compile** if a key is added to the SSOT without being declared on `BeatCues`, one round-trips all 15 through the parser
- End to end, `vibe storyboard validate` accepts `motion` and warns only on a genuinely unknown key:

```
warning  UNKNOWN_CUE   Beat "hook" uses unknown cue "bogus". Supported cues: duration, narrat...
ok: True
```

- The rendered compose plan was checked to contain all 15 keys and the motion binding line
