### PR TITLE
feat: read storyboards from a scenes/ bundle as well as one STORYBOARD.md

### DIFF
--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -1,5 +1,4 @@
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 
 import { config as loadDotenv } from "dotenv";
@@ -38,6 +37,7 @@ import {
   type ParsedStoryboard,
   type BeatCues,
 } from "./storyboard-parse.js";
+import { loadStoryboardMarkdown } from "./storyboard-source.js";
 import { readProjectConfig, type LoadedProjectConfig } from "./project-config.js";
 import { kindAssetPolicy } from "./scene-project.js";
 import { validateStoryboardMarkdown, type StoryboardValidationIssue } from "./storyboard-edit.js";
@@ -249,7 +249,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
     });
   }
 
-  const storyboardMd = await readFile(storyboardPath, "utf-8");
+  const storyboardMd = await loadStoryboardMarkdown(projectDir);
   const validation = validateStoryboardMarkdown(storyboardMd);
   const validationIssues: StoryboardValidationIssue[] = [...validation.issues];
   const parsed = parseStoryboard(storyboardMd);

--- a/packages/cli/src/commands/_shared/compose-aivideo.ts
+++ b/packages/cli/src/commands/_shared/compose-aivideo.ts
@@ -23,6 +23,7 @@ import { join, resolve } from "node:path";
 
 import { commandExists, execSafe } from "../../utils/exec-safe.js";
 import { parseStoryboard, type Beat } from "./storyboard-parse.js";
+import { loadStoryboardMarkdown } from "./storyboard-source.js";
 import { parseDesign } from "./design-parse.js";
 
 /**
@@ -302,8 +303,7 @@ export async function composeAiVideo(opts: {
     throw new Error("ffmpeg not found in PATH — required to concatenate AI-video clips.");
   }
 
-  const storyboardPath = join(projectDir, "STORYBOARD.md");
-  const md = await readFile(storyboardPath, "utf-8");
+  const md = await loadStoryboardMarkdown(projectDir);
   const beats = parseStoryboard(md).beats;
   if (beats.length === 0) throw new Error("STORYBOARD.md has no beats to compose.");
 

--- a/packages/cli/src/commands/_shared/compose-prompts.ts
+++ b/packages/cli/src/commands/_shared/compose-prompts.ts
@@ -33,7 +33,6 @@
  */
 
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 
 import {
@@ -42,6 +41,7 @@ import {
   type Beat,
   type BeatCues,
 } from "./storyboard-parse.js";
+import { loadStoryboardMarkdown } from "./storyboard-source.js";
 import { buildUserPrompt } from "./compose-beat-prompt.js";
 import { resolveProjectBeatDurations } from "./root-sync.js";
 import {
@@ -177,7 +177,7 @@ export async function getComposePrompts(opts: ComposePromptsOptions): Promise<Co
     );
   }
 
-  const storyboardMd = await readFile(storyboardPath, "utf-8");
+  const storyboardMd = await loadStoryboardMarkdown(projectDir);
   const parsed = parseStoryboard(storyboardMd);
 
   if (parsed.beats.length === 0) {

--- a/packages/cli/src/commands/_shared/project-list.ts
+++ b/packages/cli/src/commands/_shared/project-list.ts
@@ -2,6 +2,7 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { parseStoryboard } from "./storyboard-parse.js";
+import { loadStoryboardMarkdown } from "./storyboard-source.js";
 
 /**
  * @module _shared/project-list
@@ -92,7 +93,7 @@ async function describeProject(name: string, projectDir: string): Promise<Projec
 
   try {
     const storyboardPath = join(projectDir, "STORYBOARD.md");
-    const parsed = parseStoryboard(await readFile(storyboardPath, "utf-8"));
+    const parsed = parseStoryboard(await loadStoryboardMarkdown(projectDir));
     beats = parsed.beats.length;
     storyboardDurationSec = Number(
       parsed.beats.reduce((sum, beat) => sum + (beat.duration ?? 0), 0).toFixed(2)

--- a/packages/cli/src/commands/_shared/root-sync.ts
+++ b/packages/cli/src/commands/_shared/root-sync.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 
 import { getAudioDuration } from "../../utils/audio.js";
 import { parseStoryboard } from "./storyboard-parse.js";
+import { loadStoryboardMarkdown } from "./storyboard-source.js";
 import type { ReviewIssue } from "./review-report.js";
 
 export const ROOT_SYNC_FIX_CODES = {
@@ -147,7 +148,7 @@ export async function loadProjectRootSyncBeats(projectDir: string): Promise<Root
   const storyboardPath = join(root, "STORYBOARD.md");
   if (!existsSync(storyboardPath)) return [];
 
-  const parsed = parseStoryboard(await readFile(storyboardPath, "utf-8"));
+  const parsed = parseStoryboard(await loadStoryboardMarkdown(root));
   const reportBeats = await readBuildReportBeats(root);
   return parsed.beats.map((beat) => {
     const reportBeat = reportBeats.find((item) => item.id === beat.id);

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -56,6 +56,7 @@ import {
   type StoryboardCueKey,
   type ResolvedCharacter,
 } from "./storyboard-parse.js";
+import { loadStoryboardMarkdown } from "./storyboard-source.js";
 import { scaffoldSceneProject } from "./scene-project.js";
 import {
   backdropCostUsd,
@@ -498,7 +499,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   if (!buildPlan.validation.ok) {
     let invalidBeats: Beat[] = [];
     if (existsSync(storyboardPath)) {
-      invalidBeats = parseStoryboard(await readFile(storyboardPath, "utf-8")).beats;
+      invalidBeats = parseStoryboard(await loadStoryboardMarkdown(projectDir)).beats;
     }
     return finishBuildResult({
       success: false,
@@ -538,7 +539,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
       totalLatencyMs: Date.now() - startedAt,
     });
   }
-  const storyboardMd = await readFile(storyboardPath, "utf-8");
+  const storyboardMd = await loadStoryboardMarkdown(projectDir);
   const parsed = parseStoryboard(storyboardMd);
   if (parsed.beats.length === 0) {
     return finishBuildResult({

--- a/packages/cli/src/commands/_shared/scene-submit.ts
+++ b/packages/cli/src/commands/_shared/scene-submit.ts
@@ -14,7 +14,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import {
@@ -24,6 +24,7 @@ import {
   type LintFinding,
 } from "./scene-lint.js";
 import { parseStoryboard } from "./storyboard-parse.js";
+import { loadStoryboardMarkdown } from "./storyboard-source.js";
 import { resolveSyncedBeatDuration, loadProjectRootSyncBeats } from "./root-sync.js";
 
 export interface SceneSubmitOptions {
@@ -71,7 +72,7 @@ export async function executeSceneSubmit(opts: SceneSubmitOptions): Promise<Scen
       error: `STORYBOARD.md not found at ${storyboardPath}. Run \`vibe init <dir>\` first.`,
     };
   }
-  const parsed = parseStoryboard(await readFile(storyboardPath, "utf-8"));
+  const parsed = parseStoryboard(await loadStoryboardMarkdown(projectDir));
   const beat = parsed.beats.find((b) => b.id === beatId);
   if (!beat) {
     const available = parsed.beats.map((b) => b.id).join(", ") || "(none)";

--- a/packages/cli/src/commands/_shared/status-jobs.ts
+++ b/packages/cli/src/commands/_shared/status-jobs.ts
@@ -10,6 +10,7 @@ import { writeAssetMetadata } from "./build-asset-metadata.js";
 import type { ReviewAction, ReviewActionCostTier, ReviewFixOwner } from "./review-report.js";
 import { normalizeReviewActions, reviewActionsFromRetryWith } from "./review-report.js";
 import { parseStoryboard } from "./storyboard-parse.js";
+import { loadStoryboardMarkdown } from "./storyboard-source.js";
 
 export type JobStatus = "queued" | "running" | "completed" | "failed" | "cancelled" | "unknown";
 /**
@@ -1039,7 +1040,7 @@ async function readProjectBeatReadiness(
   }
 
   try {
-    const parsed = parseStoryboard(await readFile(storyboardPath, "utf-8"));
+    const parsed = parseStoryboard(await loadStoryboardMarkdown(projectDir));
     const needsAuthor: string[] = [];
     let compositionsReady = 0;
     for (const beat of parsed.beats) {

--- a/packages/cli/src/commands/_shared/storyboard-source.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  detectStoryboardLayout,
+  listSceneFiles,
+  loadStoryboard,
+  sceneFilename,
+  sceneToBeatSection,
+} from "./storyboard-source.js";
+import { parseStoryboard } from "./storyboard-parse.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "vibe-storyboard-source-"));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+const HEAD = [
+  "---",
+  'type: Storyboard',
+  'title: "Launch"',
+  "duration: 10",
+  "characters:",
+  '  mira: "arctic photographer"',
+  "---",
+  "",
+  "# Launch - Storyboard",
+  "",
+  "Pacing: keep scenes 6-15 seconds.",
+  "",
+].join("\n");
+
+async function writeBundle(scenes: Array<[string, string]>) {
+  await writeFile(join(dir, "STORYBOARD.md"), HEAD, "utf-8");
+  await mkdir(join(dir, "scenes"), { recursive: true });
+  for (const [name, body] of scenes) {
+    await writeFile(join(dir, "scenes", name), body, "utf-8");
+  }
+}
+
+describe("layout detection", () => {
+  it("reports missing when the project has neither", () => {
+    expect(detectStoryboardLayout(dir, 0)).toBe("missing");
+  });
+
+  it("reports single when only STORYBOARD.md exists", async () => {
+    await writeFile(join(dir, "STORYBOARD.md"), HEAD, "utf-8");
+    expect(detectStoryboardLayout(dir, 0)).toBe("single");
+  });
+
+  it("reports bundle as soon as one scene file exists", () => {
+    expect(detectStoryboardLayout(dir, 1)).toBe("bundle");
+  });
+});
+
+describe("scene ordering", () => {
+  it("orders by numeric prefix, not filename", async () => {
+    await writeBundle([
+      ["10-close.md", "---\nduration: 2\n---\n\nClose."],
+      ["02-proof.md", "---\nduration: 3\n---\n\nProof."],
+      ["01-hook.md", "---\nduration: 5\n---\n\nHook."],
+    ]);
+    // Plain filename sort would put "10-close" before "02-proof".
+    expect((await listSceneFiles(dir)).map((s) => s.id)).toEqual(["hook", "proof", "close"]);
+  });
+
+  it("strips the prefix from the beat id", async () => {
+    await writeBundle([["07-final-word.md", "---\nduration: 2\n---\n\nx"]]);
+    const [scene] = await listSceneFiles(dir);
+    expect(scene.id).toBe("final-word");
+    expect(scene.order).toBe(7);
+  });
+
+  it("accepts unprefixed files and sorts them after prefixed ones", async () => {
+    await writeBundle([
+      ["hook.md", "---\nduration: 1\n---\n\na"],
+      ["01-intro.md", "---\nduration: 1\n---\n\nb"],
+    ]);
+    expect((await listSceneFiles(dir)).map((s) => s.id)).toEqual(["intro", "hook"]);
+  });
+
+  it("ignores underscore-prefixed and non-markdown files", async () => {
+    await writeBundle([
+      ["01-hook.md", "---\nduration: 1\n---\n\na"],
+      ["_draft.md", "---\nduration: 1\n---\n\nb"],
+      ["notes.txt", "not markdown"],
+    ]);
+    expect((await listSceneFiles(dir)).map((s) => s.id)).toEqual(["hook"]);
+  });
+});
+
+describe("sceneToBeatSection", () => {
+  it("moves frontmatter into a cue block and keeps the body", () => {
+    const out = sceneToBeatSection(
+      { id: "hook", path: "x", filename: "01-hook.md", order: 1 },
+      '---\nduration: 5\nnarration: "Hi"\n---\n\nBody prose.\n'
+    );
+    expect(out).toContain("## Beat hook - Hook");
+    expect(out).toContain("```yaml");
+    expect(out).toContain("duration: 5");
+    expect(out).toContain("Body prose.");
+  });
+
+  it("drops the OKF type field so it never trips the unknown-cue warning", () => {
+    const out = sceneToBeatSection(
+      { id: "hook", path: "x", filename: "01-hook.md", order: 1 },
+      "---\ntype: Scene\nduration: 5\n---\n\nBody.\n"
+    );
+    expect(out).not.toContain("type:");
+    expect(out).toContain("duration: 5");
+  });
+
+  it("keeps `title` as a cue rather than promoting it to the heading", () => {
+    const out = sceneToBeatSection(
+      { id: "hook", path: "x", filename: "01-hook.md", order: 1 },
+      '---\ntitle: "Lower third copy"\n---\n\nBody.\n'
+    );
+    expect(out).toContain("## Beat hook - Hook");
+    expect(out).toContain('title: Lower third copy');
+  });
+});
+
+describe("loadStoryboard", () => {
+  it("assembles a bundle into a document the existing parser understands", async () => {
+    await writeBundle([
+      ["01-hook.md", '---\ntype: Scene\nduration: 5\nnarration: "One"\n---\n\nHook body.'],
+      ["02-proof.md", '---\ntype: Scene\nduration: 5\ncharacters: [mira]\n---\n\nProof body.'],
+    ]);
+    const loaded = await loadStoryboard(dir);
+    expect(loaded.layout).toBe("bundle");
+
+    const parsed = parseStoryboard(loaded.markdown);
+    expect(parsed.beats.map((b) => b.id)).toEqual(["hook", "proof"]);
+    expect(parsed.beats[0].cues?.narration).toBe("One");
+    expect(parsed.beats[0].duration).toBe(5);
+    expect(parsed.beats[1].cues?.characters).toEqual(["mira"]);
+    // Project frontmatter survives the round trip.
+    expect(parsed.frontmatter?.title).toBe("Launch");
+    expect(Object.keys(parsed.frontmatter?.characters ?? {})).toEqual(["mira"]);
+    // Direction prose stays in the global block.
+    expect(parsed.global).toContain("Pacing: keep scenes 6-15 seconds.");
+  });
+
+  it("reads a legacy single-file project unchanged", async () => {
+    const legacy = `${HEAD}\n## Beat hook - Hook\n\n\`\`\`yaml\nduration: 4\n\`\`\`\n\nBody.\n`;
+    await writeFile(join(dir, "STORYBOARD.md"), legacy, "utf-8");
+    const loaded = await loadStoryboard(dir);
+    expect(loaded.layout).toBe("single");
+    expect(loaded.markdown).toBe(legacy);
+    expect(parseStoryboard(loaded.markdown).beats.map((b) => b.id)).toEqual(["hook"]);
+  });
+
+  it("returns empty for a project with no storyboard at all", async () => {
+    const loaded = await loadStoryboard(dir);
+    expect(loaded.layout).toBe("missing");
+    expect(loaded.markdown).toBe("");
+  });
+
+  it("produces cues that pass validation, including no unknown-cue warnings", async () => {
+    await writeBundle([
+      [
+        "01-hook.md",
+        '---\ntype: Scene\nduration: 5\nnarration: "n"\nbackdrop: "b"\nmotion: "m"\n---\n\nBody.',
+      ],
+    ]);
+    const { validateStoryboardMarkdown } = await import("./storyboard-edit.js");
+    const result = validateStoryboardMarkdown((await loadStoryboard(dir)).markdown);
+    expect(result.issues.map((i) => i.code)).not.toContain("UNKNOWN_CUE");
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("sceneFilename", () => {
+  it("pads to two digits, widening only past 99", () => {
+    expect(sceneFilename(1, "hook")).toBe("01-hook.md");
+    expect(sceneFilename(12, "proof")).toBe("12-proof.md");
+    expect(sceneFilename(100, "late")).toBe("100-late.md");
+  });
+});

--- a/packages/cli/src/commands/_shared/storyboard-source.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.ts
@@ -1,0 +1,187 @@
+/**
+ * @module _shared/storyboard-source
+ *
+ * Resolves where a project's storyboard actually lives and hands back one
+ * markdown document either way.
+ *
+ * Two on-disk layouts are supported:
+ *
+ * **bundle** (preferred) - `STORYBOARD.md` holds project frontmatter and
+ * direction prose, and `scenes/NN-<id>.md` holds one scene per file with its
+ * cues in real document frontmatter:
+ *
+ * ```text
+ * launch/
+ *   STORYBOARD.md        --- type/title/duration/aspect/providers/characters ---
+ *   scenes/
+ *     01-hook.md         --- duration/narration/backdrop/... ---  + body
+ *     02-proof.md
+ * ```
+ *
+ * **single** (legacy) - one `STORYBOARD.md` with `## Beat <id> - <title>`
+ * headings, each carrying a leading ```yaml cue block.
+ *
+ * The bundle layout exists because `---` frontmatter is a *document* level
+ * construct. Used mid-document it is not frontmatter at all: the opening
+ * `---` is a horizontal rule and the closing one turns the lines above it
+ * into a setext heading. One scene per file is the only way per-scene cues
+ * can be written as frontmatter and still render correctly.
+ *
+ * A bundle is assembled back into the single-document shape in memory, so
+ * every existing consumer of `parseStoryboard()` keeps working unchanged.
+ * That is deliberate: the on-disk format users edit is decoupled from the
+ * in-memory representation the build already understands.
+ */
+
+import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { stringify as stringifyYaml } from "yaml";
+
+import { extractFrontmatter } from "./frontmatter.js";
+import { deriveBeatId } from "./storyboard-parse.js";
+
+/** Directory, relative to the project root, that holds one file per scene. */
+export const SCENES_DIRNAME = "scenes";
+
+/** The project-level document, present in both layouts. */
+export const STORYBOARD_FILENAME = "STORYBOARD.md";
+
+export type StoryboardLayout = "bundle" | "single" | "missing";
+
+export interface SceneFile {
+  /** Beat id derived from the filename, with any ordering prefix stripped. */
+  id: string;
+  /** Absolute path to the scene file. */
+  path: string;
+  /** Filename, e.g. `01-hook.md`. */
+  filename: string;
+  /** Numeric ordering prefix when present (`01-hook.md` -> 1). */
+  order: number | null;
+}
+
+export interface LoadedStoryboard {
+  layout: StoryboardLayout;
+  /** One markdown document in the legacy single-file shape. */
+  markdown: string;
+  /** Scene files, in play order. Empty for the single layout. */
+  scenes: SceneFile[];
+  /** Absolute path of the project-level document. */
+  storyboardPath: string;
+}
+
+/** `01-hook.md` -> { order: 1, id: "hook" }; `hook.md` -> { order: null, id: "hook" }. */
+const ORDER_PREFIX_RE = /^(\d+)[-_.]\s*(.+)$/;
+
+function sceneFileFrom(dir: string, filename: string): SceneFile {
+  const stem = filename.replace(/\.mdx?$/i, "");
+  const match = stem.match(ORDER_PREFIX_RE);
+  const order = match ? Number.parseInt(match[1], 10) : null;
+  const idSource = match ? match[2] : stem;
+  return { id: deriveBeatId(idSource), path: join(dir, filename), filename, order };
+}
+
+/**
+ * Scene files in play order: numeric prefix first (ascending), then any
+ * unprefixed files in filename order. Mixing the two is legal but a lint
+ * elsewhere should discourage it.
+ */
+export async function listSceneFiles(projectDir: string): Promise<SceneFile[]> {
+  const dir = join(projectDir, SCENES_DIRNAME);
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = entries
+    .filter((e) => e.isFile() && /\.mdx?$/i.test(e.name) && !e.name.startsWith("_"))
+    .map((e) => sceneFileFrom(dir, e.name));
+  return files.sort((a, b) => {
+    if (a.order !== null && b.order !== null) return a.order - b.order;
+    if (a.order !== null) return -1;
+    if (b.order !== null) return 1;
+    return a.filename.localeCompare(b.filename);
+  });
+}
+
+export function detectStoryboardLayout(projectDir: string, sceneCount: number): StoryboardLayout {
+  if (sceneCount > 0) return "bundle";
+  if (existsSync(join(projectDir, STORYBOARD_FILENAME))) return "single";
+  return "missing";
+}
+
+/** Title-case a beat id for the synthesized heading: `hook` -> `Hook`. */
+function humanise(id: string): string {
+  return (
+    id
+      .split(/[-_]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ") || "Scene"
+  );
+}
+
+/**
+ * Turn one scene file into the `## Beat <id> - <Title>` + cue-block section
+ * the single-document parser expects.
+ *
+ * `type:` is dropped: it is OKF bookkeeping identifying the file as a scene,
+ * not a cue, and passing it through would trip the unknown-cue warning.
+ * A `title:` in scene frontmatter is a lower-third cue, so the heading uses
+ * the humanised id and `title` stays in the cue block where it belongs.
+ */
+export function sceneToBeatSection(scene: SceneFile, contents: string): string {
+  const { data, body } = extractFrontmatter(contents);
+  const cues: Record<string, unknown> = { ...data };
+  delete cues.type;
+
+  const cueBlock =
+    Object.keys(cues).length > 0
+      ? "```yaml\n" + stringifyYaml(cues, { lineWidth: 0 }).trimEnd() + "\n```\n\n"
+      : "";
+  const prose = body.trim();
+  return `## Beat ${scene.id} - ${humanise(scene.id)}\n\n${cueBlock}${prose}\n`;
+}
+
+/**
+ * Load a project's storyboard as a single markdown document, whichever
+ * layout it uses on disk.
+ *
+ * For a bundle this concatenates `STORYBOARD.md` (frontmatter + direction
+ * prose, with any stray beat headings left alone) and one synthesized
+ * section per scene file.
+ */
+export async function loadStoryboard(projectDir: string): Promise<LoadedStoryboard> {
+  const storyboardPath = join(projectDir, STORYBOARD_FILENAME);
+  const scenes = await listSceneFiles(projectDir);
+  const layout = detectStoryboardLayout(projectDir, scenes.length);
+
+  if (layout === "missing") {
+    return { layout, markdown: "", scenes: [], storyboardPath };
+  }
+
+  const head = existsSync(storyboardPath) ? await readFile(storyboardPath, "utf-8") : "";
+
+  if (layout === "single") {
+    return { layout, markdown: head, scenes: [], storyboardPath };
+  }
+
+  const sections = await Promise.all(
+    scenes.map(async (scene) => sceneToBeatSection(scene, await readFile(scene.path, "utf-8")))
+  );
+  const prefix = head.trimEnd();
+  return {
+    layout,
+    markdown: `${prefix}${prefix ? "\n\n" : ""}${sections.join("\n")}`,
+    scenes,
+    storyboardPath,
+  };
+}
+
+/** Convenience for the many call sites that only want the markdown. */
+export async function loadStoryboardMarkdown(projectDir: string): Promise<string> {
+  return (await loadStoryboard(projectDir)).markdown;
+}
+
+/** `01-hook.md` for order 1 and id `hook`. Two digits until a project needs three. */
+export function sceneFilename(order: number, id: string): string {
+  const width = order >= 100 ? 3 : 2;
+  return `${String(order).padStart(width, "0")}-${basename(id)}.md`;
+}

--- a/packages/cli/src/commands/storyboard.ts
+++ b/packages/cli/src/commands/storyboard.ts
@@ -12,6 +12,7 @@ import {
   STORYBOARD_CUE_KEYS,
   validateStoryboardMarkdown,
 } from "./_shared/storyboard-edit.js";
+import { loadStoryboard } from "./_shared/storyboard-source.js";
 import {
   executeStoryboardRevision,
   type StoryboardRevisionResult,
@@ -112,6 +113,7 @@ storyboardCommand
         exitWithError(usageError(`Invalid JSON cue value: ${error instanceof Error ? error.message : String(error)}`));
       }
     }
+    await refuseWriteOnBundle(projectDir, "set");
     let next: string;
     try {
       next = setStoryboardCue(md, { beatId, key, value, unset: options.unset });
@@ -143,6 +145,7 @@ storyboardCommand
     const startedAt = Date.now();
     const projectDir = resolve(projectDirArg);
     const md = await readStoryboard(projectDir);
+    await refuseWriteOnBundle(projectDir, "move");
     let next: string;
     try {
       next = moveStoryboardBeat(md, { beatId, afterBeatId: options.after });
@@ -246,11 +249,33 @@ storyboardCommand
   });
 
 async function readStoryboard(projectDir: string): Promise<string> {
-  const path = storyboardPath(projectDir);
-  if (!existsSync(path)) {
-    exitWithError(generalError(`STORYBOARD.md not found at ${path}`, `Run 'vibe init ${projectDir} --from "<brief>"' first.`));
+  const loaded = await loadStoryboard(projectDir);
+  if (loaded.layout === "missing") {
+    exitWithError(
+      generalError(
+        `No storyboard found in ${projectDir}`,
+        `Run 'vibe init ${projectDir} --from "<brief>"' first.`
+      )
+    );
   }
-  return readFile(path, "utf-8");
+  return loaded.markdown;
+}
+
+/**
+ * Read-modify-write commands rewrite the whole document. In the bundle
+ * layout that document is assembled from `scenes/*.md`, so writing it back
+ * to STORYBOARD.md would silently collapse the split. Refuse instead of
+ * destroying the project, and name the per-file edit as the way forward.
+ */
+async function refuseWriteOnBundle(projectDir: string, command: string): Promise<void> {
+  const { layout, scenes } = await loadStoryboard(projectDir);
+  if (layout !== "bundle") return;
+  exitWithError(
+    generalError(
+      `\`vibe storyboard ${command}\` cannot write to a scenes/ bundle yet.`,
+      `Edit the scene file directly - this project has ${scenes.length} under ${projectDir}/scenes/.`
+    )
+  );
 }
 
 function storyboardPath(projectDir: string): string {


### PR DESCRIPTION
## Why `---` needed a new layout

Per-beat cues live in ```` ```yaml ```` blocks because **`---` frontmatter is a document-level construct**. Used mid-document it is not frontmatter at all. Rendered through GitHub's own API:

```html
<h2>Beat hook - Hook</h2>
<hr>                                          <!-- the opening --- -->
<h2>duration: 5<br>narration: "test"</h2>     <!-- the closing --- makes a setext heading -->
```

The cues come out as a giant `<h2>`. One scene per file is the only layout where per-scene cues can be frontmatter *and* render correctly. (Top-of-file frontmatter is fine — GitHub renders it as a table, confirmed against `docs/projects.md`.)

## The layout

```
launch/
  STORYBOARD.md      project frontmatter + direction prose
  scenes/
    01-hook.md       --- duration/narration/backdrop/... --- + body
    02-proof.md
    03-close.md
```

Play order is the **numeric filename prefix** — visible in `ls`, no index file to drift out of sync. Unprefixed files are accepted and sort after prefixed ones; `_`-prefixed and non-markdown files are ignored.

## Why this is additive rather than a rewrite

A bundle is **assembled back into the single-document shape in memory**, so the 15 modules that call `parseStoryboard()` are untouched. Only the 9 call sites that read the file off disk change, and they all change to one shared `loadStoryboardMarkdown(projectDir)`.

That decoupling is the point: the format users edit is now independent of the representation the build understands.

## Both layouts work

| | `scenes/` present | otherwise |
|---|---|---|
| read | assembled bundle | STORYBOARD.md, exactly as before |

## Writes are deliberately refused on a bundle

`vibe storyboard set` and `move` rewrite the whole document. Writing an *assembled* document back to STORYBOARD.md would silently collapse the split, so they refuse:

```json
{
  "success": false,
  "error": "`vibe storyboard set` cannot write to a scenes/ bundle yet.",
  "suggestion": "Edit the scene file directly - this project has 3 under .../scenes/."
}
```

Verified that STORYBOARD.md is left byte-identical after a refused write. Read commands (`list`, `get`, `validate`) work on both layouts.

## Two assembly details

- `type:` is stripped. It is OKF bookkeeping marking the file as a scene, not a cue, and would otherwise trip the unknown-cue warning.
- `title:` stays a cue rather than being promoted to the heading — at beat level `title` is lower-third copy.

## Verification

End to end against a real bundle project:

```
vibe plan            beats: ['hook','proof','close']  ok: true  $0.94
storyboard list      3 beats with full cues
storyboard get hook  id: hook, durationSec: 5
storyboard validate  ok: true, issues: []
storyboard set       refuses; STORYBOARD.md untouched (0 beat headings)
```

And a legacy single-file project still validates, plans ($0.05), and accepts `storyboard set` (duration written as 7).

- 1247 CLI tests pass, **15 new** covering layout detection, ordering, assembly, and validation round-trip
- `pnpm lint` clean, `pnpm test` all packages green
- `tsx scripts/dogfood-smoke.mts` passes against the built CLI
- `gen:reference:check` and `sync-counts --check` in sync

## Follow-ups

Migration tooling (`vibe storyboard migrate`), bundle writes, and `vibe init --bundle` are separate PRs.
