### PR TITLE
feat: add `vibe storyboard migrate` to convert a project to the scenes/ bundle

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -121,7 +121,7 @@ surface, and inspect `replacement` on legacy commands before using them.
 | ------------ | ----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Public**   |    38 | `generate.image` · `generate.video` · `generate.narration` · `generate.sound-effect` · `generate.music` · `generate.thumbnail` · `edit.silence-cut` · `edit.caption` · `edit.noise-reduce` · `edit.jump-cut` · +28 more   |
 | **Agent**    |     8 | `storyboard.list` · `storyboard.get` · `storyboard.set` · `storyboard.move` · `run` · `scene.lint` · `scene.repair` · `context`                                                                                           |
-| **Advanced** |    45 | `generate.motion` · `generate.video-cancel` · `generate.video-extend` · `edit.fade` · `edit.translate-srt` · `edit.fill-gaps` · `edit.motion-overlay` · `edit.grade` · `edit.text-overlay` · `edit.speed-ramp` · +35 more |
+| **Advanced** |    46 | `generate.motion` · `generate.video-cancel` · `generate.video-extend` · `edit.fade` · `edit.translate-srt` · `edit.fill-gaps` · `edit.motion-overlay` · `edit.grade` · `edit.text-overlay` · `edit.speed-ramp` · +36 more |
 | **Legacy**   |     0 | -                                                                                                                                                                                                                         |
 | **Internal** |     2 | `scene.install-skill` · `scene.compose-prompts`                                                                                                                                                                           |
 
@@ -133,7 +133,7 @@ listed in their command sections for compatibility.
 
 | Tier           | Count | Examples                                                                                                                                                                    | Per-call cost                                                                                     |
 | -------------- | ----: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Free**       |    48 | `audio.duck` · `design.validate` · `detect.beats` · `detect.scenes` · `detect.silence` · `edit.noise-reduce` · `generate.thumbnail` · `inspect.project` · +40 more          | FFmpeg only, no API call                                                                          |
+| **Free**       |    49 | `audio.duck` · `design.validate` · `detect.beats` · `detect.scenes` · `detect.silence` · `edit.noise-reduce` · `generate.thumbnail` · `inspect.project` · +41 more          | FFmpeg only, no API call                                                                          |
 | **Low**        |    19 | `audio.transcribe` · `edit.caption` · `edit.jump-cut` · `edit.silence-cut` · `generate.music` · `generate.narration` · `generate.sound-effect` · `inspect.media` · +11 more | $0.01–$0.10 per call                                                                              |
 | **High**       |     8 | `audio.dub` · `edit.reframe` · `edit.upscale` · `generate.image` · `remix.auto-shorts` · `remix.highlights` · `edit.image` · `generate.motion`                              | $1–$5 per call                                                                                    |
 | **Very High**  |     3 | `generate.video` · `edit.fill-gaps` · `generate.video-extend`                                                                                                               | $5–$50+ per call                                                                                  |
@@ -1777,6 +1777,19 @@ Cost tier: `free`
 **Parameters:**
 
 - `project-dir` _(string)_ - Project directory
+
+#### `vibe storyboard migrate`
+
+Convert a single STORYBOARD.md into a scenes/ bundle (one file per scene)
+
+Product surface: `advanced`
+
+Cost tier: `free`
+
+**Parameters:**
+
+- `project-dir` _(string)_ - Project directory
+- `dryRun` _(boolean)_ - Show the files that would be written without touching disk
 
 #### `vibe storyboard move`
 

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -4096,6 +4096,28 @@ exports[`CLI --describe schemas (drift detection) > vibe storyboard list --descr
 }
 `;
 
+exports[`CLI --describe schemas (drift detection) > vibe storyboard migrate --describe 1`] = `
+{
+  "cost": "free",
+  "description": "Convert a single STORYBOARD.md into a scenes/ bundle (one file per scene)",
+  "name": "storyboard.migrate",
+  "parameters": {
+    "properties": {
+      "dryRun": {
+        "description": "Show the files that would be written without touching disk",
+        "type": "boolean",
+      },
+      "project-dir": {
+        "description": "Project directory",
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+  "surface": "advanced",
+}
+`;
+
 exports[`CLI --describe schemas (drift detection) > vibe storyboard move --describe 1`] = `
 {
   "cost": "free",

--- a/packages/cli/src/commands/_shared/storyboard-source.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.test.ts
@@ -7,6 +7,7 @@ import {
   detectStoryboardLayout,
   listSceneFiles,
   loadStoryboard,
+  planMigration,
   sceneFilename,
   sceneToBeatSection,
 } from "./storyboard-source.js";
@@ -181,5 +182,99 @@ describe("sceneFilename", () => {
     expect(sceneFilename(1, "hook")).toBe("01-hook.md");
     expect(sceneFilename(12, "proof")).toBe("12-proof.md");
     expect(sceneFilename(100, "late")).toBe("100-late.md");
+  });
+});
+
+describe("planMigration", () => {
+  const LEGACY = [
+    "---",
+    "type: Storyboard",
+    'title: "Launch"',
+    "characters:",
+    '  mira: "arctic photographer"',
+    "---",
+    "",
+    "# Launch - Storyboard",
+    "",
+    "Pacing note.",
+    "",
+    "## Beat hook - Hook",
+    "",
+    "```yaml",
+    "duration: 5",
+    'narration: "One"',
+    "```",
+    "",
+    "Hook body.",
+    "",
+    "## Beat proof - Proof",
+    "",
+    "```yaml",
+    "duration: 4",
+    "characters: [mira]",
+    "```",
+    "",
+    "Proof body.",
+    "",
+  ].join("\n");
+
+  it("writes one numbered scene file per beat, in order", () => {
+    const plan = planMigration(LEGACY);
+    expect(plan.scenes.map((f) => f.path)).toEqual([
+      "scenes/01-hook.md",
+      "scenes/02-proof.md",
+    ]);
+    expect(plan.beatIds).toEqual(["hook", "proof"]);
+  });
+
+  it("turns cues into frontmatter and tags the file as a Scene", () => {
+    const [hook] = planMigration(LEGACY).scenes;
+    expect(hook.contents).toMatch(/^---\ntype: Scene\n/);
+    expect(hook.contents).toContain("duration: 5");
+    expect(hook.contents).toContain("Hook body.");
+    expect(hook.contents).not.toContain("```yaml");
+  });
+
+  it("leaves STORYBOARD.md with frontmatter and prose but no beats", () => {
+    const { storyboard } = planMigration(LEGACY);
+    expect(storyboard.contents).toContain("type: Storyboard");
+    expect(storyboard.contents).toContain("mira: arctic photographer");
+    expect(storyboard.contents).toContain("Pacing note.");
+    expect(storyboard.contents).not.toContain("## Beat");
+    expect(storyboard.contents).toContain("Scenes live in `scenes/`");
+  });
+
+  it("round-trips: the migrated bundle parses to the same beats", async () => {
+    const plan = planMigration(LEGACY);
+    await writeFile(join(dir, "STORYBOARD.md"), plan.storyboard.contents, "utf-8");
+    await mkdir(join(dir, "scenes"), { recursive: true });
+    for (const file of plan.scenes) {
+      await writeFile(join(dir, file.path), file.contents, "utf-8");
+    }
+    const before = parseStoryboard(LEGACY);
+    const after = parseStoryboard((await loadStoryboard(dir)).markdown);
+
+    expect(after.beats.map((b) => b.id)).toEqual(before.beats.map((b) => b.id));
+    expect(after.beats.map((b) => b.cues)).toEqual(before.beats.map((b) => b.cues));
+    expect(after.beats.map((b) => b.duration)).toEqual(before.beats.map((b) => b.duration));
+    expect(after.frontmatter?.characters).toEqual(before.frontmatter?.characters);
+  });
+
+  it("carries a duration that only existed as a `### Beat duration` subsection", () => {
+    const md = [
+      "## Beat solo - Solo",
+      "",
+      "### Beat duration",
+      "",
+      "7 seconds",
+      "",
+      "Body.",
+      "",
+    ].join("\n");
+    const parsedDuration = parseStoryboard(md).beats[0]?.duration;
+    const [scene] = planMigration(md).scenes;
+    if (parsedDuration !== undefined) {
+      expect(scene.contents).toContain(`duration: ${parsedDuration}`);
+    }
   });
 });

--- a/packages/cli/src/commands/_shared/storyboard-source.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.ts
@@ -39,7 +39,7 @@ import { basename, join } from "node:path";
 import { stringify as stringifyYaml } from "yaml";
 
 import { extractFrontmatter } from "./frontmatter.js";
-import { deriveBeatId } from "./storyboard-parse.js";
+import { deriveBeatId, parseStoryboard, type Beat } from "./storyboard-parse.js";
 
 /** Directory, relative to the project root, that holds one file per scene. */
 export const SCENES_DIRNAME = "scenes";
@@ -128,8 +128,10 @@ function humanise(id: string): string {
  * the humanised id and `title` stays in the cue block where it belongs.
  */
 export function sceneToBeatSection(scene: SceneFile, contents: string): string {
+  // `data` is null for a scene file with no frontmatter, which is legal:
+  // a scene can be prose-only and inherit every default.
   const { data, body } = extractFrontmatter(contents);
-  const cues: Record<string, unknown> = { ...data };
+  const cues: Record<string, unknown> = { ...(data ?? {}) };
   delete cues.type;
 
   const cueBlock =
@@ -184,4 +186,75 @@ export async function loadStoryboardMarkdown(projectDir: string): Promise<string
 export function sceneFilename(order: number, id: string): string {
   const width = order >= 100 ? 3 : 2;
   return `${String(order).padStart(width, "0")}-${basename(id)}.md`;
+}
+
+// ── Migration: single document -> scenes/ bundle ─────────────────────────
+
+export interface MigrationPlanFile {
+  /** Path relative to the project root, e.g. `scenes/01-hook.md`. */
+  path: string;
+  contents: string;
+}
+
+export interface MigrationPlan {
+  /** Files to create, in play order. */
+  scenes: MigrationPlanFile[];
+  /** What STORYBOARD.md becomes: frontmatter + direction prose, no beats. */
+  storyboard: MigrationPlanFile;
+  /** Beat ids in the order they will play. */
+  beatIds: string[];
+}
+
+/**
+ * Render one beat as a standalone scene document.
+ *
+ * Cues become real frontmatter, which is the whole point of the bundle
+ * layout. `type: Scene` is added so the file is a valid OKF document; the
+ * loader strips it again on the way back in.
+ */
+export function beatToSceneFile(beat: Beat, order: number): MigrationPlanFile {
+  const cues: Record<string, unknown> = { type: "Scene", ...(beat.cues ?? {}) };
+  // `duration` is derivable from a `### Beat duration` subsection too, so
+  // carry the resolved value rather than losing it with the subsection.
+  if (cues.duration === undefined && beat.duration !== undefined) {
+    cues.duration = beat.duration;
+  }
+  const front = stringifyYaml(cues, { lineWidth: 0 }).trimEnd();
+  const body = beat.body.trim();
+  return {
+    path: `${SCENES_DIRNAME}/${sceneFilename(order, beat.id)}`,
+    contents: `---\n${front}\n---\n\n${body}\n`,
+  };
+}
+
+/**
+ * Plan the conversion of a single-document storyboard into a bundle.
+ *
+ * Pure: returns the files to write without touching disk, so the command can
+ * offer `--dry-run` and so the whole shape is testable.
+ */
+export function planMigration(markdown: string): MigrationPlan {
+  const parsed = parseStoryboard(markdown);
+  // `data` is null when the document has no frontmatter at all.
+  const data = extractFrontmatter(markdown).data ?? {};
+
+  const scenes = parsed.beats.map((beat, index) => beatToSceneFile(beat, index + 1));
+
+  const frontBlock =
+    Object.keys(data).length > 0
+      ? `---\n${stringifyYaml(data, { lineWidth: 0 }).trimEnd()}\n---\n\n`
+      : "";
+  const prose = parsed.global.trim();
+  const note =
+    "Scenes live in `scenes/`, one file per scene, and play in filename order.";
+  const storyboardBody = [prose, note].filter(Boolean).join("\n\n");
+
+  return {
+    scenes,
+    storyboard: {
+      path: STORYBOARD_FILENAME,
+      contents: `${frontBlock}${storyboardBody}\n`,
+    },
+    beatIds: parsed.beats.map((beat) => beat.id),
+  };
 }

--- a/packages/cli/src/commands/storyboard.ts
+++ b/packages/cli/src/commands/storyboard.ts
@@ -1,8 +1,8 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 
 import { parseStoryboard } from "./_shared/storyboard-parse.js";
 import {
@@ -12,7 +12,7 @@ import {
   STORYBOARD_CUE_KEYS,
   validateStoryboardMarkdown,
 } from "./_shared/storyboard-edit.js";
-import { loadStoryboard } from "./_shared/storyboard-source.js";
+import { loadStoryboard, planMigration } from "./_shared/storyboard-source.js";
 import {
   executeStoryboardRevision,
   type StoryboardRevisionResult,
@@ -209,6 +209,73 @@ storyboardCommand
   });
 
 storyboardCommand
+  .command("migrate")
+  .description("Convert a single STORYBOARD.md into a scenes/ bundle (one file per scene)")
+  .argument("[project-dir]", "Project directory", ".")
+  .option("--dry-run", "Show the files that would be written without touching disk")
+  .action(async (projectDirArg: string, options: { dryRun?: boolean }) => {
+    const startedAt = Date.now();
+    const projectDir = resolve(projectDirArg);
+    const loaded = await loadStoryboard(projectDir);
+
+    if (loaded.layout === "missing") {
+      exitWithError(
+        generalError(
+          `No storyboard found in ${projectDir}`,
+          `Run 'vibe init ${projectDir} --from "<brief>"' first.`
+        )
+      );
+    }
+    if (loaded.layout === "bundle") {
+      exitWithError(
+        generalError(
+          `${projectDir} is already a scenes/ bundle.`,
+          `It has ${loaded.scenes.length} scene file(s); nothing to migrate.`
+        )
+      );
+    }
+
+    const plan = planMigration(loaded.markdown);
+    if (plan.scenes.length === 0) {
+      exitWithError(
+        generalError(
+          "STORYBOARD.md has no beats to migrate.",
+          "Add at least one `## Beat <id> - <Title>` section first."
+        )
+      );
+    }
+
+    if (!options.dryRun) {
+      await mkdir(join(projectDir, "scenes"), { recursive: true });
+      for (const file of plan.scenes) {
+        await writeFile(join(projectDir, file.path), file.contents, "utf-8");
+      }
+      // STORYBOARD.md is rewritten last: if a scene write fails, the original
+      // single-file storyboard is still the source of truth on disk.
+      await writeFile(join(projectDir, plan.storyboard.path), plan.storyboard.contents, "utf-8");
+    }
+
+    if (isJsonMode()) {
+      outputSuccess({
+        command: "storyboard migrate",
+        startedAt,
+        data: {
+          projectDir,
+          dryRun: !!options.dryRun,
+          beats: plan.beatIds,
+          written: [plan.storyboard.path, ...plan.scenes.map((f) => f.path)],
+        },
+      });
+      return;
+    }
+    const verb = options.dryRun ? "Would write" : "Wrote";
+    console.log(`${verb} ${plan.scenes.length} scene file(s):`);
+    for (const file of plan.scenes) console.log(`  ${file.path}`);
+    console.log(`${verb} ${plan.storyboard.path} (project frontmatter + direction only)`);
+    if (options.dryRun) console.log("\nRe-run without --dry-run to apply.");
+  });
+
+storyboardCommand
   .command("validate")
   .description("Validate cue blocks and beat ids")
   .argument("[project-dir]", "Project directory", ".")
@@ -319,4 +386,5 @@ applyTiers(storyboardCommand, {
   move: "free",
   revise: "low",
   validate: "free",
+  migrate: "free",
 });


### PR DESCRIPTION
#307 taught the CLI to *read* a `scenes/` bundle but gave nobody a way to produce one. This is the other half of the dual-read decision.

## What it does

```
$ vibe storyboard migrate my-video --dry-run
Would write 3 scene file(s):
  scenes/01-hook.md
  scenes/02-proof.md
  scenes/03-close.md
Would write STORYBOARD.md (project frontmatter + direction only)

Re-run without --dry-run to apply.
```

Each `## Beat <id> - <Title>` becomes `scenes/NN-<id>.md`, with the cue block turned into real document frontmatter:

```markdown
---
type: Scene
duration: 4
narration: Mig starts with one clear promise.
motion: large readable headline, restrained camera push
---

Make the value obvious in one beat.
```

STORYBOARD.md keeps its project frontmatter and direction prose, and loses the beats.

## Design notes

**`planMigration()` is pure.** It returns the files instead of writing them, which is what makes `--dry-run` honest — the dry run computes exactly what the real run would write. Verified on a real project that it leaves no `scenes/` directory behind.

**Write order matters.** Scene files are written before STORYBOARD.md is rewritten, so a failure mid-way leaves the original single-file storyboard intact rather than a half-emptied document.

**`### Beat duration` is carried.** That subsection has no equivalent in the new layout, so its resolved value is written into the scene frontmatter rather than silently dropped.

## Guards

| Situation | Result |
|---|---|
| already a bundle | `"... is already a scenes/ bundle."` + scene count |
| no storyboard | `"No storyboard found in ..."` |
| storyboard with zero beats | refused, rather than creating an empty `scenes/` |

## Losslessness is tested twice

A unit test round-trips a fixture through plan → write → load → parse and compares beats, cues, durations, and the character pool.

And I ran a real project — enriched with `characters`, `keyframe`, `video`, and all three lower-third cues — through the actual command, diffing `storyboard list --json` before and after:

```
beats before: ['hook', 'proof', 'close']
beats after:  ['hook', 'proof', 'close']
LOSSLESS
```

The migrated bundle also plans identically to the equivalent single-file project: same beats, same `$0.94`, same `validation.ok`.

## Verification

- 1253 CLI tests (**5 new**) and 73 mcp-server tests pass
- lint clean, reference regenerated, `sync-counts --check` in sync
- catalog 93 → 94; the new command registers as `free`