### PR TITLE
feat: let `storyboard set` and `move` write to a scenes/ bundle

### DIFF
--- a/packages/cli/src/commands/_shared/storyboard-edit.ts
+++ b/packages/cli/src/commands/_shared/storyboard-edit.ts
@@ -343,7 +343,11 @@ function isStarterStoryboard(markdown: string): boolean {
   );
 }
 
-function normalizeCueValue(key: string, value: unknown): unknown {
+/**
+ * Coerce and validate one cue value. Shared with the bundle writer so both
+ * storage layouts reject the same bad input.
+ */
+export function normalizeCueValue(key: string, value: unknown): unknown {
   if (key === "duration") {
     const n = typeof value === "number" ? value : Number.parseFloat(String(value ?? ""));
     if (!Number.isFinite(n) || n <= 0) {

--- a/packages/cli/src/commands/_shared/storyboard-source.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -7,7 +7,9 @@ import {
   detectStoryboardLayout,
   listSceneFiles,
   loadStoryboard,
+  moveScene,
   planMigration,
+  setSceneCue,
   sceneFilename,
   sceneToBeatSection,
 } from "./storyboard-source.js";
@@ -276,5 +278,80 @@ describe("planMigration", () => {
     if (parsedDuration !== undefined) {
       expect(scene.contents).toContain(`duration: ${parsedDuration}`);
     }
+  });
+});
+
+describe("bundle writes", () => {
+  async function bundle() {
+    await writeBundle([
+      ["01-hook.md", '---\ntype: Scene\nduration: 5\nnarration: "One"\n---\n\nHook body.'],
+      ["02-proof.md", '---\ntype: Scene\nduration: 4\n---\n\nProof body.'],
+      ["03-close.md", '---\ntype: Scene\nduration: 3\n---\n\nClose body.'],
+    ]);
+  }
+
+  it("sets a cue in one scene file and leaves the body alone", async () => {
+    await bundle();
+    const { cues } = await setSceneCue(dir, { beatId: "hook", key: "duration", value: 9 });
+    expect(cues.duration).toBe(9);
+    const raw = await readFile(join(dir, "scenes", "01-hook.md"), "utf-8");
+    expect(raw).toContain("duration: 9");
+    expect(raw).toContain("Hook body.");
+    expect(raw).toMatch(/^---\ntype: Scene\n/);
+  });
+
+  it("unsets a cue", async () => {
+    await bundle();
+    const { cues } = await setSceneCue(dir, { beatId: "hook", key: "narration", unset: true });
+    expect(cues.narration).toBeUndefined();
+    expect(cues.duration).toBe(5);
+  });
+
+  it("rejects an unsupported cue key", async () => {
+    await bundle();
+    await expect(setSceneCue(dir, { beatId: "hook", key: "bogus", value: "x" })).rejects.toThrow(
+      /Unsupported cue/
+    );
+  });
+
+  it("rejects a non-positive duration, like the single-document writer", async () => {
+    await bundle();
+    await expect(
+      setSceneCue(dir, { beatId: "hook", key: "duration", value: "abc" })
+    ).rejects.toThrow(/positive number/);
+  });
+
+  it("names the known scenes when the id is wrong", async () => {
+    await bundle();
+    await expect(setSceneCue(dir, { beatId: "nope", key: "duration", value: 1 })).rejects.toThrow(
+      /hook, proof, close/
+    );
+  });
+
+  it("renumbers filenames on move without leaving temp files", async () => {
+    await bundle();
+    const order = await moveScene(dir, { beatId: "hook", afterBeatId: "close" });
+    expect(order).toEqual(["proof", "close", "hook"]);
+    const names = (await listSceneFiles(dir)).map((s) => s.filename);
+    expect(names).toEqual(["01-proof.md", "02-close.md", "03-hook.md"]);
+    const { readdir } = await import("node:fs/promises");
+    const all = await readdir(join(dir, "scenes"));
+    expect(all.filter((n) => n.startsWith(".vibe-move"))).toEqual([]);
+  });
+
+  it("survives a permutation that a naive rename order would clobber", async () => {
+    await bundle();
+    // close -> front. Every file needs a new number and 01 is occupied.
+    await moveScene(dir, { beatId: "close", afterBeatId: "hook" });
+    const scenes = await listSceneFiles(dir);
+    expect(scenes.map((s) => s.id)).toEqual(["hook", "close", "proof"]);
+    // No scene was lost or overwritten.
+    expect(scenes).toHaveLength(3);
+  });
+
+  it("moving a scene onto itself is a no-op", async () => {
+    await bundle();
+    const order = await moveScene(dir, { beatId: "hook", afterBeatId: "hook" });
+    expect(order).toEqual(["hook", "proof", "close"]);
   });
 });

--- a/packages/cli/src/commands/_shared/storyboard-source.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.ts
@@ -34,12 +34,20 @@
  */
 
 import { existsSync } from "node:fs";
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { stringify as stringifyYaml } from "yaml";
 
 import { extractFrontmatter } from "./frontmatter.js";
-import { deriveBeatId, parseStoryboard, type Beat } from "./storyboard-parse.js";
+import {
+  deriveBeatId,
+  parseStoryboard,
+  STORYBOARD_CUE_KEYS,
+  type Beat,
+  type BeatCues,
+  type StoryboardCueKey,
+} from "./storyboard-parse.js";
+import { normalizeCueValue } from "./storyboard-edit.js";
 
 /** Directory, relative to the project root, that holds one file per scene. */
 export const SCENES_DIRNAME = "scenes";
@@ -257,4 +265,94 @@ export function planMigration(markdown: string): MigrationPlan {
     },
     beatIds: parsed.beats.map((beat) => beat.id),
   };
+}
+
+// ── Writing into a scenes/ bundle ────────────────────────────────────────
+
+/** Locate one scene file by beat id. */
+async function requireScene(projectDir: string, beatId: string): Promise<SceneFile> {
+  const scenes = await listSceneFiles(projectDir);
+  const scene = scenes.find((s) => s.id === beatId);
+  if (!scene) {
+    const known = scenes.map((s) => s.id).join(", ") || "(none)";
+    throw new Error(`Scene "${beatId}" not found. Scenes in this project: ${known}.`);
+  }
+  return scene;
+}
+
+/**
+ * Set or unset one cue in a scene file, rewriting only that file's
+ * frontmatter and leaving its body untouched.
+ *
+ * Key validation and value coercion come from the same helpers the
+ * single-document writer uses, so `duration: "abc"` is rejected identically
+ * in both layouts.
+ */
+export async function setSceneCue(
+  projectDir: string,
+  opts: { beatId: string; key: string; value?: unknown; unset?: boolean }
+): Promise<{ path: string; cues: BeatCues }> {
+  if (!STORYBOARD_CUE_KEYS.includes(opts.key as StoryboardCueKey)) {
+    throw new Error(
+      `Unsupported cue "${opts.key}". Supported cues: ${STORYBOARD_CUE_KEYS.join(", ")}.`
+    );
+  }
+  const scene = await requireScene(projectDir, opts.beatId);
+  const raw = await readFile(scene.path, "utf-8");
+  const { data, body } = extractFrontmatter(raw);
+  const front: Record<string, unknown> = { ...(data ?? {}) };
+
+  if (opts.unset) {
+    delete front[opts.key];
+  } else {
+    front[opts.key] = normalizeCueValue(opts.key, opts.value);
+  }
+  // `type` stays first so the file keeps reading as an OKF Scene document.
+  const ordered: Record<string, unknown> = {};
+  if (front.type !== undefined) ordered.type = front.type;
+  for (const [k, v] of Object.entries(front)) if (k !== "type") ordered[k] = v;
+
+  const next = `---\n${stringifyYaml(ordered, { lineWidth: 0 }).trimEnd()}\n---\n\n${body.trim()}\n`;
+  await writeFile(scene.path, next, "utf-8");
+
+  const cues = { ...ordered };
+  delete cues.type;
+  // The file may still hold keys outside the vocabulary from a hand edit.
+  // Surfacing those is `vibe storyboard validate`'s job, not this writer's.
+  return { path: scene.path, cues: cues as BeatCues };
+}
+
+/**
+ * Reorder scenes by renumbering their filename prefixes.
+ *
+ * Renames go through a temporary name first. Renaming `02 -> 01` while an
+ * `01` still exists would clobber it, and no ordering of direct renames is
+ * safe for an arbitrary permutation.
+ */
+export async function moveScene(
+  projectDir: string,
+  opts: { beatId: string; afterBeatId: string }
+): Promise<string[]> {
+  const scenes = await listSceneFiles(projectDir);
+  const from = scenes.findIndex((s) => s.id === opts.beatId);
+  if (from === -1) throw new Error(`Scene "${opts.beatId}" not found.`);
+  const after = scenes.findIndex((s) => s.id === opts.afterBeatId);
+  if (after === -1) throw new Error(`Scene "${opts.afterBeatId}" not found.`);
+  if (opts.beatId === opts.afterBeatId) return scenes.map((s) => s.id);
+
+  const ordered = [...scenes];
+  const [moving] = ordered.splice(from, 1);
+  ordered.splice(from < after ? after : after + 1, 0, moving);
+
+  const dir = join(projectDir, SCENES_DIRNAME);
+  const staged = ordered.map((scene, index) => ({
+    scene,
+    temp: join(dir, `.vibe-move-${index}-${scene.filename}`),
+    final: join(dir, sceneFilename(index + 1, scene.id)),
+  }));
+
+  for (const { scene, temp } of staged) await rename(scene.path, temp);
+  for (const { temp, final } of staged) await rename(temp, final);
+
+  return ordered.map((s) => s.id);
 }

--- a/packages/cli/src/commands/storyboard.ts
+++ b/packages/cli/src/commands/storyboard.ts
@@ -12,7 +12,13 @@ import {
   STORYBOARD_CUE_KEYS,
   validateStoryboardMarkdown,
 } from "./_shared/storyboard-edit.js";
-import { loadStoryboard, planMigration } from "./_shared/storyboard-source.js";
+import type { BeatCues } from "./_shared/storyboard-parse.js";
+import {
+  loadStoryboard,
+  moveScene,
+  planMigration,
+  setSceneCue,
+} from "./_shared/storyboard-source.js";
 import {
   executeStoryboardRevision,
   type StoryboardRevisionResult,
@@ -113,15 +119,20 @@ storyboardCommand
         exitWithError(usageError(`Invalid JSON cue value: ${error instanceof Error ? error.message : String(error)}`));
       }
     }
-    await refuseWriteOnBundle(projectDir, "set");
-    let next: string;
+    // A bundle edits one scene file; a single document rewrites itself.
+    // Both go through the same key validation and value coercion.
+    let cues: BeatCues;
     try {
-      next = setStoryboardCue(md, { beatId, key, value, unset: options.unset });
+      if ((await loadStoryboard(projectDir)).layout === "bundle") {
+        cues = (await setSceneCue(projectDir, { beatId, key, value, unset: options.unset })).cues;
+      } else {
+        const next = setStoryboardCue(md, { beatId, key, value, unset: options.unset });
+        await writeFile(storyboardPath(projectDir), next, "utf-8");
+        cues = getStoryboardBeat(next, beatId)?.cues ?? {};
+      }
     } catch (error) {
       exitWithError(usageError(error instanceof Error ? error.message : String(error)));
     }
-    await writeFile(storyboardPath(projectDir), next, "utf-8");
-    const beat = getStoryboardBeat(next, beatId);
     outputSuccess({
       command: "storyboard set",
       startedAt,
@@ -130,7 +141,7 @@ storyboardCommand
         beatId,
         key,
         unset: options.unset ?? false,
-        cues: beat?.cues ?? {},
+        cues,
       },
     });
   });
@@ -145,15 +156,20 @@ storyboardCommand
     const startedAt = Date.now();
     const projectDir = resolve(projectDirArg);
     const md = await readStoryboard(projectDir);
-    await refuseWriteOnBundle(projectDir, "move");
-    let next: string;
+    // A bundle reorders by renumbering filename prefixes; a single document
+    // moves the section. Either way the reported `order` is the new one.
+    let order: string[];
     try {
-      next = moveStoryboardBeat(md, { beatId, afterBeatId: options.after });
+      if ((await loadStoryboard(projectDir)).layout === "bundle") {
+        order = await moveScene(projectDir, { beatId, afterBeatId: options.after });
+      } else {
+        const next = moveStoryboardBeat(md, { beatId, afterBeatId: options.after });
+        await writeFile(storyboardPath(projectDir), next, "utf-8");
+        order = parseStoryboard(next).beats.map((beat) => beat.id);
+      }
     } catch (error) {
       exitWithError(usageError(error instanceof Error ? error.message : String(error)));
     }
-    await writeFile(storyboardPath(projectDir), next, "utf-8");
-    const parsed = parseStoryboard(next);
     outputSuccess({
       command: "storyboard move",
       startedAt,
@@ -161,7 +177,7 @@ storyboardCommand
         projectDir,
         beatId,
         after: options.after,
-        order: parsed.beats.map((beat) => beat.id),
+        order,
       },
     });
   });
@@ -328,22 +344,6 @@ async function readStoryboard(projectDir: string): Promise<string> {
   return loaded.markdown;
 }
 
-/**
- * Read-modify-write commands rewrite the whole document. In the bundle
- * layout that document is assembled from `scenes/*.md`, so writing it back
- * to STORYBOARD.md would silently collapse the split. Refuse instead of
- * destroying the project, and name the per-file edit as the way forward.
- */
-async function refuseWriteOnBundle(projectDir: string, command: string): Promise<void> {
-  const { layout, scenes } = await loadStoryboard(projectDir);
-  if (layout !== "bundle") return;
-  exitWithError(
-    generalError(
-      `\`vibe storyboard ${command}\` cannot write to a scenes/ bundle yet.`,
-      `Edit the scene file directly - this project has ${scenes.length} under ${projectDir}/scenes/.`
-    )
-  );
-}
 
 function storyboardPath(projectDir: string): string {
   return resolve(projectDir, "STORYBOARD.md");


### PR DESCRIPTION
#307 refused these two on a bundle because both rewrite the whole document, and writing an *assembled* document back to STORYBOARD.md would have collapsed the split. Each now has a bundle implementation, and the refusal is gone.

## `set` edits one scene file

Rewrites only that file's frontmatter, leaves the body alone, and re-emits `type: Scene` first so the file keeps reading as an OKF document.

```
$ vibe storyboard set my-video hook duration 9
```
```markdown
---
type: Scene
duration: 9
narration: W starts with one clear promise.
...
---

Make the value obvious in one beat.
```

Key validation and value coercion come from the same `normalizeCueValue` the single-document writer uses — now exported rather than duplicated — so both layouts reject `duration: "abc"` identically and give the same message for an unsupported key.

## `move` renumbers filenames

```
before: 01-hook.md 02-proof.md 03-close.md
$ vibe storyboard move my-video hook --after close
after:  01-proof.md 02-close.md 03-hook.md
```

**Renames go through a temporary name first.** Renaming `02 → 01` while an `01` still exists would clobber it, and for an arbitrary permutation there is no ordering of direct renames that is safe. Two passes.

Three things are asserted: the resulting order, that no scene is lost in a permutation a naive rename would clobber, and that no `.vibe-move-*` temp file survives.

## Both layouts

Each command branches on the layout the loader reports, so a legacy single-file project takes exactly the path it always did.

## Verification

Against real projects, not just fixtures.

**Bundle:**
- `set hook duration 9` → rewrites only `scenes/01-hook.md`, `type: Scene` still first
- `move hook --after close` → `01-proof 02-close 03-hook`, zero stray temp files
- `storyboard list` agrees with the new order
- moving it back preserves the earlier `set` (hook still 9s)

**Legacy:** `move hook --after close` still reorders in place.

- 1261 CLI tests (**8 new**) and 73 mcp-server tests pass
- lint clean, dogfood smoke passes, reference and counts in sync

## Remaining

`vibe init` still scaffolds the single-file layout, so the README and docs stay as they are until that lands next.