### PR TITLE
fix: stop silently merging leftover STORYBOARD.md beats into a scenes/ bundle

### DIFF
--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -37,7 +37,7 @@ import {
   type ParsedStoryboard,
   type BeatCues,
 } from "./storyboard-parse.js";
-import { loadStoryboardMarkdown } from "./storyboard-source.js";
+import { loadStoryboard, strayBeatIssues } from "./storyboard-source.js";
 import { readProjectConfig, type LoadedProjectConfig } from "./project-config.js";
 import { kindAssetPolicy } from "./scene-project.js";
 import { validateStoryboardMarkdown, type StoryboardValidationIssue } from "./storyboard-edit.js";
@@ -249,9 +249,16 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
     });
   }
 
-  const storyboardMd = await loadStoryboardMarkdown(projectDir);
+  const loaded = await loadStoryboard(projectDir);
+  const storyboardMd = loaded.markdown;
   const validation = validateStoryboardMarkdown(storyboardMd);
-  const validationIssues: StoryboardValidationIssue[] = [...validation.issues];
+  // Stray `## Beat` headings in a bundle's STORYBOARD.md are stripped before
+  // parsing, so the plan has to be told about them separately or it would
+  // price a video the project does not actually describe.
+  const validationIssues: StoryboardValidationIssue[] = [
+    ...strayBeatIssues(loaded.strayBeatIds),
+    ...validation.issues,
+  ];
   const parsed = parseStoryboard(storyboardMd);
   let sourceBeats = parsed.beats;
   if (opts.beat) {

--- a/packages/cli/src/commands/_shared/storyboard-source.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.test.ts
@@ -12,6 +12,7 @@ import {
   setSceneCue,
   sceneFilename,
   sceneToBeatSection,
+  strayBeatIssues,
 } from "./storyboard-source.js";
 import { parseStoryboard } from "./storyboard-parse.js";
 
@@ -353,5 +354,79 @@ describe("bundle writes", () => {
     await bundle();
     const order = await moveScene(dir, { beatId: "hook", afterBeatId: "hook" });
     expect(order).toEqual(["hook", "proof", "close"]);
+  });
+});
+
+describe("stray beats in a bundle's STORYBOARD.md", () => {
+  const HEAD_WITH_BEAT = [
+    "---",
+    "type: Storyboard",
+    'title: "Launch"',
+    "---",
+    "",
+    "# Launch - Storyboard",
+    "",
+    "Direction prose.",
+    "",
+    "## Beat leftover - Leftover",
+    "",
+    "```yaml",
+    "duration: 9",
+    "```",
+    "",
+    "A beat that was never moved into scenes/.",
+    "",
+  ].join("\n");
+
+  it("does not merge them into the timeline", async () => {
+    await writeFile(join(dir, "STORYBOARD.md"), HEAD_WITH_BEAT, "utf-8");
+    await mkdir(join(dir, "scenes"), { recursive: true });
+    await writeFile(join(dir, "scenes", "01-hook.md"), "---\nduration: 5\n---\n\nHook.", "utf-8");
+
+    const loaded = await loadStoryboard(dir);
+    const ids = parseStoryboard(loaded.markdown).beats.map((b) => b.id);
+    expect(ids).toEqual(["hook"]);
+    expect(ids).not.toContain("leftover");
+  });
+
+  it("reports them so they cannot pass unnoticed", async () => {
+    await writeFile(join(dir, "STORYBOARD.md"), HEAD_WITH_BEAT, "utf-8");
+    await mkdir(join(dir, "scenes"), { recursive: true });
+    await writeFile(join(dir, "scenes", "01-hook.md"), "---\nduration: 5\n---\n\nHook.", "utf-8");
+
+    const loaded = await loadStoryboard(dir);
+    expect(loaded.strayBeatIds).toEqual(["leftover"]);
+    const issues = strayBeatIssues(loaded.strayBeatIds);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe("error");
+    expect(issues[0].code).toBe("STRAY_BEATS_IN_STORYBOARD");
+    expect(issues[0].message).toContain("scenes/");
+  });
+
+  it("keeps the frontmatter and prose that precede the stray heading", async () => {
+    await writeFile(join(dir, "STORYBOARD.md"), HEAD_WITH_BEAT, "utf-8");
+    await mkdir(join(dir, "scenes"), { recursive: true });
+    await writeFile(join(dir, "scenes", "01-hook.md"), "---\nduration: 5\n---\n\nHook.", "utf-8");
+
+    const parsed = parseStoryboard((await loadStoryboard(dir)).markdown);
+    expect(parsed.frontmatter?.title).toBe("Launch");
+    expect(parsed.global).toContain("Direction prose.");
+    expect(parsed.global).not.toContain("never moved into scenes/");
+  });
+
+  it("stays empty for a clean bundle and for the single layout", async () => {
+    await writeBundle([["01-hook.md", "---\nduration: 5\n---\n\nHook."]]);
+    expect((await loadStoryboard(dir)).strayBeatIds).toEqual([]);
+
+    await rm(join(dir, "scenes"), { recursive: true, force: true });
+    await writeFile(
+      join(dir, "STORYBOARD.md"),
+      "## Beat hook - Hook\n\n```yaml\nduration: 5\n```\n\nBody.\n",
+      "utf-8"
+    );
+    const single = await loadStoryboard(dir);
+    expect(single.layout).toBe("single");
+    expect(single.strayBeatIds).toEqual([]);
+    expect(parseStoryboard(single.markdown).beats.map((b) => b.id)).toEqual(["hook"]);
   });
 });

--- a/packages/cli/src/commands/_shared/storyboard-source.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.ts
@@ -34,7 +34,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { readdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { stringify as stringifyYaml } from "yaml";
 
@@ -76,6 +76,13 @@ export interface LoadedStoryboard {
   scenes: SceneFile[];
   /** Absolute path of the project-level document. */
   storyboardPath: string;
+  /**
+   * Beat ids found as `## Beat ...` headings inside STORYBOARD.md while the
+   * project is a bundle. Those headings are ignored - `scenes/` is the only
+   * source of scenes - and reported so validation can say so out loud.
+   * Always empty for the single layout.
+   */
+  strayBeatIds: string[];
 }
 
 /** `01-hook.md` -> { order: 1, id: "hook" }; `hook.md` -> { order: null, id: "hook" }. */
@@ -150,13 +157,22 @@ export function sceneToBeatSection(scene: SceneFile, contents: string): string {
   return `## Beat ${scene.id} - ${humanise(scene.id)}\n\n${cueBlock}${prose}\n`;
 }
 
+/** Everything from the first `## ` heading onward. */
+const FIRST_HEADING_RE = /^## .*/m;
+
 /**
  * Load a project's storyboard as a single markdown document, whichever
  * layout it uses on disk.
  *
- * For a bundle this concatenates `STORYBOARD.md` (frontmatter + direction
- * prose, with any stray beat headings left alone) and one synthesized
- * section per scene file.
+ * For a bundle, STORYBOARD.md contributes only its frontmatter and direction
+ * prose. Anything from its first `## ` heading onward is dropped and its beat
+ * ids returned in `strayBeatIds`.
+ *
+ * Concatenating instead would merge two sets of scenes into one timeline: a
+ * project that has both would silently render the STORYBOARD.md beats *and*
+ * the scene files, in that order. `scenes/` is the layout the project opted
+ * into, so it is the only source of scenes, and the leftovers are surfaced as
+ * a validation error rather than quietly obeyed or quietly discarded.
  */
 export async function loadStoryboard(projectDir: string): Promise<LoadedStoryboard> {
   const storyboardPath = join(projectDir, STORYBOARD_FILENAME);
@@ -164,24 +180,30 @@ export async function loadStoryboard(projectDir: string): Promise<LoadedStoryboa
   const layout = detectStoryboardLayout(projectDir, scenes.length);
 
   if (layout === "missing") {
-    return { layout, markdown: "", scenes: [], storyboardPath };
+    return { layout, markdown: "", scenes: [], storyboardPath, strayBeatIds: [] };
   }
 
   const head = existsSync(storyboardPath) ? await readFile(storyboardPath, "utf-8") : "";
 
   if (layout === "single") {
-    return { layout, markdown: head, scenes: [], storyboardPath };
+    return { layout, markdown: head, scenes: [], storyboardPath, strayBeatIds: [] };
   }
+
+  const headingAt = head.search(FIRST_HEADING_RE);
+  const strayBeatIds =
+    headingAt === -1 ? [] : parseStoryboard(head.slice(headingAt)).beats.map((b) => b.id);
+  const preamble = headingAt === -1 ? head : head.slice(0, headingAt);
 
   const sections = await Promise.all(
     scenes.map(async (scene) => sceneToBeatSection(scene, await readFile(scene.path, "utf-8")))
   );
-  const prefix = head.trimEnd();
+  const prefix = preamble.trimEnd();
   return {
     layout,
     markdown: `${prefix}${prefix ? "\n\n" : ""}${sections.join("\n")}`,
     scenes,
     storyboardPath,
+    strayBeatIds,
   };
 }
 
@@ -355,4 +377,62 @@ export async function moveScene(
   for (const { temp, final } of staged) await rename(temp, final);
 
   return ordered.map((s) => s.id);
+}
+
+/**
+ * Write a migration plan to disk.
+ *
+ * Scene files land before STORYBOARD.md is rewritten, so a failure part way
+ * through leaves the original single-file storyboard as the source of truth
+ * rather than a half-emptied document. Shared by `storyboard migrate` and by
+ * `vibe init`, which scaffolds straight into the bundle layout.
+ */
+export async function writeMigration(projectDir: string, plan: MigrationPlan): Promise<void> {
+  await mkdir(join(projectDir, SCENES_DIRNAME), { recursive: true });
+  for (const file of plan.scenes) {
+    await writeFile(join(projectDir, file.path), file.contents, "utf-8");
+  }
+  await writeFile(join(projectDir, plan.storyboard.path), plan.storyboard.contents, "utf-8");
+}
+
+/**
+ * Scaffold a bundle from a single-document storyboard string.
+ *
+ * `vibe init` builds its starter (and its `--from` draft) as one markdown
+ * document, then hands it here rather than writing it out. That keeps one
+ * generator for the content and one converter for the layout, instead of a
+ * second scaffolder that could drift from the first.
+ */
+export async function writeStoryboardAsBundle(
+  projectDir: string,
+  markdown: string
+): Promise<MigrationPlan> {
+  const plan = planMigration(markdown);
+  await writeMigration(projectDir, plan);
+  return plan;
+}
+
+/**
+ * Validation issues for beat headings left in STORYBOARD.md after a project
+ * became a bundle.
+ *
+ * An error, not a warning: the headings look like scenes and are not being
+ * rendered, so the project on disk does not describe the video that comes
+ * out. Anything less than an error lets that gap sit unnoticed.
+ */
+export function strayBeatIssues(strayBeatIds: string[]): Array<{
+  severity: "error";
+  code: "STRAY_BEATS_IN_STORYBOARD";
+  message: string;
+  beatId: string;
+}> {
+  return strayBeatIds.map((beatId) => ({
+    severity: "error" as const,
+    code: "STRAY_BEATS_IN_STORYBOARD" as const,
+    beatId,
+    message:
+      `STORYBOARD.md still contains a "## Beat ${beatId}" section, but this project ` +
+      `uses scenes/. That heading is ignored. Move it to scenes/ as its own file, ` +
+      `or delete it from STORYBOARD.md.`,
+  }));
 }

--- a/packages/cli/src/commands/storyboard.ts
+++ b/packages/cli/src/commands/storyboard.ts
@@ -1,8 +1,8 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 
 import { parseStoryboard } from "./_shared/storyboard-parse.js";
 import {
@@ -18,6 +18,8 @@ import {
   moveScene,
   planMigration,
   setSceneCue,
+  strayBeatIssues,
+  writeMigration,
 } from "./_shared/storyboard-source.js";
 import {
   executeStoryboardRevision,
@@ -262,13 +264,7 @@ storyboardCommand
     }
 
     if (!options.dryRun) {
-      await mkdir(join(projectDir, "scenes"), { recursive: true });
-      for (const file of plan.scenes) {
-        await writeFile(join(projectDir, file.path), file.contents, "utf-8");
-      }
-      // STORYBOARD.md is rewritten last: if a scene write fails, the original
-      // single-file storyboard is still the source of truth on disk.
-      await writeFile(join(projectDir, plan.storyboard.path), plan.storyboard.contents, "utf-8");
+      await writeMigration(projectDir, plan);
     }
 
     if (isJsonMode()) {
@@ -298,8 +294,15 @@ storyboardCommand
   .action(async (projectDirArg: string) => {
     const startedAt = Date.now();
     const projectDir = resolve(projectDirArg);
-    const md = await readStoryboard(projectDir);
-    const result = validateStoryboardMarkdown(md);
+    const loaded = await loadStoryboard(projectDir);
+    const result = validateStoryboardMarkdown(loaded.markdown);
+    // Beat headings left behind in STORYBOARD.md are invisible to the parser
+    // once a project is a bundle, so they have to be reported from here.
+    const stray = strayBeatIssues(loaded.strayBeatIds);
+    if (stray.length > 0) {
+      result.issues = [...stray, ...result.issues];
+      result.ok = false;
+    }
     if (isJsonMode()) {
       outputSuccess({
         command: "storyboard validate",


### PR DESCRIPTION
The bundle loader concatenated **all** of STORYBOARD.md with the assembled scene files. Nothing said STORYBOARD.md must not contain beats, so a project with both got both — spliced into one timeline.

```
$ vibe storyboard list my-video     # bundle with 3 scenes, plus one leftover heading
["mine", "hook", "proof", "close"]  # <- four
```

That is the worst of the three possible behaviours. Someone who migrates and then edits STORYBOARD.md out of habit gets extra scenes in the render with no indication anything is wrong, and `vibe storyboard set` on one of those beats fails because it has no scene file.

## The rule

For a bundle, STORYBOARD.md contributes only what precedes its first `## ` heading — frontmatter and direction prose. Everything from that heading on is dropped, and the beat ids come back as `strayBeatIds`.

`scenes/` wins rather than STORYBOARD.md because it is the layout the project explicitly opted into by existing.

## Dropping silently would be no better

Both `vibe storyboard validate` and the build plan now report one `STRAY_BEATS_IN_STORYBOARD` **error** per stray beat:

> STORYBOARD.md still contains a `## Beat mine` section, but this project uses scenes/. That heading is ignored. Move it to scenes/ as its own file, or delete it from STORYBOARD.md.

**Error, not warning.** The project on disk describes scenes that are not being rendered — the file and the output disagree. That is not a style issue.

The build plan needs it injected separately, because by the time it validates, the stray headings have already been stripped from the markdown it sees.

## Single-file projects are untouched

`strayBeatIds` is always empty there and the whole document parses exactly as before.

## Verification

| | result |
|---|---|
| migrated bundle + `## Beat leftover` appended | lists only its 3 real scenes |
| ... `storyboard validate` | `ok: false`, `STRAY_BEATS_IN_STORYBOARD` |
| ... `plan` | `ok: false`, same code |
| clean bundle | `ok: true` |
| clean legacy project | `ok: true` |

- 1265 CLI tests (**4 new**) and 73 mcp-server tests pass
- lint clean, dogfood smoke passes, reference and counts in sync

## Scope

This is step 1 of the four remaining for the `\`\`\`yaml`-free format. `vibe init` still scaffolds single-file; that switch waits on `scene add` bundle support, which is what surfaced this bug in the first place.