### PR TITLE
feat: let `vibe scene add` write into a scenes/ bundle

### DIFF
--- a/packages/cli/src/commands/_shared/storyboard-edit.ts
+++ b/packages/cli/src/commands/_shared/storyboard-edit.ts
@@ -331,7 +331,12 @@ function humanizeBeatId(id: string): string {
     .join(" ") || "Scene";
 }
 
-function isStarterStoryboard(markdown: string): boolean {
+/**
+ * True for the untouched three-beat scaffold. Exported so the bundle writer
+ * makes the same "this is still the starter, replace it" call as the
+ * single-document writer, off the same assembled markdown.
+ */
+export function isStarterStoryboard(markdown: string): boolean {
   const parsed = parseStoryboard(markdown);
   if (parsed.beats.length !== 3) return false;
   const ids = parsed.beats.map((beat) => beat.id);

--- a/packages/cli/src/commands/_shared/storyboard-source.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.test.ts
@@ -13,6 +13,7 @@ import {
   sceneFilename,
   sceneToBeatSection,
   strayBeatIssues,
+  upsertScene,
 } from "./storyboard-source.js";
 import { parseStoryboard } from "./storyboard-parse.js";
 
@@ -428,5 +429,66 @@ describe("stray beats in a bundle's STORYBOARD.md", () => {
     expect(single.layout).toBe("single");
     expect(single.strayBeatIds).toEqual([]);
     expect(parseStoryboard(single.markdown).beats.map((b) => b.id)).toEqual(["hook"]);
+  });
+});
+
+describe("upsertScene", () => {
+  const STARTER = (id: string, prose: string) =>
+    `---\ntype: Scene\nduration: 4\n---\n\n${prose}`;
+
+  async function starterBundle() {
+    // Same three ids and prose markers `isStarterStoryboard` looks for.
+    await writeBundle([
+      ["01-hook.md", STARTER("hook", "Introduce the promise in one crisp sentence.")],
+      [
+        "02-proof.md",
+        STARTER("proof", "Show the mechanism or proof point that makes the promise believable."),
+      ],
+      ["03-close.md", STARTER("close", "Close with the action the viewer should remember.")],
+    ]);
+  }
+
+  it("clears an untouched starter instead of appending to it", async () => {
+    await starterBundle();
+    const { action } = await upsertScene(dir, { beatId: "intro", duration: 5 });
+    expect(action).toBe("replaced-starter");
+    expect((await listSceneFiles(dir)).map((s) => s.filename)).toEqual(["01-intro.md"]);
+  });
+
+  it("appends after a bundle that is no longer the starter", async () => {
+    await writeBundle([["01-mine.md", "---\ntype: Scene\nduration: 5\n---\n\nMine."]]);
+    const { action } = await upsertScene(dir, { beatId: "next", duration: 3 });
+    expect(action).toBe("appended");
+    expect((await listSceneFiles(dir)).map((s) => s.id)).toEqual(["mine", "next"]);
+  });
+
+  it("updates an existing scene in place without renumbering", async () => {
+    await writeBundle([
+      ["01-a.md", "---\ntype: Scene\nduration: 5\n---\n\nOriginal body."],
+      ["02-b.md", "---\ntype: Scene\nduration: 5\n---\n\nB."],
+    ]);
+    const { action } = await upsertScene(dir, { beatId: "a", duration: 9, title: "New" });
+    expect(action).toBe("updated");
+    expect((await listSceneFiles(dir)).map((s) => s.filename)).toEqual(["01-a.md", "02-b.md"]);
+
+    const raw = await readFile(join(dir, "scenes", "01-a.md"), "utf-8");
+    expect(raw).toContain("duration: 9");
+    expect(raw).toContain("title: New");
+    // The body survives an update that does not supply one.
+    expect(raw).toContain("Original body.");
+  });
+
+  it("keeps type: Scene first after an update", async () => {
+    await writeBundle([["01-a.md", "---\ntype: Scene\nduration: 5\n---\n\nBody."]]);
+    await upsertScene(dir, { beatId: "a", duration: 6 });
+    const raw = await readFile(join(dir, "scenes", "01-a.md"), "utf-8");
+    expect(raw).toMatch(/^---\ntype: Scene\n/);
+  });
+
+  it("creates the scenes directory when the project has none yet", async () => {
+    await writeFile(join(dir, "STORYBOARD.md"), HEAD, "utf-8");
+    const { action } = await upsertScene(dir, { beatId: "first", duration: 4 });
+    expect(action).toBe("appended");
+    expect((await listSceneFiles(dir)).map((s) => s.filename)).toEqual(["01-first.md"]);
   });
 });

--- a/packages/cli/src/commands/_shared/storyboard-source.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.ts
@@ -34,7 +34,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { stringify as stringifyYaml } from "yaml";
 
@@ -47,7 +47,7 @@ import {
   type BeatCues,
   type StoryboardCueKey,
 } from "./storyboard-parse.js";
-import { normalizeCueValue } from "./storyboard-edit.js";
+import { isStarterStoryboard, normalizeCueValue } from "./storyboard-edit.js";
 
 /** Directory, relative to the project root, that holds one file per scene. */
 export const SCENES_DIRNAME = "scenes";
@@ -435,4 +435,72 @@ export function strayBeatIssues(strayBeatIds: string[]): Array<{
       `uses scenes/. That heading is ignored. Move it to scenes/ as its own file, ` +
       `or delete it from STORYBOARD.md.`,
   }));
+}
+
+/**
+ * Create or update one scene file, mirroring `upsertStoryboardBeat`.
+ *
+ * The three actions match the single-document writer so `vibe scene add`
+ * reports the same thing either way:
+ *
+ * - `updated` - a scene with this id exists; its cues are merged and its
+ *   body is left alone unless a new one is supplied.
+ * - `replaced-starter` - the bundle is still the untouched three-beat
+ *   scaffold, so it is cleared rather than appended to.
+ * - `appended` - a new scene file after the current last one.
+ */
+export async function upsertScene(
+  projectDir: string,
+  opts: {
+    beatId: string;
+    title?: string;
+    duration?: number;
+    narration?: string;
+    backdrop?: string;
+    body?: string;
+  }
+): Promise<{ action: "updated" | "replaced-starter" | "appended"; path: string }> {
+  const beatId = deriveBeatId(opts.beatId);
+  const dir = join(projectDir, SCENES_DIRNAME);
+  await mkdir(dir, { recursive: true });
+
+  const cues: Record<string, unknown> = {};
+  if (opts.duration !== undefined) cues.duration = opts.duration;
+  if (opts.narration?.trim()) cues.narration = opts.narration.trim();
+  if (opts.backdrop?.trim()) cues.backdrop = opts.backdrop.trim();
+  if (opts.title?.trim()) cues.title = opts.title.trim();
+
+  const scenes = await listSceneFiles(projectDir);
+  const existing = scenes.find((s) => s.id === beatId);
+
+  if (existing) {
+    const raw = await readFile(existing.path, "utf-8");
+    const { data, body } = extractFrontmatter(raw);
+    const merged: Record<string, unknown> = { type: "Scene", ...(data ?? {}), ...cues };
+    const nextBody = opts.body?.trim() || body.trim();
+    await writeFile(
+      existing.path,
+      `---\n${stringifyYaml(merged, { lineWidth: 0 }).trimEnd()}\n---\n\n${nextBody}\n`,
+      "utf-8"
+    );
+    return { action: "updated", path: existing.path };
+  }
+
+  const starter = scenes.length > 0 && isStarterStoryboard((await loadStoryboard(projectDir)).markdown);
+  if (starter) {
+    for (const scene of scenes) await rm(scene.path);
+  }
+
+  const order = starter ? 1 : scenes.length + 1;
+  const path = join(dir, sceneFilename(order, beatId));
+  const front = { type: "Scene", ...cues };
+  const body =
+    opts.body?.trim() ||
+    "Scene created with `vibe scene add`. Edit this body if the build flow should recompose it.";
+  await writeFile(
+    path,
+    `---\n${stringifyYaml(front, { lineWidth: 0 }).trimEnd()}\n---\n\n${body}\n`,
+    "utf-8"
+  );
+  return { action: starter ? "replaced-starter" : "appended", path };
 }

--- a/packages/cli/src/commands/scene.ts
+++ b/packages/cli/src/commands/scene.ts
@@ -75,6 +75,7 @@ import {
   upsertStoryboardBeat,
   type StoryboardBeatUpsertAction,
 } from "./_shared/storyboard-edit.js";
+import { loadStoryboard, upsertScene } from "./_shared/storyboard-source.js";
 
 function validateDuration(value: string): number {
   const n = parseFloat(value);
@@ -1087,21 +1088,31 @@ export async function executeSceneAdd(opts: SceneAddOptions): Promise<SceneAddRe
   let storyboardAction: "skipped" | StoryboardBeatUpsertAction = "skipped";
   const shouldSyncStoryboard = opts.syncStoryboard !== false && (await pathExists(storyboardAbsPath));
   if (shouldSyncStoryboard) {
-    opts.onProgress?.("Syncing STORYBOARD.md...");
-    const before = await readFile(storyboardAbsPath, "utf-8");
-    const synced = upsertStoryboardBeat(before, {
+    const upsert = {
       beatId: id,
       title: opts.headline,
       duration,
       narration: narrationText && !opts.skipAudio ? narrationText : undefined,
       backdrop: opts.visuals && !opts.skipImage ? opts.visuals : undefined,
-    });
-    if (synced.markdown !== before) {
-      await writeFile(storyboardAbsPath, synced.markdown, "utf-8");
+    };
+    // A bundle gets its own scene file; a single document gets a new section.
+    // Both report the same three actions.
+    if ((await loadStoryboard(projectDir)).layout === "bundle") {
+      opts.onProgress?.("Syncing scenes/...");
+      const synced = await upsertScene(projectDir, upsert);
+      storyboardPath = relative(process.cwd(), synced.path) || synced.path;
+      storyboardAction = synced.action;
+    } else {
+      opts.onProgress?.("Syncing STORYBOARD.md...");
+      const before = await readFile(storyboardAbsPath, "utf-8");
+      const synced = upsertStoryboardBeat(before, upsert);
+      if (synced.markdown !== before) {
+        await writeFile(storyboardAbsPath, synced.markdown, "utf-8");
+      }
+      storyboardPath = relative(process.cwd(), storyboardAbsPath) || storyboardAbsPath;
+      storyboardAction = synced.action;
     }
-    storyboardPath = relative(process.cwd(), storyboardAbsPath) || storyboardAbsPath;
     storyboardSynced = true;
-    storyboardAction = synced.action;
   }
 
   // -- Emit scene HTML -----------------------------------------------------


### PR DESCRIPTION
`scene add` was the last writer still assuming a single STORYBOARD.md.

On a bundle it appended a `## Beat` section to a file that — since #310 — no longer contributes beats at all. So the new scene was written to disk, reported as synced, and then **silently dropped from the timeline**.

## `upsertScene()` mirrors `upsertStoryboardBeat()`

Same three actions, so `scene add` behaves identically whichever layout the project uses:

| Action | Bundle behaviour |
|---|---|
| `updated` | cues merged into the existing scene's frontmatter; keeps its number; body survives unless a new one is supplied |
| `replaced-starter` | the untouched three-beat scaffold is cleared rather than appended to |
| `appended` | a new file after the current last one |

The starter check is the existing `isStarterStoryboard`, now **exported and run against the assembled markdown**, so both layouts make that call from one piece of logic instead of two that can disagree. Its prose markers survive migration, so a migrated starter is still recognised as one.

## Verified against real projects

**Bundle:**
```
before: 01-hook.md 02-proof.md 03-close.md   (migrated starter)
$ vibe scene add intro ...        -> "replaced-starter"
after:  01-intro.md

$ vibe scene add second ...       -> "appended"
        01-intro.md 02-second.md

$ vibe scene add second --force   -> "updated"
        01-intro.md 02-second.md   (count unchanged)
        title: Two revised         (rewritten in place)
```

`storyboard list` agrees throughout: `["intro", "second"]`.

**Legacy:** `scene add intro` still reports `replaced-starter` and writes one beat into STORYBOARD.md.

## Verification

- 1270 CLI tests (**5 new**) and 73 mcp-server tests pass
- lint clean, dogfood smoke passes, reference and counts in sync

## Where this leaves the roadmap

```
1. ambiguity rule        done (#310)
2. scene add bundle      this PR
3. init writes bundle    next - was written and reverted; it is what surfaced #310
4. storyboard revise
5. docs (6 places)
```