### PR TITLE
feat: scaffold new projects as a scenes/ bundle

### DIFF
--- a/packages/cli/src/commands/_shared/scene-project.test.ts
+++ b/packages/cli/src/commands/_shared/scene-project.test.ts
@@ -390,6 +390,10 @@ describe("scaffoldSceneProject", () => {
       "SCRIPT.md",
       "CHARACTERS.md",
       ".gitignore",
+      // The starter storyboard scaffolds as a scenes/ bundle.
+      "scenes/01-hook.md",
+      "scenes/02-proof.md",
+      "scenes/03-close.md",
     ];
     for (const f of expected) {
       expect(await pathExists(resolve(dir, f))).toBe(true);

--- a/packages/cli/src/commands/_shared/scene-project.ts
+++ b/packages/cli/src/commands/_shared/scene-project.ts
@@ -12,6 +12,7 @@
  */
 
 import { mkdir, readFile, writeFile, access } from "node:fs/promises";
+import { writeStoryboardAsBundle } from "./storyboard-source.js";
 import { resolve, basename } from "node:path";
 
 import type { VisualStyle } from "./visual-styles.js";
@@ -536,15 +537,25 @@ media in \`references/\`; older VibeFrame versions vendored composition rules
 there, and current installs keep the rules under \`.agents/skills/hyperframes/\`
 via \`vibe scene install-skill\`.
 
-When a beat should reuse a local file, reference it from \`STORYBOARD.md\`
-with a project-relative path:
+Scenes live in \`scenes/\`, one file per scene, and play in filename order.
+Each scene is a markdown file whose frontmatter carries its cues:
 
-\`\`\`yaml
-backdrop: "media/product-shot.png" # existing still image
-video: "media/broll.mp4"           # existing video/B-roll
-narration: "media/voice.wav"       # existing recorded narration
-asset: "media/logo.png"            # generic local asset reference
-\`\`\`
+    ---
+    type: Scene
+    duration: 5
+    narration: "One crisp sentence."
+    backdrop: "Clean editorial background plate, generous negative space"
+    ---
+
+    Direction prose for this scene goes in the body.
+
+When a scene should reuse a local file, give the cue a project-relative path
+instead of a prompt:
+
+    backdrop: "media/product-shot.png"   # existing still image
+    video: "media/broll.mp4"             # existing video/B-roll
+    narration: "media/voice.wav"         # existing recorded narration
+    asset: "media/logo.png"              # generic local asset reference
 
 Use text cues when you want VibeFrame to generate an asset. Use path cues
 when you want VibeFrame to reuse a local file. Avoid absolute paths or parent
@@ -957,8 +968,13 @@ export async function scaffoldSceneProject(opts: ScaffoldOptions): Promise<Scaff
   if (await pathExists(storyboardPath)) {
     skipped.push(storyboardPath);
   } else {
-    await writeFile(storyboardPath, buildStoryboardMd(name, duration), "utf-8");
+    // Scaffold straight into the scenes/ bundle. The starter is generated as
+    // one document and converted by the same code `vibe storyboard migrate`
+    // runs, so there is one content generator and one layout converter
+    // rather than two scaffolders that can drift.
+    const plan = await writeStoryboardAsBundle(dir, buildStoryboardMd(name, duration));
     created.push(storyboardPath);
+    for (const file of plan.scenes) created.push(resolve(dir, file.path));
   }
 
   // SCRIPT.md - always-on narrative spine (authored before STORYBOARD beats).

--- a/packages/cli/src/commands/_shared/scene-render.test.ts
+++ b/packages/cli/src/commands/_shared/scene-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -313,13 +313,15 @@ describe("executeSceneRender — Chrome-gated render", () => {
     const dir = await makeTmp("vibe-scene-render-int-");
     await scaffoldSceneProject({ dir, name: "fixture", aspect: "16:9", duration: 2 });
 
-    // The scaffold seeds a three-beat storyboard. Trim it to the single beat
+    // The scaffold seeds a three-scene bundle. Trim it to the single scene
     // this test authors HTML for: the pre-render sync injects a clip ref per
-    // storyboard beat, and the producer now fails the compile stage when a
+    // scene, and the producer fails the compile stage when a
     // data-composition-src target is missing instead of rendering it black.
+    await rm(resolve(dir, "scenes"), { recursive: true, force: true });
+    await mkdir(resolve(dir, "scenes"), { recursive: true });
     await writeFile(
-      resolve(dir, "STORYBOARD.md"),
-      `# fixture — Storyboard\n\n## Beat intro — Intro\n\n\`\`\`yaml\nnarration: "One line."\nduration: 1.5\n\`\`\`\n`,
+      resolve(dir, "scenes", "01-intro.md"),
+      `---\ntype: Scene\nnarration: "One line."\nduration: 1.5\n---\n\nIntro.\n`,
       "utf-8"
     );
 

--- a/packages/cli/src/commands/_shared/scene-repair.test.ts
+++ b/packages/cli/src/commands/_shared/scene-repair.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -82,23 +82,19 @@ describe("executeSceneRepair", () => {
       "<template></template>",
       "utf-8"
     );
+    // The scaffold above is a scenes/ bundle; replace its starter scenes with
+    // the two this test needs. Beats written into STORYBOARD.md would be
+    // ignored (and reported) now that the project is a bundle.
+    await rm(resolve(dir, "scenes"), { recursive: true, force: true });
+    await mkdir(resolve(dir, "scenes"), { recursive: true });
     await writeFile(
-      resolve(dir, "STORYBOARD.md"),
-      `# Root sync
-
-## Beat hook - Hook
-
-\`\`\`yaml
-duration: 3
-narration: "Hello."
-\`\`\`
-
-## Beat close - Close
-
-\`\`\`yaml
-duration: 2
-\`\`\`
-`,
+      resolve(dir, "scenes", "01-hook.md"),
+      `---\ntype: Scene\nduration: 3\nnarration: "Hello."\n---\n\nHook.\n`,
+      "utf-8"
+    );
+    await writeFile(
+      resolve(dir, "scenes", "02-close.md"),
+      `---\ntype: Scene\nduration: 2\n---\n\nClose.\n`,
       "utf-8"
     );
     await writeFile(

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -38,6 +38,7 @@ import {
 } from "./_shared/scene-project.js";
 import { getVisualStyle, visualStyleNames } from "./_shared/visual-styles.js";
 import { draftStoryboardFromBrief } from "./_shared/storyboard-draft.js";
+import { writeStoryboardAsBundle } from "./_shared/storyboard-source.js";
 import { projectConfigJson, VIBE_CONFIG_FILENAME } from "./_shared/project-config.js";
 import {
   HYPERFRAMES_SKILL_INSTALL_COMMAND,
@@ -395,8 +396,14 @@ async function runSceneInit(
     const storyboardPath = resolve(projectDir, "STORYBOARD.md");
     const designPath = resolve(projectDir, "DESIGN.md");
     if (options.force || result.created.includes(storyboardPath) || !existsSync(storyboardPath)) {
-      await writeFile(storyboardPath, draft.storyboardMd, "utf-8");
+      // The draft is generated as one document and split into scenes/ by the
+      // same conversion `vibe storyboard migrate` runs.
+      const plan = await writeStoryboardAsBundle(projectDir, draft.storyboardMd);
       if (!result.created.includes(storyboardPath)) result.created.push(storyboardPath);
+      for (const file of plan.scenes) {
+        const scenePath = resolve(projectDir, file.path);
+        if (!result.created.includes(scenePath)) result.created.push(scenePath);
+      }
     }
     if (options.force || result.created.includes(designPath) || !existsSync(designPath)) {
       await writeFile(designPath, draft.designMd, "utf-8");

--- a/packages/cli/src/commands/scene.test.ts
+++ b/packages/cli/src/commands/scene.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, readFile, writeFile, access } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile, access } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { scaffoldSceneProject } from "./_shared/scene-project.js";
 import { executeSceneAdd, resolveSceneRepairTarget } from "./scene.js";
 import { parseStoryboard } from "./_shared/storyboard-parse.js";
+import { loadStoryboard } from "./_shared/storyboard-source.js";
 
 async function pathExists(p: string): Promise<boolean> {
   try {
@@ -58,9 +59,9 @@ describe("executeSceneAdd — offline (--no-audio --no-image)", () => {
     expect(rootHtml).toContain('data-start="0"');
     expect(rootHtml).toContain('data-duration="4"');
 
-    const storyboard = parseStoryboard(
-      await readFile(resolve(projectDir, "STORYBOARD.md"), "utf-8")
-    );
+    // The scaffold is a bundle, so the beats live in scenes/. Going through
+    // the loader is also what every consumer does.
+    const storyboard = parseStoryboard((await loadStoryboard(projectDir)).markdown);
     expect(storyboard.beats.map((beat) => beat.id)).toEqual(["intro-scene"]);
     expect(storyboard.beats[0].duration).toBe(4);
     expect(result.storyboardSynced).toBe(true);
@@ -107,9 +108,11 @@ describe("executeSceneAdd — offline (--no-audio --no-image)", () => {
 
   it("appends to a custom storyboard and syncs root refs from storyboard order", async () => {
     const projectDir = await makeProject();
+    await rm(resolve(projectDir, "scenes"), { recursive: true, force: true });
+    await mkdir(resolve(projectDir, "scenes"), { recursive: true });
     await writeFile(
-      resolve(projectDir, "STORYBOARD.md"),
-      `# Custom\n\n## Beat existing - Existing\n\n\`\`\`yaml\nduration: 2\n\`\`\`\n\nKeep this body.\n`,
+      resolve(projectDir, "scenes", "01-existing.md"),
+      `---\ntype: Scene\nduration: 2\n---\n\nKeep this body.\n`,
       "utf-8"
     );
 
@@ -125,7 +128,7 @@ describe("executeSceneAdd — offline (--no-audio --no-image)", () => {
     expect(result.success).toBe(true);
     expect(result.storyboardAction).toBe("appended");
     expect(result.start).toBe(2);
-    const storyboardMd = await readFile(resolve(projectDir, "STORYBOARD.md"), "utf-8");
+    const storyboardMd = (await loadStoryboard(projectDir)).markdown;
     expect(storyboardMd).toContain("Keep this body.");
     expect(parseStoryboard(storyboardMd).beats.map((beat) => beat.id)).toEqual([
       "existing",
@@ -136,11 +139,16 @@ describe("executeSceneAdd — offline (--no-audio --no-image)", () => {
     expect(root).toContain('data-composition-id="scene-new-proof"');
   });
 
-  it("updates an existing storyboard beat without clobbering body text", async () => {
+  it("updates an existing scene without clobbering body text", async () => {
     const projectDir = await makeProject();
+    // The scaffold is a scenes/ bundle, so replace its starter scenes with
+    // one hand-written scene rather than writing beats into STORYBOARD.md -
+    // beats there are ignored, and reported, once a project is a bundle.
+    await rm(resolve(projectDir, "scenes"), { recursive: true, force: true });
+    await mkdir(resolve(projectDir, "scenes"), { recursive: true });
     await writeFile(
-      resolve(projectDir, "STORYBOARD.md"),
-      `# Custom\n\n## Beat intro - Old title\n\n\`\`\`yaml\nduration: 2\n\`\`\`\n\nCustom body stays.\n`,
+      resolve(projectDir, "scenes", "01-intro.md"),
+      `---\ntype: Scene\nduration: 2\n---\n\nCustom body stays.\n`,
       "utf-8"
     );
 
@@ -155,9 +163,9 @@ describe("executeSceneAdd — offline (--no-audio --no-image)", () => {
 
     expect(result.success).toBe(true);
     expect(result.storyboardAction).toBe("updated");
-    const storyboardMd = await readFile(resolve(projectDir, "STORYBOARD.md"), "utf-8");
-    expect(storyboardMd).toContain("duration: 6");
-    expect(storyboardMd).toContain("Custom body stays.");
+    const scene = await readFile(resolve(projectDir, "scenes", "01-intro.md"), "utf-8");
+    expect(scene).toContain("duration: 6");
+    expect(scene).toContain("Custom body stays.");
   });
 
   it("uses the narration text as the subhead even when --no-audio is set", async () => {


### PR DESCRIPTION
`vibe init` now writes one file per scene with its cues in frontmatter. **A freshly scaffolded project contains zero ```yaml fences**, which was the point of the whole exercise.

```
launch/
  STORYBOARD.md        project frontmatter + direction, 0 beats
  scenes/
    01-hook.md
    02-proof.md
    03-close.md
  DESIGN.md  SCRIPT.md  CHARACTERS.md  AGENTS.md  CLAUDE.md  vibe.config.json
```

```markdown
---
type: Scene
duration: 4
narration: Launch starts with one clear promise.
backdrop: topic-aligned editorial background plate, clean negative space
motion: large readable headline, restrained camera push
---

Make the value obvious in one beat.
```

## One generator, one converter

Both scaffold paths — the starter and the `--from` draft — keep generating one markdown document and hand it to `writeStoryboardAsBundle`, the same conversion `vibe storyboard migrate` runs. The intermediate document never reaches disk. That avoids a second scaffolder that could drift from the first.

## AGENTS.md was the last file teaching the old shape

It now shows a scene file with frontmatter, and the reuse-a-local-file example is an indented block rather than a fenced one — so the file handed to an agent matches the files beside it.

## About the four test failures

This is the change I wrote earlier and reverted, because it depended on `scene add` understanding bundles (#311) and on a rule for what happens when both layouts are present (#310). With those in, the failures resolve into two honest categories:

| Test | Category |
|---|---|
| `scene-project` | expected 11 scaffolded files, now sees 14. **Correct** — the three scene files are real output |
| `scene.test`, `scene-repair`, `scene-render` | each scaffolded a project then overwrote STORYBOARD.md with its own beats |

That second group was building an **ambiguous project** — since #310 those beats are ignored and reported. They now build their fixtures as scene files, and the two that read STORYBOARD.md directly read through `loadStoryboard` instead, which is what every consumer does.

Patching the assertions to match the new numbers would have hidden that; those three tests were describing a project shape the CLI no longer considers valid.

## Existing projects

Untouched. Single-file projects still read, edit, and build exactly as before.

## Verification

```
fresh init --from  ->  scenes/01-hook.md 02-proof.md 03-close.md
                       0 beats in STORYBOARD.md
                       0 ```yaml fences anywhere in the project
                       storyboard validate: ok
                       plan: $0.05
```

- 1270 CLI tests and 73 mcp-server tests pass
- lint clean, dogfood smoke passes, reference / counts / agent-sync all in sync

## Remaining

```
4. storyboard revise bundle support
5. docs - README x2, docs/projects.md x3, vibe-scene/SKILL.md x1
```