### PR TITLE
feat: make `vibe storyboard revise` work on a scenes/ bundle

### DIFF
--- a/packages/cli/src/commands/_shared/storyboard-revise.ts
+++ b/packages/cli/src/commands/_shared/storyboard-revise.ts
@@ -11,6 +11,7 @@ import {
 } from "./composer-resolve.js";
 import { readProjectConfig } from "./project-config.js";
 import { parseStoryboard, STORYBOARD_CUE_KEYS } from "./storyboard-parse.js";
+import { loadStoryboard, rewriteBundleFromMarkdown } from "./storyboard-source.js";
 import {
   validateStoryboardMarkdown,
   type StoryboardValidationIssue,
@@ -70,7 +71,10 @@ export async function executeStoryboardRevision(opts: StoryboardRevisionOptions)
     });
   }
 
-  const currentStoryboard = await readFile(storyboardPath, "utf-8");
+  // Read through the loader: on a bundle the current storyboard is the
+  // assembled scenes, not the near-empty STORYBOARD.md on disk.
+  const loaded = await loadStoryboard(projectDir);
+  const currentStoryboard = loaded.markdown;
   const projectConfig = await readProjectConfig(projectDir);
   const explicitComposer = opts.composer ?? projectConfig.config.providers.composer ?? undefined;
 
@@ -175,7 +179,15 @@ export async function executeStoryboardRevision(opts: StoryboardRevisionOptions)
 
   const storyboardMd = normalizeMarkdown(payload.storyboardMd);
   if (!opts.dryRun) {
-    await writeFile(storyboardPath, storyboardMd, "utf-8");
+    if (loaded.layout === "bundle") {
+      // Writing the model's single document to STORYBOARD.md would lose the
+      // revision entirely: scenes/ still wins, so the old scenes would render
+      // while the new beats sat in STORYBOARD.md being reported as stray.
+      // Re-split instead, and drop scene files the revision no longer names.
+      await rewriteBundleFromMarkdown(projectDir, storyboardMd);
+    } else {
+      await writeFile(storyboardPath, storyboardMd, "utf-8");
+    }
   }
 
   const changedBeats = unique([...diffChangedBeats(currentStoryboard, storyboardMd), ...payload.changedBeats]);

--- a/packages/cli/src/commands/_shared/storyboard-source.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.test.ts
@@ -9,6 +9,7 @@ import {
   loadStoryboard,
   moveScene,
   planMigration,
+  rewriteBundleFromMarkdown,
   setSceneCue,
   sceneFilename,
   sceneToBeatSection,
@@ -490,5 +491,87 @@ describe("upsertScene", () => {
     const { action } = await upsertScene(dir, { beatId: "first", duration: 4 });
     expect(action).toBe("appended");
     expect((await listSceneFiles(dir)).map((s) => s.filename)).toEqual(["01-first.md"]);
+  });
+});
+
+describe("rewriteBundleFromMarkdown", () => {
+  const revised = (ids: string[]) =>
+    [
+      "---",
+      "type: Storyboard",
+      'title: "Launch"',
+      "---",
+      "",
+      "# Launch",
+      "",
+      ...ids.flatMap((id) => [
+        `## Beat ${id} - ${id}`,
+        "",
+        "```yaml",
+        "duration: 5",
+        `narration: "${id} line"`,
+        "```",
+        "",
+        `${id} body.`,
+        "",
+      ]),
+    ].join("\n");
+
+  it("replaces the scenes with the ones the document names", async () => {
+    await writeBundle([
+      ["01-hook.md", "---\ntype: Scene\nduration: 1\n---\n\nOld hook."],
+      ["02-proof.md", "---\ntype: Scene\nduration: 1\n---\n\nOld proof."],
+    ]);
+    await rewriteBundleFromMarkdown(dir, revised(["hook", "proof"]));
+
+    const scenes = await listSceneFiles(dir);
+    expect(scenes.map((s) => s.id)).toEqual(["hook", "proof"]);
+    const hook = await readFile(join(dir, "scenes", "01-hook.md"), "utf-8");
+    expect(hook).toContain("duration: 5");
+    expect(hook).toContain("hook body.");
+    expect(hook).not.toContain("Old hook.");
+  });
+
+  it("deletes scene files the revision dropped", async () => {
+    await writeBundle([
+      ["01-hook.md", "---\ntype: Scene\nduration: 1\n---\n\nHook."],
+      ["02-proof.md", "---\ntype: Scene\nduration: 1\n---\n\nProof."],
+      ["03-close.md", "---\ntype: Scene\nduration: 1\n---\n\nClose."],
+    ]);
+    await rewriteBundleFromMarkdown(dir, revised(["hook", "close"]));
+
+    const scenes = await listSceneFiles(dir);
+    expect(scenes.map((s) => s.id)).toEqual(["hook", "close"]);
+    // Not merely unreferenced - gone, so it cannot keep playing.
+    const { readdir } = await import("node:fs/promises");
+    expect(await readdir(join(dir, "scenes"))).toEqual(["01-hook.md", "02-close.md"]);
+  });
+
+  it("renumbers when the revision reorders", async () => {
+    await writeBundle([
+      ["01-a.md", "---\ntype: Scene\nduration: 1\n---\n\nA."],
+      ["02-b.md", "---\ntype: Scene\nduration: 1\n---\n\nB."],
+    ]);
+    await rewriteBundleFromMarkdown(dir, revised(["b", "a"]));
+    expect((await listSceneFiles(dir)).map((s) => s.filename)).toEqual(["01-b.md", "02-a.md"]);
+  });
+
+  it("leaves STORYBOARD.md free of beats afterwards", async () => {
+    await writeBundle([["01-hook.md", "---\ntype: Scene\nduration: 1\n---\n\nHook."]]);
+    await rewriteBundleFromMarkdown(dir, revised(["hook", "extra"]));
+
+    const head = await readFile(join(dir, "STORYBOARD.md"), "utf-8");
+    expect(head).not.toContain("## Beat");
+    expect((await loadStoryboard(dir)).strayBeatIds).toEqual([]);
+  });
+
+  it("round-trips: the rewritten bundle parses to the revised beats", async () => {
+    await writeBundle([["01-hook.md", "---\ntype: Scene\nduration: 1\n---\n\nHook."]]);
+    const md = revised(["hook", "proof", "close"]);
+    await rewriteBundleFromMarkdown(dir, md);
+
+    const after = parseStoryboard((await loadStoryboard(dir)).markdown);
+    expect(after.beats.map((b) => b.id)).toEqual(["hook", "proof", "close"]);
+    expect(after.beats.every((b) => b.duration === 5)).toBe(true);
   });
 });

--- a/packages/cli/src/commands/_shared/storyboard-source.ts
+++ b/packages/cli/src/commands/_shared/storyboard-source.ts
@@ -504,3 +504,30 @@ export async function upsertScene(
   );
   return { action: starter ? "replaced-starter" : "appended", path };
 }
+
+/**
+ * Replace a bundle's scenes with the ones described by a single markdown
+ * document.
+ *
+ * Used when something produces a whole storyboard at once - today
+ * `vibe storyboard revise`, whose model returns one document. Writing that
+ * document to STORYBOARD.md would lose the revision: `scenes/` still wins, so
+ * the old scenes would keep rendering while the new beats sat in
+ * STORYBOARD.md being reported as stray.
+ *
+ * Scene files the new document does not name are deleted, so a revision that
+ * removes a beat actually removes it rather than leaving an orphan that keeps
+ * playing.
+ */
+export async function rewriteBundleFromMarkdown(
+  projectDir: string,
+  markdown: string
+): Promise<MigrationPlan> {
+  const plan = planMigration(markdown);
+  const keep = new Set(plan.scenes.map((file) => basename(file.path)));
+  for (const scene of await listSceneFiles(projectDir)) {
+    if (!keep.has(scene.filename)) await rm(scene.path);
+  }
+  await writeMigration(projectDir, plan);
+  return plan;
+}


### PR DESCRIPTION
`revise` was the last command that could quietly lose work.

It read STORYBOARD.md directly and wrote the model's whole document back to it. On a bundle that meant the model was handed a near-empty file with no beats in it, and its revision landed somewhere nothing reads — `scenes/` still wins, so the old scenes kept rendering while the new beats sat in STORYBOARD.md being reported as stray.

Unlike `set` and `move`, which #307 guarded before #309 taught them bundles, **this one had no guard at all.**

## Both halves

**Read** goes through `loadStoryboard`, so the model sees the assembled scenes rather than the project header.

**Write** branches: a single-file project is rewritten as before; a bundle is re-split by `rewriteBundleFromMarkdown`.

## The wrinkle a plain re-split would get wrong

A revision that removes a beat has to remove its scene file. The loader lists whatever is in `scenes/`, not whatever the last revision named — so an orphan keeps playing. Scene files the new document does not name are deleted before the plan is written.

## Verified with a real revision

```
BEFORE: 01-hook.md 02-proof.md 03-close.md

$ vibe storyboard revise rv --from "cut it to exactly two scenes: hook and close"

AFTER:  01-hook.md 02-close.md
```

- the proof scene is **deleted**, not orphaned
- close renumbered 03 → 02
- 0 beats written into STORYBOARD.md
- `validate: ok`, 0 stray beats, 0 ```yaml fences anywhere
- `plan` prices the two remaining scenes

The dry run before it confirmed the read half: the model's summary described all three beats and their motion cues, which only exist in the scene files.

## Verification

- 1275 CLI tests (**5 new**) and 73 mcp-server tests pass
- lint clean, dogfood smoke passes, reference and counts in sync

## Roadmap

```
1. ambiguity rule        #310
2. scene add bundle      #311
3. init writes bundle    #312
4. storyboard revise     this PR
5. docs                  README x2, docs/projects.md x3, vibe-scene/SKILL.md x1
```

That is every writer. Docs are the only thing left teaching the old shape.