### PR TITLE
docs: teach the scenes/ bundle instead of beat blocks

### DIFF
--- a/.agents/skills/vibe-scene/SKILL.md
+++ b/.agents/skills/vibe-scene/SKILL.md
@@ -127,19 +127,23 @@ for visual decisions:
 - animation timing and transition style
 - what to avoid
 
-For `STORYBOARD.md`, prefer compact beat blocks:
+Scenes live in `scenes/`, one markdown file per scene, playing in filename
+order. Cues go in the frontmatter, direction in the body:
 
-````markdown
-## Beat hook - First claim
-
-```yaml
+```markdown
+---
+type: Scene
 narration: "The first sentence the viewer hears."
 backdrop: "Specific visual prompt for the scene backdrop"
 duration: 5
-```
+---
 
 What the scene should show.
-````
+```
+
+`STORYBOARD.md` holds only project frontmatter and direction prose. Beat
+headings left in it are ignored and reported - move them into `scenes/`, or
+run `vibe storyboard migrate` on an older single-file project.
 
 ## Lint Feedback Loop
 

--- a/.claude/skills/vibe-scene/SKILL.md
+++ b/.claude/skills/vibe-scene/SKILL.md
@@ -129,19 +129,23 @@ for visual decisions:
 - animation timing and transition style
 - what to avoid
 
-For `STORYBOARD.md`, prefer compact beat blocks:
+Scenes live in `scenes/`, one markdown file per scene, playing in filename
+order. Cues go in the frontmatter, direction in the body:
 
-````markdown
-## Beat hook - First claim
-
-```yaml
+```markdown
+---
+type: Scene
 narration: "The first sentence the viewer hears."
 backdrop: "Specific visual prompt for the scene backdrop"
 duration: 5
-```
+---
 
 What the scene should show.
-````
+```
+
+`STORYBOARD.md` holds only project frontmatter and direction prose. Beat
+headings left in it are ignored and reported - move them into `scenes/`, or
+run `vibe storyboard migrate` on an older single-file project.
 
 ## Lint Feedback Loop
 

--- a/README.md
+++ b/README.md
@@ -113,30 +113,37 @@ vibe inspect render launch --cheap          # check the result
 ```
 
 `brief.md` can be messy notes, links, or a single line.
-What `init` produces are two files you then own:
+What `init` produces is a project you then own:
 
-| File            | What it holds                                                            |
-| --------------- | ------------------------------------------------------------------------ |
-| `STORYBOARD.md` | Beats: narration, duration, and image/video/music cues. The intent layer. |
-| `DESIGN.md`     | Palette, typography, layout, motion, transitions. The visual system.      |
+```text
+launch/
+  STORYBOARD.md     title, duration, aspect, providers, cast - and the direction prose
+  DESIGN.md         palette, typography, layout, motion, transitions
+  scenes/
+    01-hook.md      one scene per file, in play order
+    02-proof.md
+    03-close.md
+```
 
-Edit them directly, or ask a coding agent to research and revise them.
-The rest is convention: `media/` for footage you supply, `assets/` for generated ones, `renders/` for output, and `vibe.config.json` for the provider, model, and quality contract.
+Each scene is a markdown file. Its frontmatter carries the cues, its body carries the direction:
 
-Each beat carries YAML cues.
-A cue's value is either a prompt to generate from, or a project-relative path to a file you already have:
-
-````markdown
-## Beat hook - Open
-
-```yaml
+```markdown
+---
+type: Scene
+duration: 5
 narration: "Start with a storyboard. VibeFrame turns each beat into a render plan."
 backdrop: "Clean developer terminal beside structured storyboard cues"
-video: "media/broll.mp4"   # a path reuses your file instead of generating
+video: "media/broll.mp4"
 voice: "alloy"
-duration: 5
+---
+
+Open on the terminal. Let the storyboard cues land before the camera moves.
 ```
-````
+
+A cue's value is either a prompt to generate from, or a project-relative path to a file you already have - `video: "media/broll.mp4"` above reuses your footage instead of generating any.
+
+Scenes play in filename order, so `vibe storyboard move` reorders by renumbering. Edit the files directly, or ask a coding agent to research and revise them.
+The rest is convention: `media/` for footage you supply, `assets/` for generated ones, `renders/` for output, and `vibe.config.json` for the provider, model, and quality contract.
 
 Add `--json` to any command for structured output.
 `plan`, `build`, `preview`, `render`, and both `inspect` commands take `--beat <id>` to work one beat at a time instead of rebuilding everything.
@@ -148,27 +155,32 @@ Profiles (`--profile minimal | agent | full`), [the full cue vocabulary](docs/pr
 ## What the spend buys: one character, many scenes
 
 Generating four shots that look like the same film is the hard part, and it is what the paid path is for.
-Declare a character pool in the storyboard frontmatter and reference it from individual beats.
+Declare a character pool in `STORYBOARD.md` and reference it from individual scenes.
 VibeFrame generates the character sheet once and reuses it as the reference image for Seedance image-to-video, so the character stays consistent across scenes.
 
-````markdown
+`STORYBOARD.md` declares who exists:
+
+```markdown
 ---
 characters:
   mira: "arctic aurora photographer, deep-red fur-lined parka, dark hair under a charcoal beanie, vintage 35mm camera"
   rival: { image: "media/rival-ref.png" }
 ---
+```
 
-## Beat hook - Hook
+`scenes/01-hook.md` says who is in this shot:
 
-```yaml
+```markdown
+---
+type: Scene
 duration: 5
 characters: [mira]
 keyframe: "MIRA stands on the frozen ice, camera lowered, looking up as the aurora fills the sky"
 video: "slow tilt up as the aurora ripples and pulses overhead"
+---
 ```
-````
 
-Each beat pairs a `keyframe` still with a `video` motion prompt.
+Each scene pairs a `keyframe` still with a `video` motion prompt.
 Generate the cheap image storyboard first, review it, then animate only the stills you approve.
 That is also the cheapest way to keep a run under its ceiling, since stills cost a fraction of the video.
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -241,21 +241,41 @@ Use the folders consistently:
 | Path            | Role                                                                                 |
 | --------------- | ------------------------------------------------------------------------------------ |
 | `brief.md`      | Optional rough input before `vibe init`; can live outside or beside the project.     |
-| `STORYBOARD.md` | Beats, narration, duration, and image/video/music cues. Scene audio comes only from explicit `narration`/`music` cues - composition never invents ambient/foley SFX. |
+| `STORYBOARD.md` | Project frontmatter (title, duration, aspect, providers, character pool) and the direction prose. No scenes. |
+| `scenes/`       | One markdown file per scene, in filename order. Frontmatter carries the cues; the body carries the direction. Scene audio comes only from explicit `narration`/`music` cues - composition never invents ambient/foley SFX. |
 | `DESIGN.md`     | Palette, typography, layout, motion, transitions, and visual anti-patterns.          |
 | `media/`        | User-provided source files: photos, screenshots, logos, B-roll, voice recordings.    |
 | `assets/`       | Generated or canonical build assets such as narration, backdrops, music, and videos. |
 | `references/`   | Legacy only: older projects kept vendored composition rules here. New installs put them under `.agents/skills/hyperframes/` via `vibe scene install-skill`. |
 | `renders/`      | Final and intermediate MP4 outputs.                                                  |
 
-When a beat should reuse a local file, use a project-relative path in
-`STORYBOARD.md`:
+A scene file looks like this:
 
-```yaml
+```markdown
+---
+type: Scene
+duration: 5
+narration: "One crisp sentence."
+backdrop: "Clean editorial background plate, generous negative space"
+---
+
+Direction prose for this scene goes in the body.
+```
+
+Scenes play in filename order. `vibe storyboard move` reorders by renumbering
+the prefixes, so `01-`, `02-`, `03-` stay contiguous.
+
+When a scene should reuse a local file, give the cue a project-relative path
+instead of a prompt:
+
+```markdown
+---
+type: Scene
 backdrop: "media/product-shot.png"
 video: "media/broll.mp4"
 narration: "media/voice.wav"
 asset: "media/logo.png"
+---
 ```
 
 ### The cue vocabulary
@@ -277,7 +297,7 @@ refuses it, so a typo surfaces instead of being silently ignored.
 | `characters` | Names from the frontmatter `characters:` pool. One name or a list. |
 | `motion` | Animation direction for the scene-authoring agent (see below). |
 | `eyebrow` / `kicker` | Lower-third eyebrow. `eyebrow` wins when both are set. |
-| `title` | Lower-third headline. Falls back to the beat heading. |
+| `title` | Lower-third headline. Falls back to the scene id. |
 | `caption` / `sub` | Lower-third sub-line. `caption` wins when both are set. |
 
 `motion` is the one cue no deterministic stage reads.
@@ -288,29 +308,37 @@ Every other cue above feeds the build or the composer directly.
 
 ### Characters (consistent AI video)
 
-Declare a reusable character pool in the document frontmatter, then reference it
-from a beat's `characters` cue. During `vibe build`, each referenced character
-is rendered once as a turnaround sheet (`assets/character-<name>.png`) and used
-as a reference image for that beat's `video` generation (Seedance
-reference-to-video), so the same character stays consistent across beats. A
+Declare a reusable character pool in `STORYBOARD.md`, then reference it from a
+scene's `characters` cue. During `vibe build`, each referenced character is
+rendered once as a turnaround sheet (`assets/character-<name>.png`) and used as
+a reference image for that scene's `video` generation (Seedance
+reference-to-video), so the same character stays consistent across scenes. A
 character value is a generation prompt, or `{ image: <path> }` to bring your own
 reference (skips generation).
 
-```yaml
+`STORYBOARD.md` declares who exists:
+
+```markdown
 ---
 characters:
   mira: "arctic aurora photographer, deep-red fur-lined parka, dark hair under a charcoal beanie, vintage 35mm camera"
   rival: { image: "media/rival-ref.png" }
 ---
+```
 
-## Beat hook - Hook
+`scenes/01-hook.md` says who is in this shot:
 
-```yaml
+```markdown
+---
+type: Scene
 duration: 5
 characters: [mira]
 video: "MIRA treks across the moonlit snowfield, handheld tracking shot, wind and crunching snow"
+---
 ```
-```
+
+The same key means different things at the two levels: a map of who exists at
+the project level, a list of who appears at the scene level.
 
 Character sheets add image-generation cost, and each character video beat is a
 provider video call - run `vibe build --dry-run` to see the estimate and gate
@@ -318,18 +346,21 @@ with `--max-cost`.
 
 ### Keyframe → image-to-video
 
-For tighter art direction, a beat can declare a `keyframe` cue. During
+For tighter art direction, a scene can declare a `keyframe` cue. During
 `vibe build`, the keyframe prompt first produces a still
-(`assets/keyframe-<beatId>.png`) - edited from the beat's `characters` sheet when
-present (for consistency), otherwise generated from text - and that exact frame
-is then animated with Seedance **image-to-video**. The `video` cue, if present,
-supplies the motion prompt; otherwise the keyframe prompt is reused.
+(`assets/keyframe-<beatId>.png`) - edited from the scene's `characters` sheet
+when present (for consistency), otherwise generated from text - and that exact
+frame is then animated with Seedance **image-to-video**. The `video` cue, if
+present, supplies the motion prompt; otherwise the keyframe prompt is reused.
 
-```yaml
+```markdown
+---
+type: Scene
 duration: 5
 characters: [mira]
 keyframe: "MIRA stands on the frozen ice, low-angle hero shot, dramatic aurora light"
 video: "slow tilt up as the aurora ripples and pulses overhead"
+---
 ```
 
 Keyframe mode costs one extra image generation per beat plus the clip


### PR DESCRIPTION
Every writer produces the bundle layout now (#307, #309, #311, #312, #313), so the docs are the last thing describing the old one. Six examples across README, `docs/projects.md`, and the vibe-scene skill taught `## Beat` headings with ```` ```yaml ```` cue blocks — no longer what `vibe init` writes.

## Before / after

```markdown
## Beat hook - Open

```yaml
narration: "..."
duration: 5
```
```

becomes

```markdown
---
type: Scene
duration: 5
narration: "..."
---

Open on the terminal. Let the storyboard cues land before the camera moves.
```

## README

Gains the project tree, since "what init produces" changed from two files to a directory:

```text
launch/
  STORYBOARD.md     title, duration, aspect, providers, cast - and the direction prose
  DESIGN.md         palette, typography, layout, motion, transitions
  scenes/
    01-hook.md      one scene per file, in play order
    02-proof.md
    03-close.md
```

And loses its **four-backtick wrappers**. Those existed only to nest a yaml fence inside a markdown fence — the thing that made this format awkward to document in the first place, and the reason this whole line of work started.

## docs/projects.md

- `scenes/` row added to Project File Roles; `STORYBOARD.md` row now says "No scenes."
- characters and keyframe sections rewritten
- the characters example now shows **why the two `characters` spellings differ**: a map of who exists at the project level, a list of who appears at the scene level

Its old characters example was **broken markdown** — a ```` ```yaml ```` block nested inside another ```` ```yaml ```` block, so the outer fence closed early and the inner content rendered as prose. Fixed as a side effect of rewriting it.

## vibe-scene skill

Also says what happens to beat headings left in STORYBOARD.md, and points at `vibe storyboard migrate` for older projects. `pnpm agent-sync` regenerated the Claude copy.

## Verification

```
storyboard cue fences remaining:
  README.md                            0
  docs/projects.md                     0
  docs/recipes.md                      0
  docs/hyperframes.md                  0
  .agents/skills/vibe-scene/SKILL.md   0
  .claude/skills/vibe-scene/SKILL.md   0

four-backtick wrappers:                0
```

- every local link and heading anchor resolves
- no em dashes in any added line
- 1275 CLI tests pass, lint clean, reference / counts / agent-sync in sync

## That completes it

```
1. ambiguity rule        #310
2. scene add bundle      #311
3. init writes bundle    #312
4. storyboard revise     #313
5. docs                  this PR
```