### PR TITLE
chore: bump version to 0.115.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.115.0] - 2026-07-26
+
+### Added
+
+- make `vibe storyboard revise` work on a scenes/ bundle (#313)
+- scaffold new projects as a scenes/ bundle (#312)
+- let `vibe scene add` write into a scenes/ bundle (#311)
+- let `storyboard set` and `move` write to a scenes/ bundle (#309)
+- add `vibe storyboard migrate` to convert a project to the scenes/ bundle (#308)
+- read storyboards from a scenes/ bundle as well as one STORYBOARD.md (#307)
+
+### Changed
+
+- make the cue vocabulary one list instead of five (#306)
+- make each landing section say one thing, once (#304)
+
+### Documentation
+
+- teach the scenes/ bundle instead of beat blocks (#314)
+- document the build and review reports, and link the hero cards to them (#303)
+
+### Fixed
+
+- stop silently merging leftover STORYBOARD.md beats into a scenes/ bundle (#310)
+- link the CLI package from the landing, and give #install-to-mp4 a referrer (#305)
+
 ## [0.114.0] - 2026-07-25
 
 ### Changed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "VibeFrame Web - landing and demo site for the frontier-video-generation CLI for coding agents",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,7 +15,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.114.0`
+> CLI version: `0.115.0`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "Frontier AI video generation for coding agents - Seedance, Runway, Veo, and Kling on your own keys, behind a hard cost cap. CLI + MCP.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "Frontier AI video generation for coding agents - Seedance, Runway, Veo, and Kling on your own keys, behind a hard cost cap",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "VibeFrame MCP Server - frontier AI video generation for agents (Seedance, Runway, Veo, Kling) on your own keys, behind a hard cost cap",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Release-Type: minor: new project layout - `vibe init` now scaffolds one markdown file per scene under scenes/ with cues in frontmatter, and adds the `vibe storyboard migrate` command. Existing single-file STORYBOARD.md projects still read, edit, build, and render unchanged.
