### PR TITLE
fix: stop `init --from` leaving starter scenes beside the draft's

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,7 +25,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { basename, dirname, resolve } from "node:path";
+import { basename, dirname, resolve, sep } from "node:path";
 
 import { detectedAgentHosts, type AgentHostId } from "../utils/agent-host-detect.js";
 import {
@@ -38,7 +38,7 @@ import {
 } from "./_shared/scene-project.js";
 import { getVisualStyle, visualStyleNames } from "./_shared/visual-styles.js";
 import { draftStoryboardFromBrief } from "./_shared/storyboard-draft.js";
-import { writeStoryboardAsBundle } from "./_shared/storyboard-source.js";
+import { rewriteBundleFromMarkdown } from "./_shared/storyboard-source.js";
 import { projectConfigJson, VIBE_CONFIG_FILENAME } from "./_shared/project-config.js";
 import {
   HYPERFRAMES_SKILL_INSTALL_COMMAND,
@@ -397,11 +397,21 @@ async function runSceneInit(
     const designPath = resolve(projectDir, "DESIGN.md");
     if (options.force || result.created.includes(storyboardPath) || !existsSync(storyboardPath)) {
       // The draft is generated as one document and split into scenes/ by the
-      // same conversion `vibe storyboard migrate` runs.
-      const plan = await writeStoryboardAsBundle(projectDir, draft.storyboardMd);
+      // same conversion `vibe storyboard migrate` runs. Rewrite semantics,
+      // not write: the scaffold has already seeded starter scenes, and any
+      // of them the draft does not name must be deleted, or they survive
+      // beside the draft (a fresh `init --from` with a 4-beat draft used to
+      // leave the starter's `03-close.md` next to `03-mechanism.md` - five
+      // scenes, two of them numbered 03).
+      const plan = await rewriteBundleFromMarkdown(projectDir, draft.storyboardMd);
       if (!result.created.includes(storyboardPath)) result.created.push(storyboardPath);
-      for (const file of plan.scenes) {
-        const scenePath = resolve(projectDir, file.path);
+      const planScenePaths = new Set(plan.scenes.map((file) => resolve(projectDir, file.path)));
+      const scenesDir = resolve(projectDir, "scenes") + sep;
+      // Starter scenes the rewrite deleted must leave the created list too.
+      result.created = result.created.filter(
+        (path) => !path.startsWith(scenesDir) || planScenePaths.has(path)
+      );
+      for (const scenePath of planScenePaths) {
         if (!result.created.includes(scenePath)) result.created.push(scenePath);
       }
     }

--- a/scripts/dogfood-smoke.mts
+++ b/scripts/dogfood-smoke.mts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -97,6 +97,32 @@ try {
   assert.ok(existsSync(join(project, "STORYBOARD.md")), "init should write STORYBOARD.md");
   assert.ok(existsSync(join(project, "DESIGN.md")), "init should write DESIGN.md");
   assert.ok(existsSync(join(project, "vibe.config.json")), "init should write vibe.config.json");
+
+  // `init --from` rewrites the starter bundle with the draft. A duration
+  // long enough for a 4-beat draft makes the draft's scene set differ from
+  // the 3-scene starter, which is exactly the case where leftover starter
+  // files used to survive (two files both numbered 03). The short-duration
+  // init above cannot catch that: its draft ids match the starter's.
+  const fourBeat = join(tmp, "dogfood-four-beat");
+  dataOf(
+    runJson([
+      "init",
+      fourBeat,
+      "--from",
+      "A 20-second four-scene product film to exercise the draft rewrite.",
+      "--duration",
+      "20",
+      "--json",
+    ])
+  );
+  const sceneFiles = (await readdir(join(fourBeat, "scenes"))).filter((f) => f.endsWith(".md")).sort();
+  const prefixes = sceneFiles.map((f) => f.split("-")[0]);
+  assert.equal(
+    new Set(prefixes).size,
+    prefixes.length,
+    `scene filename prefixes must be unique, got: ${sceneFiles.join(", ")}`
+  );
+  assert.ok(sceneFiles.length >= 4, `4-beat draft should yield 4 scenes, got: ${sceneFiles.join(", ")}`);
 
   const validation = dataOf(runJson(["storyboard", "validate", project, "--json"]));
   assertRecord(validation, "storyboard validation");


### PR DESCRIPTION
Found in the first real `init --from` after 0.115.0 shipped (the hybrid-composition experiment).

## The bug

```
$ vibe init vibe-side --from SCRIPT.md --duration 20
$ ls vibe-side/scenes
01-hook.md  02-proof.md  03-close.md  03-mechanism.md  04-close.md
                         ^^^^^^^^^^^  two scenes numbered 03
```

The scaffold seeds three starter scenes, then the draft path wrote its own with `writeStoryboardAsBundle` — **write semantics, no deletion**. Starter files whose names the draft reused were overwritten; the rest survived. A 20-second brief drafts four beats, so every such init shipped five scene files with a duplicate `03-` prefix.

## The fix

The draft path now calls `rewriteBundleFromMarkdown` — the same delete-then-write conversion `storyboard revise` uses — and reconciles `result.created` so deleted starter scenes leave the list rather than being reported as created.

## Why no test caught it

The dogfood smoke's short-duration init drafts the same three ids as the starter (`hook/proof/close`), so overwrite-by-name looked identical to rewrite. That is precisely the blind spot. A second 20-second init in the smoke now asserts scene filename prefixes are unique and all four draft scenes are present.

## Verification

- Reproduction case now yields exactly `01-hook 02-proof 03-mechanism 04-close`, created list matches disk
- 1275 CLI tests pass, lint clean, dogfood smoke (with the new guard) passes