### PR TITLE
fix: stop real `generate video` runs reporting costUsd 0

### DIFF
--- a/packages/cli/src/commands/generate/video-cost.test.ts
+++ b/packages/cli/src/commands/generate/video-cost.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { realRunCost } from "./video.js";
+
+describe("realRunCost", () => {
+  it("prices seedance with the token-accurate estimator, no warning", () => {
+    const { costUsd, warnings } = realRunCost("seedance", { duration: "5" });
+    expect(costUsd).toBeGreaterThan(0);
+    expect(costUsd).toBeLessThan(5); // accurate estimate, not the tier bound
+    expect(warnings).toEqual([]);
+  });
+
+  it("reports the tier upper bound for providers without an estimator", () => {
+    for (const provider of ["runway", "veo", "kling", "grok"]) {
+      const { costUsd, warnings } = realRunCost(provider, { duration: "5" });
+      // Never 0: a paid run reporting $0 reads as "free" to an agent budget
+      // loop - the bug this guards against (hybrid-brew dogfood, 2026-07-26).
+      expect(costUsd).toBeGreaterThan(0);
+      expect(warnings.join(" ")).toContain(provider);
+      expect(warnings.join(" ")).toContain("upper bound");
+    }
+  });
+
+  it("treats the deprecated fal alias like seedance", () => {
+    expect(realRunCost("fal", { duration: "5" }).warnings).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/generate/video.ts
+++ b/packages/cli/src/commands/generate/video.ts
@@ -26,6 +26,7 @@ import { requireApiKey, hasConfiguredApiKey } from "../../utils/api-key.js";
 import { hasTTY, prompt as promptText } from "../../utils/tty.js";
 import {
   isJsonMode,
+  lookupCostEstimateUpperBound,
   outputSuccess,
   log,
   exitWithError,
@@ -721,9 +722,12 @@ Examples:
             outputPath = resolve(process.cwd(), options.output);
             await writeFile(outputPath, buffer);
           }
+          const cost = realRunCost(provider, options);
           outputSuccess({
             command: "generate video",
             startedAt,
+            costUsd: cost.costUsd,
+            warnings: cost.warnings,
             data: {
               provider,
               taskId: result?.id,
@@ -761,6 +765,43 @@ Examples:
         exitWithError(apiError(`Video generation failed: ${(error as Error).message}`));
       }
     });
+}
+
+
+/**
+ * Cost figure for a REAL (non-dry-run) generation envelope.
+ *
+ * Seedance has a token-accurate estimator; every other provider reports the
+ * command's tier upper bound with a warning naming it an estimate. Without
+ * this the success envelope defaulted to costUsd 0, which an agent budget
+ * loop reads as "free" - the hybrid-brew dogfood run billed Runway twice
+ * while reporting $0.
+ */
+export function realRunCost(provider: string, options: {
+  duration?: string;
+  resolution?: string;
+  ratio?: string;
+  seedanceModel?: string;
+  refVideos?: string[];
+}): { costUsd: number; warnings: string[] } {
+  if (provider === "seedance" || provider === "fal") {
+    return {
+      costUsd: estimateSeedanceVideoCostUsd({
+        durationSec: Number(options.duration) || 5,
+        resolution: options.resolution,
+        aspectRatio: options.ratio,
+        fast: options.seedanceModel === "fast",
+        hasVideoReference: Boolean(options.refVideos),
+      }),
+      warnings: [],
+    };
+  }
+  return {
+    costUsd: lookupCostEstimateUpperBound("generate video") ?? 5,
+    warnings: [
+      `costUsd is the tier upper bound for ${provider} - actual provider billing is typically lower and is not metered here.`,
+    ],
+  };
 }
 
 async function prepareSeedanceReferences(opts: {

--- a/packages/cli/src/commands/output.ts
+++ b/packages/cli/src/commands/output.ts
@@ -259,7 +259,12 @@ export interface SuccessEnvelopeOptions {
 }
 
 /** Look up the upper-bound cost estimate for a command (used by dry-run). */
-function lookupCostEstimateUpperBound(command: string): number {
+/**
+ * Exported for real-run envelopes that want the same tier bound the dry-run
+ * default uses (e.g. `generate video` on providers without an accurate
+ * estimator) instead of the misleading non-dry default of 0.
+ */
+export function lookupCostEstimateUpperBound(command: string): number {
   return COST_ESTIMATES[command]?.max ?? 0;
 }
 


### PR DESCRIPTION
Found dogfooding the hybrid-composition experiment: two paid Runway generations each returned an envelope with `costUsd: 0`. **An agent budget loop reads that as "free"** — the exact signal the cost-gate product promise exists to prevent.

## The gap

| Path | costUsd |
|---|---|
| dry-run | tier upper bound (outputSuccess default) ✓ |
| **real run** | **0 — no cost ever passed, every provider** |

## The fix

Real runs report through one helper:

- **Seedance/fal** — keeps the token-accurate estimate, no warning
- **Everything else** — the same tier upper bound the dry run uses, plus a warning: *"costUsd is the tier upper bound for runway — actual provider billing is typically lower and is not metered here."*

An upper bound errs in the safe direction for budget gates; zero errs in the dangerous one. `lookupCostEstimateUpperBound` is exported from output.ts so the real-run path uses exactly the dry-run's fallback rather than a second hardcoded table.

## Tests

Three focused tests pin the property that matters:
- no provider's real-run cost is ever 0
- seedance stays accurate (below the tier bound, no warning)
- the deprecated `fal` alias prices like seedance

## For the record

The companion observation from the same dogfood session — spinner text polluting `--json` stdout — turned out to be an **observation artifact** (the capture merged stderr via `2>&1`; ora writes to stderr). No change needed there; the friction log was corrected.

1278 CLI tests pass (3 new), lint clean, reference current.