### PR TITLE
fix: keep every beat in build-report.json across a --beat run

### DIFF
--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -665,6 +665,7 @@ backdrop: "../outside.png"
     });
 
     expect(r.success).toBe(true);
+    // The RETURNED envelope describes this run: one beat.
     expect(r.beats).toHaveLength(1);
     expect(r.beats[0].beatId).toBe("hook");
 
@@ -675,7 +676,11 @@ backdrop: "../outside.png"
       selectedStage: "assets",
       success: true,
     });
-    expect(report.beats).toHaveLength(1);
+    // The WRITTEN report is the host loop's state and covers every
+    // storyboard beat - a scoped run must not shrink it (the other beats
+    // are reconstructed from disk, untouched ones reporting "skipped").
+    expect(report.beats.map((b) => b.id)).toEqual(["hook", "close"]);
+    expect(report.beats[1].narration).toMatchObject({ status: "skipped" });
     expect(report.beats[0]).toMatchObject({
       id: "hook",
       startSec: 0,
@@ -981,5 +986,53 @@ music: "Minimal confident pulse."
     });
     expect(report.jobs).toHaveLength(2);
     expect(report.retryWith).toContain(`vibe status project ${projectDir} --refresh --json`);
+  });
+});
+
+describe("beat-scoped report preservation", () => {
+  it("a failed --beat run does not shrink build-report.json to that beat", async () => {
+    // Full build first: both beats succeed and the report records them.
+    const full = await executeSceneBuild({
+      projectDir,
+      stage: "assets",
+      skipBackdrop: true,
+      skipMusic: true,
+      skipVideo: true,
+    });
+    expect(full.success).toBe(true);
+    const reportPath = join(projectDir, "build-report.json");
+    const before = JSON.parse(readFileSync(reportPath, "utf-8"));
+    expect(before.beats.map((b: { id: string }) => b.id)).toEqual(["hook", "close"]);
+    const closeNarrationPath = before.beats.find(
+      (b: { id: string }) => b.id === "close"
+    ).narration.path;
+    expect(closeNarrationPath).toBeTruthy();
+
+    // Now make narration fail and retry ONE beat. The report used to be
+    // overwritten with just that failed beat, losing the other beat's
+    // records mid-recovery (hybrid-brew dogfood, 2026-07-26).
+    vi.mocked(resolveTtsProvider).mockResolvedValue({
+      provider: "kokoro",
+      audioExtension: "wav",
+      call: vi.fn().mockResolvedValue({ success: false, error: "boom" }),
+    } as never);
+    const scoped = await executeSceneBuild({
+      projectDir,
+      stage: "assets",
+      beatId: "hook",
+      force: true,
+      skipBackdrop: true,
+      skipMusic: true,
+      skipVideo: true,
+    });
+    expect(scoped.success).toBe(false);
+
+    const after = JSON.parse(readFileSync(reportPath, "utf-8"));
+    expect(after.beats.map((b: { id: string }) => b.id)).toEqual(["hook", "close"]);
+    expect(after.status).toBe("failed");
+    const afterById = Object.fromEntries(after.beats.map((b: { id: string }) => [b.id, b]));
+    expect(afterById.hook.narration.status).toBe("failed");
+    // The untouched beat keeps its on-disk record.
+    expect(afterById.close.narration.path).toBe(closeNarrationPath);
   });
 });

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -463,11 +463,37 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   });
   warnings.push(...buildPlan.warnings);
   retryWith.push(...buildPlan.retryWith);
-  const finishBuildResult = (result: SceneBuildResult) =>
-    finalizeBuildResult(projectDir, startedAt, {
+  const finishBuildResult = async (result: SceneBuildResult) => {
+    const withResolution: SceneBuildResult = {
       providerResolution: buildPlan.providerResolution,
       ...result,
-    });
+    };
+    // A --beat run must not shrink build-report.json to that one beat: the
+    // report is the host loop's state, and the success path preserves the
+    // other beats by reconstructing them from disk during sync. Failure
+    // paths return before sync, so do the same reconstruction here - a
+    // failed per-beat retry used to overwrite a four-beat report with a
+    // single failed beat (hybrid-brew dogfood, 2026-07-26). The merge is
+    // applied to the WRITTEN report only: the returned envelope keeps
+    // describing what this run did, i.e. the one beat.
+    let reportResult = withResolution;
+    if (opts.beatId && result.beats?.length) {
+      try {
+        const parsedAll = parseStoryboard(await loadStoryboardMarkdown(projectDir));
+        reportResult = {
+          ...withResolution,
+          beats: mergeBeatOutcomes(
+            collectExistingBeatOutcomes(parsedAll.beats, projectDir),
+            result.beats
+          ),
+          beatSummary: undefined, // recomputed from the merged beats
+        };
+      } catch {
+        // Reconstruction is best-effort; a scoped report beats no report.
+      }
+    }
+    return finalizeBuildResult(projectDir, startedAt, withResolution, reportResult);
+  };
 
   // ffprobe powers every narration-duration probe. Without it the assets
   // and sync stages would "succeed" with storyboard durations and the final
@@ -2803,27 +2829,38 @@ async function apiKeyForVideoProvider(
 async function finalizeBuildResult(
   projectDir: string,
   startedAt: number,
-  result: SceneBuildResult
+  result: SceneBuildResult,
+  /**
+   * What gets WRITTEN to build-report.json. Defaults to `result`; a
+   * beat-scoped run passes a variant whose beats are merged with the other
+   * beats reconstructed from disk, so the on-disk loop state stays whole
+   * while the returned envelope still describes only this run.
+   */
+  reportResult: SceneBuildResult = result
 ): Promise<SceneBuildResult> {
   const reportPath = join(projectDir, "build-report.json");
-  if (result.stageReports) {
-    for (const report of Object.values(result.stageReports)) {
-      if (report.status === "pending") report.status = "skipped";
+  for (const source of new Set([result, reportResult])) {
+    if (source.stageReports) {
+      for (const report of Object.values(source.stageReports)) {
+        if (report.status === "pending") report.status = "skipped";
+      }
     }
   }
-  const withMeta: SceneBuildResult = {
-    ...result,
-    status: result.status ?? buildWorkflowStatus(result),
-    currentStage: result.currentStage ?? buildCurrentStage(result),
-    beatSummary: result.beatSummary ?? summarizeBuildBeats(projectDir, result.beats),
-    sceneRepair: result.sceneRepair ?? skippedSceneRepairSummary(),
+  const decorate = (base: SceneBuildResult): SceneBuildResult => ({
+    ...base,
+    status: base.status ?? buildWorkflowStatus(base),
+    currentStage: base.currentStage ?? buildCurrentStage(base),
+    beatSummary: base.beatSummary ?? summarizeBuildBeats(projectDir, base.beats),
+    sceneRepair: base.sceneRepair ?? skippedSceneRepairSummary(),
     reportPath,
     totalLatencyMs: Date.now() - startedAt,
-  };
+  });
+  const withMeta = decorate(result);
+  const reportMeta = reportResult === result ? withMeta : decorate(reportResult);
   try {
     await writeFile(
       reportPath,
-      JSON.stringify(toBuildReport(projectDir, withMeta), null, 2) + "\n",
+      JSON.stringify(toBuildReport(projectDir, reportMeta), null, 2) + "\n",
       "utf-8"
     );
   } catch {


### PR DESCRIPTION
Found dogfooding the hybrid experiment: a failed `--beat pour` retry overwrote a four-beat `build-report.json` with a single failed beat. The report is the host loop's state — shrinking it mid-recovery deletes the records of the beats that already succeeded.

## The asymmetry

| Path | Other beats in the written report |
|---|---|
| successful scoped run | preserved — sync stage reconstructs every beat from disk |
| **failed scoped run** | **lost — returns before sync** |

Reproduced deterministically with a dispatch-stage narration failure:

```
before:  [hook, proof, close]
after failed --beat hook:  [hook]        <- proof and close records gone
```

## The fix

The same disk reconstruction now runs at the single report chokepoint (`finishBuildResult`) whenever the run is beat-scoped.

**Deliberately split:** the merge applies to the *written report* only; the *returned envelope* keeps describing what this run did — the one beat. The first version merged both, and an existing test correctly flagged the envelope growing. Report and envelope answer different questions, and `finalizeBuildResult` now takes a separate `reportResult` to say so in the signature.

An untouched beat reconstructs with `status: "skipped"` for assets it has no file for — the same thing a full run with those skip flags would have reported.

## The "stable contract" test was the bug

One existing test codified the old behavior (scoped report contains exactly one beat) as a contract. It now asserts the new one:

- envelope → this run's beat
- report → every storyboard beat, untouched ones `skipped`

A new regression test drives the original failure end to end: full build → failed scoped retry → report still lists all beats, marks the retried one failed, and preserves the untouched beat's narration path.

## Verification

```
after failed --beat hook:  [hook, proof, close]
status: failed · hook narration: failed · proof narration path: preserved
```

1279 CLI tests pass, lint clean, dogfood smoke passes.