### PR TITLE
docs: add the HyperFrames hybrid recipe and the Seedance face-filter note

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -189,6 +189,16 @@ Grok Imagine supports 14 aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:
 
 > `-p fal` is a deprecated v0.x alias for `-p seedance` and will be removed at the 1.0 cut. Use `-p seedance` in new scripts.
 
+> ⚠️ **Seedance rejects image-to-video inputs showing a recognizable face.**
+> The fal.ai endpoint returns a deterministic HTTP 422 ("The images or videos
+> provided may contain likenesses of real people") for keyframes where a
+> person's face is clearly visible; hands-only or back-of-head shots pass.
+> Retrying does not help. For character work where the face must appear, route
+> those shots through another provider, e.g.
+> `vibe generate video "<motion>" -p runway -i keyframe.png`, or through a
+> project build's video provider override. Observed 2026-07-26 on
+> `seedance-2.0`.
+
 > ⚠️ **Gemini Omni is experimental.** It is not wired into default provider resolution — you must pass `-p omni` explicitly. The preview interactions schema may change; treat it as unstable.
 
 ### Veo Advanced Options

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -246,6 +246,78 @@ Available positions: `full`, `center`, `top-left`, `top-right`, `bottom-left`,
 `bottom-right`. The overlay loops by default; pass `--no-loop` for one-shot
 animations. Use `--start <sec>` to delay when the overlay appears.
 
+## 7. Compose VibeFrame Footage With HyperFrames
+
+VibeFrame and upstream [HyperFrames](https://github.com/heygen-com/hyperframes)
+each own half of a narrated, footage-led video: VibeFrame generates the
+frontier clips (cast continuity, keyframe review, a hard `--max-cost`), and
+HyperFrames' `faceless-explainer` workflow owns narration timing, word-synced
+captions, a designed frame system, and transitions. This recipe runs them
+together. It was validated end to end on 2026-07-26; the sharp edges below
+are all from that run.
+
+Requires:
+
+- image + video provider keys for the vibe side (e.g. `GOOGLE_API_KEY`,
+  `FAL_API_KEY`, and `RUNWAY_API_SECRET` for the face-shot fallback)
+- `npx hyperframes` ≥ 0.7.72 with its skills installed
+- for local TTS: a Python ≥ 3.10 venv with `kokoro-onnx` (see step 3)
+
+**1. Generate the footage with vibe.** Author scenes with `keyframe:` +
+`video:` cues and a `characters:` pool, then build assets only - narration,
+music, and composition belong to the other side:
+
+```bash
+vibe init film --from brief.md
+vibe build film --dry-run --max-cost 8 --json     # price gate
+vibe build film --stage assets --skip-video \
+  --skip-narration --skip-music --skip-backdrop   # stills first - review them
+vibe build film --stage assets \
+  --skip-narration --skip-music --skip-backdrop   # animate approved stills
+```
+
+Review the keyframes before animating: cross-scene prop drift (a kettle
+changing color between scenes) is cheap to fix at the still stage and
+expensive after. If Seedance rejects a face-visible keyframe (HTTP 422
+likeness filter - see MODELS.md), route that shot through Runway:
+
+```bash
+vibe generate video "<the scene's motion prompt>" \
+  -p runway -i film/assets/keyframe-<beat>.png -d 5 \
+  -o film/assets/video-<beat>.mp4
+```
+
+**2. Hand the clips to a HyperFrames project.** Scaffold with the
+faceless-explainer skill, copy the clips into `public/`, and write its
+`SCRIPT.md` with the same narration your scenes carried (`VO_MODE:
+verbatim`). One script, both sides - if they drift, visuals and voice
+disagree.
+
+**3. Let upstream own the timing.** Its `audio.mjs` synthesizes narration
+(Kokoro locally - a Python dependency, unlike vibe's built-in Kokoro:
+`uv venv --python 3.12 && uv pip install kokoro-onnx soundfile`, then export
+`HYPERFRAMES_PYTHON=<venv>/bin/python`), and `sync-durations` sets each
+frame's length from the measured voice.
+
+Three sharp edges, all hit in the validation run:
+
+- **Duration has no floor upstream.** `sync-durations` REPLACES a frame's
+  duration with the voice length (vibe keeps `max(declared, voice)`), so a
+  5s clip under a 2s narration line gets hard-trimmed. Write narration long
+  enough for the shot, or add silent frames - upstream keeps their
+  estimates.
+- **Frame ids start with digits** (`01-grind`), and `.01-grind-x` is an
+  illegal CSS/`querySelector` selector. Prefix authored classes with a
+  letter (`f01-`) or gsap throws before registering the timeline and the
+  render "completes" with frozen motion.
+- **Give every `<video>` an `id`.** Upstream lint enforces it
+  (`media_missing_id`) - without one the renderer cannot drive the video
+  and it renders frozen.
+
+**4. Render upstream** (`npx hyperframes lint && npx hyperframes render`)
+and you get the hybrid: your generated footage under their word-synced
+captions and design system.
+
 ## Tips
 
 - Use `--dry-run` before provider-backed steps.


### PR DESCRIPTION
The hybrid path - vibe generates continuity-gated frontier clips,
upstream's faceless-explainer composes them under narration timing - was
validated end to end on a real four-scene project (2026-07-26). This
writes down what that run actually required, so the next person does not
rediscover it the hard way.

docs/recipes.md gains recipe 7: assets-only build with the stills-first
review loop, the Runway fallback for face shots Seedance rejects, the
shared-script rule (one SCRIPT.md, both sides, VO_MODE verbatim), the
Python venv upstream Kokoro needs, and the three sharp edges hit in the
validation run - upstream duration sync has no floor for fixed-length
footage, digit-first frame ids make illegal CSS/querySelector selectors
that fail silently, and every <video> needs an id or it renders frozen.

MODELS.md documents the Seedance likeness filter: a deterministic HTTP
422 for image-to-video keyframes with a clearly visible face (hands-only
shots pass; retrying does not help), with the Runway routing as the
workaround. Anyone doing character work on the default provider hits
this on their first face shot.

Every command cited resolves against the current CLI; no em dashes in
the added text; lint clean.

Claude-Session: https://claude.ai/code/session_016GaqNugbAWTb8Eyim9futp
