### PR TITLE
feat: crossfade-cut generated clips with vibe assemble --footage

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -229,7 +229,7 @@ Cost tier: _not tagged_
 
 #### `vibe assemble`
 
-Mux a scene project's audio onto an already-rendered (silent) video
+Mux a scene project's audio onto a rendered video, or crossfade-cut its generated clips (--footage)
 
 Product surface: `advanced`
 Note: Standalone audio-mux stage; `render` does this automatically.
@@ -242,6 +242,12 @@ Cost tier: _not tagged_
 - `video` _(string)_ _(default: `"preview.mp4"`)_ - Rendered video to add audio to (default: preview.mp4)
 - `root` _(string)_ _(default: `"index.html"`)_ - Root composition file
 - `format` _(string)_ _(default: `"mp4"`)_ - Output container: mp4|webm|mov
+- `footage` _(boolean)_ - Assemble assets/video-<beat>.mp4 clips into one cinematic cut (no HTML render)
+- `output` _(string)_ - Footage-cut output path (default: renders/footage.mp4)
+- `transition` _(number)_ _(default: `0.5`)_ - Footage crossfade length in seconds
+- `fade` _(number)_ _(default: `0.6`)_ - Footage fade-from/to-black length in seconds
+- `music` _(string)_ - Footage music bed: a file path or "none" (default: auto-detect assets/music\*)
+- `musicVolume` _(string)_ _(default: `"0.35"`)_ - Footage music-bed volume before ducking (0-1)
 - `dryRun` _(boolean)_ - Preview parameters without muxing
 
 #### `vibe build`

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -63,7 +63,7 @@ exports[`CLI --describe schemas (drift detection) > vibe agent --describe 1`] = 
 
 exports[`CLI --describe schemas (drift detection) > vibe assemble --describe 1`] = `
 {
-  "description": "Mux a scene project's audio onto an already-rendered (silent) video",
+  "description": "Mux a scene project's audio onto a rendered video, or crossfade-cut its generated clips (--footage)",
   "name": "assemble",
   "note": "Standalone audio-mux stage; \`render\` does this automatically.",
   "parameters": {
@@ -72,9 +72,31 @@ exports[`CLI --describe schemas (drift detection) > vibe assemble --describe 1`]
         "description": "Preview parameters without muxing",
         "type": "boolean",
       },
+      "fade": {
+        "default": 0.6,
+        "description": "Footage fade-from/to-black length in seconds",
+        "type": "number",
+      },
+      "footage": {
+        "description": "Assemble assets/video-<beat>.mp4 clips into one cinematic cut (no HTML render)",
+        "type": "boolean",
+      },
       "format": {
         "default": "mp4",
         "description": "Output container: mp4|webm|mov",
+        "type": "string",
+      },
+      "music": {
+        "description": "Footage music bed: a file path or "none" (default: auto-detect assets/music*)",
+        "type": "string",
+      },
+      "musicVolume": {
+        "default": "0.35",
+        "description": "Footage music-bed volume before ducking (0-1)",
+        "type": "string",
+      },
+      "output": {
+        "description": "Footage-cut output path (default: renders/footage.mp4)",
         "type": "string",
       },
       "project-dir": {
@@ -85,6 +107,11 @@ exports[`CLI --describe schemas (drift detection) > vibe assemble --describe 1`]
         "default": "index.html",
         "description": "Root composition file",
         "type": "string",
+      },
+      "transition": {
+        "default": 0.5,
+        "description": "Footage crossfade length in seconds",
+        "type": "number",
       },
       "video": {
         "default": "preview.mp4",
@@ -1750,51 +1777,6 @@ exports[`CLI --describe schemas (drift detection) > vibe edit upscale --describe
 }
 `;
 
-exports[`CLI --describe schemas (drift detection) > vibe generate background --describe 1`] = `
-{
-  "cost": "high",
-  "description": "Generate video background using DALL-E",
-  "name": "generate.background",
-  "note": "Backdrops are generated through image generation or the project build.",
-  "parameters": {
-    "properties": {
-      "apiKey": {
-        "description": "OpenAI API key (or set OPENAI_API_KEY env)",
-        "type": "string",
-      },
-      "aspect": {
-        "default": "16:9",
-        "description": "Aspect ratio: 16:9, 9:16, 1:1",
-        "enum": [
-          "16:9",
-          "9:16",
-          "1:1",
-        ],
-        "type": "string",
-      },
-      "description": {
-        "description": "Background description",
-        "type": "string",
-      },
-      "dryRun": {
-        "description": "Preview parameters without executing",
-        "type": "boolean",
-      },
-      "output": {
-        "description": "Output file path (downloads image)",
-        "type": "string",
-      },
-    },
-    "required": [
-      "description",
-    ],
-    "type": "object",
-  },
-  "replacement": "vibe generate image or vibe build --stage assets",
-  "surface": "legacy",
-}
-`;
-
 exports[`CLI --describe schemas (drift detection) > vibe generate image --describe 1`] = `
 {
   "cost": "high",
@@ -2039,33 +2021,6 @@ exports[`CLI --describe schemas (drift detection) > vibe generate music --descri
 }
 `;
 
-exports[`CLI --describe schemas (drift detection) > vibe generate music-status --describe 1`] = `
-{
-  "cost": "free",
-  "description": "Check music generation status",
-  "name": "generate.music-status",
-  "note": "Provider-task polling primitive retained for compatibility.",
-  "parameters": {
-    "properties": {
-      "apiKey": {
-        "description": "Replicate API token (or set REPLICATE_API_TOKEN env)",
-        "type": "string",
-      },
-      "task-id": {
-        "description": "Task ID from music generation",
-        "type": "string",
-      },
-    },
-    "required": [
-      "task-id",
-    ],
-    "type": "object",
-  },
-  "replacement": "vibe status job <job-id> --json",
-  "surface": "legacy",
-}
-`;
-
 exports[`CLI --describe schemas (drift detection) > vibe generate narration --describe 1`] = `
 {
   "cost": "low",
@@ -2142,100 +2097,6 @@ exports[`CLI --describe schemas (drift detection) > vibe generate sound-effect -
     "type": "object",
   },
   "surface": "public",
-}
-`;
-
-exports[`CLI --describe schemas (drift detection) > vibe generate speech --describe 1`] = `
-{
-  "cost": "low",
-  "description": "Generate speech from text using ElevenLabs",
-  "name": "generate.speech",
-  "note": "Compatibility alias for product-facing narration generation.",
-  "parameters": {
-    "properties": {
-      "apiKey": {
-        "description": "ElevenLabs API key (or set ELEVENLABS_API_KEY env)",
-        "type": "string",
-      },
-      "dryRun": {
-        "description": "Preview parameters without executing",
-        "type": "boolean",
-      },
-      "fitDuration": {
-        "description": "Speed up audio to fit target duration (via FFmpeg atempo)",
-        "type": "number",
-      },
-      "listVoices": {
-        "description": "List available voices",
-        "type": "boolean",
-      },
-      "output": {
-        "default": "output.mp3",
-        "description": "Output audio file path",
-        "type": "string",
-      },
-      "text": {
-        "description": "Text to convert to speech (interactive if omitted)",
-        "type": "string",
-      },
-      "voice": {
-        "default": "21m00Tcm4TlvDq8ikWAM",
-        "description": "Voice ID (default: Rachel)",
-        "type": "string",
-      },
-    },
-    "type": "object",
-  },
-  "replacement": "vibe generate narration",
-  "surface": "legacy",
-}
-`;
-
-exports[`CLI --describe schemas (drift detection) > vibe generate storyboard --describe 1`] = `
-{
-  "cost": "high",
-  "description": "Generate video storyboard from content using Claude",
-  "name": "generate.storyboard",
-  "note": "Project-ready storyboard drafting belongs in init/revise.",
-  "parameters": {
-    "properties": {
-      "apiKey": {
-        "description": "Anthropic API key (or set ANTHROPIC_API_KEY env)",
-        "type": "string",
-      },
-      "content": {
-        "description": "Content to analyze (text or file path)",
-        "type": "string",
-      },
-      "creativity": {
-        "default": "low",
-        "description": "Creativity level: low (default, consistent) or high (varied, unexpected)",
-        "type": "string",
-      },
-      "dryRun": {
-        "description": "Preview parameters without executing",
-        "type": "boolean",
-      },
-      "duration": {
-        "description": "Target total duration in seconds",
-        "type": "number",
-      },
-      "file": {
-        "description": "Treat content argument as file path",
-        "type": "boolean",
-      },
-      "output": {
-        "description": "Output JSON file path",
-        "type": "string",
-      },
-    },
-    "required": [
-      "content",
-    ],
-    "type": "object",
-  },
-  "replacement": "vibe init --from <brief> or vibe storyboard revise",
-  "surface": "legacy",
 }
 `;
 
@@ -2501,57 +2362,6 @@ exports[`CLI --describe schemas (drift detection) > vibe generate video-extend -
     "type": "object",
   },
   "surface": "advanced",
-}
-`;
-
-exports[`CLI --describe schemas (drift detection) > vibe generate video-status --describe 1`] = `
-{
-  "cost": "free",
-  "description": "Check video generation status (Grok, Runway, Kling, or Veo)",
-  "name": "generate.video-status",
-  "note": "Provider-task polling primitive retained for compatibility.",
-  "parameters": {
-    "properties": {
-      "apiKey": {
-        "description": "API key (or set XAI_API_KEY / RUNWAY_API_SECRET / KLING_API_KEY / GOOGLE_API_KEY env)",
-        "type": "string",
-      },
-      "output": {
-        "description": "Download video when complete",
-        "type": "string",
-      },
-      "provider": {
-        "default": "grok",
-        "description": "Provider: grok, runway, kling, veo",
-        "enum": [
-          "grok",
-          "runway",
-          "kling",
-          "veo",
-        ],
-        "type": "string",
-      },
-      "task-id": {
-        "description": "Task ID from video generation",
-        "type": "string",
-      },
-      "type": {
-        "default": "text2video",
-        "description": "Task type: text2video or image2video (Kling only)",
-        "type": "string",
-      },
-      "wait": {
-        "description": "Wait for completion",
-        "type": "boolean",
-      },
-    },
-    "required": [
-      "task-id",
-    ],
-    "type": "object",
-  },
-  "replacement": "vibe status job <job-id> --json",
-  "surface": "legacy",
 }
 `;
 
@@ -2869,54 +2679,6 @@ exports[`CLI --describe schemas (drift detection) > vibe inspect render --descri
 }
 `;
 
-exports[`CLI --describe schemas (drift detection) > vibe inspect review --describe 1`] = `
-{
-  "cost": "low",
-  "description": "Review video quality using Gemini AI and optionally auto-fix issues",
-  "name": "inspect.review",
-  "note": "Project render review now lives under inspect render.",
-  "parameters": {
-    "properties": {
-      "autoApply": {
-        "description": "Automatically apply fixable corrections",
-        "type": "boolean",
-      },
-      "dryRun": {
-        "description": "Preview parameters without executing",
-        "type": "boolean",
-      },
-      "model": {
-        "default": "flash",
-        "description": "Gemini model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-* model ID",
-        "type": "string",
-      },
-      "output": {
-        "description": "Output video file path (for auto-apply)",
-        "type": "string",
-      },
-      "source": {
-        "description": "Video file path",
-        "type": "string",
-      },
-      "storyboard": {
-        "description": "Storyboard JSON file for context",
-        "type": "string",
-      },
-      "verify": {
-        "description": "Run verification pass after applying fixes",
-        "type": "boolean",
-      },
-    },
-    "required": [
-      "source",
-    ],
-    "type": "object",
-  },
-  "replacement": "vibe inspect render --ai",
-  "surface": "legacy",
-}
-`;
-
 exports[`CLI --describe schemas (drift detection) > vibe inspect suggest --describe 1`] = `
 {
   "cost": "low",
@@ -2953,71 +2715,6 @@ exports[`CLI --describe schemas (drift detection) > vibe inspect suggest --descr
     "type": "object",
   },
   "surface": "advanced",
-}
-`;
-
-exports[`CLI --describe schemas (drift detection) > vibe inspect video --describe 1`] = `
-{
-  "cost": "low",
-  "description": "Analyze video using Gemini (summarize, Q&A, extract info)",
-  "name": "inspect.video",
-  "note": "Compatibility alias for media understanding.",
-  "parameters": {
-    "properties": {
-      "apiKey": {
-        "description": "Google API key (or set GOOGLE_API_KEY env)",
-        "type": "string",
-      },
-      "dryRun": {
-        "description": "Preview parameters without executing",
-        "type": "boolean",
-      },
-      "end": {
-        "description": "End offset in seconds (for clipping)",
-        "type": "number",
-      },
-      "fields": {
-        "description": "Comma-separated fields to include in output (e.g., response,model)",
-        "type": "string",
-      },
-      "fps": {
-        "description": "Frames per second (default: 1, higher for action)",
-        "type": "number",
-      },
-      "lowRes": {
-        "description": "Use low resolution mode (fewer tokens, longer videos)",
-        "type": "boolean",
-      },
-      "model": {
-        "default": "flash",
-        "description": "Model: flash/latest (Gemini 3.5 Flash), flash-3.5, flash-3, flash-2.5, pro, pro-3.1, or a full gemini-* model ID",
-        "type": "string",
-      },
-      "prompt": {
-        "description": "Analysis prompt (e.g., 'Summarize this video')",
-        "type": "string",
-      },
-      "source": {
-        "description": "Video file path or YouTube URL",
-        "type": "string",
-      },
-      "start": {
-        "description": "Start offset in seconds (for clipping)",
-        "type": "number",
-      },
-      "verbose": {
-        "description": "Show token usage",
-        "type": "boolean",
-      },
-    },
-    "required": [
-      "source",
-      "prompt",
-    ],
-    "type": "object",
-  },
-  "replacement": "vibe inspect media",
-  "surface": "legacy",
 }
 `;
 
@@ -3428,77 +3125,6 @@ exports[`CLI --describe schemas (drift detection) > vibe remix highlights --desc
     "type": "object",
   },
   "surface": "public",
-}
-`;
-
-exports[`CLI --describe schemas (drift detection) > vibe remix regenerate-scene --describe 1`] = `
-{
-  "cost": "very-high",
-  "description": "Regenerate a specific scene in a script-to-video output directory",
-  "name": "remix.regenerate-scene",
-  "note": "Scene regeneration belongs in the project build flow.",
-  "parameters": {
-    "properties": {
-      "aspectRatio": {
-        "default": "16:9",
-        "description": "Aspect ratio: 16:9 | 9:16 | 1:1",
-        "type": "string",
-      },
-      "dryRun": {
-        "description": "Preview parameters without executing",
-        "type": "boolean",
-      },
-      "generator": {
-        "default": "grok",
-        "description": "Video generator: grok | kling | runway | veo",
-        "type": "string",
-      },
-      "imageOnly": {
-        "description": "Only regenerate image",
-        "type": "boolean",
-      },
-      "imageProvider": {
-        "default": "gemini",
-        "description": "Image provider: gemini | openai | grok",
-        "type": "string",
-      },
-      "narrationOnly": {
-        "description": "Only regenerate narration",
-        "type": "boolean",
-      },
-      "project-dir": {
-        "description": "Path to the script-to-video output directory",
-        "type": "string",
-      },
-      "referenceScene": {
-        "description": "Use another scene's image as reference for character consistency",
-        "type": "string",
-      },
-      "retries": {
-        "default": 2,
-        "description": "Number of retries for video generation failures",
-        "type": "number",
-      },
-      "scene": {
-        "description": "Scene number(s) to regenerate (1-based), e.g., 3 or 3,4,5",
-        "type": "string",
-      },
-      "videoOnly": {
-        "description": "Only regenerate video",
-        "type": "boolean",
-      },
-      "voice": {
-        "description": "ElevenLabs voice ID for narration",
-        "type": "string",
-      },
-    },
-    "required": [
-      "project-dir",
-    ],
-    "type": "object",
-  },
-  "replacement": "vibe build <project> --beat <id> --force --json",
-  "surface": "legacy",
 }
 `;
 
@@ -4776,22 +4402,6 @@ exports[`envelope shape (--dry-run --json) > detect scenes (free, basic) 1`] = `
 }
 `;
 
-exports[`envelope shape (--dry-run --json) > generate background (low cost) 1`] = `
-{
-  "command": "generate background",
-  "costUsd": 0,
-  "data": {
-    "params": {
-      "aspect": "16:9",
-      "description": "sunset over ocean",
-    },
-  },
-  "dryRun": true,
-  "elapsedMs": "<elapsedMs>",
-  "warnings": [],
-}
-`;
-
 exports[`envelope shape (--dry-run --json) > generate image (low cost, OpenAI default) 1`] = `
 {
   "command": "generate image",
@@ -4804,23 +4414,6 @@ exports[`envelope shape (--dry-run --json) > generate image (low cost, OpenAI de
       "quality": "standard",
       "ratio": "1:1",
       "size": "1024x1024",
-    },
-  },
-  "dryRun": true,
-  "elapsedMs": "<elapsedMs>",
-  "warnings": [],
-}
-`;
-
-exports[`envelope shape (--dry-run --json) > generate speech (medium cost) 1`] = `
-{
-  "command": "generate speech",
-  "costUsd": 0.3,
-  "data": {
-    "params": {
-      "output": "output.mp3",
-      "text": "hello",
-      "voice": "21m00Tcm4TlvDq8ikWAM",
     },
   },
   "dryRun": true,

--- a/packages/cli/src/commands/_shared/footage-assemble.test.ts
+++ b/packages/cli/src/commands/_shared/footage-assemble.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFootageAssembleArgs,
+  planFootageTimeline,
+  FOOTAGE_DEFAULTS,
+} from "./footage-assemble.js";
+
+describe("planFootageTimeline", () => {
+  it("chains segments with a crossfade overlap and reports xfade-ready offsets", () => {
+    const plan = planFootageTimeline(
+      [
+        { id: "a", clipDurationSec: 5 },
+        { id: "b", clipDurationSec: 5 },
+        { id: "c", clipDurationSec: 4 },
+      ],
+      { transitionSec: 0.5 }
+    );
+    expect(plan.transitionSec).toBe(0.5);
+    expect(plan.beats.map((b) => b.startSec)).toEqual([0, 4.5, 9]);
+    // total = 5 + 5 + 4 - 2 * 0.5
+    expect(plan.totalDurationSec).toBe(13);
+    expect(plan.warnings).toEqual([]);
+  });
+
+  it("extends a segment by holding the last frame when narration outruns the clip", () => {
+    const plan = planFootageTimeline(
+      [
+        { id: "a", clipDurationSec: 5, narrationDurationSec: 6 },
+        { id: "b", clipDurationSec: 5 },
+      ],
+      { transitionSec: 0.5, narrationLeadSec: 0.35, narrationTailSec: 0.4 }
+    );
+    const a = plan.beats[0];
+    // required = 0.35 lead + 6 narration + 0.4 tail = 6.75
+    expect(a.segmentDurationSec).toBe(6.75);
+    expect(a.extendedSec).toBe(1.75);
+    expect(a.narrationStartSec).toBe(0.35);
+    expect(plan.beats[1].startSec).toBe(6.25);
+    expect(plan.warnings.some((w) => w.includes('"a"'))).toBe(true);
+  });
+
+  it("keeps the clip length as the floor when narration is shorter", () => {
+    const plan = planFootageTimeline(
+      [
+        { id: "a", clipDurationSec: 5, narrationDurationSec: 2 },
+        { id: "b", clipDurationSec: 5, narrationDurationSec: 2 },
+      ],
+      { transitionSec: 0.5, narrationLeadSec: 0.35 }
+    );
+    expect(plan.beats.map((b) => b.segmentDurationSec)).toEqual([5, 5]);
+    expect(plan.beats.map((b) => b.extendedSec)).toEqual([0, 0]);
+    // Beat b's narration starts after half the incoming crossfade + the lead.
+    expect(plan.beats[1].narrationStartSec).toBe(4.5 + 0.25 + 0.35);
+  });
+
+  it("reserves the tail fade after the last beat's narration", () => {
+    const plan = planFootageTimeline(
+      [{ id: "only", clipDurationSec: 3, narrationDurationSec: 3 }],
+      { transitionSec: 0.5, fadeSec: 1, narrationLeadSec: 0.35, narrationTailSec: 0.4 }
+    );
+    // tail = max(0.4, fade 1) => 0.35 + 3 + 1
+    expect(plan.totalDurationSec).toBe(4.35);
+  });
+
+  it("clamps the transition to half the shortest clip with a warning", () => {
+    const plan = planFootageTimeline(
+      [
+        { id: "a", clipDurationSec: 5 },
+        { id: "b", clipDurationSec: 1 },
+      ],
+      { transitionSec: 2 }
+    );
+    expect(plan.transitionSec).toBe(0.45);
+    expect(plan.warnings.some((w) => w.includes("clamped"))).toBe(true);
+  });
+
+  it("throws on an empty clip list", () => {
+    expect(() => planFootageTimeline([])).toThrow(/No clips/);
+  });
+});
+
+describe("buildFootageAssembleArgs", () => {
+  const plan = planFootageTimeline(
+    [
+      { id: "a", clipDurationSec: 5, narrationDurationSec: 6 },
+      { id: "b", clipDurationSec: 5 },
+    ],
+    { transitionSec: 0.5 }
+  );
+
+  it("builds the xfade chain at planned offsets with normalized inputs", () => {
+    const args = buildFootageAssembleArgs({
+      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      plan,
+      narrationPaths: new Map(),
+      outputPath: "/p/out.mp4",
+    });
+    expect(args[0]).toBe("-y");
+    const fc = args[args.indexOf("-filter_complex") + 1];
+    expect(fc).toContain(`[0:v]scale=1920:1080`);
+    expect(fc).toContain("tpad=stop_mode=clone:stop_duration=1.75");
+    expect(fc).toContain(`xfade=transition=fade:duration=0.5:offset=${plan.beats[1].startSec}`);
+    expect(fc).toContain("fade=t=in:st=0");
+    expect(args).toContain("-an");
+    expect(args[args.length - 1]).toBe("/p/out.mp4");
+    expect(args).toContain("+faststart");
+  });
+
+  it("delays each narration to its planned start and mixes over ducked music", () => {
+    const args = buildFootageAssembleArgs({
+      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      plan,
+      narrationPaths: new Map([[0, "/p/nar-a.mp3"]]),
+      musicPath: "/p/music.mp3",
+      outputPath: "/p/out.mp4",
+    });
+    const fc = args[args.indexOf("-filter_complex") + 1];
+    const expectedMs = Math.round((plan.beats[0].narrationStartSec ?? 0) * 1000);
+    expect(fc).toContain(`[2:a]adelay=${expectedMs}:all=1[nd0]`);
+    expect(fc).toContain("sidechaincompress=threshold=");
+    expect(fc).toContain(`volume=${FOOTAGE_DEFAULTS.musicVolume}`);
+    expect(args).toContain("-stream_loop");
+    expect(args).toContain("[aout]");
+    expect(args).not.toContain("-an");
+  });
+
+  it("mixes multiple narrations without music via amix", () => {
+    const args = buildFootageAssembleArgs({
+      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      plan: planFootageTimeline(
+        [
+          { id: "a", clipDurationSec: 5, narrationDurationSec: 2 },
+          { id: "b", clipDurationSec: 5, narrationDurationSec: 2 },
+        ],
+        { transitionSec: 0.5 }
+      ),
+      narrationPaths: new Map([
+        [0, "/p/nar-a.mp3"],
+        [1, "/p/nar-b.mp3"],
+      ]),
+      outputPath: "/p/out.mp4",
+    });
+    const fc = args[args.indexOf("-filter_complex") + 1];
+    expect(fc).toContain("amix=inputs=2:normalize=0[nar]");
+    expect(fc).not.toContain("sidechaincompress");
+  });
+});

--- a/packages/cli/src/commands/_shared/footage-assemble.ts
+++ b/packages/cli/src/commands/_shared/footage-assemble.ts
@@ -1,0 +1,541 @@
+/**
+ * @module _shared/footage-assemble
+ *
+ * The footage-cut assembler: crossfade-concatenate a scene project's generated
+ * per-beat clips (`assets/video-<beat>.mp4`) into one cinematic cut, laying
+ * per-beat narration at computed offsets with an optional ducked music bed —
+ * all in a single FFmpeg pass, no HTML composition or browser capture.
+ *
+ * This is the footage-led alternative to the HyperFrames render path: provider
+ * clips are the picture, so timing is derived from the real files on disk
+ * (ffprobe), not from declared storyboard durations. Segments whose narration
+ * outruns the clip are extended by cloning the last frame (`tpad`), which is
+ * the footage equivalent of the "voice duration wins, with a floor" rule in
+ * `root-sync`.
+ */
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+import { execSafe, ffprobeDuration } from "../../utils/exec-safe.js";
+import { ffmpegToolsAvailable } from "./ffmpeg-gate.js";
+import { parseStoryboard } from "./storyboard-parse.js";
+import { loadStoryboardMarkdown } from "./storyboard-source.js";
+import type { ReviewAction } from "./review-report.js";
+
+// ── planning (pure) ────────────────────────────────────────────────────────
+
+export interface FootageClipInput {
+  id: string;
+  clipDurationSec: number;
+  narrationDurationSec?: number;
+}
+
+export interface FootagePlanOptions {
+  /** Crossfade length between segments (seconds). */
+  transitionSec?: number;
+  /** Fade-from/to-black length at the head and tail of the cut (seconds). */
+  fadeSec?: number;
+  /** Gap between a segment becoming dominant and its narration starting. */
+  narrationLeadSec?: number;
+  /** Silence required after narration ends before the segment may end. */
+  narrationTailSec?: number;
+}
+
+export interface FootageBeatPlan {
+  id: string;
+  clipDurationSec: number;
+  narrationDurationSec?: number;
+  /** Segment length on the timeline (clip, possibly tpad-extended). */
+  segmentDurationSec: number;
+  /** Seconds of last-frame clone added so narration + tail fit. 0 = untouched. */
+  extendedSec: number;
+  /** Timeline position where this segment (and its incoming crossfade) starts. */
+  startSec: number;
+  /** Timeline position where this segment's narration starts (when present). */
+  narrationStartSec?: number;
+}
+
+export interface FootageTimelinePlan {
+  beats: FootageBeatPlan[];
+  transitionSec: number;
+  fadeSec: number;
+  totalDurationSec: number;
+  warnings: string[];
+}
+
+export const FOOTAGE_DEFAULTS = {
+  transitionSec: 0.5,
+  fadeSec: 0.6,
+  narrationLeadSec: 0.35,
+  narrationTailSec: 0.4,
+  width: 1920,
+  height: 1080,
+  fps: 30,
+  crf: 18,
+  musicVolume: 0.35,
+  duck: { thresholdDb: -30, ratio: 3, attackMs: 20, releaseMs: 200 },
+} as const;
+
+const round3 = (n: number): number => Math.round(n * 1000) / 1000;
+
+/**
+ * Compute segment lengths and timeline offsets from real clip/narration
+ * durations. Deterministic and side-effect free so agents can reason about the
+ * cut from the report alone.
+ *
+ * Timeline model: segment i starts at `start_i = start_{i-1} + seg_{i-1} - T`
+ * (each crossfade overlaps T seconds), so the xfade filter offset for join i
+ * is exactly `start_i`. When clips are too short to host the requested
+ * transition, T is clamped (with a warning) instead of failing the run.
+ */
+export function planFootageTimeline(
+  inputs: FootageClipInput[],
+  opts: FootagePlanOptions = {}
+): FootageTimelinePlan {
+  if (inputs.length === 0) {
+    throw new Error("No clips to assemble.");
+  }
+  const fadeSec = opts.fadeSec ?? FOOTAGE_DEFAULTS.fadeSec;
+  const narrationLeadSec = opts.narrationLeadSec ?? FOOTAGE_DEFAULTS.narrationLeadSec;
+  const narrationTailSec = opts.narrationTailSec ?? FOOTAGE_DEFAULTS.narrationTailSec;
+  const warnings: string[] = [];
+
+  // A transition consumes T seconds at both ends of a segment; every clip must
+  // keep some of its own frames on screen, so cap T at half the shortest clip.
+  let transitionSec = opts.transitionSec ?? FOOTAGE_DEFAULTS.transitionSec;
+  if (inputs.length > 1) {
+    const shortest = Math.min(...inputs.map((c) => c.clipDurationSec));
+    const maxTransition = round3(Math.max(0, shortest / 2 - 0.05));
+    if (transitionSec > maxTransition) {
+      warnings.push(
+        `Transition ${transitionSec}s exceeds half the shortest clip (${shortest}s); clamped to ${maxTransition}s.`
+      );
+      transitionSec = maxTransition;
+    }
+  }
+
+  const beats: FootageBeatPlan[] = [];
+  let cursor = 0;
+  for (let i = 0; i < inputs.length; i++) {
+    const input = inputs[i];
+    const isFirst = i === 0;
+    const isLast = i === inputs.length - 1;
+    const startSec = round3(cursor);
+
+    // Narration starts once the incoming crossfade has (mostly) resolved.
+    const inSegmentOffset = (isFirst ? 0 : transitionSec / 2) + narrationLeadSec;
+    let segmentDurationSec = input.clipDurationSec;
+    let narrationStartSec: number | undefined;
+    if (input.narrationDurationSec !== undefined) {
+      narrationStartSec = round3(startSec + inSegmentOffset);
+      const tail = isLast ? Math.max(narrationTailSec, fadeSec) : narrationTailSec;
+      const required = inSegmentOffset + input.narrationDurationSec + tail;
+      segmentDurationSec = Math.max(segmentDurationSec, required);
+    }
+    segmentDurationSec = round3(segmentDurationSec);
+    const extendedSec = round3(segmentDurationSec - input.clipDurationSec);
+    if (extendedSec > 0) {
+      warnings.push(
+        `Beat "${input.id}": narration outruns the clip; last frame held for ${extendedSec}s.`
+      );
+    }
+
+    beats.push({
+      id: input.id,
+      clipDurationSec: input.clipDurationSec,
+      narrationDurationSec: input.narrationDurationSec,
+      segmentDurationSec,
+      extendedSec,
+      startSec,
+      narrationStartSec,
+    });
+    cursor = startSec + segmentDurationSec - (isLast ? 0 : transitionSec);
+  }
+
+  return {
+    beats,
+    transitionSec,
+    fadeSec,
+    totalDurationSec: round3(cursor),
+    warnings,
+  };
+}
+
+// ── ffmpeg args (pure) ─────────────────────────────────────────────────────
+
+export interface FootageAssembleArgsOptions {
+  /** Absolute clip paths, in beat order (parallel to `plan.beats`). */
+  clipPaths: string[];
+  plan: FootageTimelinePlan;
+  /** Absolute narration paths keyed by beat index (sparse — not every beat narrates). */
+  narrationPaths: ReadonlyMap<number, string>;
+  /** Absolute music-bed path; looped and ducked under narration when present. */
+  musicPath?: string;
+  outputPath: string;
+  width?: number;
+  height?: number;
+  fps?: number;
+  crf?: number;
+  musicVolume?: number;
+}
+
+/**
+ * Build the single-pass FFmpeg invocation: normalize every clip to one
+ * geometry/fps, xfade-chain them at the planned offsets, fade the head and
+ * tail, and mix narration (adelay per beat) over an optional looped,
+ * sidechain-ducked music bed.
+ */
+export function buildFootageAssembleArgs(opts: FootageAssembleArgsOptions): string[] {
+  const { plan, clipPaths, narrationPaths, musicPath, outputPath } = opts;
+  const width = opts.width ?? FOOTAGE_DEFAULTS.width;
+  const height = opts.height ?? FOOTAGE_DEFAULTS.height;
+  const fps = opts.fps ?? FOOTAGE_DEFAULTS.fps;
+  const crf = opts.crf ?? FOOTAGE_DEFAULTS.crf;
+  const musicVolume = opts.musicVolume ?? FOOTAGE_DEFAULTS.musicVolume;
+  const total = plan.totalDurationSec;
+  const fade = plan.fadeSec;
+
+  const args: string[] = ["-y"];
+  for (const clip of clipPaths) args.push("-i", clip);
+  const narrationEntries = [...narrationPaths.entries()].sort(([a], [b]) => a - b);
+  const narrationInputIndex = new Map<number, number>();
+  for (const [beatIndex, path] of narrationEntries) {
+    narrationInputIndex.set(beatIndex, clipPaths.length + narrationInputIndex.size);
+    args.push("-i", path);
+  }
+  let musicInputIndex: number | undefined;
+  if (musicPath) {
+    musicInputIndex = clipPaths.length + narrationInputIndex.size;
+    args.push("-stream_loop", "-1", "-i", musicPath);
+  }
+
+  const filters: string[] = [];
+
+  // Video: normalize each clip, extend where the plan says so, xfade-chain.
+  for (let i = 0; i < clipPaths.length; i++) {
+    const extend = plan.beats[i].extendedSec;
+    const tpad = extend > 0 ? `,tpad=stop_mode=clone:stop_duration=${extend}` : "";
+    filters.push(
+      `[${i}:v]scale=${width}:${height}:force_original_aspect_ratio=increase,` +
+        `crop=${width}:${height},setsar=1,fps=${fps},settb=AVTB,format=yuv420p${tpad}[v${i}]`
+    );
+  }
+  let videoLabel = "[v0]";
+  for (let i = 1; i < clipPaths.length; i++) {
+    const out = `[vx${i}]`;
+    filters.push(
+      `${videoLabel}[v${i}]xfade=transition=fade:duration=${plan.transitionSec}:` +
+        `offset=${plan.beats[i].startSec}${out}`
+    );
+    videoLabel = out;
+  }
+  filters.push(
+    `${videoLabel}fade=t=in:st=0:d=${fade},` +
+      `fade=t=out:st=${round3(Math.max(0, total - fade))}:d=${fade}[vout]`
+  );
+
+  // Audio: narration mix (delayed per beat) over an optional ducked music bed.
+  let audioLabel: string | undefined;
+  if (narrationInputIndex.size > 0) {
+    const delayed: string[] = [];
+    for (const [beatIndex, inputIndex] of narrationInputIndex) {
+      const ms = Math.round((plan.beats[beatIndex].narrationStartSec ?? 0) * 1000);
+      const label = `[nd${beatIndex}]`;
+      filters.push(`[${inputIndex}:a]adelay=${ms}:all=1${label}`);
+      delayed.push(label);
+    }
+    if (delayed.length === 1) {
+      filters.push(`${delayed[0]}anull[nar]`);
+    } else {
+      filters.push(`${delayed.join("")}amix=inputs=${delayed.length}:normalize=0[nar]`);
+    }
+    audioLabel = "[nar]";
+  }
+  if (musicInputIndex !== undefined) {
+    filters.push(
+      `[${musicInputIndex}:a]atrim=0:${total},asetpts=PTS-STARTPTS,volume=${musicVolume}[mb]`
+    );
+    if (audioLabel) {
+      const { thresholdDb, ratio, attackMs, releaseMs } = FOOTAGE_DEFAULTS.duck;
+      const thresholdLinear = round3(Math.pow(10, thresholdDb / 20));
+      filters.push(
+        `${audioLabel}asplit=2[narA][narSC]`,
+        `[mb][narSC]sidechaincompress=threshold=${thresholdLinear}:ratio=${ratio}:` +
+          `attack=${attackMs}:release=${releaseMs}[mduck]`,
+        `[mduck][narA]amix=inputs=2:normalize=0[mix]`
+      );
+      audioLabel = "[mix]";
+    } else {
+      audioLabel = "[mb]";
+    }
+  }
+  if (audioLabel) {
+    filters.push(
+      `${audioLabel}apad,atrim=0:${total},` +
+        `afade=t=out:st=${round3(Math.max(0, total - fade))}:d=${fade}[aout]`
+    );
+  }
+
+  args.push("-filter_complex", filters.join(";"), "-map", "[vout]");
+  if (audioLabel) {
+    args.push("-map", "[aout]", "-c:a", "aac", "-b:a", "192k");
+  } else {
+    args.push("-an");
+  }
+  args.push(
+    "-c:v",
+    "libx264",
+    "-crf",
+    String(crf),
+    "-pix_fmt",
+    "yuv420p",
+    "-movflags",
+    "+faststart",
+    "-t",
+    String(total),
+    outputPath
+  );
+  return args;
+}
+
+// ── executor ───────────────────────────────────────────────────────────────
+
+export interface FootageAssembleOptions {
+  projectDir: string;
+  /** Output path (relative paths resolve against projectDir). Default: renders/footage.mp4. */
+  output?: string;
+  transitionSec?: number;
+  fadeSec?: number;
+  /**
+   * Music bed: an explicit path, `"none"` to disable, or undefined to
+   * auto-detect `assets/music.mp3|wav` then `assets/music-<firstBeat>.mp3|wav`.
+   */
+  music?: string;
+  musicVolume?: number;
+  dryRun?: boolean;
+}
+
+export interface FootageAssembleReport {
+  schemaVersion: "1";
+  kind: "footage-assemble";
+  project: string;
+  output: string;
+  totalDurationSec: number;
+  transitionSec: number;
+  fadeSec: number;
+  beats: Array<
+    FootageBeatPlan & {
+      clip: string;
+      narration?: string;
+    }
+  >;
+  music: { path: string; source: "flag" | "auto"; volume: number; ducked: boolean } | null;
+  warnings: string[];
+  nextActions: ReviewAction[];
+}
+
+export interface FootageAssembleResult {
+  success: boolean;
+  dryRun: boolean;
+  outputPath: string;
+  reportPath?: string;
+  report?: FootageAssembleReport;
+  error?: string;
+  suggestion?: string;
+}
+
+const DEFAULT_FOOTAGE_OUTPUT = "renders/footage.mp4";
+
+/**
+ * Assemble a scene project's generated clips into the footage cut. Probes real
+ * durations, plans the timeline, runs one FFmpeg pass, and writes
+ * `assemble-report.json` so the driving agent can read the cut's anatomy
+ * (offsets, extensions, clamps) without watching the video.
+ */
+export async function executeFootageAssemble(
+  opts: FootageAssembleOptions
+): Promise<FootageAssembleResult> {
+  const projectDir = resolve(opts.projectDir);
+  const outputRel = opts.output ?? DEFAULT_FOOTAGE_OUTPUT;
+  const outputPath = isAbsolute(outputRel) ? outputRel : resolve(projectDir, outputRel);
+
+  if (!ffmpegToolsAvailable()) {
+    return {
+      success: false,
+      dryRun: Boolean(opts.dryRun),
+      outputPath,
+      error: "FFmpeg toolchain (ffmpeg + ffprobe) not found in PATH.",
+      suggestion: "Install with: brew install ffmpeg (macOS) or apt install ffmpeg (Linux).",
+    };
+  }
+
+  let beats;
+  try {
+    const md = await loadStoryboardMarkdown(projectDir);
+    beats = parseStoryboard(md).beats;
+  } catch (err) {
+    return {
+      success: false,
+      dryRun: Boolean(opts.dryRun),
+      outputPath,
+      error: err instanceof Error ? err.message : String(err),
+      suggestion: "Run inside a vibe scene project (needs STORYBOARD.md / scenes/).",
+    };
+  }
+  if (beats.length === 0) {
+    return {
+      success: false,
+      dryRun: Boolean(opts.dryRun),
+      outputPath,
+      error: "STORYBOARD.md has no beats to assemble.",
+    };
+  }
+
+  const missing: string[] = [];
+  const clipRels: string[] = [];
+  for (const beat of beats) {
+    const rel = `assets/video-${beat.id}.mp4`;
+    if (!existsSync(join(projectDir, rel))) missing.push(`${beat.id} (${rel})`);
+    clipRels.push(rel);
+  }
+  if (missing.length > 0) {
+    return {
+      success: false,
+      dryRun: Boolean(opts.dryRun),
+      outputPath,
+      error: `Missing clips for beat(s): ${missing.join(", ")}.`,
+      suggestion: `Generate them first: vibe build ${projectDir} --stage assets --json`,
+    };
+  }
+
+  const narrationRels = new Map<number, string>();
+  for (let i = 0; i < beats.length; i++) {
+    const rel = ["mp3", "wav"]
+      .map((ext) => `assets/narration-${beats[i].id}.${ext}`)
+      .find((r) => existsSync(join(projectDir, r)));
+    if (rel) narrationRels.set(i, rel);
+  }
+
+  const music = resolveMusicBed(projectDir, beats[0]?.id, opts.music);
+  if (!music.ok) {
+    return {
+      success: false,
+      dryRun: Boolean(opts.dryRun),
+      outputPath,
+      error: music.error,
+    };
+  }
+
+  const inputs: FootageClipInput[] = [];
+  for (let i = 0; i < beats.length; i++) {
+    const clipDurationSec = round3(await ffprobeDuration(join(projectDir, clipRels[i])));
+    const narrationRel = narrationRels.get(i);
+    const narrationDurationSec = narrationRel
+      ? round3(await ffprobeDuration(join(projectDir, narrationRel)))
+      : undefined;
+    inputs.push({ id: beats[i].id, clipDurationSec, narrationDurationSec });
+  }
+
+  const plan = planFootageTimeline(inputs, {
+    transitionSec: opts.transitionSec,
+    fadeSec: opts.fadeSec,
+  });
+
+  const musicVolume = opts.musicVolume ?? FOOTAGE_DEFAULTS.musicVolume;
+  const report: FootageAssembleReport = {
+    schemaVersion: "1",
+    kind: "footage-assemble",
+    project: projectDir,
+    output: outputPath,
+    totalDurationSec: plan.totalDurationSec,
+    transitionSec: plan.transitionSec,
+    fadeSec: plan.fadeSec,
+    beats: plan.beats.map((b, i) => ({
+      ...b,
+      clip: clipRels[i],
+      narration: narrationRels.get(i),
+    })),
+    music: music.rel
+      ? {
+          path: music.rel,
+          source: music.source,
+          volume: musicVolume,
+          ducked: narrationRels.size > 0,
+        }
+      : null,
+    warnings: plan.warnings,
+    nextActions: [
+      {
+        id: "inspect-footage-cut",
+        kind: "command",
+        label: "Inspect the assembled cut",
+        command: `vibe inspect render ${outputPath} --cheap --json`,
+        fixOwner: "vibe",
+        costTier: "free",
+        safeToAutoRun: true,
+        requiresConfirmation: false,
+        reason: "Verify duration, black frames, and audio coverage without watching the video.",
+      },
+    ],
+  };
+
+  if (opts.dryRun) {
+    return { success: true, dryRun: true, outputPath, report };
+  }
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  const args = buildFootageAssembleArgs({
+    clipPaths: clipRels.map((r) => join(projectDir, r)),
+    plan,
+    narrationPaths: new Map(
+      [...narrationRels.entries()].map(([i, rel]) => [i, join(projectDir, rel)])
+    ),
+    musicPath: music.rel
+      ? isAbsolute(music.rel)
+        ? music.rel
+        : join(projectDir, music.rel)
+      : undefined,
+    outputPath,
+    musicVolume,
+  });
+  try {
+    await execSafe("ffmpeg", args, { timeout: 600_000 });
+  } catch (err) {
+    return {
+      success: false,
+      dryRun: false,
+      outputPath,
+      report,
+      error: `FFmpeg assembly failed: ${err instanceof Error ? err.message : String(err)}`,
+      suggestion: "Re-run with --dry-run --json to inspect the planned timeline.",
+    };
+  }
+
+  const reportPath = join(projectDir, "assemble-report.json");
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+  return { success: true, dryRun: false, outputPath, reportPath, report };
+}
+
+type MusicResolution =
+  | { ok: true; rel?: string; source: "flag" | "auto" }
+  | { ok: false; error: string };
+
+function resolveMusicBed(
+  projectDir: string,
+  firstBeatId: string | undefined,
+  flag: string | undefined
+): MusicResolution {
+  if (flag === "none") return { ok: true, source: "flag" };
+  if (flag) {
+    const abs = isAbsolute(flag) ? flag : join(projectDir, flag);
+    if (!existsSync(abs)) return { ok: false, error: `Music file not found: ${abs}` };
+    return { ok: true, rel: flag, source: "flag" };
+  }
+  const candidates = ["assets/music.mp3", "assets/music.wav"];
+  if (firstBeatId) {
+    candidates.push(`assets/music-${firstBeatId}.mp3`, `assets/music-${firstBeatId}.wav`);
+  }
+  const rel = candidates.find((r) => existsSync(join(projectDir, r)));
+  return { ok: true, rel, source: "auto" };
+}

--- a/packages/cli/src/commands/assemble.ts
+++ b/packages/cli/src/commands/assemble.ts
@@ -4,6 +4,10 @@ import ora from "ora";
 import { resolve } from "node:path";
 
 import { executeSceneAssemble, type SceneAssembleResult } from "./_shared/scene-assemble.js";
+import {
+  executeFootageAssemble,
+  type FootageAssembleResult,
+} from "./_shared/footage-assemble.js";
 import type { RenderFormat } from "./_shared/scene-render.js";
 import { exitWithError, generalError, isJsonMode, isQuietMode, outputSuccess, usageError } from "./output.js";
 
@@ -11,24 +15,43 @@ const VALID_FORMATS: RenderFormat[] = ["mp4", "webm", "mov"];
 const DEFAULT_VIDEO = "preview.mp4";
 
 export const assembleCommand = new Command("assemble")
-  .description("Mux a scene project's audio onto an already-rendered (silent) video")
+  .description(
+    "Mux a scene project's audio onto a rendered video, or crossfade-cut its generated clips (--footage)"
+  )
   .argument("[project-dir]", "Video project directory", ".")
   .option("--video <path>", `Rendered video to add audio to (default: ${DEFAULT_VIDEO})`, DEFAULT_VIDEO)
   .option("--root <file>", "Root composition file", "index.html")
   .option("--format <f>", `Output container: ${VALID_FORMATS.join("|")}`, "mp4")
+  .option("--footage", "Assemble assets/video-<beat>.mp4 clips into one cinematic cut (no HTML render)")
+  .option("-o, --output <path>", "Footage-cut output path (default: renders/footage.mp4)")
+  .option("--transition <sec>", "Footage crossfade length in seconds", "0.5")
+  .option("--fade <sec>", "Footage fade-from/to-black length in seconds", "0.6")
+  .option("--music <path>", 'Footage music bed: a file path or "none" (default: auto-detect assets/music*)')
+  .option("--music-volume <v>", "Footage music-bed volume before ducking (0-1)", "0.35")
   .option("--dry-run", "Preview parameters without muxing")
   .addHelpText("after", `
-The assemble stage lays the project's <audio> elements onto a silent video in
-one FFmpeg pass (-c:v copy, no re-encode). Pair it with \`vibe render --silent\`:
+The default assemble stage lays the project's <audio> elements onto a silent
+video in one FFmpeg pass (-c:v copy, no re-encode). Pair it with \`vibe render
+--silent\`:
 
   $ vibe render my-video --silent -o draft.mp4
   $ vibe assemble my-video --video draft.mp4
 
-Plain \`vibe render\` already renders + assembles in one shot - use this only when
-you want the two steps separated (e.g. swap the audio bed without re-rendering).`)
+With --footage the project's generated clips become the picture: they are
+crossfade-concatenated in beat order, narration is laid at computed offsets,
+an optional music bed is ducked under it, and the head/tail fade to black -
+one FFmpeg pass, no HTML composition or browser capture. Timing comes from
+the real files (ffprobe), and assemble-report.json records every offset:
+
+  $ vibe build my-video --stage assets --json     # clips + narration
+  $ vibe assemble my-video --footage --json`)
   .action(async (projectDirArg: string, options) => {
     const startedAt = Date.now();
     const projectDir = resolve(projectDirArg);
+    if (options.footage) {
+      await runFootageAssemble(projectDir, options, startedAt);
+      return;
+    }
     const format = parseFormat(String(options.format));
     const video = String(options.video ?? DEFAULT_VIDEO);
 
@@ -71,6 +94,86 @@ you want the two steps separated (e.g. swap the audio bed without re-rendering).
 
     printAssembleResult(spinner, result);
   });
+
+async function runFootageAssemble(
+  projectDir: string,
+  options: Record<string, unknown>,
+  startedAt: number
+): Promise<void> {
+  const transitionSec = parseSeconds("--transition", options.transition);
+  const fadeSec = parseSeconds("--fade", options.fade);
+  const musicVolume = parseSeconds("--music-volume", options.musicVolume);
+
+  const spinner =
+    isJsonMode() || isQuietMode() || options.dryRun ? null : ora("Assembling footage cut...").start();
+  const result = await executeFootageAssemble({
+    projectDir,
+    output: options.output as string | undefined,
+    transitionSec,
+    fadeSec,
+    music: options.music as string | undefined,
+    musicVolume,
+    dryRun: Boolean(options.dryRun),
+  });
+
+  if (!result.success) {
+    spinner?.fail("Footage assemble failed");
+    exitWithError(generalError(result.error ?? "Footage assemble failed", result.suggestion));
+  }
+
+  if (isJsonMode() || isQuietMode()) {
+    outputSuccess({ command: "assemble", startedAt, dryRun: result.dryRun, data: { ...result } });
+    return;
+  }
+  printFootageResult(spinner, result);
+}
+
+function printFootageResult(
+  spinner: ReturnType<typeof ora> | null,
+  result: FootageAssembleResult
+): void {
+  const report = result.report;
+  if (result.dryRun) {
+    console.log();
+    console.log(chalk.bold.cyan("VibeFrame Assemble - footage dry run"));
+  } else {
+    spinner?.succeed(chalk.green(`Footage cut assembled: ${result.outputPath}`));
+    console.log();
+    console.log(chalk.bold.cyan("Footage cut"));
+  }
+  console.log(chalk.dim("-".repeat(60)));
+  if (report) {
+    console.log(`  Output:     ${chalk.bold(report.output)}`);
+    console.log(`  Duration:   ${chalk.bold(`${report.totalDurationSec}s`)}`);
+    console.log(`  Transition: ${report.transitionSec}s crossfade, ${report.fadeSec}s head/tail fade`);
+    console.log(
+      `  Music:      ${report.music ? `${report.music.path}${report.music.ducked ? " (ducked)" : ""}` : chalk.dim("none")}`
+    );
+    for (const beat of report.beats) {
+      const narration = beat.narrationStartSec !== undefined ? ` nar@${beat.narrationStartSec}s` : "";
+      const extended = beat.extendedSec > 0 ? chalk.yellow(` +${beat.extendedSec}s hold`) : "";
+      console.log(
+        `    ${beat.id.padEnd(12)} ${String(beat.startSec).padStart(7)}s  ${beat.segmentDurationSec}s${narration}${extended}`
+      );
+    }
+    for (const warning of report.warnings) console.log(chalk.yellow(`  Warning: ${warning}`));
+  }
+  if (result.dryRun) {
+    console.log();
+    console.log(chalk.dim("No FFmpeg pass ran; nothing was written."));
+  } else if (result.reportPath) {
+    console.log(`  Report:     ${result.reportPath}`);
+  }
+}
+
+function parseSeconds(flag: string, value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number.parseFloat(String(value));
+  if (!Number.isFinite(n) || n < 0) {
+    exitWithError(usageError(`Invalid ${flag}: ${String(value)}`, "Expected a non-negative number."));
+  }
+  return n;
+}
 
 type AssembleDryRunParams = {
   projectDir: string;


### PR DESCRIPTION
## What

Adds the footage-cut assembler - the missing organ of the Tier 1 footage harness. `vibe assemble --footage` crossfade-concatenates a scene project's generated per-beat clips (`assets/video-<beat>.mp4`) into one cinematic cut in a single FFmpeg pass, with no HTML composition or browser capture.

- **Timeline planner** (pure): timing comes from the real files on disk (ffprobe), not declared storyboard durations. Segments whose narration outruns the clip are extended by holding the last frame (`tpad`); transitions longer than half the shortest clip are clamped with a warning instead of failing an unattended run.
- **One-pass FFmpeg graph** (pure builder): per-clip normalize (scale/crop/fps) -> xfade chain at planned offsets -> head/tail fade to black; narration `adelay`-placed per beat and mixed over an optional looped, sidechain-ducked music bed (auto-detected from `assets/music*`, or `--music <path>`/`--music none`).
- **Report-first contract**: `assemble-report.json` records every offset, extension, and clamp plus `nextActions` (inspect the cut with `vibe inspect render --cheap`), so a driving agent can read the cut's anatomy without watching the video. `--dry-run --json` returns the full plan for free.

## Why

Gap analysis against the premium-pipeline playbook showed `xfade` appeared nowhere in the codebase: `batch concat` is transition-less and `assemble` only muxed audio onto an already-rendered video. This is PR-B of the footage-harness sequence; PR-C will wire it into `vibe build --composer footage` for the unattended end-to-end path.

## Validation

- 9 new unit tests over the pure planner and args builder.
- Zero-cost E2E on The Pour's four real generated clips: silent cut matches the plan to the frame (18.67s, 1920x1080@30, three 0.5s crossfades).
- Synthetic narration/music project: 7s narration in a 5.04s clip produced the planned 3.158s last-frame hold; 4s music bed looped across the 21.8s cut; narration window probes ~9 dB above the music-only window (duck + mix verified).
- `pnpm build`, `pnpm lint`, full CLI suite (schema snapshot updated for the new options), `pnpm gen:reference` regenerated.