### PR TITLE
feat: unattended footage cut via vibe build --composer footage

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -265,7 +265,7 @@ Cost tier: _not tagged_
 - `stage` _(string)_ _(default: `"all"`)_ - Build stage: assets|transcript|compose|sync|render|all
 - `beat` _(string)_ - Restrict asset/compose work to one beat id
 - `mode` _(string)_ _(default: `"auto"`)_ - Retained for compatibility; scene HTML is always authored by your host agent unless --composer template is set
-- `composer` _(string)_ - Set to `template` for the deterministic AI-video composer (concat bg + lower-thirds, no model). Omit to let the host agent author each scene.
+- `composer` _(string)_ - Set to `template` for the deterministic AI-video composer (concat bg + lower-thirds, no model) or `footage` for the crossfade footage cut (clips + narration + music, no HTML render). Omit to let the host agent author each scene.
 - `maxCost` _(number)_ - Fail before provider spend when estimated cost exceeds this USD cap
 - `skipNarration` _(boolean)_ - Don't dispatch TTS even when beats declare narration cues
 - `skipBackdrop` _(boolean)_ - Don't dispatch image-gen even when beats declare backdrop cues

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -599,7 +599,7 @@ exports[`CLI --describe schemas (drift detection) > vibe build --describe 1`] = 
         "type": "string",
       },
       "composer": {
-        "description": "Set to \`template\` for the deterministic AI-video composer (concat bg + lower-thirds, no model). Omit to let the host agent author each scene.",
+        "description": "Set to \`template\` for the deterministic AI-video composer (concat bg + lower-thirds, no model) or \`footage\` for the crossfade footage cut (clips + narration + music, no HTML render). Omit to let the host agent author each scene.",
         "type": "string",
       },
       "dryRun": {

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -211,7 +211,11 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
   // OR'd with the explicit `--skip-*` flags. Applied here so the dry-run plan +
   // cost estimate match what the build actually runs.
   const kindPolicy = kindAssetPolicy(config.config.kind);
-  const skipBackdrop = opts.skipBackdrop ?? kindPolicy.skipBackdrop ?? false;
+  // Mirrors executeSceneBuild: the footage composer renders no HTML, so
+  // backdrops default off there and must be priced accordingly.
+  const composerIsFootage = stringOrUndefined(opts.composer)?.toLowerCase() === "footage";
+  const skipBackdrop =
+    opts.skipBackdrop ?? (composerIsFootage ? true : (kindPolicy.skipBackdrop ?? false));
   const skipKeyframe = opts.skipKeyframe ?? kindPolicy.skipKeyframe ?? false;
   const skipVideo = opts.skipVideo ?? kindPolicy.skipVideo ?? false;
   const storyboardPath = join(projectDir, "STORYBOARD.md");
@@ -1008,6 +1012,19 @@ async function resolveComposerProvider(
   projectDir: string
 ): Promise<ProviderResolution> {
   const requested = input.value.toLowerCase();
+  // Deterministic composers (template concat, footage crossfade cut) run
+  // entirely in FFmpeg — resolving an LLM here would report a phantom key need.
+  if (requested === "template" || requested === "footage") {
+    return {
+      kind: "composer",
+      requested: input.requested,
+      resolved: requested,
+      source: input.source,
+      requiresKey: false,
+      configured: true,
+      retryWith: [],
+    };
+  }
   const explicit = isComposerProvider(requested) ? requested : undefined;
   const resolved = explicit ?? (await firstConfiguredComposer(projectDir)) ?? "claude";
   const configKey = composerConfigKey(resolved);

--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -38,6 +38,10 @@ vi.mock("./scene-render.js", () => ({
   executeSceneRender: vi.fn(),
 }));
 
+vi.mock("./footage-assemble.js", () => ({
+  executeFootageAssemble: vi.fn(),
+}));
+
 vi.mock("../ai-video.js", () => ({
   executeVideoGenerate: vi.fn(),
 }));
@@ -50,6 +54,7 @@ import { resolveTtsProvider } from "./tts-resolve.js";
 import { GeminiProvider, GrokProvider, OpenAIImageProvider } from "@vibeframe/ai-providers";
 import { transcribeNarrationWords } from "./transcribe-narration.js";
 import { executeSceneRender } from "./scene-render.js";
+import { executeFootageAssemble } from "./footage-assemble.js";
 import { executeVideoGenerate } from "../ai-video.js";
 import { executeMusic } from "../generate/music.js";
 
@@ -1034,5 +1039,82 @@ describe("beat-scoped report preservation", () => {
     expect(afterById.hook.narration.status).toBe("failed");
     // The untouched beat keeps its on-disk record.
     expect(afterById.close.narration.path).toBe(closeNarrationPath);
+  });
+});
+
+describe("footage composer", () => {
+  const footageReport = {
+    schemaVersion: "1" as const,
+    kind: "footage-assemble" as const,
+    project: "",
+    output: "",
+    totalDurationSec: 9.5,
+    transitionSec: 0.5,
+    fadeSec: 0.6,
+    beats: [],
+    music: null,
+    warnings: ["Beat \"close\": narration outruns the clip; last frame held for 1s."],
+    nextActions: [],
+  };
+
+  it("skips compose/sync/transcript/backdrop and renders via the footage assembler", async () => {
+    vi.mocked(executeFootageAssemble).mockResolvedValue({
+      success: true,
+      dryRun: false,
+      outputPath: join(projectDir, "renders", "footage.mp4"),
+      reportPath: join(projectDir, "assemble-report.json"),
+      report: { ...footageReport, project: projectDir },
+    });
+
+    const r = await executeSceneBuild({ projectDir, composer: "footage" });
+
+    expect(r.success).toBe(true);
+    expect(r.phase).toBe("done");
+    expect(r.mode).toBe("batch");
+    expect(r.outputPath).toBe(join(projectDir, "renders", "footage.mp4"));
+    expect(r.footageReport?.kind).toBe("footage-assemble");
+    expect(r.stageReports?.compose.status).toBe("skipped");
+    expect(r.stageReports?.sync.status).toBe("skipped");
+    expect(r.stageReports?.transcript.status).toBe("skipped");
+    expect(r.stageReports?.render.status).toBe("done");
+    // The assembler's warnings surface on the build envelope.
+    expect(r.warnings).toEqual(expect.arrayContaining([expect.stringContaining("last frame held")]));
+    // The HTML render path never runs.
+    expect(executeSceneRender).not.toHaveBeenCalled();
+    // Backdrops are composition backgrounds — pure waste with no HTML render.
+    const hook = r.beats.find((b) => b.beatId === "hook");
+    expect(hook?.backdropStatus).toBe("skipped");
+
+    const report = readBuildReport();
+    expectBuildReportContract(report, { phase: "done", status: "done" });
+  });
+
+  it("fails the render stage with FOOTAGE_ASSEMBLE_FAILED and actionable retryWith", async () => {
+    vi.mocked(executeFootageAssemble).mockResolvedValue({
+      success: false,
+      dryRun: false,
+      outputPath: join(projectDir, "renders", "footage.mp4"),
+      error: "Missing clips for beat(s): hook (assets/video-hook.mp4).",
+      suggestion: "Generate them first: vibe build --stage assets --json",
+    });
+
+    const r = await executeSceneBuild({ projectDir, composer: "footage" });
+
+    expect(r.success).toBe(false);
+    expect(r.code).toBe("FOOTAGE_ASSEMBLE_FAILED");
+    expect(r.recoverable).toBe(true);
+    expect(r.stageReports?.render.status).toBe("failed");
+    expect(r.retryWith).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("--stage assets"),
+        expect.stringContaining("--footage --dry-run"),
+      ])
+    );
+  });
+
+  it("stops before assembly when --skip-render is set", async () => {
+    const r = await executeSceneBuild({ projectDir, composer: "footage", skipRender: true });
+    expect(r.success).toBe(true);
+    expect(executeFootageAssemble).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -36,6 +36,7 @@ import { getAudioDuration } from "../../utils/audio.js";
 import { ffmpegToolsAvailable } from "./ffmpeg-gate.js";
 import { mapWithConcurrency } from "../../utils/concurrency.js";
 import { composeAiVideo } from "./compose-aivideo.js";
+import { executeFootageAssemble, type FootageAssembleReport } from "./footage-assemble.js";
 import {
   composerDefaultForKind,
   isSceneKind,
@@ -245,7 +246,7 @@ export interface SceneBuildOptions {
    * based on env keys (claude > gemini > openai). Pass an explicit value
    * to require that provider's key.
    */
-  composer?: ComposerProvider | "template";
+  composer?: ComposerProvider | "template" | "footage";
   skipNarration?: boolean;
   skipBackdrop?: boolean;
   skipRender?: boolean;
@@ -358,6 +359,12 @@ export interface SceneBuildResult {
   outputPath?: string;
   renderResult?: SceneRenderResult;
   /**
+   * The footage composer's cut anatomy (offsets, extensions, clamps) — also
+   * persisted as `assemble-report.json`. Present only when
+   * `composer === "footage"` reached the render phase.
+   */
+  footageReport?: FootageAssembleReport;
+  /**
    * Populated only in agent mode when {@link phase} === `"needs-author"`.
    * The host agent should consume this to write each beat's HTML, then
    * re-run `vibe scene build`.
@@ -411,17 +418,24 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   const projectKind = readProjectKindSync(projectDir);
   const kindPolicy = kindAssetPolicy(projectKind);
   const composer = opts.composer ?? composerDefaultForKind(projectKind);
-  const skipBackdrop = opts.skipBackdrop ?? kindPolicy.skipBackdrop ?? false;
+  // The footage composer never renders HTML, so backdrops (composition
+  // backgrounds) would be paid images nothing ever shows. Explicit flag wins.
+  const skipBackdrop =
+    opts.skipBackdrop ?? (composer === "footage" ? true : (kindPolicy.skipBackdrop ?? false));
   const skipKeyframe = opts.skipKeyframe ?? kindPolicy.skipKeyframe ?? false;
   // Asset-stage video skip (don't generate i2v clips). Distinct from the
   // explicit `--skip-video` render-stop below: a `product`/`motion` kind has no
   // i2v but still RENDERS (backdrops / graphics), so only the explicit flag
   // stops the render.
   const skipVideoAssets = opts.skipVideo ?? kindPolicy.skipVideo ?? false;
+  // The footage cut has no caption layer, so word timings default off there.
+  const skipTranscript = opts.skipTranscript ?? composer === "footage";
 
-  // The deterministic template composer is a batch (CLI-authored) path — it must
-  // not route to agent/needs-author even when an agent host is detected.
-  const mode = composer === "template" ? "batch" : resolveSceneBuildMode(opts);
+  // The deterministic template/footage composers are batch (CLI-authored) paths
+  // — they must not route to agent/needs-author even when an agent host is
+  // detected.
+  const mode =
+    composer === "template" || composer === "footage" ? "batch" : resolveSceneBuildMode(opts);
   const selectedStage = opts.stage ?? (opts.skipRender ? "sync" : "all");
   // --skip-video produces keyframe stills (an image storyboard) for review, not
   // a final video. The composition would reference <video> clips that were never
@@ -458,6 +472,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     imageSize: opts.imageSize,
     videoProvider: opts.videoProvider,
     musicProvider: opts.musicProvider,
+    skipTranscript,
     composer,
     force: opts.force,
   });
@@ -798,7 +813,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   // never fails the build. Narration paths/freshness come from `beatOutcomes`
   // (fresh asset run OR `collectExistingBeatOutcomes` on disk), so this works
   // standalone via `--stage transcript`.
-  if (shouldRunStage(selectedStage, "transcript") && !(opts.skipTranscript ?? false)) {
+  if (shouldRunStage(selectedStage, "transcript") && !skipTranscript) {
     const { statuses } = await runTranscriptStage(activeBeats, beatOutcomes, {
       projectDir,
       force: opts.force ?? false,
@@ -875,6 +890,10 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
       // All compositions present — fall through to render (no compose call).
       onProgress({ type: "phase-start", phase: "compose" });
       stageReports.compose.status = "done";
+    } else if (composer === "footage") {
+      // Footage composer: no HTML is authored at all — the cut is assembled
+      // straight from the generated clips in the render phase.
+      stageReports.compose.status = "skipped";
     } else if (composer === "template") {
       // Deterministic AI-video composer: concat clips → one bg video +
       // transparent lower-third overlays. No LLM, no multi-video render race.
@@ -985,7 +1004,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   // Both batch and agent modes need this — agents that just authored
   // composition HTML still need them referenced from the root index for
   // the producer to find them.
-  if (shouldRunStage(selectedStage, "sync")) {
+  if (composer !== "footage" && shouldRunStage(selectedStage, "sync")) {
     if (!existsSync(join(projectDir, "index.html"))) {
       await scaffoldSceneProject({
         dir: projectDir,
@@ -1060,7 +1079,54 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   // ── Phase 3: render (optional) ────────────────────────────────────────
   let outputPath: string | undefined;
   let renderResult: SceneRenderResult | undefined;
-  if (shouldRunStage(selectedStage, "render")) {
+  let footageReport: FootageAssembleReport | undefined;
+  if (composer === "footage" && shouldRunStage(selectedStage, "render")) {
+    // Footage composer: the render IS the one-pass FFmpeg assembly — no HTML,
+    // no browser capture. assemble-report.json carries the cut's anatomy.
+    onProgress({ type: "phase-start", phase: "render" });
+    onProgress({ type: "render-start" });
+    const assembled = await executeFootageAssemble({ projectDir });
+    if (!assembled.success) {
+      stageReports.render.status = "failed";
+      const renderRetryWith = unique([
+        ...retryWith,
+        `vibe build ${projectDir} --stage assets --json`,
+        `vibe assemble ${projectDir} --footage --dry-run --json`,
+      ]);
+      stageReports.render.retryWith = unique([
+        ...stageReports.render.retryWith,
+        ...renderRetryWith,
+      ]);
+      return finishBuildResult({
+        success: false,
+        phase: "failed",
+        mode,
+        selectedStage,
+        code: "FOOTAGE_ASSEMBLE_FAILED",
+        error: `footage assemble failed: ${assembled.error ?? "unknown"}`,
+        message: `footage assemble failed: ${assembled.error ?? "unknown"}`,
+        suggestion:
+          assembled.suggestion ??
+          "Ensure every beat has a generated clip (run --stage assets), then retry.",
+        recoverable: true,
+        beats: beatOutcomes,
+        estimatedCostUsd: buildPlan.estimatedCostUsd,
+        costUsd: stageReports.assets.costUsd + stageReports.compose.costUsd,
+        stageReports,
+        sceneRepair,
+        warnings,
+        retryWith: renderRetryWith,
+        status: "failed",
+        currentStage: "render",
+        totalLatencyMs: Date.now() - startedAt,
+      });
+    }
+    outputPath = assembled.outputPath;
+    footageReport = assembled.report;
+    warnings.push(...(assembled.report?.warnings ?? []));
+    onProgress({ type: "render-done", outputPath });
+    stageReports.render.status = "done";
+  } else if (shouldRunStage(selectedStage, "render")) {
     onProgress({ type: "phase-start", phase: "render" });
     onProgress({ type: "render-start" });
     renderResult = await executeSceneRender({ projectDir });
@@ -1116,6 +1182,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     beats: beatOutcomes,
     outputPath,
     renderResult,
+    footageReport,
     estimatedCostUsd: buildPlan.estimatedCostUsd,
     costUsd: stageReports.assets.costUsd + stageReports.compose.costUsd,
     stageReports,

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -43,7 +43,7 @@ export const buildCommand = new Command("build")
   .option("--mode <mode>", "Retained for compatibility; scene HTML is always authored by your host agent unless --composer template is set", "auto")
   .option(
     "--composer <provider>",
-    "Set to `template` for the deterministic AI-video composer (concat bg + lower-thirds, no model). Omit to let the host agent author each scene."
+    "Set to `template` for the deterministic AI-video composer (concat bg + lower-thirds, no model) or `footage` for the crossfade footage cut (clips + narration + music, no HTML render). Omit to let the host agent author each scene."
   )
   .option("--max-cost <usd>", "Fail before provider spend when estimated cost exceeds this USD cap")
   .option("--skip-narration", "Don't dispatch TTS even when beats declare narration cues")


### PR DESCRIPTION
## What

PR-C of the footage-harness sequence: wires the #321 assembler into the build pipeline. `vibe build --composer footage` now goes from storyboard to cinematic cut in one unattended command - assets (keyframes -> i2v clips -> narration -> music) then a single-pass FFmpeg assembly. No HTML composition, no browser capture, no host-agent authoring step.

- `--composer footage` forces batch mode; compose and sync report `skipped`, and the render phase runs `executeFootageAssemble`. The build envelope carries `footageReport` (the cut's offsets/extensions/clamps) and surfaces its warnings.
- Backdrops default off (they are HTML-composition backgrounds nothing would render) and transcripts default off (no caption layer). Both defaults live in `executeSceneBuild` **and** `createBuildPlan`, so `--dry-run` estimates match what the build actually runs - the dry-run/real mismatch class from the hybrid friction log.
- `resolveComposerProvider` short-circuits deterministic composers (`template`, `footage`) instead of resolving a phantom LLM key requirement.
- Failures surface as `FOOTAGE_ASSEMBLE_FAILED` with the assembler's beat-scoped error and actionable `retryWith` (`--stage assets`, `assemble --footage --dry-run`).

## Validation

- Three new scene-build tests: stage skips + footage render + warning surfacing; failure contract with retryWith; `--skip-render` stops before assembly. Full CLI suite green (build `--describe` snapshot updated for the new help text).
- Real-project E2E: `build --composer footage --stage render` produced the 4-beat 21.8s cut (stages: assets/transcript/compose/sync skipped, render done); `--dry-run` resolves `composer -> footage` with `requiresKey: false` and no backdrop line in the estimate.
- `pnpm build`, `pnpm lint`, `pnpm gen:reference` regenerated.