### PR TITLE
feat: pass --image-model through build to backdrop/keyframe/character generation

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -277,6 +277,7 @@ Cost tier: _not tagged_
 - `tts` _(string)_ - TTS provider: auto|elevenlabs|openai|kokoro
 - `voice` _(string)_ - Voice id
 - `imageProvider` _(string)_ - Image provider: openai|gemini|grok
+- `imageModel` _(string)_ - Image model for keyframes/backdrops/character sheets (gemini: flash|pro, openai: gpt-image-2). Provider default when omitted.
 - `videoProvider` _(string)_ - Video provider: seedance|grok|kling|runway|veo
 - `musicProvider` _(string)_ - Music provider: elevenlabs|replicate
 - `quality` _(string)_ _(default: `"hd"`)_ - Image quality: standard|hd

--- a/packages/ai-providers/src/index.ts
+++ b/packages/ai-providers/src/index.ts
@@ -49,6 +49,7 @@ export {
   omniProvider,
   isGeminiTextModelAlias,
   resolveGeminiTextModel,
+  type GeminiImageModel,
   type GeminiTextModel,
   type GeminiTextModelAlias,
 } from "./gemini/index.js";
@@ -68,7 +69,7 @@ export {
 } from "./kokoro/index.js";
 export type { KokoroTTSOptions, KokoroTTSResult, KokoroLoadEvent } from "./kokoro/index.js";
 export { OpenAIImageProvider, openaiImageProvider } from "./openai-image/index.js";
-export type { ImageOptions, ImageResult, ImageEditOptions } from "./openai-image/index.js";
+export type { ImageOptions, ImageResult, ImageEditOptions, GPTImageModel } from "./openai-image/index.js";
 export { OpenAiTtsProvider, openaiTtsProvider, OPENAI_TTS_VOICES } from "./openai-tts/index.js";
 export type { OpenAiTtsModel, OpenAiTtsVoice, OpenAiTtsOptions, OpenAiTtsResult } from "./openai-tts/index.js";
 export { RunwayProvider, runwayProvider } from "./runway/index.js";

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -610,6 +610,10 @@ exports[`CLI --describe schemas (drift detection) > vibe build --describe 1`] = 
         "description": "Re-dispatch primitives even when assets already exist",
         "type": "boolean",
       },
+      "imageModel": {
+        "description": "Image model for keyframes/backdrops/character sheets (gemini: flash|pro, openai: gpt-image-2). Provider default when omitted.",
+        "type": "string",
+      },
       "imageProvider": {
         "description": "Image provider: openai|gemini|grok",
         "type": "string",

--- a/packages/cli/src/commands/_shared/build-cache-model.test.ts
+++ b/packages/cli/src/commands/_shared/build-cache-model.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  backdropCacheDescriptor,
+  characterCacheDescriptor,
+  keyframeCacheDescriptor,
+} from "./build-cache.js";
+
+describe("image-model cache keying", () => {
+  const base = {
+    beatId: "hook",
+    cue: "a barista at dawn",
+    provider: "gemini",
+    quality: "hd" as const,
+    size: "1536x1024",
+  };
+
+  it("keeps existing keys stable when no model is set (undefined is dropped from the hash)", () => {
+    expect(backdropCacheDescriptor(base).key).toBe(
+      backdropCacheDescriptor({ ...base, model: undefined }).key
+    );
+    expect(keyframeCacheDescriptor(base).key).toBe(
+      keyframeCacheDescriptor({ ...base, model: undefined }).key
+    );
+  });
+
+  it("re-keys backdrops, keyframes, and character sheets on a model switch", () => {
+    expect(backdropCacheDescriptor({ ...base, model: "pro" }).key).not.toBe(
+      backdropCacheDescriptor(base).key
+    );
+    expect(keyframeCacheDescriptor({ ...base, model: "pro" }).key).not.toBe(
+      keyframeCacheDescriptor({ ...base, model: "flash" }).key
+    );
+    const charBase = { name: "yuna", cue: "sheet", provider: "gemini", quality: "hd" as const, size: "1536x1024" };
+    expect(characterCacheDescriptor({ ...charBase, model: "pro" }).key).not.toBe(
+      characterCacheDescriptor(charBase).key
+    );
+  });
+});

--- a/packages/cli/src/commands/_shared/build-cache.ts
+++ b/packages/cli/src/commands/_shared/build-cache.ts
@@ -52,11 +52,14 @@ export function backdropCacheDescriptor(opts: {
   quality: "standard" | "hd";
   size: string;
   ratio?: string;
+  /** Provider-specific image model override — switching models re-keys the asset. */
+  model?: string;
 }): CacheAssetDescriptor {
   return cacheAssetDescriptor("backdrop", {
     beatId: opts.beatId,
     cue: opts.cue,
     provider: opts.provider,
+    model: opts.model,
     quality: opts.quality,
     size: opts.size,
     ratio: opts.ratio,
@@ -70,11 +73,14 @@ export function characterCacheDescriptor(opts: {
   provider: string;
   quality: "standard" | "hd";
   size: string;
+  /** Provider-specific image model override — switching models re-keys the asset. */
+  model?: string;
 }): CacheAssetDescriptor {
   return cacheAssetDescriptor("character", {
     name: opts.name,
     cue: opts.cue,
     provider: opts.provider,
+    model: opts.model,
     quality: opts.quality,
     size: opts.size,
     ext: "png",
@@ -90,10 +96,13 @@ export function keyframeCacheDescriptor(opts: {
   ratio?: string;
   /** Character sheet paths used as edit references — changing them re-keys the keyframe. */
   characters?: string[];
+  /** Provider-specific image model override — switching models re-keys the asset. */
+  model?: string;
 }): CacheAssetDescriptor {
   return cacheAssetDescriptor("keyframe", {
     beatId: opts.beatId,
     cue: opts.cue,
+    model: opts.model,
     provider: opts.provider,
     quality: opts.quality,
     size: opts.size,

--- a/packages/cli/src/commands/_shared/build-plan.ts
+++ b/packages/cli/src/commands/_shared/build-plan.ts
@@ -163,6 +163,8 @@ export interface CreateBuildPlanOptions {
   imageProvider?: string;
   imageQuality?: "standard" | "hd";
   imageSize?: string;
+  /** Provider-specific image model override — must match executeSceneBuild for cache parity. */
+  imageModel?: string;
   videoProvider?: string;
   musicProvider?: string;
   composer?: string;
@@ -359,6 +361,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
             quality: imageQuality,
             size: imageSize,
             ratio: imageRatio,
+            model: opts.imageModel,
           })
         : null;
     const videoCache =
@@ -379,6 +382,7 @@ export async function createBuildPlan(opts: CreateBuildPlanOptions): Promise<Bui
           quality: imageQuality,
           size: imageSize,
           ratio: imageRatio,
+          model: opts.imageModel,
         })
       : null;
     const musicCache =

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -29,6 +29,8 @@ import {
   GrokProvider,
   OpenAIImageProvider,
   estimateSeedanceVideoCostUsd,
+  type GPTImageModel,
+  type GeminiImageModel,
   type ImageOptions,
 } from "@vibeframe/ai-providers";
 
@@ -273,6 +275,12 @@ export interface SceneBuildOptions {
    * kinetic-type reveals to speech. Pass true to opt out (no transcribe cost).
    */
   skipTranscript?: boolean;
+  /**
+   * Provider-specific image model for backdrops/keyframes/character sheets
+   * (e.g. gemini `flash` | `pro`, openai `gpt-image-2`). Provider default when
+   * omitted; grok has a single model and ignores it.
+   */
+  imageModel?: string;
   /** OpenAI image quality — see `vibe generate image --quality`. */
   imageQuality?: "standard" | "hd";
   /** OpenAI image size. Default 1536x1024 for cinematic 16:9-ish framing. */
@@ -470,6 +478,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
     imageProvider: opts.imageProvider,
     imageQuality: opts.imageQuality,
     imageSize: opts.imageSize,
+    imageModel: opts.imageModel,
     videoProvider: opts.videoProvider,
     musicProvider: opts.musicProvider,
     skipTranscript,
@@ -682,6 +691,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
             imageProvider,
             imageSize: opts.imageSize ?? "1536x1024",
             imageQuality: opts.imageQuality ?? "hd",
+            imageModel: opts.imageModel,
             force: opts.force ?? false,
             onProgress,
           }
@@ -705,6 +715,7 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
           musicProvider,
           imageQuality: opts.imageQuality ?? "hd",
           imageSize: opts.imageSize ?? "1536x1024",
+          imageModel: opts.imageModel,
           skipNarration: opts.skipNarration ?? false,
           skipBackdrop,
           skipVideo: skipVideoAssets,
@@ -1204,6 +1215,7 @@ interface BeatDispatchContext {
   musicProvider: BuildMusicProvider;
   imageQuality: "standard" | "hd";
   imageSize: ImageOptions["size"];
+  imageModel?: string;
   skipNarration: boolean;
   skipBackdrop: boolean;
   skipVideo: boolean;
@@ -1704,6 +1716,7 @@ async function buildCharacters(
       provider: ctx.imageProvider,
       quality: ctx.imageQuality,
       size,
+      model: ctx.imageModel,
     });
 
     if (existsSync(abs) && !ctx.force) {
@@ -1752,6 +1765,7 @@ async function buildCharacters(
         imageProvider: ctx.imageProvider,
         imageSize: size,
         imageQuality: ctx.imageQuality,
+        imageModel: ctx.imageModel,
       },
       imageRatioForSize(size)
     );
@@ -1808,6 +1822,7 @@ async function dispatchBackdrop(beat: Beat, ctx: BeatDispatchContext): Promise<P
     quality: ctx.imageQuality,
     size,
     ratio,
+    model: ctx.imageModel,
   });
   const metadataPath = assetMetadataPath("backdrop", beat.id);
   if (existsSync(abs) && !ctx.force) {
@@ -1918,6 +1933,7 @@ interface ImageGenContext {
   imageProvider: BuildImageProvider;
   imageSize: ImageOptions["size"];
   imageQuality: "standard" | "hd";
+  imageModel?: string;
 }
 
 async function generateBackdropImage(
@@ -1942,7 +1958,9 @@ async function generateBackdropImage(
     const provider = new OpenAIImageProvider();
     await provider.initialize({ apiKey });
     const result = await provider.generateImage(prompt, {
-      model: "gpt-image-2",
+      // CLI input is free-form; an alias the provider doesn't know fails the
+      // API call and surfaces as a beat-scoped backdrop/keyframe error.
+      model: (ctx.imageModel as GPTImageModel | undefined) ?? "gpt-image-2",
       size: ctx.imageSize,
       quality: ctx.imageQuality,
     });
@@ -1953,7 +1971,7 @@ async function generateBackdropImage(
     const provider = new GeminiProvider();
     await provider.initialize({ apiKey });
     const result = await provider.generateImage(prompt, {
-      model: "flash",
+      model: (ctx.imageModel as GeminiImageModel | undefined) ?? "flash",
       aspectRatio: ratio as "1:1" | "2:3" | "3:2" | "16:9",
     });
     return imageBufferFromResult(result);
@@ -2003,7 +2021,7 @@ async function editKeyframeImage(
     const provider = new GeminiProvider();
     await provider.initialize({ apiKey });
     const result = await provider.editImage(sheetBuffers, prompt, {
-      model: "flash",
+      model: (ctx.imageModel as GeminiImageModel | undefined) ?? "flash",
       aspectRatio: ratio as "1:1" | "2:3" | "3:2" | "16:9",
     });
     return imageBufferFromResult(result);
@@ -2040,6 +2058,7 @@ async function ensureKeyframe(
     size,
     ratio,
     characters: characterRefsRel,
+    model: ctx.imageModel,
   });
 
   if (existsSync(abs) && !ctx.force) {
@@ -2087,6 +2106,7 @@ async function ensureKeyframe(
     imageProvider: ctx.imageProvider,
     imageSize: size,
     imageQuality: ctx.imageQuality,
+    imageModel: ctx.imageModel,
   };
   // Identity-lock prefix: editing a scene from the character sheet drifts the
   // face unless we explicitly pin the facial features. Only applies when we have

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -62,6 +62,10 @@ export const buildCommand = new Command("build")
   .option("--tts <provider>", "TTS provider: auto|elevenlabs|openai|kokoro")
   .option("--voice <id>", "Voice id")
   .option("--image-provider <name>", `Image provider: ${VALID_IMAGE_PROVIDERS.join("|")}`)
+  .option(
+    "--image-model <model>",
+    "Image model for keyframes/backdrops/character sheets (gemini: flash|pro, openai: gpt-image-2). Provider default when omitted."
+  )
   .option("--video-provider <name>", `Video provider: ${VALID_VIDEO_PROVIDERS.join("|")}`)
   .option("--music-provider <name>", `Music provider: ${VALID_MUSIC_PROVIDERS.join("|")}`)
   .option("--quality <q>", "Image quality: standard|hd", "hd")
@@ -139,6 +143,7 @@ Advanced equivalent: \`vibe scene build\`.`
       videoProvider,
       musicProvider,
       imageQuality: options.quality,
+      imageModel: options.imageModel,
       imageSize: options.imageSize,
       force: options.force ?? false,
     };
@@ -159,6 +164,7 @@ Advanced equivalent: \`vibe scene build\`.`
         voice: options.voice,
         imageProvider,
         imageQuality: options.quality,
+        imageModel: options.imageModel,
         imageSize: options.imageSize,
         videoProvider,
         musicProvider,
@@ -238,6 +244,7 @@ Advanced equivalent: \`vibe scene build\`.`
       videoProvider,
       musicProvider,
       imageQuality: options.quality,
+      imageModel: options.imageModel,
       imageSize: options.imageSize,
       force: options.force,
       onProgress: (e: SceneBuildProgressEvent) => {

--- a/packages/cli/src/pipeline/executor.ts
+++ b/packages/cli/src/pipeline/executor.ts
@@ -371,6 +371,7 @@ async function ensureActionsRegistered(): Promise<void> {
       voice: params.voice as string | undefined,
       imageProvider: params.imageProvider as "openai" | undefined,
       imageQuality: params.quality as "standard" | "hd" | undefined,
+      imageModel: params.imageModel as string | undefined,
       force: params.force as boolean | undefined,
     });
     return {

--- a/packages/cli/src/tools/manifest/scene.ts
+++ b/packages/cli/src/tools/manifest/scene.ts
@@ -601,6 +601,12 @@ const sceneBuildSchema = z.object({
     .enum(["standard", "hd"])
     .optional()
     .describe("OpenAI image quality. Default 'standard'."),
+  imageModel: z
+    .string()
+    .optional()
+    .describe(
+      "Image model for keyframes/backdrops/character sheets (gemini: flash|pro, openai: gpt-image-2). Provider default when omitted."
+    ),
   imageSize: z
     .enum(["1024x1024", "1536x1024", "1024x1536"])
     .optional()
@@ -744,6 +750,7 @@ export const sceneBuildTool = defineTool({
         videoProvider: args.videoProvider,
         musicProvider: args.musicProvider,
         imageQuality: args.imageQuality,
+        imageModel: args.imageModel,
         imageSize: args.imageSize,
         maxCostUsd: args.maxCostUsd,
         force: args.force,


### PR DESCRIPTION
## What

PR-A of the footage-harness sequence. `vibe build` hardcoded gemini to the `flash` image model, so the premium keyframe path (Nano Banana Pro) was unreachable from the build pipeline even though `generate image -m pro` exists.

- New `--image-model` flag threads through `executeSceneBuild` to all three image dispatch sites - backdrops, keyframe edits (character-sheet i2i), and character sheets - on gemini and openai. Grok has a single model and ignores it; an alias the provider doesn't know fails the API call and surfaces as the usual beat-scoped asset error.
- **Cache correctness**: backdrop/keyframe/character cache descriptors now include the model, so switching models regenerates instead of serving stale cache hits (the exact gotcha class recorded from the provider-switch incident). `undefined` is dropped from the JSON hash, so every existing cache key stays byte-identical for users not passing the flag - covered by new key-stability tests.
- `createBuildPlan` takes the same `imageModel` so dry-run freshness/cost reporting matches the real run.
- Exposed on the MCP `build` tool schema and the YAML pipeline executor. `GPTImageModel`/`GeminiImageModel` types are now exported from `@vibeframe/ai-providers` for the boundary casts.

## Validation

- 2 new cache-key tests (stability without the flag, re-key on model switch across all three asset kinds).
- Full monorepo suite green; build `--describe` snapshot and `docs/cli-reference.md` regenerated.
- `pnpm build`, `pnpm lint` clean.