### PR TITLE
feat: cinematic finish pass (vignette + film grain) for the footage cut

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -248,6 +248,7 @@ Cost tier: _not tagged_
 - `fade` _(number)_ _(default: `0.6`)_ - Footage fade-from/to-black length in seconds
 - `music` _(string)_ - Footage music bed: a file path or "none" (default: auto-detect assets/music\*)
 - `musicVolume` _(string)_ _(default: `"0.35"`)_ - Footage music-bed volume before ducking (0-1)
+- `finish` _(boolean)_ - Footage cinematic finish: vignette + film grain before the fades
 - `dryRun` _(boolean)_ - Preview parameters without muxing
 
 #### `vibe build`

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -77,6 +77,10 @@ exports[`CLI --describe schemas (drift detection) > vibe assemble --describe 1`]
         "description": "Footage fade-from/to-black length in seconds",
         "type": "number",
       },
+      "finish": {
+        "description": "Footage cinematic finish: vignette + film grain before the fades",
+        "type": "boolean",
+      },
       "footage": {
         "description": "Assemble assets/video-<beat>.mp4 clips into one cinematic cut (no HTML render)",
         "type": "boolean",

--- a/packages/cli/src/commands/_shared/footage-assemble.test.ts
+++ b/packages/cli/src/commands/_shared/footage-assemble.test.ts
@@ -146,3 +146,40 @@ describe("buildFootageAssembleArgs", () => {
     expect(fc).not.toContain("sidechaincompress");
   });
 });
+
+describe("finish pass", () => {
+  const plan = planFootageTimeline(
+    [
+      { id: "a", clipDurationSec: 5 },
+      { id: "b", clipDurationSec: 5 },
+    ],
+    { transitionSec: 0.5 }
+  );
+
+  it("inserts vignette + grain between the xfade chain and the fades", () => {
+    const args = buildFootageAssembleArgs({
+      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      plan,
+      narrationPaths: new Map(),
+      outputPath: "/p/out.mp4",
+      finish: true,
+    });
+    const fc = args[args.indexOf("-filter_complex") + 1];
+    expect(fc).toContain("vignette=angle=PI/5,noise=alls=7:allf=t,fade=t=in");
+    const xfadeIdx = fc.indexOf("xfade=");
+    expect(xfadeIdx).toBeGreaterThan(-1);
+    expect(fc.indexOf("vignette=")).toBeGreaterThan(xfadeIdx);
+  });
+
+  it("is off by default", () => {
+    const args = buildFootageAssembleArgs({
+      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      plan,
+      narrationPaths: new Map(),
+      outputPath: "/p/out.mp4",
+    });
+    const fc = args[args.indexOf("-filter_complex") + 1];
+    expect(fc).not.toContain("vignette");
+    expect(fc).not.toContain("noise=");
+  });
+});

--- a/packages/cli/src/commands/_shared/footage-assemble.ts
+++ b/packages/cli/src/commands/_shared/footage-assemble.ts
@@ -73,8 +73,16 @@ export const FOOTAGE_DEFAULTS = {
   height: 1080,
   fps: 30,
   crf: 18,
+  finishCrf: 23,
   musicVolume: 0.35,
   duck: { thresholdDb: -30, ratio: 3, attackMs: 20, releaseMs: 200 },
+  /**
+   * The cinematic finish pass: subtle vignette + temporal film grain, applied
+   * before the head/tail fades. These are the field-tested values that pull
+   * provider clips away from the too-clean "AI look"; the fades multiply over
+   * them so blacks stay black.
+   */
+  finish: ["vignette=angle=PI/5", "noise=alls=7:allf=t"],
 } as const;
 
 const round3 = (n: number): number => Math.round(n * 1000) / 1000;
@@ -178,6 +186,8 @@ export interface FootageAssembleArgsOptions {
   fps?: number;
   crf?: number;
   musicVolume?: number;
+  /** Apply the cinematic finish pass (vignette + film grain) before the fades. */
+  finish?: boolean;
 }
 
 /**
@@ -191,7 +201,10 @@ export function buildFootageAssembleArgs(opts: FootageAssembleArgsOptions): stri
   const width = opts.width ?? FOOTAGE_DEFAULTS.width;
   const height = opts.height ?? FOOTAGE_DEFAULTS.height;
   const fps = opts.fps ?? FOOTAGE_DEFAULTS.fps;
-  const crf = opts.crf ?? FOOTAGE_DEFAULTS.crf;
+  // Temporal grain is pure entropy to x264 — at crf 18 it inflates the file
+  // ~15x. The grain itself masks compression, so a softer crf keeps the look
+  // at a deliverable size.
+  const crf = opts.crf ?? (opts.finish ? FOOTAGE_DEFAULTS.finishCrf : FOOTAGE_DEFAULTS.crf);
   const musicVolume = opts.musicVolume ?? FOOTAGE_DEFAULTS.musicVolume;
   const total = plan.totalDurationSec;
   const fade = plan.fadeSec;
@@ -230,8 +243,9 @@ export function buildFootageAssembleArgs(opts: FootageAssembleArgsOptions): stri
     );
     videoLabel = out;
   }
+  const finishChain = opts.finish ? `${FOOTAGE_DEFAULTS.finish.join(",")},` : "";
   filters.push(
-    `${videoLabel}fade=t=in:st=0:d=${fade},` +
+    `${videoLabel}${finishChain}fade=t=in:st=0:d=${fade},` +
       `fade=t=out:st=${round3(Math.max(0, total - fade))}:d=${fade}[vout]`
   );
 
@@ -313,6 +327,8 @@ export interface FootageAssembleOptions {
    */
   music?: string;
   musicVolume?: number;
+  /** Apply the cinematic finish pass (vignette + film grain). */
+  finish?: boolean;
   dryRun?: boolean;
 }
 
@@ -331,6 +347,8 @@ export interface FootageAssembleReport {
     }
   >;
   music: { path: string; source: "flag" | "auto"; volume: number; ducked: boolean } | null;
+  /** The finish filters applied before the fades, or null when skipped. */
+  finish: { filters: string[] } | null;
   warnings: string[];
   nextActions: ReviewAction[];
 }
@@ -464,6 +482,7 @@ export async function executeFootageAssemble(
           ducked: narrationRels.size > 0,
         }
       : null,
+    finish: opts.finish ? { filters: [...FOOTAGE_DEFAULTS.finish] } : null,
     warnings: plan.warnings,
     nextActions: [
       {
@@ -498,6 +517,7 @@ export async function executeFootageAssemble(
       : undefined,
     outputPath,
     musicVolume,
+    finish: opts.finish,
   });
   try {
     await execSafe("ffmpeg", args, { timeout: 600_000 });

--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -1053,6 +1053,7 @@ describe("footage composer", () => {
     fadeSec: 0.6,
     beats: [],
     music: null,
+    finish: { filters: ["vignette=angle=PI/5", "noise=alls=7:allf=t"] },
     warnings: ["Beat \"close\": narration outruns the clip; last frame held for 1s."],
     nextActions: [],
   };
@@ -1081,6 +1082,10 @@ describe("footage composer", () => {
     expect(r.warnings).toEqual(expect.arrayContaining([expect.stringContaining("last frame held")]));
     // The HTML render path never runs.
     expect(executeSceneRender).not.toHaveBeenCalled();
+    // The footage composer encodes the playbook: finish pass on by default.
+    expect(executeFootageAssemble).toHaveBeenCalledWith(
+      expect.objectContaining({ finish: true })
+    );
     // Backdrops are composition backgrounds — pure waste with no HTML render.
     const hook = r.beats.find((b) => b.beatId === "hook");
     expect(hook?.backdropStatus).toBe("skipped");

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -1094,9 +1094,12 @@ export async function executeSceneBuild(opts: SceneBuildOptions): Promise<SceneB
   if (composer === "footage" && shouldRunStage(selectedStage, "render")) {
     // Footage composer: the render IS the one-pass FFmpeg assembly — no HTML,
     // no browser capture. assemble-report.json carries the cut's anatomy.
+    // The finish pass (vignette + grain) is on by default here: this composer
+    // encodes the cinematic playbook; run `vibe assemble --footage` directly
+    // for an unfinished cut.
     onProgress({ type: "phase-start", phase: "render" });
     onProgress({ type: "render-start" });
-    const assembled = await executeFootageAssemble({ projectDir });
+    const assembled = await executeFootageAssemble({ projectDir, finish: true });
     if (!assembled.success) {
       stageReports.render.status = "failed";
       const renderRetryWith = unique([

--- a/packages/cli/src/commands/assemble.ts
+++ b/packages/cli/src/commands/assemble.ts
@@ -28,6 +28,7 @@ export const assembleCommand = new Command("assemble")
   .option("--fade <sec>", "Footage fade-from/to-black length in seconds", "0.6")
   .option("--music <path>", 'Footage music bed: a file path or "none" (default: auto-detect assets/music*)')
   .option("--music-volume <v>", "Footage music-bed volume before ducking (0-1)", "0.35")
+  .option("--finish", "Footage cinematic finish: vignette + film grain before the fades")
   .option("--dry-run", "Preview parameters without muxing")
   .addHelpText("after", `
 The default assemble stage lays the project's <audio> elements onto a silent
@@ -113,6 +114,7 @@ async function runFootageAssemble(
     fadeSec,
     music: options.music as string | undefined,
     musicVolume,
+    finish: Boolean(options.finish),
     dryRun: Boolean(options.dryRun),
   });
 


### PR DESCRIPTION
## What

PR-D of the footage-harness sequence - playbook step 6, the finish that pulls provider clips away from the too-clean "AI look". One boolean, deterministic FFmpeg filters, no new dependencies.

- `vibe assemble --footage --finish` inserts `vignette=angle=PI/5` + `noise=alls=7:allf=t` between the xfade chain and the head/tail fades (fades multiply over the grain, so blacks stay black).
- `vibe build --composer footage` applies the finish **by default** - that composer encodes the cinematic playbook; `assemble --footage` without the flag remains the unfinished path.
- **Encoding correction found during validation**: temporal grain is pure entropy to x264 - at crf 18 the finished cut ballooned ~15x (170MB / 62 Mbps for 22s). Finish runs now encode at crf 23, where the grain itself masks compression: measured 12.0MB finished vs 11.1MB unfinished on the 4-beat test cut, with the vignette and grain clearly visible in extracted frames.
- `assemble-report.json` records the applied finish filters so the driving agent knows what the cut carries.

## Validation

- 2 new args-builder tests (filter order xfade -> vignette -> grain -> fade; off by default) + scene-build assertion that the footage composer passes `finish: true`.
- Real E2E on the 4-clip test project; frame-extracted visual check of grain + vignette.
- Full CLI suite green (assemble `--describe` snapshot updated), lint clean, reference regenerated.