### PR TITLE
feat: per-beat video provider cue + automatic Runway fallback on likeness 422

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -190,14 +190,15 @@ Grok Imagine supports 14 aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:
 > `-p fal` is a deprecated v0.x alias for `-p seedance` and will be removed at the 1.0 cut. Use `-p seedance` in new scripts.
 
 > ⚠️ **Seedance rejects image-to-video inputs showing a recognizable face.**
-> The fal.ai endpoint returns a deterministic HTTP 422 ("The images or videos
-> provided may contain likenesses of real people") for keyframes where a
-> person's face is clearly visible; hands-only or back-of-head shots pass.
-> Retrying does not help. For character work where the face must appear, route
-> those shots through another provider, e.g.
-> `vibe generate video "<motion>" -p runway -i keyframe.png`, or through a
-> project build's video provider override. Observed 2026-07-26 on
-> `seedance-2.0`.
+> This is ByteDance's platform-wide likeness policy, not a fal.ai quirk: the
+> API returns a deterministic HTTP 422 ("The images or videos provided may
+> contain likenesses of real people") for keyframes where a person's face is
+> clearly visible — including AI-generated photoreal faces. Hands-only or
+> back-of-head shots pass. Retrying does not help. `vibe build` falls back to
+> Runway automatically for such beats when `RUNWAY_API_SECRET` is configured;
+> you can also pin a beat with a `provider: runway` cue, or run
+> `vibe generate video "<motion>" -p runway -i keyframe.png` directly.
+> Observed 2026-07-26 on `seedance-2.0`.
 
 > ⚠️ **Gemini Omni is experimental.** It is not wired into default provider resolution — you must pass `-p omni` explicitly. The preview interactions schema may change; treat it as unstable.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1843,7 +1843,7 @@ Cost tier: `free`
 
 - `project-dir` _(string)_ **required** - Project directory
 - `beat` _(string)_ **required** - Beat id
-- `key` _(string)_ **required** - Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters | eyebrow | title | caption | kicker | sub
+- `key` _(string)_ **required** - Cue key: duration | narration | backdrop | video | keyframe | provider | motion | voice | music | asset | characters | eyebrow | title | caption | kicker | sub
 - `value` _(array)_ - Cue value. Use --json-value to pass a JSON scalar/object.
 - `jsonValue` _(boolean)_ - Parse value as JSON instead of a string
 - `unset` _(boolean)_ - Remove the cue key from the beat

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -280,7 +280,7 @@ asset: "media/logo.png"
 
 ### The cue vocabulary
 
-Fifteen keys, and only these fifteen.
+Sixteen keys, and only these sixteen.
 `vibe storyboard validate` warns on anything else and `vibe storyboard set`
 refuses it, so a typo surfaces instead of being silently ignored.
 
@@ -291,6 +291,7 @@ refuses it, so a typo surfaces instead of being silently ignored.
 | `backdrop` | Image prompt for the backdrop plate, or a path to an existing image. |
 | `video` | Motion prompt for video generation, or a path to existing footage. |
 | `keyframe` | Still prompt. Generates a keyframe, then runs image-to-video on it. |
+| `provider` | Video-provider override for this beat (`seedance`/`runway`/`kling`/`veo`/`grok`). Pin face-visible keyframes to a provider that accepts them. |
 | `music` | Music prompt, or a path to an existing track. |
 | `asset` | A project-relative file this beat reuses instead of generating. |
 | `voice` | Voice override for this beat, above the project frontmatter default. |

--- a/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/envelope-snapshots.test.ts.snap
@@ -3835,7 +3835,7 @@ exports[`CLI --describe schemas (drift detection) > vibe storyboard set --descri
         "type": "boolean",
       },
       "key": {
-        "description": "Cue key: duration | narration | backdrop | video | keyframe | motion | voice | music | asset | characters | eyebrow | title | caption | kicker | sub",
+        "description": "Cue key: duration | narration | backdrop | video | keyframe | provider | motion | voice | music | asset | characters | eyebrow | title | caption | kicker | sub",
         "type": "string",
       },
       "project-dir": {

--- a/packages/cli/src/commands/_shared/scene-build.test.ts
+++ b/packages/cli/src/commands/_shared/scene-build.test.ts
@@ -9,7 +9,7 @@ import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { executeSceneBuild, type BuildReport } from "./scene-build.js";
+import { executeSceneBuild, isLikenessRejection, type BuildReport } from "./scene-build.js";
 import { __setFfmpegToolsForTests } from "./ffmpeg-gate.js";
 import { buildEmptyRootHtml } from "./scene-project.js";
 
@@ -1121,5 +1121,112 @@ describe("footage composer", () => {
     const r = await executeSceneBuild({ projectDir, composer: "footage", skipRender: true });
     expect(r.success).toBe(true);
     expect(executeFootageAssemble).not.toHaveBeenCalled();
+  });
+});
+
+describe("video provider override + likeness fallback", () => {
+  const VIDEO_STORYBOARD = `---
+project: video-fallback-test
+providers:
+  tts: kokoro
+---
+
+## Beat pour — Pour
+
+\`\`\`yaml
+video: "steady spiral pour, steam in window light"
+\`\`\`
+
+### Concept
+
+Face-visible shot.
+`;
+
+  const pendingResult = (provider: string) => ({
+    success: true,
+    taskId: "task-1",
+    status: "running",
+    provider,
+  });
+
+  beforeEach(() => {
+    writeFileSync(join(projectDir, "STORYBOARD.md"), VIDEO_STORYBOARD);
+  });
+
+  it("honors a per-beat provider cue", async () => {
+    writeFileSync(
+      join(projectDir, "STORYBOARD.md"),
+      VIDEO_STORYBOARD.replace('window light"', 'window light"\nprovider: runway')
+    );
+    vi.mocked(executeVideoGenerate).mockResolvedValue(pendingResult("runway") as never);
+    process.env.RUNWAY_API_SECRET = "test-runway";
+    try {
+      const r = await executeSceneBuild({ projectDir, stage: "assets", skipNarration: true });
+      expect(r.success).toBe(true);
+      expect(executeVideoGenerate).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(executeVideoGenerate).mock.calls[0][0]).toMatchObject({
+        provider: "runway",
+      });
+    } finally {
+      delete process.env.RUNWAY_API_SECRET;
+    }
+  });
+
+  it("falls back to runway on a Seedance likeness 422 when a key is configured", async () => {
+    vi.mocked(executeVideoGenerate)
+      .mockResolvedValueOnce({
+        success: false,
+        error:
+          "HTTP 422 - body.image_url: The images or videos provided may contain likenesses of real people.",
+      } as never)
+      .mockResolvedValueOnce(pendingResult("runway") as never);
+    process.env.RUNWAY_API_SECRET = "test-runway";
+    const events: Array<{ type: string }> = [];
+    try {
+      const r = await executeSceneBuild({
+        projectDir,
+        stage: "assets",
+        skipNarration: true,
+        onProgress: (e) => events.push(e),
+      });
+      expect(r.success).toBe(true);
+      expect(executeVideoGenerate).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(executeVideoGenerate).mock.calls[0][0]).toMatchObject({
+        provider: "seedance",
+      });
+      expect(vi.mocked(executeVideoGenerate).mock.calls[1][0]).toMatchObject({
+        provider: "runway",
+      });
+      expect(events.some((e) => e.type === "video-fallback")).toBe(true);
+    } finally {
+      delete process.env.RUNWAY_API_SECRET;
+    }
+  });
+
+  it("does not fall back on a non-likeness failure (no double spend on generic errors)", async () => {
+    vi.mocked(executeVideoGenerate).mockResolvedValue({
+      success: false,
+      error: "provider timeout",
+    } as never);
+    process.env.RUNWAY_API_SECRET = "test-runway";
+    try {
+      const r = await executeSceneBuild({ projectDir, stage: "assets", skipNarration: true });
+      expect(r.success).toBe(false);
+      expect(executeVideoGenerate).toHaveBeenCalledTimes(1);
+      expect(r.code).toBe("ASSET_GENERATION_FAILED");
+    } finally {
+      delete process.env.RUNWAY_API_SECRET;
+    }
+  });
+
+  it("recognizes the ByteDance likeness rejection shape", () => {
+    expect(
+      isLikenessRejection(
+        "HTTP 422 - The images or videos provided may contain likenesses of real people."
+      )
+    ).toBe(true);
+    expect(isLikenessRejection("likeness of real people")).toBe(true);
+    expect(isLikenessRejection("provider timeout")).toBe(false);
+    expect(isLikenessRejection(undefined)).toBe(false);
   });
 });

--- a/packages/cli/src/commands/_shared/scene-build.ts
+++ b/packages/cli/src/commands/_shared/scene-build.ts
@@ -145,6 +145,7 @@ export type SceneBuildProgressEvent =
   | { type: "video-generated"; beatId: string; path: string; provider: string }
   | { type: "video-pending"; beatId: string; jobId: string; provider: string }
   | { type: "video-failed"; beatId: string; error: string }
+  | { type: "video-fallback"; beatId: string; from: string; to: string; reason: string }
   | { type: "video-skipped"; beatId: string; reason: string }
   | { type: "music-cached"; beatId: string; path: string }
   | { type: "music-generated"; beatId: string; path: string; provider: string }
@@ -2205,6 +2206,14 @@ async function dispatchVideo(
   const prompt = stringOrUndefined(beat.cues?.video) ?? keyframeCue;
   if (!prompt) return { status: "no-cue" };
 
+  // Per-beat override: a `provider:` cue pins this beat's video provider (e.g.
+  // route a face-visible keyframe straight to runway instead of tripping
+  // Seedance's likeness filter). Falls back to the build-level provider.
+  const providerCue = stringOrUndefined(beat.cues?.provider);
+  const requestedProvider = providerCue
+    ? resolveBuildVideoProvider(providerCue)
+    : ctx.videoProvider;
+
   // Resolve this beat's character sheets (generated up front by buildCharacters)
   // into Seedance reference-to-video inputs. Relative paths key the cache (stable
   // across machines); absolute paths are handed to the generator.
@@ -2218,7 +2227,7 @@ async function dispatchVideo(
   const cache = videoCacheDescriptor({
     beatId: beat.id,
     cue: prompt,
-    provider: ctx.videoProvider,
+    provider: requestedProvider,
     duration: normalizeVideoDuration(beat.duration),
     // Keyframe mode keys the clip to the keyframe prompt; refs feed the keyframe,
     // not the clip directly.
@@ -2235,7 +2244,7 @@ async function dispatchVideo(
         kind: "video",
         beatId: beat.id,
         cue: prompt,
-        provider: ctx.videoProvider,
+        provider: requestedProvider,
         options: { duration: normalizeVideoDuration(beat.duration), ratio: "16:9" },
         cacheKey: cache.key,
       })
@@ -2244,7 +2253,7 @@ async function dispatchVideo(
       return {
         status: "cached",
         path: rel,
-        provider: metadata?.provider ?? ctx.videoProvider,
+        provider: metadata?.provider ?? requestedProvider,
         cachePath: metadata?.cachePath ?? cache.path,
         cacheKey: metadata?.cacheKey ?? cache.key,
         metadataPath,
@@ -2261,7 +2270,7 @@ async function dispatchVideo(
       kind: "video",
       beatId: beat.id,
       cue: prompt,
-      provider: ctx.videoProvider,
+      provider: requestedProvider,
       options: { duration: normalizeVideoDuration(beat.duration), ratio: "16:9" },
       cacheKey: cache.key,
       canonicalPath: rel,
@@ -2271,7 +2280,7 @@ async function dispatchVideo(
     return {
       status: "cached",
       path: rel,
-      provider: ctx.videoProvider,
+      provider: requestedProvider,
       cachePath: cache.path,
       cacheKey: cache.key,
       metadataPath,
@@ -2297,31 +2306,60 @@ async function dispatchVideo(
   const keyframeImageAbs = keyframeImageRel ? join(ctx.projectDir, keyframeImageRel) : undefined;
 
   loadSceneBuildEnv(ctx.projectDir);
-  const result = await executeVideoGenerate({
-    prompt,
-    provider: ctx.videoProvider,
-    duration: normalizeVideoDuration(beat.duration),
-    ratio: "16:9",
-    output: abs,
-    wait: false,
-    // Keyframe mode → single init frame (image-to-video); otherwise character
-    // reference-to-video.
-    image: keyframeImageAbs,
-    refImages: keyframeImageAbs
-      ? undefined
-      : characterRefsAbs.length > 0
-        ? characterRefsAbs
-        : undefined,
-    // Build clips are always muted in the composition (a separate narration/music
-    // track carries audio), so the model's generated audio is never used. Disable
-    // it: it's wasted, and Seedance's audio moderation can spuriously fail a beat.
-    generateAudio: false,
-    apiKey: await apiKeyForVideoProvider(ctx.videoProvider, ctx.projectDir),
-  });
+  const generateWith = (provider: BuildVideoProvider, apiKey: string | undefined) =>
+    executeVideoGenerate({
+      prompt,
+      provider,
+      duration: normalizeVideoDuration(beat.duration),
+      ratio: "16:9",
+      output: abs,
+      wait: false,
+      // Keyframe mode → single init frame (image-to-video); otherwise character
+      // reference-to-video.
+      image: keyframeImageAbs,
+      refImages: keyframeImageAbs
+        ? undefined
+        : characterRefsAbs.length > 0
+          ? characterRefsAbs
+          : undefined,
+      // Build clips are always muted in the composition (a separate narration/music
+      // track carries audio), so the model's generated audio is never used. Disable
+      // it: it's wasted, and Seedance's audio moderation can spuriously fail a beat.
+      generateAudio: false,
+      apiKey,
+    });
+  let activeProvider = requestedProvider;
+  let result = await generateWith(
+    activeProvider,
+    await apiKeyForVideoProvider(activeProvider, ctx.projectDir)
+  );
   if (!result.success || !result.taskId) {
     const error = result.error ?? "video generation did not return a task id";
-    ctx.onProgress({ type: "video-failed", beatId: beat.id, error });
-    return { status: "failed", error };
+    // ByteDance rejects face-visible i2v inputs with a deterministic likeness
+    // 422 — retrying the same provider is useless, but Runway accepts the same
+    // keyframe. Fall back automatically when a Runway key is configured.
+    const runwayKey =
+      isLikenessRejection(error) && activeProvider !== "runway"
+        ? await apiKeyForVideoProvider("runway", ctx.projectDir)
+        : undefined;
+    if (!runwayKey) {
+      ctx.onProgress({ type: "video-failed", beatId: beat.id, error });
+      return { status: "failed", error };
+    }
+    ctx.onProgress({
+      type: "video-fallback",
+      beatId: beat.id,
+      from: activeProvider,
+      to: "runway",
+      reason: error,
+    });
+    activeProvider = "runway";
+    result = await generateWith(activeProvider, runwayKey);
+    if (!result.success || !result.taskId) {
+      const fallbackError = result.error ?? "video generation did not return a task id";
+      ctx.onProgress({ type: "video-failed", beatId: beat.id, error: fallbackError });
+      return { status: "failed", error: fallbackError };
+    }
   }
 
   if (result.status === "completed" && existsSync(abs)) {
@@ -2332,7 +2370,7 @@ async function dispatchVideo(
       kind: "video",
       beatId: beat.id,
       cue: prompt,
-      provider: result.provider ?? ctx.videoProvider,
+      provider: result.provider ?? activeProvider,
       options: { duration: normalizeVideoDuration(beat.duration), ratio: "16:9" },
       cacheKey: cache.key,
       canonicalPath: rel,
@@ -2342,12 +2380,12 @@ async function dispatchVideo(
       type: "video-generated",
       beatId: beat.id,
       path: rel,
-      provider: result.provider ?? ctx.videoProvider,
+      provider: result.provider ?? activeProvider,
     });
     return {
       status: "generated",
       path: rel,
-      provider: result.provider ?? ctx.videoProvider,
+      provider: result.provider ?? activeProvider,
       cachePath: cache.path,
       cacheKey: cache.key,
       metadataPath,
@@ -2357,7 +2395,7 @@ async function dispatchVideo(
 
   const job = await createAndWriteJobRecord({
     jobType: "generate-video",
-    provider: result.provider ?? ctx.videoProvider,
+    provider: result.provider ?? activeProvider,
     providerTaskId: result.taskId,
     providerTaskType: keyframeImageAbs ? "image2video" : "text2video",
     status: "running",
@@ -2895,6 +2933,15 @@ function resolveBuildVideoProvider(value: unknown): BuildVideoProvider {
 function resolveBuildMusicProvider(value: unknown): BuildMusicProvider {
   const provider = String(value ?? "elevenlabs").toLowerCase();
   return provider === "replicate" ? "replicate" : "elevenlabs";
+}
+
+/**
+ * ByteDance's platform-wide moderation rejects i2v inputs showing a
+ * recognizable face with a deterministic 422 ("likenesses of real people") —
+ * it applies to AI-generated photoreal faces too, and retrying never helps.
+ */
+export function isLikenessRejection(error: string | undefined): boolean {
+  return typeof error === "string" && /likeness(es)? of real people/i.test(error);
 }
 
 function stringOrUndefined(value: unknown): string | undefined {

--- a/packages/cli/src/commands/_shared/storyboard-edit.ts
+++ b/packages/cli/src/commands/_shared/storyboard-edit.ts
@@ -57,7 +57,7 @@ interface BeatSection {
 const HEADING_RE = /^##\s+(.+?)\s*$/gm;
 const LEADING_CUE_RE = /^(\s*)```ya?ml\s*\n([\s\S]*?)\n```\s*(?:\n|$)/;
 const ALLOWED_CUE_KEYS = new Set<string>(STORYBOARD_CUE_KEYS);
-const STRING_CUE_KEYS = new Set<string>(["narration", "backdrop", "video", "keyframe", "motion", "voice", "music", "asset", "eyebrow", "title", "caption", "kicker", "sub"]);
+const STRING_CUE_KEYS = new Set<string>(["narration", "backdrop", "video", "keyframe", "provider", "motion", "voice", "music", "asset", "eyebrow", "title", "caption", "kicker", "sub"]);
 
 /** Beats beyond this render as static, overstuffed scenes. */
 export const MAX_RECOMMENDED_BEAT_SEC = 15;

--- a/packages/cli/src/commands/_shared/storyboard-parse.test.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.test.ts
@@ -443,6 +443,7 @@ describe("cue vocabulary is one list", () => {
       backdrop: "b",
       video: "v",
       keyframe: "k",
+      provider: "runway",
       motion: "m",
       voice: "alloy",
       music: "mu",

--- a/packages/cli/src/commands/_shared/storyboard-parse.ts
+++ b/packages/cli/src/commands/_shared/storyboard-parse.ts
@@ -139,6 +139,7 @@ export const STORYBOARD_CUE_KEYS = [
   "backdrop",
   "video",
   "keyframe",
+  "provider",
   "motion",
   "voice",
   "music",
@@ -185,6 +186,12 @@ export interface BeatCues {
    * and shapes the HTML that agent writes.
    */
   motion?: string;
+  /**
+   * Video-provider override for this beat (seedance|runway|kling|veo|grok).
+   * Use to pin a face-visible keyframe to a provider that accepts it (e.g.
+   * `provider: runway` — Seedance's likeness filter rejects face i2v inputs).
+   */
+  provider?: string;
   /** Voice override for this beat (overrides project frontmatter `voice`). */
   voice?: string;
   /** Music prompt or a project-relative path to an existing track. */


### PR DESCRIPTION
## What

PR-E of the footage-harness sequence - encodes the hybrid experiment's key finding into the build: ByteDance's platform-wide likeness policy deterministically rejects face-visible i2v keyframes (HTTP 422, applies to AI-generated photoreal faces too), so the real engine of character continuity is multi-provider fallback under one cost gate.

- **New `provider:` beat cue** (the 16th cue key) pins a beat's video provider (`seedance`/`runway`/`kling`/`veo`/`grok`) - author-time routing for face shots. Registered in `STORYBOARD_CUE_KEYS` (single source of truth: `BeatCues`, validate, `storyboard set`, and the compose/revise prompts all derive from it), documented in `docs/projects.md`.
- **Automatic fallback**: when a beat fails with the likeness rejection and a Runway key is configured, `dispatchVideo` retries the same beat on Runway, emits a `video-fallback` progress event, and records the actual provider in asset metadata. Generic failures never trigger it (no double spend); no Runway key keeps the existing failure contract (`ASSET_GENERATION_FAILED` + beat-scoped retryWith).
- Cache keys stay keyed to the *requested* provider, so re-runs of the same storyboard hit cache regardless of which provider actually fulfilled the clip.
- **MODELS.md correction**: the likeness filter is ByteDance platform policy, not a fal.ai layer quirk - the warning block now says so and points at the new cue + fallback.

## Validation

- 4 new tests: per-beat cue honored; likeness 422 -> Runway retry with `video-fallback` event; non-likeness failure does NOT fall back; `isLikenessRejection` shape matching.
- Full CLI suite green (storyboard `set --describe` snapshot updated for the new cue; the cue-vocabulary-is-one-list type test caught the `BeatCues` declaration as designed).
- `pnpm build`, `pnpm lint`, reference regenerated.