### PR TITLE
feat: ken-burns keyframe fallback for missing clips in the footage cut

### DIFF
--- a/packages/cli/src/commands/_shared/footage-assemble.test.ts
+++ b/packages/cli/src/commands/_shared/footage-assemble.test.ts
@@ -91,7 +91,10 @@ describe("buildFootageAssembleArgs", () => {
 
   it("builds the xfade chain at planned offsets with normalized inputs", () => {
     const args = buildFootageAssembleArgs({
-      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      sources: [
+        { path: "/p/a.mp4", kind: "video" as const },
+        { path: "/p/b.mp4", kind: "video" as const },
+      ],
       plan,
       narrationPaths: new Map(),
       outputPath: "/p/out.mp4",
@@ -109,7 +112,10 @@ describe("buildFootageAssembleArgs", () => {
 
   it("delays each narration to its planned start and mixes over ducked music", () => {
     const args = buildFootageAssembleArgs({
-      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      sources: [
+        { path: "/p/a.mp4", kind: "video" as const },
+        { path: "/p/b.mp4", kind: "video" as const },
+      ],
       plan,
       narrationPaths: new Map([[0, "/p/nar-a.mp3"]]),
       musicPath: "/p/music.mp3",
@@ -127,7 +133,10 @@ describe("buildFootageAssembleArgs", () => {
 
   it("mixes multiple narrations without music via amix", () => {
     const args = buildFootageAssembleArgs({
-      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      sources: [
+        { path: "/p/a.mp4", kind: "video" as const },
+        { path: "/p/b.mp4", kind: "video" as const },
+      ],
       plan: planFootageTimeline(
         [
           { id: "a", clipDurationSec: 5, narrationDurationSec: 2 },
@@ -158,7 +167,10 @@ describe("finish pass", () => {
 
   it("inserts vignette + grain between the xfade chain and the fades", () => {
     const args = buildFootageAssembleArgs({
-      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      sources: [
+        { path: "/p/a.mp4", kind: "video" as const },
+        { path: "/p/b.mp4", kind: "video" as const },
+      ],
       plan,
       narrationPaths: new Map(),
       outputPath: "/p/out.mp4",
@@ -173,7 +185,10 @@ describe("finish pass", () => {
 
   it("is off by default", () => {
     const args = buildFootageAssembleArgs({
-      clipPaths: ["/p/a.mp4", "/p/b.mp4"],
+      sources: [
+        { path: "/p/a.mp4", kind: "video" as const },
+        { path: "/p/b.mp4", kind: "video" as const },
+      ],
       plan,
       narrationPaths: new Map(),
       outputPath: "/p/out.mp4",
@@ -181,5 +196,37 @@ describe("finish pass", () => {
     const fc = args[args.indexOf("-filter_complex") + 1];
     expect(fc).not.toContain("vignette");
     expect(fc).not.toContain("noise=");
+  });
+});
+
+describe("ken-burns keyframe fallback", () => {
+  it("loops the still for the full segment and animates it with zoompan", () => {
+    const plan = planFootageTimeline(
+      [
+        { id: "a", clipDurationSec: 5 },
+        { id: "b", clipDurationSec: 4, narrationDurationSec: 5 },
+      ],
+      { transitionSec: 0.5 }
+    );
+    const args = buildFootageAssembleArgs({
+      sources: [
+        { path: "/p/a.mp4", kind: "video" as const },
+        { path: "/p/keyframe-b.png", kind: "image" as const },
+      ],
+      plan,
+      narrationPaths: new Map(),
+      outputPath: "/p/out.mp4",
+    });
+    const loopIdx = args.indexOf("-loop");
+    expect(loopIdx).toBeGreaterThan(-1);
+    // The looped still runs for the planned segment (narration floor included).
+    const tIdx = args.indexOf("-t", loopIdx);
+    expect(args[tIdx + 1]).toBe(String(plan.beats[1].segmentDurationSec));
+    const fc = args[args.indexOf("-filter_complex") + 1];
+    expect(fc).toContain("zoompan=z='min(pzoom+");
+    // The image segment gets no tpad — its length comes from the loop itself.
+    expect(fc).not.toContain("tpad");
+    // Still xfade-chained like any clip.
+    expect(fc).toContain("xfade=transition=fade");
   });
 });

--- a/packages/cli/src/commands/_shared/footage-assemble.ts
+++ b/packages/cli/src/commands/_shared/footage-assemble.ts
@@ -83,9 +83,14 @@ export const FOOTAGE_DEFAULTS = {
    * them so blacks stay black.
    */
   finish: ["vignette=angle=PI/5", "noise=alls=7:allf=t"],
+  /** Base segment length for a ken-burns keyframe fallback (no clip to probe). */
+  kenburnsSec: 4,
+  /** Slow-push ceiling for the ken-burns zoom. */
+  kenburnsMaxZoom: 1.1,
 } as const;
 
 const round3 = (n: number): number => Math.round(n * 1000) / 1000;
+const round6 = (n: number): number => Math.round(n * 1e6) / 1e6;
 
 /**
  * Compute segment lengths and timeline offsets from real clip/narration
@@ -172,9 +177,16 @@ export function planFootageTimeline(
 
 // ── ffmpeg args (pure) ─────────────────────────────────────────────────────
 
+/** One visual source per beat: a generated clip, or a keyframe still to ken-burns. */
+export interface FootageSource {
+  /** Absolute path to the clip (video) or keyframe still (image). */
+  path: string;
+  kind: "video" | "image";
+}
+
 export interface FootageAssembleArgsOptions {
-  /** Absolute clip paths, in beat order (parallel to `plan.beats`). */
-  clipPaths: string[];
+  /** Visual sources in beat order (parallel to `plan.beats`). */
+  sources: FootageSource[];
   plan: FootageTimelinePlan;
   /** Absolute narration paths keyed by beat index (sparse — not every beat narrates). */
   narrationPaths: ReadonlyMap<number, string>;
@@ -197,7 +209,7 @@ export interface FootageAssembleArgsOptions {
  * sidechain-ducked music bed.
  */
 export function buildFootageAssembleArgs(opts: FootageAssembleArgsOptions): string[] {
-  const { plan, clipPaths, narrationPaths, musicPath, outputPath } = opts;
+  const { plan, sources, narrationPaths, musicPath, outputPath } = opts;
   const width = opts.width ?? FOOTAGE_DEFAULTS.width;
   const height = opts.height ?? FOOTAGE_DEFAULTS.height;
   const fps = opts.fps ?? FOOTAGE_DEFAULTS.fps;
@@ -210,23 +222,54 @@ export function buildFootageAssembleArgs(opts: FootageAssembleArgsOptions): stri
   const fade = plan.fadeSec;
 
   const args: string[] = ["-y"];
-  for (const clip of clipPaths) args.push("-i", clip);
+  for (let i = 0; i < sources.length; i++) {
+    const source = sources[i];
+    if (source.kind === "image") {
+      // A looped still becomes this beat's segment; zoompan animates it below.
+      args.push(
+        "-loop",
+        "1",
+        "-framerate",
+        String(fps),
+        "-t",
+        String(plan.beats[i].segmentDurationSec),
+        "-i",
+        source.path
+      );
+    } else {
+      args.push("-i", source.path);
+    }
+  }
   const narrationEntries = [...narrationPaths.entries()].sort(([a], [b]) => a - b);
   const narrationInputIndex = new Map<number, number>();
   for (const [beatIndex, path] of narrationEntries) {
-    narrationInputIndex.set(beatIndex, clipPaths.length + narrationInputIndex.size);
+    narrationInputIndex.set(beatIndex, sources.length + narrationInputIndex.size);
     args.push("-i", path);
   }
   let musicInputIndex: number | undefined;
   if (musicPath) {
-    musicInputIndex = clipPaths.length + narrationInputIndex.size;
+    musicInputIndex = sources.length + narrationInputIndex.size;
     args.push("-stream_loop", "-1", "-i", musicPath);
   }
 
   const filters: string[] = [];
 
-  // Video: normalize each clip, extend where the plan says so, xfade-chain.
-  for (let i = 0; i < clipPaths.length; i++) {
+  // Video: normalize each source, extend where the plan says so, xfade-chain.
+  for (let i = 0; i < sources.length; i++) {
+    const seg = plan.beats[i].segmentDurationSec;
+    if (sources[i].kind === "image") {
+      // Ken-burns slow push: upsample 2x (zoompan jitters at 1:1), crop to the
+      // target aspect, then zoom toward the ceiling over the full segment.
+      const rate = round6((FOOTAGE_DEFAULTS.kenburnsMaxZoom - 1) / Math.max(1, seg * fps));
+      filters.push(
+        `[${i}:v]scale=${width * 2}:${height * 2}:force_original_aspect_ratio=increase,` +
+          `crop=${width * 2}:${height * 2},` +
+          `zoompan=z='min(pzoom+${rate},${FOOTAGE_DEFAULTS.kenburnsMaxZoom})':` +
+          `x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)':d=1:s=${width}x${height}:fps=${fps},` +
+          `setsar=1,settb=AVTB,format=yuv420p[v${i}]`
+      );
+      continue;
+    }
     const extend = plan.beats[i].extendedSec;
     const tpad = extend > 0 ? `,tpad=stop_mode=clone:stop_duration=${extend}` : "";
     filters.push(
@@ -235,7 +278,7 @@ export function buildFootageAssembleArgs(opts: FootageAssembleArgsOptions): stri
     );
   }
   let videoLabel = "[v0]";
-  for (let i = 1; i < clipPaths.length; i++) {
+  for (let i = 1; i < sources.length; i++) {
     const out = `[vx${i}]`;
     filters.push(
       `${videoLabel}[v${i}]xfade=transition=fade:duration=${plan.transitionSec}:` +
@@ -342,7 +385,10 @@ export interface FootageAssembleReport {
   fadeSec: number;
   beats: Array<
     FootageBeatPlan & {
+      /** The visual source file (generated clip, or keyframe still on fallback). */
       clip: string;
+      /** How the segment was produced. */
+      source: "clip" | "keyframe-kenburns";
       narration?: string;
     }
   >;
@@ -410,19 +456,32 @@ export async function executeFootageAssemble(
     };
   }
 
+  // Source resolution per beat: generated clip, else ken-burns the keyframe
+  // still (a failed or skipped clip must not sink the whole unattended cut).
   const missing: string[] = [];
-  const clipRels: string[] = [];
+  const sourceRels: Array<{ rel: string; kind: "video" | "image" }> = [];
+  const kenburnsBeatIds: string[] = [];
   for (const beat of beats) {
-    const rel = `assets/video-${beat.id}.mp4`;
-    if (!existsSync(join(projectDir, rel))) missing.push(`${beat.id} (${rel})`);
-    clipRels.push(rel);
+    const clipRel = `assets/video-${beat.id}.mp4`;
+    if (existsSync(join(projectDir, clipRel))) {
+      sourceRels.push({ rel: clipRel, kind: "video" });
+      continue;
+    }
+    const keyframeRel = `assets/keyframe-${beat.id}.png`;
+    if (existsSync(join(projectDir, keyframeRel))) {
+      sourceRels.push({ rel: keyframeRel, kind: "image" });
+      kenburnsBeatIds.push(beat.id);
+      continue;
+    }
+    missing.push(`${beat.id} (${clipRel})`);
+    sourceRels.push({ rel: clipRel, kind: "video" });
   }
   if (missing.length > 0) {
     return {
       success: false,
       dryRun: Boolean(opts.dryRun),
       outputPath,
-      error: `Missing clips for beat(s): ${missing.join(", ")}.`,
+      error: `No clip or keyframe for beat(s): ${missing.join(", ")}.`,
       suggestion: `Generate them first: vibe build ${projectDir} --stage assets --json`,
     };
   }
@@ -447,7 +506,12 @@ export async function executeFootageAssemble(
 
   const inputs: FootageClipInput[] = [];
   for (let i = 0; i < beats.length; i++) {
-    const clipDurationSec = round3(await ffprobeDuration(join(projectDir, clipRels[i])));
+    // Ken-burns segments have no file duration to probe: use the declared beat
+    // duration (the narration floor still extends them like any clip).
+    const clipDurationSec =
+      sourceRels[i].kind === "image"
+        ? (beats[i].duration ?? FOOTAGE_DEFAULTS.kenburnsSec)
+        : round3(await ffprobeDuration(join(projectDir, sourceRels[i].rel)));
     const narrationRel = narrationRels.get(i);
     const narrationDurationSec = narrationRel
       ? round3(await ffprobeDuration(join(projectDir, narrationRel)))
@@ -471,7 +535,8 @@ export async function executeFootageAssemble(
     fadeSec: plan.fadeSec,
     beats: plan.beats.map((b, i) => ({
       ...b,
-      clip: clipRels[i],
+      clip: sourceRels[i].rel,
+      source: sourceRels[i].kind === "image" ? ("keyframe-kenburns" as const) : ("clip" as const),
       narration: narrationRels.get(i),
     })),
     music: music.rel
@@ -483,7 +548,12 @@ export async function executeFootageAssemble(
         }
       : null,
     finish: opts.finish ? { filters: [...FOOTAGE_DEFAULTS.finish] } : null,
-    warnings: plan.warnings,
+    warnings: [
+      ...plan.warnings,
+      ...kenburnsBeatIds.map(
+        (id) => `Beat "${id}": no generated clip; keyframe ken-burns fallback used.`
+      ),
+    ],
     nextActions: [
       {
         id: "inspect-footage-cut",
@@ -496,6 +566,17 @@ export async function executeFootageAssemble(
         requiresConfirmation: false,
         reason: "Verify duration, black frames, and audio coverage without watching the video.",
       },
+      ...kenburnsBeatIds.map((id) => ({
+        id: `regenerate-clip-${id}`,
+        kind: "command" as const,
+        label: `Regenerate the missing clip for beat "${id}"`,
+        command: `vibe build ${projectDir} --beat ${id} --stage assets --force --json`,
+        fixOwner: "vibe" as const,
+        costTier: "very-high" as const,
+        safeToAutoRun: false,
+        requiresConfirmation: true,
+        reason: `Beat "${id}" shipped as a ken-burns still; regenerating the clip restores real motion.`,
+      })),
     ],
   };
 
@@ -505,7 +586,7 @@ export async function executeFootageAssemble(
 
   await mkdir(dirname(outputPath), { recursive: true });
   const args = buildFootageAssembleArgs({
-    clipPaths: clipRels.map((r) => join(projectDir, r)),
+    sources: sourceRels.map((s) => ({ path: join(projectDir, s.rel), kind: s.kind })),
     plan,
     narrationPaths: new Map(
       [...narrationRels.entries()].map(([i, rel]) => [i, join(projectDir, rel)])


### PR DESCRIPTION
## What

PR-F, the last mechanical gap in the Tier 1 footage-harness sequence (playbook step 8): a failed or skipped clip must not sink the whole unattended cut.

- When `assets/video-<beat>.mp4` is missing but the beat's keyframe still exists, the assembler loops the still for the planned segment and animates it with a zoompan slow push (2x upsample against zoompan jitter, 1.10 zoom ceiling reached over the segment) - inline in the same single FFmpeg pass, xfade-chained like any clip.
- Segment length comes from the declared beat duration (default 4s); the narration floor extends it exactly like a real clip.
- `assemble-report.json` marks the beat `source: "keyframe-kenburns"`, warns, and adds a **confirm-gated very-high-cost nextAction** to regenerate the real clip (`safeToAutoRun: false` - a fallback must never trigger silent provider spend).
- Hard error only when a beat has neither clip nor keyframe.

## Validation

- New args-builder test (loop -t = planned segment, zoompan present, no tpad on stills, still xfade-chained); existing tests migrated to the new `sources` input shape.
- E2E: removed one clip from the 4-beat test project - the cut assembled with the keyframe segment at the narration-floored 8.2s, extracted frames within the segment differ (the zoom actually moves, verified visually), and the regenerate action carries `requiresConfirmation: true`.
- Full CLI suite green, lint clean, reference check passes (no CLI surface change).