### PR TITLE
chore: bump version to 0.115.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.115.2] - 2026-07-26
+
+### Added
+
+- ken-burns keyframe fallback for missing clips in the footage cut (#326)
+- per-beat video provider cue + automatic Runway fallback on likeness 422 (#325)
+- cinematic finish pass (vignette + film grain) for the footage cut (#324)
+- pass --image-model through build to backdrop/keyframe/character generation (#323)
+- unattended footage cut via vibe build --composer footage (#322)
+- crossfade-cut generated clips with vibe assemble --footage (#321)
+
 ## [0.115.1] - 2026-07-26
 
 ### Documentation

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/web",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "description": "VibeFrame Web - landing and demo site for the frontier-video-generation CLI for coding agents",
   "private": true,
   "keywords": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,7 +15,7 @@ lists every command, its arguments, and its options. For agentic /
 machine-readable access use `vibe schema --list` and
 `vibe schema <command>` directly; both return JSON.
 
-> CLI version: `0.115.1`
+> CLI version: `0.115.2`
 
 ## Mental model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeframe",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "description": "Frontier AI video generation for coding agents - Seedance, Runway, Veo, and Kling on your own keys, behind a hard cost cap. CLI + MCP.",
   "private": true,
   "license": "MIT",

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ai-providers",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "description": "VibeFrame AI Providers - pluggable AI integrations (OpenAI, Claude, Gemini, etc.)",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/cli",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "description": "Frontier AI video generation for coding agents - Seedance, Runway, Veo, and Kling on your own keys, behind a hard cost cap",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/core",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "description": "VibeFrame Core - timeline data structures, effects, and FFmpeg export",
   "private": true,
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/mcp-server",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "description": "VibeFrame MCP Server - frontier AI video generation for agents (Seedance, Runway, Veo, Kling) on your own keys, behind a hard cost cap",
   "type": "module",
   "bin": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibeframe/ui",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "description": "VibeFrame UI - shared React components (Radix UI + Tailwind)",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Release commit for v0.115.2 - covers the six Tier 1 footage-harness features (#321-#326): `vibe assemble --footage`, `vibe build --composer footage`, `--image-model` pass-through, the cinematic finish pass, the per-beat `provider:` cue with automatic Runway likeness fallback, and the ken-burns keyframe fallback. Changelog regenerated with git-cliff; all packages at 0.115.2; full suite green.